### PR TITLE
Small bug fixes.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -726,7 +726,8 @@ namespace NewRelic.Agent.Core.DataTransport
 
             if(cancellationToken.IsCancellationRequested)
             {
-                ProcessFailedItems(items, collection);   
+                ProcessFailedItems(items, collection);
+                return false;
             }
 
             return true;

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Delayer.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Delayer.cs
@@ -2,6 +2,7 @@
 * Copyright 2020 New Relic Corporation. All rights reserved.
 * SPDX-License-Identifier: Apache-2.0
 */
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +17,14 @@ namespace NewRelic.Agent.Core.DataTransport
     {
         public void Delay(int milliseconds, CancellationToken token)
         {
-            Task.Delay(milliseconds).Wait(token);
+            try
+            {
+                Task.Delay(milliseconds).Wait(token);
+            }
+            catch (OperationCanceledException)
+            {
+                //A cancelation was triggered and we don't need the Delayer to bubble up the exception
+            }
         }
     }
 


### PR DESCRIPTION
Ensures that our delayer doesn't bubble up an exception when the cancellation token is triggered, and ensures that the span batch is not sent when the cancellation token is triggered and the items are added back to the queue.