### PR TITLE
Fixed build_functions.ps1 to not include x86 GRPC .SO file

### DIFF
--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -155,7 +155,7 @@ function Copy-AgentRoot {
 
     $grpcDir = Get-GrpcPackagePath $RootDirectory
     if ($Linux) {
-        Copy-Item -Path "$grpcDir\runtimes\linux\native\*.so" -Destination "$Destination" -Force 
+        Copy-Item -Path "$grpcDir\runtimes\linux\native\libgrpc_csharp_ext.x64.so" -Destination "$Destination" -Force 
         Copy-Item -Path "$RootDirectory\src\Agent\_profilerBuild\linux-release\libNewRelicProfiler.so" -Destination "$Destination" -Force 
     }
     else {


### PR DESCRIPTION
Migration over to new home builder scripting reintroduced the x86 GRPC SO file that we didn't want in the package.

No only copies the x64 version.