### PR TITLE
Update memory physical metric source for linux

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+* Fixes issue where applications running on Linux were either reporting no physical memory usage or using VmData to report the physical memory usage of the application. The agent now uses VmRSS through a call to [`Process.WorkingSet64`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.workingset64) to report physical memory usage. See the [dotnet runtime discussion](https://github.com/dotnet/runtime/issues/28990) and the [proc man pages](https://man7.org/linux/man-pages/man5/proc.5.html) for more details about this change.
 
 ## [8.29] - 2020-06-25
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -91,6 +91,13 @@ namespace NewRelic.Agent.Core
             AgentInfo = GetAgentInfo();
         }
 
+        //This method and delegate is here to allow dependency injecting the IsWindows logic via a typed delegate
+        public delegate bool IsWindowsDelegate();
+        public static bool GetIsWindows()
+        {
+            return IsWindows;
+        }
+
         private static string GetAgentVersion()
         {
             try

--- a/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
+++ b/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
@@ -76,6 +76,7 @@ namespace NewRelic.Agent.Core.DependencyInjection
 
             // Other
             container.Register<ICpuSampleTransformer, CpuSampleTransformer>();
+            container.Register<AgentInstallConfiguration.IsWindowsDelegate>(AgentInstallConfiguration.GetIsWindows);
             container.Register<IMemorySampleTransformer, MemorySampleTransformer>();
             container.Register<IThreadStatsSampleTransformer, ThreadStatsSampleTransformer>();
             container.Register<IEnvironment, SystemInterfaces.Environment>();


### PR DESCRIPTION
Fixes issue where applications running on Linux were either reporting no physical memory usage or using VmData to report the physical memory usage of the application. The agent now uses VmRSS through a call to [`Process.WorkingSet64`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.workingset64) to report physical memory usage. See the [dotnet runtime discussion](https://github.com/dotnet/runtime/issues/28990) and the [proc man pages](https://man7.org/linux/man-pages/man5/proc.5.html) for more details about this change.