### PR TITLE
Infinite Tracing - Record Seen supportability metric when dropping b/c of no capacity; update default for batch size

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
@@ -26,6 +26,7 @@ namespace NewRelic.Agent.Core.Aggregators
         bool IsServiceAvailable { get; }
         bool HasCapacity(int proposedItems);
         void RecordDroppedSpans(int countDroppedSpans);
+        void RecordSeenSpans(int countSeenSpans);
         void ReportSupportabilityMetrics();
         int Capacity { get; }
     }
@@ -150,9 +151,14 @@ namespace NewRelic.Agent.Core.Aggregators
             _agentHealthReporter.ReportInfiniteTracingSpanEventsDropped(countDroppedSpans);
         }
 
+        public void RecordSeenSpans(int countSeenSpans)
+        {
+            _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(countSeenSpans);
+        }
+
         public void Collect(ISpanEventWireModel wireModel)
         {
-            _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(1);
+            RecordSeenSpans(1);
 
             if (_spanEvents == null || !_spanEvents.TryAdd(wireModel.Span))
             {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1036,7 +1036,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         private int? _infiniteTracingBatchSizeSpans;
         public int InfiniteTracingBatchSizeSpans => _infiniteTracingBatchSizeSpans
-                ?? (_infiniteTracingBatchSizeSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsBatchSize"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_BATCH_SIZE").GetValueOrDefault(500)).Value;
+                ?? (_infiniteTracingBatchSizeSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsBatchSize"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_BATCH_SIZE").GetValueOrDefault(700)).Value;
 
         private bool _infiniteTracingObtainedSettingsForTest;
         private void GetInfiniteTracingFlakyAndDelayTestSettings()

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -323,6 +323,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             if (useInfiniteTracing && !_spanEventAggregatorInfiniteTracing.HasCapacity(countProposedSpans))
             {
+                _spanEventAggregatorInfiniteTracing.RecordSeenSpans(countProposedSpans);
                 _spanEventAggregatorInfiniteTracing.RecordDroppedSpans(countProposedSpans);
                 return;
             }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2195,16 +2195,16 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
         [TestCase("100", "232", ExpectedResult = 100)]
         [TestCase("-342", "198", ExpectedResult = -342)]
-        [TestCase(null, null, ExpectedResult = 500)]
-        [TestCase("", null, ExpectedResult = 500)]
-        [TestCase(null, "", ExpectedResult = 500)]
-        [TestCase("", "", ExpectedResult = 500)]
+        [TestCase(null, null, ExpectedResult = 700)]
+        [TestCase("", null, ExpectedResult = 700)]
+        [TestCase(null, "", ExpectedResult = 700)]
+        [TestCase("", "", ExpectedResult = 700)]
         [TestCase("", "203", ExpectedResult = 203)]
         [TestCase("XYZ", "876", ExpectedResult = 876)]
-        [TestCase("XYZ", "ABC", ExpectedResult = 500)]
-        [TestCase("103.98", null, ExpectedResult = 500)]
+        [TestCase("XYZ", "ABC", ExpectedResult = 700)]
+        [TestCase("103.98", null, ExpectedResult = 700)]
         [TestCase("103.98", "200", ExpectedResult = 200)]
-        [TestCase(null, "98.6", ExpectedResult = 500)]
+        [TestCase(null, "98.6", ExpectedResult = 700)]
         public int InfiniteTracing_SpanBatchSize(string envConfigVal, string appSettingVal)
         {
             _localConfig.appSettings.Add(new configurationAdd { key = "InfiniteTracingSpanEventsBatchSize", value = appSettingVal });


### PR DESCRIPTION
* Update Default value for Infinite Tracing Batch size to 700
* When Infinite Tracing Queue Capacity is not available during transaction transform, update both Seen and Sent supportability metrics (add Seen)