### PR TITLE
Fixing SpanEventsEnabled and DistributedTracingEnabled checks for Infinite Tracing

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
@@ -127,7 +127,9 @@ namespace NewRelic.Agent.Core.Aggregators
             Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration Setting - Queue Partitions - {_configuration.InfiniteTracingPartitionCountSpans}");
         }
 
-        public bool IsServiceEnabled => _spanStreamingService.IsServiceEnabled;
+        public bool IsServiceEnabled => _configuration.SpanEventsEnabled
+            && _configuration.DistributedTracingEnabled
+            && _spanStreamingService.IsServiceEnabled;
         public bool IsServiceAvailable => IsServiceEnabled && _spanEvents != null && _spanStreamingService.IsServiceAvailable;
 
         public void RecordDroppedSpans(int countDroppedSpans)

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -851,12 +851,18 @@ namespace NewRelic.Agent.Core.Configuration
 
         #region Span Events
 
+        bool? _spanEventsEnabled = null;
         public virtual bool SpanEventsEnabled
         {
             get
             {
-                var enabled = ServerCanDisable(_serverConfiguration.SpanEventCollectionEnabled, EnvironmentOverrides(_localConfiguration.spanEvents.enabled, "NEW_RELIC_SPAN_EVENTS_ENABLED"));
-                return enabled && DistributedTracingEnabled;
+                if (!_spanEventsEnabled.HasValue)
+                {
+                    var enabled = ServerCanDisable(_serverConfiguration.SpanEventCollectionEnabled, EnvironmentOverrides(_localConfiguration.spanEvents.enabled, "NEW_RELIC_SPAN_EVENTS_ENABLED"));
+                    _spanEventsEnabled = enabled && DistributedTracingEnabled;
+                }
+
+                return _spanEventsEnabled.Value;
             }
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventAggregatorInfiniteTracingTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventAggregatorInfiniteTracingTests.cs
@@ -348,6 +348,32 @@ namespace NewRelic.Agent.Core.Spans.Tests
             );
         }
 
+        [Test]
+        public void AggregatorIsEnabledShouldRespondsToConfig
+        (
+            [Values(true, false)] bool streamingSvcEnabled,
+            [Values(true, false)] bool distributedTracingEnabled,
+            [Values(true, false)] bool spanEventsEnabled)
+        {
+            bool expectedIsServiceEnabledValue = streamingSvcEnabled && distributedTracingEnabled && spanEventsEnabled;
+
+            Mock.Arrange(() => _currentConfiguration.InfiniteTracingTraceObserverHost).Returns(streamingSvcEnabled ? "infiniteTracing.net" : null);
+            Mock.Arrange(() => _currentConfiguration.InfiniteTracingQueueSizeSpans).Returns(10);
+            Mock.Arrange(() => _currentConfiguration.DistributedTracingEnabled).Returns(distributedTracingEnabled);
+            Mock.Arrange(() => _currentConfiguration.SpanEventsEnabled).Returns(spanEventsEnabled);
+
+            var streamingSvc = GetMockStreamingService(streamingSvcEnabled, true);
+
+            var aggregator = CreateAggregator(streamingSvc);
+
+            FireAgentConnectedEvent();
+
+            NrAssert.Multiple
+            (
+                () => Assert.AreEqual(expectedIsServiceEnabledValue, aggregator.IsServiceEnabled)
+            );
+        }
+
 
         /// <summary>
         /// 


### PR DESCRIPTION
Updates the Infinite Tracing version of the span event aggregator to respect the SpanEventsEnabled and DistributedTracingEnabled configuration settings, and adds some caching to the SpanEventsEnabled configuration setting.