### PR TITLE
Expected error classes and error messages implementation.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1200,8 +1200,7 @@ namespace NewRelic.Agent.Core.Configuration
             ExpectedErrorStatusCodesForAgentSettings = string.Join(",", expectedStatusCodes);
         }
 
-        public virtual ReadOnlyDictionary<string, IEnumerable<string>> ExpectedErrorsInfo { get; private set; }
-
+        public IDictionary<string, IEnumerable<string>> ExpectedErrorsInfo { get; private set; }
         public IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; private set; }
         public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; private set; }
         public string ExpectedErrorStatusCodesForAgentSettings { get; private set; }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1194,13 +1194,13 @@ namespace NewRelic.Agent.Core.Configuration
                 }
             }
 
-            ExpectedErrorsInfo = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
+            ExpectedErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
             ExpectedErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedMessages);
             ExpectedErrorClassesForAgentSettings = expectedClasses;
             ExpectedErrorStatusCodesForAgentSettings = string.Join(",", expectedStatusCodes);
         }
 
-        public IDictionary<string, IEnumerable<string>> ExpectedErrorsInfo { get; private set; }
+        public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; private set; }
         public IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; private set; }
         public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; private set; }
         public string ExpectedErrorStatusCodesForAgentSettings { get; private set; }

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorData.cs
@@ -14,6 +14,7 @@ namespace NewRelic.Agent.Core.Errors
         public DateTime NoticedAt { get; }
         public string Path { get; set; }
         public ReadOnlyDictionary<string, object> CustomAttributes { get; }
+        public bool IsExpected { get;}
 
         public const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
@@ -26,5 +27,12 @@ namespace NewRelic.Agent.Core.Errors
             Path = null;
             CustomAttributes = customAttributes;
         }
+
+        public ErrorData(string errorMessage, string errorTypeName, string stackTrace, DateTime noticedAt, ReadOnlyDictionary<string, object> customAttributes, bool isExpected)
+        : this(errorMessage, errorTypeName, stackTrace, noticedAt, customAttributes)
+        {
+            IsExpected = isExpected;
+        }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
@@ -85,11 +85,11 @@ namespace NewRelic.Agent.Core.Errors
             return false;
         }
 
-        private bool ContainsSubstring(IEnumerable<string> list, string subString)
+        private bool ContainsSubstring(IEnumerable<string> subStringList, string sourceString)
         {
-            foreach (var item in list)
+            foreach (var item in subStringList)
             {
-                if (item.Contains(subString))
+                if (sourceString.Contains(item))
                 {
                     return true;
                 }

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
@@ -261,10 +261,13 @@ namespace NewRelic.Agent.Core.Metric
         #region Errors
 
         public const string Errors = "Errors";
+        public const string ErrorsExpected = "ErrorsExpected";
+
 
         public static readonly MetricName ErrorsAll = MetricName.Create(Errors + PathSeparator + All);
         public static readonly MetricName ErrorsAllWeb = MetricName.Create(Errors + PathSeparator + AllWeb);
         public static readonly MetricName ErrorsAllOther = MetricName.Create(Errors + PathSeparator + AllOther);
+        public static readonly MetricName ErrorsExpectedAll = MetricName.Create(ErrorsExpected + PathSeparator + All);
 
         public static MetricName GetErrorTransaction(string transactionMetricName)
         {

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -276,11 +276,10 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 GetApdexMetrics(immutableTransaction, apdexT.Value, transactionApdexMetricName, txStats);
             }
 
-            if (ErrorCollectionEnabled()
-                && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError
-                && !immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.IsExpected)
+            if (ErrorCollectionEnabled() && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
             {
-                MetricBuilder.TryBuildErrorsMetrics(isWebTransaction, txStats);
+                var isErrorExpected = immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.IsExpected;
+                MetricBuilder.TryBuildErrorsMetrics(isWebTransaction, txStats, isErrorExpected);
             }
 
             var referrerCrossProcessId = immutableTransaction.TransactionMetadata.CrossApplicationReferrerProcessId;

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -439,7 +439,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
         {
             var isWebTransaction = immutableTransaction.IsWebTransaction();
 
-            if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError
+                && !immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.IsExpected)
             {
                 MetricBuilder.TryBuildFrustratedApdexMetrics(isWebTransaction, transactionApdexMetricName, txStats);
             }

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -276,7 +276,9 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 GetApdexMetrics(immutableTransaction, apdexT.Value, transactionApdexMetricName, txStats);
             }
 
-            if (ErrorCollectionEnabled() && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (ErrorCollectionEnabled()
+                && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError
+                && !immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.IsExpected)
             {
                 MetricBuilder.TryBuildErrorsMetrics(isWebTransaction, txStats);
             }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -265,22 +265,29 @@ namespace NewRelic.Agent.Core.WireModels
 
             #region Error metrics
 
-            public static void TryBuildErrorsMetrics(bool isWebTransaction, TransactionMetricStatsCollection txStats)
+            public static void TryBuildErrorsMetrics(bool isWebTransaction, TransactionMetricStatsCollection txStats, bool isErrorExpected)
             {
                 var data = MetricDataWireModel.BuildCountData();
 
-                //All metric
-                txStats.MergeUnscopedStats(MetricNames.ErrorsAll, data);
+                if (!isErrorExpected)
+                {
+                    //All metric
+                    txStats.MergeUnscopedStats(MetricNames.ErrorsAll, data);
 
-                //all web/other metric
-                var proposedName = isWebTransaction
-                    ? MetricNames.ErrorsAllWeb
-                    : MetricNames.ErrorsAllOther;
-                txStats.MergeUnscopedStats(proposedName, data);
+                    //all web/other metric
+                    var proposedName = isWebTransaction
+                        ? MetricNames.ErrorsAllWeb
+                        : MetricNames.ErrorsAllOther;
+                    txStats.MergeUnscopedStats(proposedName, data);
 
-                //transaction error metric
-                proposedName = MetricNames.GetErrorTransaction(txStats.GetTransactionName().PrefixedName);
-                txStats.MergeUnscopedStats(proposedName, data);
+                    //transaction error metric
+                    proposedName = MetricNames.GetErrorTransaction(txStats.GetTransactionName().PrefixedName);
+                    txStats.MergeUnscopedStats(proposedName, data);
+                }
+                else
+                {
+                    txStats.MergeUnscopedStats(MetricNames.ErrorsExpectedAll, data);
+                }
             }
 
             #endregion

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -91,7 +91,7 @@ namespace NewRelic.Agent.Configuration
         IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; }
         string ExpectedErrorStatusCodesForAgentSettings { get; }
-        IDictionary<string, IEnumerable<string>> ExpectedErrorsInfo { get; }
+        IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; }
         IEnumerable<string> ExceptionsToIgnore { get; }
         Dictionary<string, string> RequestHeadersMap { get; }
         string EncodingKey { get; }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -91,6 +91,7 @@ namespace NewRelic.Agent.Configuration
         IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; }
         string ExpectedErrorStatusCodesForAgentSettings { get; }
+        IDictionary<string, IEnumerable<string>> ExpectedErrorsInfo { get; }
         IEnumerable<string> ExceptionsToIgnore { get; }
         Dictionary<string, string> RequestHeadersMap { get; }
         string EncodingKey { get; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -920,9 +920,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             _defaultConfig = new TestableDefaultConfiguration(_environment, localConfiguration, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
-            Assert.That(_defaultConfig.ExpectedErrorsInfo.ContainsKey("404"));
+            Assert.That(_defaultConfig.ExpectedErrorsConfiguration.ContainsKey("404"));
 
-            var expectedMessages = _defaultConfig.ExpectedErrorsInfo;
+            var expectedMessages = _defaultConfig.ExpectedErrorsConfiguration;
 
             Assert.That(expectedMessages.ContainsKey("ErrorClass1"));
 
@@ -946,7 +946,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             CreateDefaultConfiguration();
 
-            return _defaultConfig.ExpectedErrorsInfo.FirstOrDefault().Key;
+            return _defaultConfig.ExpectedErrorsConfiguration.FirstOrDefault().Key;
         }
 
         [TestCase(new[] { 401f }, new[] { "405" }, ExpectedResult = "405")]
@@ -958,7 +958,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             CreateDefaultConfiguration();
 
-            return _defaultConfig.ExpectedErrorsInfo.Keys.FirstOrDefault();
+            return _defaultConfig.ExpectedErrorsConfiguration.Keys.FirstOrDefault();
         }
 
         [TestCase(true, ExpectedResult = "server")]
@@ -980,7 +980,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             CreateDefaultConfiguration();
 
-            return _defaultConfig.ExpectedErrorsInfo.FirstOrDefault().Key;
+            return _defaultConfig.ExpectedErrorsConfiguration.FirstOrDefault().Key;
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
@@ -53,7 +53,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldCollectErrors_MatchesErrorCollectorEnabledConfig([Values(true, false)]bool errorCollectorEnabledSetting)
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: errorCollectorEnabledSetting);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, errorCollectorEnabled: errorCollectorEnabledSetting);
 
             Assert.AreEqual(errorCollectorEnabledSetting, _errorService.ShouldCollectErrors);
         }
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsFalse_IfExceptionIsNotIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, errorCollectorEnabled: true);
 
             var exception = new Exception();
             Assert.IsFalse(_errorService.ShouldIgnoreException(exception));
@@ -70,7 +70,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, errorCollectorEnabled: true);
 
             var exception = new ArithmeticException();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -79,7 +79,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfInnerExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, errorCollectorEnabled: true);
 
             var exception = new Exception("OuterException", new ArithmeticException("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -88,7 +88,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfOuterExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, true);
 
             var exception = new ArithmeticException("OuterException", new Exception("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -97,7 +97,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionWithTypeParameterIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, true);
 
             var exception = new ExceptionWithTypeParameter<string>();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -110,7 +110,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(500, null, ExpectedResult = false)]
         public bool ShouldIgnoreHttpStatusCode_ReturnsExpectedResult(int statusCode, int? subStatusCode)
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages: false, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, false, null, null, true);
 
             return _errorService.ShouldIgnoreHttpStatusCode(statusCode, subStatusCode);
         }
@@ -119,7 +119,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(false)]
         public void FromException_ReturnsExpectedErrorData(bool stripExceptionMessages)
         {
-            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, _statusCodesToIgnore, stripExceptionMessages, null, null, true);
 
             var exception = new Exception();
             var errorData = _errorService.FromException(exception);
@@ -141,42 +141,6 @@ namespace NewRelic.Agent.Core.Errors
             Assert.IsEmpty(errorData.CustomAttributes);
         }
 
-        private void SetupConfiguration(List<string> exceptionsToIgnore, List<float> statusCodesToIgnore, bool stripExceptionMessages, bool errorCollectorEnabled)
-        {
-            var config = new configuration();
-            config.errorCollector.enabled = errorCollectorEnabled;
-            config.errorCollector.ignoreErrors.exception = exceptionsToIgnore;
-            config.errorCollector.ignoreStatusCodes.code = statusCodesToIgnore;
-            config.stripExceptionMessages.enabled = stripExceptionMessages;
-            EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
-        }
-
-        private void SetupConfiguration(List<string> errorClassesToBeExpected, IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeExpected, bool errorCollectorEnabled)
-        {
-            var config = new configuration();
-            config.errorCollector.enabled = errorCollectorEnabled;
-            if (errorClassesToBeExpected != null)
-            {
-                config.errorCollector.expectedClasses.errorClass = errorClassesToBeExpected;
-            }
-
-            if (errorMessagesToBeExpected != null)
-            {
-                foreach (var errorMessage in errorMessagesToBeExpected)
-                {
-                    var x = new configurationErrorCollectorErrorClass()
-                    {
-                        name = errorMessage.Key,
-                        message = errorMessage.Value.ToList()
-                    };
-
-                    config.errorCollector.expectedMessages.Add(x);
-                }
-            }
-
-            EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
-        }
-
         [TestCase(true)]
         [TestCase(false)]
         public void FromException_MarkErrorDataAsExpected_ExpectedErrorClasses(bool hasExpectedError)
@@ -188,7 +152,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasExpectedError)
             {
-                SetupConfiguration(expectedClasses, null, errorCollectorEnabled: true);
+                SetupConfiguration(expectedClasses, null, false, null, null, true);
             }
 
             var expectedExceptionRoot = new IOException("Root Exception", new DirectoryNotFoundException());
@@ -220,7 +184,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasExpectedError)
             {
-                SetupConfiguration(null, expectedMessages, errorCollectorEnabled: true);
+                SetupConfiguration(null, null, false, null, expectedMessages, errorCollectorEnabled: true);
             }
 
             var expectedException1 = new DirectoryNotFoundException("this is error message 1 ");
@@ -254,7 +218,7 @@ namespace NewRelic.Agent.Core.Errors
                 "System.IO.DirectoryNotFoundException",
             };
 
-            SetupConfiguration(expectedClasses, expectedMessages, errorCollectorEnabled: true);
+            SetupConfiguration(null, null, false, expectedClasses, expectedMessages, true);
             var expectedException = new DirectoryNotFoundException("any error messages");
 
             var errorData = _errorService.FromException(expectedException);
@@ -262,5 +226,47 @@ namespace NewRelic.Agent.Core.Errors
             Assert.IsTrue(errorData.IsExpected);
 
         }
+
+        private void SetupConfiguration(List<string> exceptionsToIgnore, List<float> statusCodesToIgnore,
+            bool stripExceptionMessages, List<string> errorClassesToBeExpected,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeExpected, bool errorCollectorEnabled)
+        {
+            var config = new configuration();
+
+            config.errorCollector.enabled = errorCollectorEnabled;
+            config.stripExceptionMessages.enabled = stripExceptionMessages;
+
+            if (exceptionsToIgnore != null)
+            {
+                config.errorCollector.ignoreErrors.exception = exceptionsToIgnore;
+            }
+
+            if (statusCodesToIgnore != null)
+            {
+                config.errorCollector.ignoreStatusCodes.code = statusCodesToIgnore;
+            }
+
+            if (errorClassesToBeExpected != null)
+            {
+                config.errorCollector.expectedClasses.errorClass = errorClassesToBeExpected;
+            }
+
+            if (errorMessagesToBeExpected != null)
+            {
+                foreach (var errorMessage in errorMessagesToBeExpected)
+                {
+                    var x = new configurationErrorCollectorErrorClass()
+                    {
+                        name = errorMessage.Key,
+                        message = errorMessage.Value.ToList()
+                    };
+
+                    config.errorCollector.expectedMessages.Add(x);
+                }
+            }
+
+            EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
+        }
+
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
@@ -152,7 +152,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasExpectedError)
             {
-                SetupConfiguration(expectedClasses, null, false, null, null, true);
+                SetupConfiguration(null, null, false, expectedClasses, null, true);
             }
 
             var expectedExceptionRoot = new IOException("Root Exception", new DirectoryNotFoundException());

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -64,7 +64,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             var priority = 0.5f;
 
             var configuration = configurationService?.Configuration ?? GetDefaultConfiguration();
-            var errorService = configurationService != null ? new ErrorService(configurationService) : Mock.Create<ErrorService>();
+            var errorService = configurationService != null ? new ErrorService(configurationService) : new ErrorService(Mock.Create<IConfigurationService>());
 
             var internalTransaction = new Transaction(configuration, immutableTransaction.TransactionName, Mock.Create<ITimer>(), DateTime.UtcNow, Mock.Create<ICallStackManager>(),
                 _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), Mock.Create<IDistributedTracePayloadHandler>(),

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
@@ -845,6 +845,54 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         }
 
         [Test]
+        public void IgnoredErrors_Override_ExpectedErrors()
+        {
+            var generatedMetrics = new MetricStatsDictionary<string, MetricDataWireModel>();
+            var errorEvents = new List<ErrorEventWireModel>();
+            var errorTraces = new List<ErrorTraceWireModel>();
+
+            _errorTraceMaker = new ErrorTraceMaker(_configurationService);
+            _errorEventMaker = new ErrorEventMaker(_attribDefSvc);
+
+            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<TransactionMetricStatsCollection>())).DoInstead<TransactionMetricStatsCollection>(txStats => generatedMetrics = txStats.GetUnscopedForTesting());
+            Mock.Arrange(() => _errorEventAggregator.Collect(Arg.IsAny<ErrorEventWireModel>())).DoInstead<ErrorEventWireModel>(errorEvent => errorEvents.Add(errorEvent));
+            Mock.Arrange(() => _errorTraceAggregator.Collect(Arg.IsAny<ErrorTraceWireModel>())).DoInstead<ErrorTraceWireModel>(errorTrace => errorTraces.Add(errorTrace));
+            Mock.Arrange(() => _metricNameService.TryGetApdex_t(Arg.IsAny<string>())).Returns(TimeSpan.FromSeconds(2));
+
+            Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
+            Mock.Arrange(() => _configuration.ExpectedErrorsInfo).Returns(new Dictionary<string, IEnumerable<string>>()
+            {
+                { "System.IO.IOException", Enumerable.Empty<string>()}
+            });
+            Mock.Arrange(() => _configuration.ExceptionsToIgnore).Returns(new List<string>()
+            {
+                { "System.IO.IOException"}
+            });
+
+            var transaction = TestTransactions.CreateDefaultTransaction(false, configurationService: _configurationService, exception: new IOException());
+
+            _transactionTransformer.Transform(transaction);
+
+            string[] unscoped = new string[] {
+                "Errors/all", "Errors/allOther", "Errors/OtherTransaction/TransactionName"};
+
+            // When an error is ignored, unscoped error metrics should not be generated.
+            foreach (string current in unscoped)
+            {
+                Assert.IsFalse(generatedMetrics.ContainsKey(current), "Metric should not contain: " + current);
+            }
+
+            // When an error is ignored, ErrorsExpected/all metric is generated, frustrating score apdex metric should not be generated. 
+            Assert.IsFalse(generatedMetrics.ContainsKey("ErrorsExpected/all"));
+            Assert.AreEqual(1, generatedMetrics["ApdexOther/Transaction/TransactionName"].Value0); //sastisfying apdex
+            Assert.AreEqual(1, generatedMetrics["ApdexOther"].Value0); //sastisfying apdex
+            Assert.AreEqual(1, generatedMetrics["ApdexAll"].Value0); //sastisfying apdex
+
+            Assert.That(errorEvents.Count == 0, "Expect no error events.");
+            Assert.That(errorTraces.Count == 0, "Expect no error traces.");
+        }
+
+        [Test]
         public void ClientApplicationMetricIsGenerated_IfReferringCrossProcessIdIsNotNull()
         {
             var generatedMetrics = new MetricStatsDictionary<string, MetricDataWireModel>();

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
@@ -797,7 +797,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             if (expectForError)
             {
                 Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
-                Mock.Arrange(() => _configuration.ExpectedErrorsInfo).Returns(new Dictionary<string, IEnumerable<string>>()
+                Mock.Arrange(() => _configuration.ExpectedErrorsConfiguration).Returns(new Dictionary<string, IEnumerable<string>>()
                 {
                     { "System.IO.IOException", Enumerable.Empty<string>()}
                 });
@@ -860,7 +860,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             Mock.Arrange(() => _metricNameService.TryGetApdex_t(Arg.IsAny<string>())).Returns(TimeSpan.FromSeconds(2));
 
             Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
-            Mock.Arrange(() => _configuration.ExpectedErrorsInfo).Returns(new Dictionary<string, IEnumerable<string>>()
+            Mock.Arrange(() => _configuration.ExpectedErrorsConfiguration).Returns(new Dictionary<string, IEnumerable<string>>()
             {
                 { "System.IO.IOException", Enumerable.Empty<string>()}
             });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry should be included.
-->

## Summary

Expected error classes and error messages implementation.

## Details
- When an error is expected, Frustrated Apdex metric should not be created automatically for the error transaction.
- When an error is expected, increments count for "ErrorsExpected/all" metric, but MUST NOT increment any of the Errors/* metrics.
- When an error is expected, still increments count for "Supportability/Events/TransactionError/Seen" and "Supportability/Events/TransactionError/Sent".
- When an error is expected, traced errors and error events, span event error attributes are still generated.
- When an error is expected, error trace should include `error.expected` attribute, but this will be addressed in a different PR.
- If an error is set to be ignored and expected, it will be ignored.
 
## Links

<!--
Any relevant links that will help reviewers.
-->

## Proposed Release Notes

<!--
Proposed test of release notes, if applicable.
-->

