### PR TITLE
Infinite Tracing - PartitionedBlockingCollection

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1024,6 +1024,11 @@ namespace NewRelic.Agent.Core.Configuration
                 .GetValueOrDefault(100000);
         }
 
+        private int? _infiniteTracingPartitionCountSpans;
+        public int InfiniteTracingPartitionCountSpans => (_infiniteTracingPartitionCountSpans
+                ?? (_infiniteTracingPartitionCountSpans = TryGetAppSettingAsIntWithDefault("InfiniteTracingSpanEventsPartitionCount", 62))).Value;
+
+
         private bool _infiniteTracingObtainedSettingsForTest;
         private void GetInfiniteTracingFlakyAndDelayTestSettings()
         {

--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -211,7 +211,7 @@ namespace NewRelic.Agent.Core.Segments
 
             if (!string.IsNullOrWhiteSpace(CommandText))
             {
-                AttribDefs.DbStatement.TrySetValue(AttribVals, GetObfuscatedSQL);
+                AttribDefs.DbStatement.TrySetValue(AttribVals, GetObfuscatedSQL());
             }
 
             AttribDefs.DbCollection.TrySetValue(AttribVals, _parsedSqlStatement.Model);

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -231,7 +231,7 @@ namespace NewRelic.Agent.Core.Segments
         public void SetAttributeValues()
         {
             AttribDefs.Duration.TrySetValue(_attribValues, DurationOrZero);
-            AttribDefs.NameForSpan.TrySetValue(_attribValues, () => GetTransactionTraceName());
+            AttribDefs.NameForSpan.TrySetValue(_attribValues, GetTransactionTraceName());
 
             if (ErrorData != null)
             {

--- a/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
@@ -97,7 +97,7 @@ namespace NewRelic.Agent.Core.Spans
 
             segment.SetAttributeValues();
 
-            _attribDefs.ParentId.TrySetValue(segment.AttribValues, () => GetParentSpanId(segment, immutableTransaction, rootSpanId));
+            _attribDefs.ParentId.TrySetValue(segment.AttribValues, GetParentSpanId(segment, immutableTransaction, rootSpanId));
         }
 
         /// <summary>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -74,6 +74,7 @@ namespace NewRelic.Agent.Configuration
         float? InfiniteTracingTraceObserverTestFlaky { get; }
         int? InfiniteTracingTraceObserverTestDelayMs { get; }
         int InfiniteTracingQueueSizeSpans { get; }
+        int InfiniteTracingPartitionCountSpans { get; }
         int InfiniteTracingTraceTimeoutMsConnect { get; }
         int InfiniteTracingTraceTimeoutMsSendData { get; }
         string PrimaryApplicationId { get; }

--- a/src/NewRelic.Core/NewRelic.Collections/PartitionedBlockingCollection.cs
+++ b/src/NewRelic.Core/NewRelic.Collections/PartitionedBlockingCollection.cs
@@ -1,0 +1,119 @@
+﻿/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace NewRelic.Collections
+{
+    public class PartitionedBlockingCollection<T>
+    {
+        private BlockingCollection<T>[] _collections;
+
+        public readonly int Capacity;
+
+        private int _count;
+        public int Count => _count;
+
+        public int PartitionCount => _collections.Length;
+
+        public PartitionedBlockingCollection(int capacity, int partitionCount)
+        {
+            Capacity = capacity;
+            var collections = new List<BlockingCollection<T>>();
+            var proposedPartitionSize = Convert.ToInt32(Math.Ceiling(Convert.ToSingle(capacity) / partitionCount));
+            var totalTaken = 0;
+
+            for (var i = 0; i < partitionCount; i++)
+            {
+                var actualPartitionSize = Math.Min(capacity, proposedPartitionSize);
+                collections.Add(new BlockingCollection<T>(actualPartitionSize));
+
+                capacity = capacity - actualPartitionSize;
+
+                if (capacity <= 0)
+                {
+                    break;
+                }
+            }
+
+            _collections = collections.ToArray();
+        }
+
+        public PartitionedBlockingCollection(int capacity, int partitionCount, PartitionedBlockingCollection<T> fromCollection)
+            :this(capacity,partitionCount)
+        {
+            while (fromCollection.TryTake(out var item)  && TryAdd(item))
+#pragma warning disable S108 // Nested blocks of code should not be left empty
+            {
+            }
+#pragma warning restore S108 // Nested blocks of code should not be left empty
+
+        }
+
+        public PartitionedBlockingCollection(int capacity, int partitionCount, IEnumerable<T> items)
+            : this(capacity, partitionCount)
+        {
+            TryAdd(items);
+        }
+
+        public bool TryAdd(T item)
+        {
+            if(BlockingCollection<T>.TryAddToAny(_collections, item) != -1)
+            {
+                Interlocked.Increment(ref _count);
+                return true;
+            }
+
+            return false;
+        }
+
+        public int TryAdd(IEnumerable<T> items)
+        {
+            var count = 0;
+            foreach (var item in items)
+            {
+                if (!TryAdd(item))
+                {
+                    return count;
+                }
+
+                count++;
+            }
+
+            return count;
+        }
+
+        public bool TryTake(out T item)
+        {
+            if(BlockingCollection<T>.TryTakeFromAny(_collections, out item) != -1)
+            {
+                Interlocked.Decrement(ref _count);
+                return true;
+            }
+
+            return false;
+        }
+
+
+        public bool Take(out T item, CancellationToken token)
+        {
+            if(BlockingCollection<T>.TakeFromAny(_collections, out item, token) != -1)
+            {
+                Interlocked.Decrement(ref _count);
+                return true;
+            }
+
+            return false;
+        }
+
+        public List<T> ToList()
+        {
+            return _collections.SelectMany(x => x).ToList();
+        }
+    }
+}


### PR DESCRIPTION
* Creates a new `PartitionedBlockingCollection<T>` that allows the unification of multiple blocking collections into a single structure.  The rationale is that multiple smaller collections use less memory that a single larger collection.
* Modifies Infinite Tracing `SpanEventAggregatorInfiniteTracing` and the `SpanDataStreamingService` to use this collection.