### PR TITLE
Error collector enabled setting updates

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
@@ -13,6 +13,8 @@ namespace NewRelic.Agent.Core.Errors
 {
     public interface IErrorService
     {
+        bool ShouldCollectErrors { get; }
+
         bool ShouldIgnoreException(Exception exception);
         bool ShouldIgnoreHttpStatusCode(int statusCode, int? subStatusCode);
 
@@ -34,6 +36,8 @@ namespace NewRelic.Agent.Core.Errors
         {
             _configurationService = configurationService;
         }
+
+        public bool ShouldCollectErrors => _configurationService.Configuration.ErrorCollectorEnabled;
 
         public bool ShouldIgnoreException(Exception exception)
         {

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -227,7 +227,7 @@ namespace NewRelic.Agent.Core.Segments
             AttribDefs.Duration.TrySetValue(attribValues, DurationOrZero);
             AttribDefs.NameForSpan.TrySetValue(attribValues, GetTransactionTraceName());
 
-            if (ErrorData != null)
+            if (ErrorData != null && _transactionSegmentState.ErrorService.ShouldCollectErrors)
             {
                 AttribDefs.SpanErrorClass.TrySetValue(attribValues, ErrorData.ErrorTypeName);
                 AttribDefs.SpanErrorMessage.TrySetValue(attribValues, ErrorData.ErrorMessage);

--- a/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
@@ -3,6 +3,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 using System.Collections.Generic;
+using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Attributes;
 using NewRelic.Agent.Core.Segments;
 using NewRelic.Agent.Core.Transactions;
@@ -19,10 +20,12 @@ namespace NewRelic.Agent.Core.Spans
     {
         private readonly IAttributeDefinitionService _attribDefSvc;
         private IAttributeDefinitions _attribDefs => _attribDefSvc?.AttributeDefs;
+        private readonly IConfigurationService _configurationService;
 
-        public SpanEventMaker(IAttributeDefinitionService attribDefSvc)
+        public SpanEventMaker(IAttributeDefinitionService attribDefSvc, IConfigurationService configurationService)
         {
             _attribDefSvc = attribDefSvc;
+            _configurationService = configurationService;
         }
 
         public IEnumerable<ISpanEventWireModel> GetSpanEvents(ImmutableTransaction immutableTransaction, string transactionName, IAttributeValueCollection transactionAttribValues)
@@ -64,7 +67,7 @@ namespace NewRelic.Agent.Core.Spans
                 _attribDefs.TracingVendors.TrySetValue(spanAttributes, immutableTransaction.TracingState.VendorStateEntries ?? null);
             }
 
-            if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (_configurationService.Configuration.ErrorCollectorEnabled && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
             {
                 _attribDefs.SpanErrorClass.TrySetValue(spanAttributes, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.ErrorTypeName);
                 _attribDefs.SpanErrorMessage.TrySetValue(spanAttributes, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.ErrorMessage);

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -86,7 +86,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 _attribDefs.DatabaseCallCount.TrySetValue(attribValues, databaseData.Value0);
             }
 
-            if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (_configurationService.Configuration.ErrorCollectorEnabled && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
             {
                 var errorData = immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData;
 
@@ -198,7 +198,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 _attribDefs.GetCustomAttributeForTransaction(userAttrib.Key).TrySetValue(attribValues, userAttrib.Value);
             }
 
-            if (metadata.ReadOnlyTransactionErrorState.HasError && metadata.ReadOnlyTransactionErrorState.ErrorData != null && metadata.ReadOnlyTransactionErrorState.ErrorData.CustomAttributes != null)
+            if (_configurationService.Configuration.ErrorCollectorEnabled && metadata.ReadOnlyTransactionErrorState.HasError && metadata.ReadOnlyTransactionErrorState.ErrorData != null && metadata.ReadOnlyTransactionErrorState.ErrorData.CustomAttributes != null)
             {
                 foreach(var errAttrib in metadata.ReadOnlyTransactionErrorState.ErrorData.CustomAttributes)
                 {

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -180,7 +180,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         private ErrorTraceWireModel GenerateErrorTrace(ImmutableTransaction immutableTransaction, IAttributeValueCollection attributes, TransactionMetricName transactionMetricName)
         {
-            if (!_configurationService.Configuration.ErrorCollectorEnabled)
+            if (!ErrorCollectionEnabled())
                 return null;
 
             return _errorTraceMaker.GetErrorTrace(immutableTransaction, attributes, transactionMetricName);
@@ -250,7 +250,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                     MetricBuilder.TryBuildDistributedTraceTransportDuration(type, account, app, transport, isWebTransaction, duration, txStats);
                 }
 
-                if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+                if (ErrorCollectionEnabled() && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
                 {
                     MetricBuilder.TryBuildDistributedTraceErrorsByCaller(type, account, app, transport, isWebTransaction, txStats);
                 }
@@ -276,7 +276,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 GetApdexMetrics(immutableTransaction, apdexT.Value, transactionApdexMetricName, txStats);
             }
 
-            if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (ErrorCollectionEnabled() && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
             {
                 MetricBuilder.TryBuildErrorsMetrics(isWebTransaction, txStats);
             }
@@ -458,6 +458,11 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             {
                 transaction.SetSampled(_adaptiveSampler);
             }
+        }
+
+        private bool ErrorCollectionEnabled()
+        {
+            return _configurationService.Configuration.ErrorCollectorEnabled;
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
@@ -49,9 +49,17 @@ namespace NewRelic.Agent.Core.Errors
         }
 
         [Test]
+        public void ShouldCollectErrors_MatchesErrorCollectorEnabledConfig([Values(true, false)]bool errorCollectorEnabledSetting)
+        {
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: errorCollectorEnabledSetting);
+
+            Assert.AreEqual(errorCollectorEnabledSetting, _errorService.ShouldCollectErrors);
+        }
+
+        [Test]
         public void ShouldIgnoreException_ReturnsFalse_IfExceptionIsNotIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             var exception = new Exception();
             Assert.IsFalse(_errorService.ShouldIgnoreException(exception));
@@ -60,7 +68,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             var exception = new ArithmeticException();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -69,7 +77,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfInnerExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             var exception = new Exception("OuterException", new ArithmeticException("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -78,7 +86,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfOuterExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             var exception = new ArithmeticException("OuterException", new Exception("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -87,7 +95,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionWithTypeParameterIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             var exception = new ExceptionWithTypeParameter<string>();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -100,7 +108,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(500, null, ExpectedResult = false)]
         public bool ShouldIgnoreHttpStatusCode_ReturnsExpectedResult(int statusCode, int? subStatusCode)
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
 
             return _errorService.ShouldIgnoreHttpStatusCode(statusCode, subStatusCode);
         }
@@ -109,7 +117,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(false)]
         public void FromException_ReturnsExpectedErrorData(bool stripExceptionMessages)
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages, errorCollectorEnabled: true);
 
             var exception = new Exception();
             var errorData = _errorService.FromException(exception);
@@ -131,9 +139,10 @@ namespace NewRelic.Agent.Core.Errors
             Assert.IsEmpty(errorData.CustomAttributes);
         }
 
-        private void SetupConfiguration(List<string> exceptionsToIgnore, List<float> statusCodesToIgnore, bool stripExceptionMessages)
+        private void SetupConfiguration(List<string> exceptionsToIgnore, List<float> statusCodesToIgnore, bool stripExceptionMessages, bool errorCollectorEnabled)
         {
             var config = new configuration();
+            config.errorCollector.enabled = errorCollectorEnabled;
             config.errorCollector.ignoreErrors.exception = exceptionsToIgnore;
             config.errorCollector.ignoreStatusCodes.code = statusCodesToIgnore;
             config.stripExceptionMessages.enabled = stripExceptionMessages;

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
@@ -193,6 +193,13 @@ namespace NewRelic.Agent.Core.Transactions
             return this;
         }
 
+        public ImmutableTransactionBuilder WithExceptionFromSegment(Segment segmentWithError)
+        {
+            _transactionErrorState.AddExceptionData(segmentWithError.ErrorData);
+            _transactionErrorState.TrySetSpanIdForErrorData(segmentWithError.ErrorData, segmentWithError.SpanId);
+            return this;
+        }
+
         private TimeSpan _duration = TimeSpan.FromSeconds(1);
 
         public ImmutableTransactionBuilder WithDuration(TimeSpan duration)

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
@@ -46,6 +46,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
            
 
             _configuration = Mock.Create<IConfiguration>();
+            Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
             _configurationService = Mock.Create<IConfigurationService>();
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
 


### PR DESCRIPTION
With this PR we should now match the behavior of other New Relic agents with how the error collector enabled setting is used.

When the error collector is disabled the following should occur:
- Error metrics should not be generated
- Error Events and Error Traces should not be generated
- Transaction Events should not have error attributes generated
- Span events should not have error attributes generated
- "Frustrated" Apdex metrics should still be generated if a transaction has an error, because errors usually result in "frustrated" users
- apdex perf zone attribute should still be generated
