### PR TITLE
Infinite Tracing - Defer Creation of SpanAttributeValueCollection

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Segments/AbstractSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/AbstractSegmentData.cs
@@ -17,7 +17,6 @@ namespace NewRelic.Agent.Core.Segments
     {
         protected ISegmentDataState _segmentState;
 
-        protected IAttributeValueCollection AttribVals => _segmentState.AttribValues;
         protected IAttributeDefinitions AttribDefs => _segmentState.AttribDefs;
 
         public virtual SpanCategory SpanCategory => SpanCategory.Generic;
@@ -41,9 +40,9 @@ namespace NewRelic.Agent.Core.Segments
         public abstract string GetTransactionTraceName();
         public abstract void AddMetricStats(Segment segment, TimeSpan durationOfChildren, TransactionMetricStatsCollection txStats, IConfigurationService configService);
 
-        public virtual void RecordSpanTypeSpecificAttributes()
+        public virtual void SetSpanTypeSpecificAttributes(SpanAttributeValueCollection attribVals)
         {
-            AttribDefs.SpanCategory.TrySetValue(AttribVals, SpanCategory.Generic);
+            AttribDefs.SpanCategory.TrySetValue(attribVals, SpanCategory.Generic);
         }
 
         internal virtual void AddTransactionTraceParameters(IConfigurationService configurationService, Segment segment, IDictionary<string, object> segmentParameters, ImmutableTransaction immutableTransaction)

--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -204,21 +204,21 @@ namespace NewRelic.Agent.Core.Segments
             return _databaseService.GetObfuscatedSql(CommandText, DatastoreVendorName);
         }
 
-        public override void RecordSpanTypeSpecificAttributes()
+        public override void SetSpanTypeSpecificAttributes(SpanAttributeValueCollection attribVals)
         {
-            AttribDefs.SpanCategory.TrySetValue(AttribVals, SpanCategory.Datastore);
-            AttribDefs.Component.TrySetValue(AttribVals, EnumNameCache<DatastoreVendor>.GetName(DatastoreVendorName));
+            AttribDefs.SpanCategory.TrySetValue(attribVals, SpanCategory.Datastore);
+            AttribDefs.Component.TrySetValue(attribVals, EnumNameCache<DatastoreVendor>.GetName(DatastoreVendorName));
 
             if (!string.IsNullOrWhiteSpace(CommandText))
             {
-                AttribDefs.DbStatement.TrySetValue(AttribVals, GetObfuscatedSQL());
+                AttribDefs.DbStatement.TrySetValue(attribVals, GetObfuscatedSQL());
             }
 
-            AttribDefs.DbCollection.TrySetValue(AttribVals, _parsedSqlStatement.Model);
-            AttribDefs.DbInstance.TrySetValue(AttribVals, DatabaseName);
-            AttribDefs.PeerAddress.TrySetValue(AttribVals, $"{Host}:{PortPathOrId}");
-            AttribDefs.PeerHostname.TrySetValue(AttribVals, Host);
-            AttribDefs.SpanKind.TrySetDefault(AttribVals);
+            AttribDefs.DbCollection.TrySetValue(attribVals, _parsedSqlStatement.Model);
+            AttribDefs.DbInstance.TrySetValue(attribVals, DatabaseName);
+            AttribDefs.PeerAddress.TrySetValue(attribVals, $"{Host}:{PortPathOrId}");
+            AttribDefs.PeerHostname.TrySetValue(attribVals, Host);
+            AttribDefs.SpanKind.TrySetDefault(attribVals);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Segments/ExternalSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/ExternalSegmentData.cs
@@ -86,14 +86,14 @@ namespace NewRelic.Agent.Core.Segments
         }
 
 
-        public override void RecordSpanTypeSpecificAttributes()
+        public override void SetSpanTypeSpecificAttributes(SpanAttributeValueCollection attribVals)
         {
-            AttribDefs.SpanCategory.TrySetValue(AttribVals, SpanCategory.Http);
-            AttribDefs.HttpUrl.TrySetValue(AttribVals, Uri);
-            AttribDefs.HttpMethod.TrySetValue(AttribVals, Method);
-            AttribDefs.Component.TrySetValue(AttribVals, _segmentState.TypeName);
-            AttribDefs.SpanKind.TrySetDefault(AttribVals);
-            AttribDefs.HttpStatusCode.TrySetValue(AttribVals, _httpStatusCode);   //Attrib handles null
+            AttribDefs.SpanCategory.TrySetValue(attribVals, SpanCategory.Http);
+            AttribDefs.HttpUrl.TrySetValue(attribVals, Uri);
+            AttribDefs.HttpMethod.TrySetValue(attribVals, Method);
+            AttribDefs.Component.TrySetValue(attribVals, _segmentState.TypeName);
+            AttribDefs.SpanKind.TrySetDefault(attribVals);
+            AttribDefs.HttpStatusCode.TrySetValue(attribVals, _httpStatusCode);   //Attrib handles null
         }
 
         public override string GetTransactionTraceName()

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -182,9 +182,7 @@ namespace NewRelic.Agent.Core.Transactions
         {
             var methodCallData = GetMethodCallData(methodCall);
 
-            var attribValues = new SpanAttributeValueCollection();
-
-            return new Segment(this, methodCallData, attribValues);
+            return new Segment(this, methodCallData);
         }
 
         public ISegment StartCustomSegment(MethodCall methodCall, string segmentName)

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/CustomSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/CustomSegmentDataTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         private Segment CreateCustomSegmentBuilder(MethodCallData methodCallData, string name, bool combinable)
         {
             var customSegmentData = new CustomSegmentData(name);
-            var segment = new Segment(_transactionSegmentState, methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(_transactionSegmentState, methodCallData);
             segment.Combinable = combinable;
             segment.SetSegmentData(customSegmentData);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/ExternalSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/ExternalSegmentDataTests.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         public static Segment createExternalSegmentBuilder(TimeSpan relativeStart, TimeSpan duration, int uniqueId, int? parentId, MethodCallData methodCallData, IEnumerable<KeyValuePair<string, object>> parameters, Uri uri, string method, CrossApplicationResponseData crossApplicationResponseData, bool combinable)
         {
             var data = new ExternalSegmentData(uri, method, crossApplicationResponseData);
-            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData);
             segment.SetSegmentData(data);
             segment.Combinable = combinable;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/ExternalSegmentTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/ExternalSegmentTests.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         [Test]
         public void Build_IncludesCatParameter_IfCatResponseDataIsSet()
         {
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(new ExternalSegmentData(new Uri("http://www.google.com"), "method", new CrossApplicationResponseData("cpId", "name", 1.1f, 2.2f, 3, "guid", false)));
             segment.End();
 
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         [Test]
         public void Build_DoesNotIncludeCatParameter_IfCatResponseDataIsNotSet()
         {
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(new ExternalSegmentData(new Uri("http://www.google.com"), "method"));
 
             Assert.IsFalse(segment.Parameters.ToDictionary().ContainsKey(TransactionGuidSegmentParameterKey));

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/MessageBrokerSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/MessageBrokerSegmentDataTests.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
 
         public static Segment createMessageBrokerSegmentBuilder(TimeSpan start, TimeSpan duration, int uniqueId, int? parentId, MethodCallData methodCallData, IEnumerable<KeyValuePair<string, object>> enumerable, string vendor, string queue, MetricNames.MessageBrokerDestinationType type, MetricNames.MessageBrokerAction action, bool combinable)
         {
-            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData);
             segment.SetSegmentData(new MessageBrokerSegmentData(vendor, queue, type, action));
             segment.Combinable = combinable;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/MethodSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/MethodSegmentDataTests.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
 
         public static Segment createMethodSegmentBuilder(TimeSpan start, TimeSpan duration, int uniqueId, int? parentId, MethodCallData methodCallData, IEnumerable<KeyValuePair<string, object>> enumerable, string type, string method, bool combinable)
         {
-            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(SimpleSegmentDataTests.createTransactionSegmentState(uniqueId, parentId), methodCallData);
             segment.SetSegmentData(new MethodSegmentData(type, method));
             segment.Combinable = combinable;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/SegmentTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/SegmentTests.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         [Test]
         public void End_WithException_HasErrorData()
         {
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("Type", "Method", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("Type", "Method", 1));
 
             segment.End(new Exception("Unhandled exception"));
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/SimpleSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/SimpleSegmentDataTests.cs
@@ -34,7 +34,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         public static Segment createSimpleSegmentBuilder(TimeSpan start, TimeSpan duration, int uniqueId, int? parentId, MethodCallData methodCallData, IEnumerable<KeyValuePair<string, object>> parameters, string name, bool combinable, int managedThreadId = 1)
         {
             var segmentState = createTransactionSegmentState(uniqueId, parentId, managedThreadId);
-            var segment = new Segment(segmentState, methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(segmentState, methodCallData);
             segment.SetSegmentData(new SimpleSegmentData(name));
             segment.Combinable = combinable;
 
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.Core.Segments.Tests
         [Test]
         public void ThreadIdIsSet()
         {
-            var segment = new Segment(createTransactionSegmentState(3, null, 666), new MethodCallData("type", "method", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(createTransactionSegmentState(3, null, 666), new MethodCallData("type", "method", 1));
             segment.SetSegmentData(new SimpleSegmentData("test"));
 
             Assert.AreEqual(666, segment.ThreadId);

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -155,21 +155,21 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             _startTime = new DateTime(2018, 7, 18, 7, 0, 0, DateTimeKind.Utc); // unixtime = 1531897200000
 
             // Generic Segments
-            _baseGenericSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1), new SpanAttributeValueCollection());
+            _baseGenericSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
             _baseGenericSegment.SetSegmentData(new SimpleSegmentData(SegmentName));
 
-            _childGenericSegment = new Segment(CreateTransactionSegmentState(4, 3, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1), new SpanAttributeValueCollection());
+            _childGenericSegment = new Segment(CreateTransactionSegmentState(4, 3, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
             _childGenericSegment.SetSegmentData(new SimpleSegmentData(SegmentName));
 
             // Datastore Segments
             _connectionInfo = new ConnectionInfo("localhost", "1234", "default", "maininstance");
             _parsedSqlStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, System.Data.CommandType.Text, ShortQuery);
             _obfuscatedSql = _databaseService.GetObfuscatedSql(ShortQuery, DatastoreVendor.MSSQL);
-            _baseDatastoreSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1), new SpanAttributeValueCollection());
+            _baseDatastoreSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
             _baseDatastoreSegment.SetSegmentData(new DatastoreSegmentData(_databaseService, _parsedSqlStatement, ShortQuery, _connectionInfo));
 
             // Http Segments
-            _baseHttpSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1), new SpanAttributeValueCollection());
+            _baseHttpSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
             _baseHttpSegment.SetSegmentData(new ExternalSegmentData(new Uri(HttpUri), HttpMethod));
         }
 
@@ -374,7 +374,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             {
                 // ARRANGE
                 var longSqlStatement = new ParsedSqlStatement(DatastoreVendor.MSSQL, customerStmt[i], "select");
-                var longDatastoreSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1), new SpanAttributeValueCollection());
+                var longDatastoreSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
                 longDatastoreSegment.SetSegmentData(new DatastoreSegmentData(_databaseService, longSqlStatement, customerStmt[i], _connectionInfo));
 
                 var segments = new List<Segment>()

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/CustomSegmentTransformersTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/CustomSegmentTransformersTests.cs
@@ -189,7 +189,7 @@ namespace NewRelic.Agent.Core.Transformers
         private static Segment GetSegment(string name, double duration)
         {
             var methodCallData = new MethodCallData("foo", "bar", 1);
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(new CustomSegmentData(name));
 
             return new Segment(new TimeSpan(), TimeSpan.FromSeconds(duration), segment, null);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/DatastoreSegmentTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/DatastoreSegmentTransformerTests.cs
@@ -278,7 +278,7 @@ namespace NewRelic.Agent.Core.Transformers
         private Segment GetSegment(DatastoreVendor vendor, string operation, string model)
         {
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, operation));
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(data);
 
             return segment;
@@ -288,7 +288,7 @@ namespace NewRelic.Agent.Core.Transformers
         {
             var methodCallData = new MethodCallData("foo", "bar", 1);
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, operation), null, new ConnectionInfo(host, portPathOrId, null));
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 
             return segment.CreateSimilar(new TimeSpan(), TimeSpan.FromSeconds(duration), null);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/ExternalSegmentTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/ExternalSegmentTransformerTests.cs
@@ -321,7 +321,7 @@ namespace NewRelic.Agent.Core.Transformers
         private static Segment GetSegment(string uri, string method, CrossApplicationResponseData catResponseData = null)
         {
             var data = new ExternalSegmentData(new Uri(uri), method, catResponseData);
-            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             builder.SetSegmentData(data);
             builder.End();
             return builder;
@@ -332,7 +332,7 @@ namespace NewRelic.Agent.Core.Transformers
             var methodCallData = new MethodCallData("foo", "bar", 1);
 
             var data = new ExternalSegmentData(new Uri(uri), method, catResponseData);
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 
             return new Segment(new TimeSpan(), TimeSpan.FromSeconds(duration), segment, null);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/MessageBrokerTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/MessageBrokerTransformerTests.cs
@@ -204,7 +204,7 @@ namespace NewRelic.Agent.Core.Transformers
 
         private static Segment GetSegment(string vendor, MetricNames.MessageBrokerDestinationType destinationType, string destination, MetricNames.MessageBrokerAction action)
         {
-            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             builder.SetSegmentData(new MessageBrokerSegmentData(vendor, destination, destinationType, action));
             builder.End();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/MethodSegmentTransformersTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/MethodSegmentTransformersTests.cs
@@ -175,7 +175,7 @@ namespace NewRelic.Agent.Core.Transformers
 
         private static Segment GetSegment(string type, string method)
         {
-            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             builder.SetSegmentData(new MethodSegmentData(type, method));
             builder.End();
             return builder;

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/SimpleSegmentTransformersTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/SimpleSegmentTransformersTests.cs
@@ -171,7 +171,7 @@ namespace NewRelic.Agent.Core.Transformers
 
         private static Segment GetSegment(string name)
         {
-            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var builder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             builder.SetSegmentData(new SimpleSegmentData(name));
             builder.End();
             return builder;

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -330,7 +330,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private static ImmutableSegmentTreeNode BuildNode(TimeSpan relativeStart = new TimeSpan(), TimeSpan? duration = null)
         {
             var methodCallData = new MethodCallData("typeName", "methodName", 1);
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(new SimpleSegmentData(""));
 
             return new SegmentTreeNodeBuilder(

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
@@ -156,7 +156,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 new ConnectionInfo(host, portPathOrId, databaseName));
             methodCallData = methodCallData ?? new MethodCallData("typeName", "methodName", 1);
 
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 
             return new Segment(startTime, duration, segment, parameters);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -104,7 +104,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             methodCallData = methodCallData ?? new MethodCallData("typeName", "methodName", 1);
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, null), commandText, new ConnectionInfo(host, portPathOrId, databaseName));
-            var segment = new Segment(txSegmentState, methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(txSegmentState, methodCallData);
             segment.SetSegmentData(data);
 
             return new Segment(startTime, duration, segment, parameters);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
@@ -325,7 +325,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(DatastoreVendor.MSSQL, "test_table", "SELECT"), "SELECT * FROM test_table");
 
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 
             return new SegmentTreeNodeBuilder(
@@ -341,7 +341,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 "SELECT * FROM test_table",
                 new ConnectionInfo("My Host", "My Port", "My Database"));
 
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData, new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 
             return new SegmentTreeNodeBuilder(new Segment(startTime, duration ?? TimeSpan.Zero, segment, null))

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
@@ -1146,7 +1146,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private Segment GetSegment(string name)
         {
-            var builder = new Segment(_transactionSegmentState, new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var builder = new Segment(_transactionSegmentState, new MethodCallData("foo", "bar", 1));
             builder.SetSegmentData(new SimpleSegmentData(name));
             builder.End();
             return builder;

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/SqlTraceWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/SqlTraceWireModelTests.cs
@@ -82,7 +82,7 @@ namespace NewRelic.Agent.Core.WireModels
             foreach (string query in queries)
             {
                 var data = new DatastoreSegmentData(databaseService, new ParsedSqlStatement(DatastoreVendor.MSSQL, null, null), query);
-                var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("typeName", "methodName", 1), new SpanAttributeValueCollection());
+                var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("typeName", "methodName", 1));
                 segment.SetSegmentData(data);
 
                 var segments = new List<Segment>()

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -681,7 +681,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
             var headers = new Dictionary<string, string>();
             var externalSegmentData = new ExternalSegmentData(new Uri("http://www.google.com"), "method");
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(externalSegmentData);
 
             _agent.CurrentTransaction.ProcessInboundResponse(headers, segment);
@@ -698,7 +698,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Mock.Arrange(() => _transactionService.GetCurrentInternalTransaction()).Returns(transaction);
 
             var headers = new Dictionary<string, string>();
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(new ExternalSegmentData(new Uri("http://www.google.com"), "method"));
 
             _agent.CurrentTransaction.ProcessInboundResponse(headers, segment);
@@ -715,7 +715,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
             var headers = new Dictionary<string, string>();
             var externalSegmentData = new ExternalSegmentData(new Uri("http://www.google.com"), "method");
-            var segmentBuilder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segmentBuilder = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segmentBuilder.SetSegmentData(externalSegmentData);
 
             _agent.CurrentTransaction.ProcessInboundResponse(headers, segmentBuilder);
@@ -735,7 +735,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
             var headers = new Dictionary<string, string>();
             var externalSegmentData = new ExternalSegmentData(new Uri("http://www.google.com"), "method");
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("foo", "bar", 1));
             segment.SetSegmentData(externalSegmentData);
 
             _agent.CurrentTransaction.ProcessInboundResponse(headers, segment);

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionTests.cs
@@ -171,7 +171,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
 
             for (int i = 0; i < segmentCount; i++)
             {
-                var segment = new Segment(transaction, new MethodCallData("foo" + i, "bar" + i, 1), new SpanAttributeValueCollection());
+                var segment = new Segment(transaction, new MethodCallData("foo" + i, "bar" + i, 1));
                 segment.SetSegmentData(new ExternalSegmentData(new Uri("http://www.test.com"), "method"));
 
                 segment.End();

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/TransactionFinalizerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/TransactionFinalizerTests.cs
@@ -302,7 +302,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
         private static Segment GetFinishedSegment(DateTime transactionStartTime, DateTime startTime, TimeSpan? duration)
         {
-            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("type", "method", 1), new SpanAttributeValueCollection());
+            var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), new MethodCallData("type", "method", 1));
             segment.SetSegmentData(new SimpleSegmentData(""));
 
             return new Segment(startTime - transactionStartTime, duration, segment, null);


### PR DESCRIPTION
* Defer the creation of the `SpanAttributeValueCollection` until later in the lifecycle of the transaction.  The rationale is to save memory by:
    * avoiding the creation of this object unless a Span will actually be created (DT sampled, or Infinite Tracing has capacity)
    * Making the `SpanAttributeValueCollection` a shorter-lived object to help in GC