### PR TITLE
Integration Tests - Cleanup

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -383,6 +383,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "sendDataOnExit", "true");
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "sendDataOnExitThreshold", "0");
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "completeTransactionsOnThread", "true");
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "requestTimeout", "10000");
+
         }
 
         public void AddInstrumentationPoint(string extensionFileName, string assemblyName, string className, string methodName, string tracerFactoryName = null)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ConnectResponseHandlingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ConnectResponseHandlingTests.cs
@@ -32,6 +32,7 @@ namespace NewRelic.Agent.IntegrationTests
                 {
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
                     configModifier.EnableSpanEvents(true);
+                    configModifier.ForceTransactionTraces();
                     configModifier.SetLogLevel("finest");
                 },
                 exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/HighSecurityModeEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HighSecurityModeEnabled.cs
@@ -64,9 +64,9 @@ namespace NewRelic.Agent.IntegrationTests
             };
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
-                {"type", "Transaction"},
-                {"nr.apdexPerfZone", "F"}
+                {"type", "Transaction"}
             };
+
             var expectedTransactionEventIntrinsicAttributes2 = new List<string>
             {
                 "timestamp",
@@ -74,7 +74,8 @@ namespace NewRelic.Agent.IntegrationTests
                 "webDuration",
                 "queueDuration",
                 "totalTime",
-                "name"
+                "name",
+                "nr.apdexPerfZone"
             };
             var expectedTransactionEventAgentAttributes = new Dictionary<string, object>
             {
@@ -140,6 +141,8 @@ namespace NewRelic.Agent.IntegrationTests
                 () => Assertions.TransactionTraceHasAttributes(expectedTransactionTraceAgentAttributes, TransactionTraceAttributeType.Agent, transactionSample),
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes1, TransactionEventAttributeType.Intrinsic, getDataTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes2, TransactionEventAttributeType.Intrinsic, getDataTransactionEvent),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes1, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes2, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventAgentAttributes, TransactionEventAttributeType.Agent, getDataTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedErrorTransactionEventAttributes, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent),
                 () => Assertions.ErrorTraceHasAttributes(expectedAgentErrorTraceAttributes, ErrorTraceAttributeType.Agent, firstErrorTrace),

--- a/tests/Agent/IntegrationTests/IntegrationTests/SecurityPoliciesMostRestrictiveTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/SecurityPoliciesMostRestrictiveTests.cs
@@ -62,11 +62,12 @@ namespace NewRelic.Agent.IntegrationTests
             };
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
-                {"type", "Transaction"},
-                {"nr.apdexPerfZone", "F"}
+                {"type", "Transaction"}
+                
             };
             var expectedTransactionEventIntrinsicAttributes2 = new List<string>
             {
+                "nr.apdexPerfZone",
                 "timestamp",
                 "duration",
                 "webDuration",
@@ -124,9 +125,14 @@ namespace NewRelic.Agent.IntegrationTests
             NrAssert.Multiple
             (
                 () => Assertions.TransactionTraceHasAttributes(expectedTransactionTraceAgentAttributes, TransactionTraceAttributeType.Agent, transactionSample),
+
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes1, TransactionEventAttributeType.Intrinsic, getDataTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes2, TransactionEventAttributeType.Intrinsic, getDataTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedTransactionEventAgentAttributes, TransactionEventAttributeType.Agent, getDataTransactionEvent),
+
+
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes1, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes2, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent),
                 () => Assertions.TransactionEventHasAttributes(expectedErrorTransactionEventAttributes, TransactionEventAttributeType.Intrinsic, getExceptionTransactionEvent)
             );
         }


### PR DESCRIPTION
* Modifies requestTimeout for test projects to be 10sec by default
    * Because tests Force Send On Exit, the default was 2s.

* Modifies High Security Mode and Security Policies Most Restrictive Tests
    * To validate existence of Apdex, but not the value for a passing transaction b/c that value can vary and makes the test flaky.

* Modifies Connect Response Tests
    * To Force Transaction Traces to make it less flaky.