### PR TITLE
Garbage Collection Performance Counters Fixes

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
 
 ### Fixes
-* **Fix Title** <br/>
-Fix Description
+* **Garbage Collection Performance Metrics for Windows** <br/>
+Fixes an issue where Garbage Collection Performance Metrics may not be reported for Windows Applications.
  
 ### Docs Changes
 * [Doc Title](https://urlToDraft)

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
-* **New Feature Title** <br/>
-Change Description
+* **The .NET Agent is now open source!** <br/>
+The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
 
 ### Fixes
 * **Fix Title** <br/>

--- a/src/Agent/NewRelic/Agent/Core/Samplers/GcSampler.cs
+++ b/src/Agent/NewRelic/Agent/Core/Samplers/GcSampler.cs
@@ -33,21 +33,24 @@ namespace NewRelic.Agent.Core.Samplers
 
 #if NETFRAMEWORK
 
-	public class GcSampler : AbstractSampler
-	{
-		private const string GCPerfCounterCategoryName = ".NET CLR Memory";
+    public class GcSampler : AbstractSampler
+    {
+        private const string GCPerfCounterCategoryName = ".NET CLR Memory";
+        private const int MaxConsecutiveFailuresBeforeDisable = 5;
 
-		private readonly IGcSampleTransformer _transformer;
-		private const int GcSampleIntervalSeconds = 60;
-		private IPerformanceCounterProxyFactory _pcProxyFactory;
-		private readonly object _lockObj = new object();
+        private readonly IGcSampleTransformer _transformer;
+        private const int GcSampleIntervalSeconds = 60;
+        private readonly IPerformanceCounterProxyFactory _pcProxyFactory;
 
-		/// <summary>
-		/// Translates the sample type enum to the name of the windows performance counter
-		/// </summary>
-		private readonly Dictionary<GCSampleType, string> _perfCounterNames = new Dictionary<GCSampleType, string>
-		{
-			{ GCSampleType.Gen0Size , "Gen 0 heap size"},					// BuildByteData (MB)
+        private int _countConsecutiveSamplingFailures = 0;
+        private string _perfCounterInstanceName;
+
+        /// <summary>
+        /// Translates the sample type enum to the name of the windows performance counter
+        /// </summary>
+        private readonly Dictionary<GCSampleType, string> _perfCounterNames = new Dictionary<GCSampleType, string>
+        {
+            { GCSampleType.Gen0Size , "Gen 0 heap size"},					// BuildByteData (MB)
 			{ GCSampleType.Gen0Promoted , "Promoted Memory from Gen 0"},	// BuildByteData
 			{ GCSampleType.Gen1Size , "Gen 1 heap size"},					// BuildByteData
 			{ GCSampleType.Gen1Promoted , "Promoted Memory from Gen 1"},	// BuildByteData
@@ -61,186 +64,304 @@ namespace NewRelic.Agent.Core.Samplers
 			{ GCSampleType.Gen2CollectionCount , "# Gen 2 Collections"}		// reset on sample}, BuildCountData
 		};
 
-		private readonly Dictionary<GCSampleType, Func<IPerformanceCounterProxy, float>> _perfCounterValueHandlers;
+        private readonly Dictionary<GCSampleType, Func<IPerformanceCounterProxy, float>> _perfCounterValueHandlers;
 
-		private float GetPerfCounterValue_Raw(IPerformanceCounterProxy proxy)
-		{
-			return proxy.NextValue();
-		}
+        private float GetPerfCounterValue_Raw(IPerformanceCounterProxy proxy)
+        {
+            return proxy.NextValue();
+        }
 
-		private float GetPerfCounterValue_DeltaValue(IPerformanceCounterProxy proxy, ref float prevValue)
-		{
-			var currentPerfCounterVal = proxy.NextValue();
-			var prevPerfCounterVal = Interlocked.Exchange(ref prevValue, currentPerfCounterVal);
-			return currentPerfCounterVal - prevPerfCounterVal;
-		}
+        private float GetPerfCounterValue_DeltaValue(IPerformanceCounterProxy proxy, ref float prevValue)
+        {
+            var currentPerfCounterVal = proxy.NextValue();
+            var prevPerfCounterVal = Interlocked.Exchange(ref prevValue, currentPerfCounterVal);
+            return currentPerfCounterVal - prevPerfCounterVal;
+        }
 
-		private float GetPerfCounterValue_Gen0CollectionCount(IPerformanceCounterProxy proxy)
-		{
-			return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen0CollectionCount);
-		}
+        private float GetPerfCounterValue_Gen0CollectionCount(IPerformanceCounterProxy proxy)
+        {
+            return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen0CollectionCount);
+        }
 
-		private float GetPerfCounterValue_Gen1CollectionCount(IPerformanceCounterProxy proxy)
-		{
-			return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen1CollectionCount);
-		}
+        private float GetPerfCounterValue_Gen1CollectionCount(IPerformanceCounterProxy proxy)
+        {
+            return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen1CollectionCount);
+        }
 
-		private float GetPerfCounterValue_Gen2CollectionCount(IPerformanceCounterProxy proxy)
-		{
-			return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen2CollectionCount);
-		}
+        private float GetPerfCounterValue_Gen2CollectionCount(IPerformanceCounterProxy proxy)
+        {
+            return GetPerfCounterValue_DeltaValue(proxy, ref _PrevGen2CollectionCount);
+        }
 
-		private float GetPerfCounterValue_InducedCount(IPerformanceCounterProxy proxy)
-		{
-			return GetPerfCounterValue_DeltaValue(proxy, ref _PrevInducedCount);
-		}
+        private float GetPerfCounterValue_InducedCount(IPerformanceCounterProxy proxy)
+        {
+            return GetPerfCounterValue_DeltaValue(proxy, ref _PrevInducedCount);
+        }
 
-		/// <summary>
-		/// Holds the performance counter proxies used to capture the data from the windows performance counters.
-		/// </summary>
-		private Dictionary<GCSampleType, IPerformanceCounterProxy> _perfCounterProxies;
+        /// <summary>
+        /// Holds the performance counter proxies used to capture the data from the windows performance counters.
+        /// </summary>
+        private Dictionary<GCSampleType, IPerformanceCounterProxy> _perfCounterProxies;
 
-		// These hold previous values to compute delta between samplings.
-		private float _PrevGen0CollectionCount = 0;
-		private float _PrevGen1CollectionCount = 0;
-		private float _PrevGen2CollectionCount = 0;
-		private float _PrevInducedCount = 0;
+        // These hold previous values to compute delta between samplings.
+        private float _PrevGen0CollectionCount = 0;
+        private float _PrevGen1CollectionCount = 0;
+        private float _PrevGen2CollectionCount = 0;
+        private float _PrevInducedCount = 0;
 
-		public GcSampler(IScheduler scheduler, IGcSampleTransformer gcSampleTransformer, IPerformanceCounterProxyFactory pcProxyFactory)
-		 : base(scheduler, TimeSpan.FromSeconds(GcSampleIntervalSeconds))
-		{
-			_pcProxyFactory = pcProxyFactory;
-			_transformer = gcSampleTransformer;
+        public GcSampler(IScheduler scheduler, IGcSampleTransformer gcSampleTransformer, IPerformanceCounterProxyFactory pcProxyFactory)
+         : base(scheduler, TimeSpan.FromSeconds(GcSampleIntervalSeconds))
+        {
+            _pcProxyFactory = pcProxyFactory;
+            _transformer = gcSampleTransformer;
 
-			//Assign functions to handle the values for the different performance counters collected.
-			_perfCounterValueHandlers = new Dictionary<GCSampleType, Func<IPerformanceCounterProxy, float>>()
-			{
-				{ GCSampleType.Gen0Size, GetPerfCounterValue_Raw },
-				{ GCSampleType.Gen0Promoted , GetPerfCounterValue_Raw },
-				{ GCSampleType.Gen1Size, GetPerfCounterValue_Raw },
-				{ GCSampleType.Gen1Promoted, GetPerfCounterValue_Raw },
-				{ GCSampleType.Gen2Size, GetPerfCounterValue_Raw },
-				{ GCSampleType.LOHSize, GetPerfCounterValue_Raw },
-				{ GCSampleType.HandlesCount, GetPerfCounterValue_Raw },
-				{ GCSampleType.InducedCount, GetPerfCounterValue_InducedCount },
-				{ GCSampleType.PercentTimeInGc, GetPerfCounterValue_Raw },
-				{ GCSampleType.Gen0CollectionCount, GetPerfCounterValue_Gen0CollectionCount },
-				{ GCSampleType.Gen1CollectionCount, GetPerfCounterValue_Gen1CollectionCount },
-				{ GCSampleType.Gen2CollectionCount, GetPerfCounterValue_Gen2CollectionCount }
-			};
-		}
+            //Assign functions to handle the values for the different performance counters collected.
+            _perfCounterValueHandlers = new Dictionary<GCSampleType, Func<IPerformanceCounterProxy, float>>()
+            {
+                { GCSampleType.Gen0Size, GetPerfCounterValue_Raw },
+                { GCSampleType.Gen0Promoted , GetPerfCounterValue_Raw },
+                { GCSampleType.Gen1Size, GetPerfCounterValue_Raw },
+                { GCSampleType.Gen1Promoted, GetPerfCounterValue_Raw },
+                { GCSampleType.Gen2Size, GetPerfCounterValue_Raw },
+                { GCSampleType.LOHSize, GetPerfCounterValue_Raw },
+                { GCSampleType.HandlesCount, GetPerfCounterValue_Raw },
+                { GCSampleType.InducedCount, GetPerfCounterValue_InducedCount },
+                { GCSampleType.PercentTimeInGc, GetPerfCounterValue_Raw },
+                { GCSampleType.Gen0CollectionCount, GetPerfCounterValue_Gen0CollectionCount },
+                { GCSampleType.Gen1CollectionCount, GetPerfCounterValue_Gen1CollectionCount },
+                { GCSampleType.Gen2CollectionCount, GetPerfCounterValue_Gen2CollectionCount }
+            };
+        }
 
-		public override void Start()
-		{
-			if (!Enabled)
-			{
-				Log.Debug($"The GC Sampler is NOT enabled");
-				//We always want to do this because we don't want to code with the internals 
-				//of the base class in mind.
-				base.Start();
-				return;
-			}
+        public override void Start()
+        {
+            if (!Enabled)
+            {
+                Log.Debug($"The GC Sampler is NOT enabled");
+                //We always want to do this because we don't want to code with the internals 
+                //of the base class in mind.
+                base.Start();
+                return;
+            }
 
-			var failedSampleTypes = new List<GCSampleType>();
+            _perfCounterInstanceName = null;
+            _countConsecutiveSamplingFailures = 0;
 
-			var countInstantiated = 0;
-			lock (_lockObj)
-			{
-				//Build a set of proxies for each performance counter being sampled.
-				_perfCounterProxies = new Dictionary<GCSampleType, IPerformanceCounterProxy>();
-				
-				foreach (var sampleTypeEnum in _perfCounterNames.Keys)
-				{
+            //Defer the creation of Performance Counter Proxies until the first sampling occurs.
+            //Performance Counter Instance Names can change based on the number of running processes
+            //for the same executable.
 
-					try
-					{
-						_perfCounterProxies[sampleTypeEnum] = _pcProxyFactory.CreatePerformanceCounterProxy(GCPerfCounterCategoryName, _perfCounterNames[sampleTypeEnum]);
-						countInstantiated++;
-					}
-					catch (UnauthorizedAccessException)
-					{
-						var userName = "<unknown>";
-						try
-						{
-							userName = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
-						}
-						catch
-						{ }
+            base.Start();
+        }
 
-						Log.Warn($"The executing user, {userName}, has insufficient permissions to collect Windows Performance Counters.");
-						break;
-					}
-					catch (Exception ex)
-					{
-						failedSampleTypes.Add(sampleTypeEnum);
-						Log.Debug($"Error encountered during the creation of performance counter proxy for GC sample type '{sampleTypeEnum}'.  Metrics of this type will not be captured.  Error : {ex}");
-					}
-				}
-			}
+        protected override void Stop()
+        {
+            base.Stop();
 
-			//Print message indicating which perf counter proxies failed to start.
-			if (failedSampleTypes.Count > 0)
-			{
-				var msgToken = string.Join(", ", failedSampleTypes.Select(x => x.ToString()).ToArray());
-				Log.Warn($"The following Garbage Collection Performance Counters could not be started: {msgToken}.  Debug Level logs will contain more information.");
-			}
+            if (_perfCounterProxies == null)
+            {
+                return;
+            }
 
-			//We always want to do this because we don't want to code with the internals 
-			//of the base class in mind.
-			base.Start();
+            var proxies = Interlocked.Exchange(ref _perfCounterProxies, null);
 
-			//If unable to create any proxies, there is no need to run the timer
-			if (countInstantiated == 0)
-			{
-				Log.Warn("No GC performance counters were instantiated.  GC Metrics will not be captured.");
-				Stop();
-			}
-			else
-			{
-				Log.Debug($"The GC Sampler was started, collecting {_perfCounterProxies.Count} performance counter(s).");
-			}
-		}
+            DisposeProxies(proxies.Values);
+        }
 
-		protected override void Stop()
-		{
-			base.Stop();
+        private void DisposeProxies(IEnumerable<IPerformanceCounterProxy> proxies)
+        {
+            foreach (var perfCounterProxy in proxies)
+            {
+                perfCounterProxy.Dispose();
+            }
+        }
 
-			lock (_lockObj)
-			{
-				if (_perfCounterProxies != null)
-				{
-					foreach (var perfCounterProxy in _perfCounterProxies.Values)
-					{
-						perfCounterProxy.Dispose();
-					}
-					_perfCounterProxies = null;
-				}
-			}
-		}
+        private int CreatePerfCounterProxies(string processInstanceName)
+        {
+            var perfCounterProxies = new Dictionary<GCSampleType, IPerformanceCounterProxy>();
 
-		public override void Sample()
-		{
-			try
-			{
-				var sampleValues = new Dictionary<GCSampleType, float>();
+            var failedSampleTypes = new List<GCSampleType>();
 
-				lock (_lockObj)
-				{
-					foreach (var proxy in _perfCounterProxies)
-					{
-						var val = _perfCounterValueHandlers[proxy.Key](proxy.Value);
-						sampleValues[proxy.Key] = val;
-					}
-				}
+            foreach (var sampleTypeEnum in _perfCounterNames.Keys)
+            {
+                try
+                {
+                    perfCounterProxies[sampleTypeEnum] = _pcProxyFactory.CreatePerformanceCounterProxy(GCPerfCounterCategoryName, _perfCounterNames[sampleTypeEnum], processInstanceName);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    throw;  //Let the caller receive this so that they may shutdown the sampler.
+                }
+                catch (Exception ex)
+                {
+                    failedSampleTypes.Add(sampleTypeEnum);
+                    LogMessage(LogLevel.Debug, $"Error encountered during the creation of performance counter for '{sampleTypeEnum}' for Performance Counter Instance '{processInstanceName}'.  Metrics of this type will not be captured.  Error : {ex}");
+                }
+            }
 
-				_transformer.Transform(sampleValues);
-			}
-			catch (Exception ex)
-			{
-				Log.Error($"Unable to get Garbage Collection performance counter sample.  Further .Net GC metrics will not be collected.  Error : {ex}");
-				Stop();
-			}
-		}
-	}
+            //Print message indicating which perf counter proxies failed to start.
+            if (failedSampleTypes.Count > 0)
+            {
+                var msgToken = string.Join(", ", failedSampleTypes.Select(x => x.ToString()).ToArray());
+                LogMessage(LogLevel.Warn, $"The following Performance Counters for Performance Counter Instance '{processInstanceName}' could not be started: {msgToken}.  Debug Level logs will contain more information.");
+            }
+
+            var oldProxies = Interlocked.Exchange(ref _perfCounterProxies, perfCounterProxies);
+
+            if (_perfCounterProxies.Count > 0)
+            {
+                LogMessage(LogLevel.Debug, $"Sampler is collecting {_perfCounterProxies.Count} performance counter(s) for Performance Counter Instance '{processInstanceName}'.");
+            }
+
+            if (oldProxies != null && oldProxies.Count > 0)
+            {
+                DisposeProxies(oldProxies.Values);
+            }
+
+            return _perfCounterProxies.Count;
+        }
+
+        private void LogMessage(LogLevel level, string message, Exception ex = null)
+        {
+            if (!Log.IsEnabledFor(level))
+            {
+                return;
+            }
+
+            if (ex == null)
+            {
+                Log.LogMessage(level, $"GC Performance Counters: {message}");
+            }
+            else
+            {
+                Log.LogMessage(level, $"GC Performance Counters: {message}, {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Method ensures that the performance counters are available and up-to-date.
+        /// If the Performance Counter Instance name has changed since last sampling, create new performance
+        /// counters.
+        /// </summary>
+        /// <returns>bool indicating success of doing so</returns>
+        private bool EnsurePerformanceCounters(string currentProcessInstanceName)
+        {
+            if (currentProcessInstanceName == _perfCounterInstanceName && _perfCounterProxies != null && _perfCounterProxies.Count > 0)
+            {
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_perfCounterInstanceName))
+            {
+                LogMessage(LogLevel.Debug, $"Performance Counter Instance name change detected, rebuilding performance counters:  changed from '{_perfCounterInstanceName}' to '{currentProcessInstanceName}'");
+            }
+
+            _perfCounterInstanceName = currentProcessInstanceName;
+
+            var countPerfCountersCreated = CreatePerfCounterProxies(_perfCounterInstanceName);
+
+            return countPerfCountersCreated > 0;
+        }
+
+        private void HandleUnauthorizedException()
+        {
+            var userName = "<unknown>";
+            try
+            {
+                userName = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+            }
+            catch
+            { }
+
+            LogMessage(LogLevel.Warn, $"The executing user, {userName}, has insufficient permissions to collect Windows Performance Counters.");
+
+            Stop();
+        }
+
+        private void HandleException(Exception ex)
+        {
+            if (ex is UnauthorizedAccessException)
+            {
+                HandleUnauthorizedException();
+                return;
+            }
+
+            HandleProblem();
+
+        }
+
+        private void HandleProblem()
+        {
+            _countConsecutiveSamplingFailures++;
+
+            if (_countConsecutiveSamplingFailures >= MaxConsecutiveFailuresBeforeDisable)
+            {
+                LogMessage(LogLevel.Warn, $"After {MaxConsecutiveFailuresBeforeDisable} failed attempts, GC Metrics sampling will be disabled.");
+                Stop();
+            }
+        }
+
+        public override void Sample()
+        {
+            var currentPerfCounterInstName = default(string);
+            try
+            {
+                currentPerfCounterInstName = _pcProxyFactory.GetCurrentProcessInstanceNameForCategory(GCPerfCounterCategoryName);
+
+                if (string.IsNullOrWhiteSpace(currentPerfCounterInstName))
+                {
+                    // If there was a prior value from last sampling and now there isn't a value, something is wrong so safely stop the sampler.
+                    if (!string.IsNullOrWhiteSpace(_perfCounterInstanceName))
+                    {
+                        LogMessage(LogLevel.Warn, $"Unable to obtain the current Performance Counter Instance Name. The prior name was '{_perfCounterInstanceName}'.  GC Samples will no longer be collected.");
+                        Stop();
+                        return;
+                    }
+
+                    LogMessage(LogLevel.Finest, $"Unable to obtain the current Perforance Counter Instance Name. GC Samples will not be collected at this time.  Will try again during next sampling cycle.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+                return;
+            }
+
+            try
+            {
+                if (!EnsurePerformanceCounters(currentPerfCounterInstName))
+                {
+                    var logLevel = _countConsecutiveSamplingFailures + 1 >= MaxConsecutiveFailuresBeforeDisable
+                        ? LogLevel.Warn
+                        : LogLevel.Debug;
+
+                    LogMessage(logLevel, $"Unable to instantiate any perf counters.  (Performance Counter Instance '{_perfCounterInstanceName}', attempt #{_countConsecutiveSamplingFailures})");
+
+                    HandleProblem();
+
+                    return;
+                }
+
+                var sampleValues = new Dictionary<GCSampleType, float>();
+
+                foreach (var proxy in _perfCounterProxies)
+                {
+                    var val = _perfCounterValueHandlers[proxy.Key](proxy.Value);
+                    sampleValues[proxy.Key] = val;
+                }
+
+                _transformer.Transform(sampleValues);
+
+                _countConsecutiveSamplingFailures = 0;
+            }
+            catch (Exception ex)
+            {
+                LogMessage(LogLevel.Error, $"Unable to get GC performance counter sample for Performance Counter Instance '{_perfCounterInstanceName}'.", ex);
+
+                HandleException(ex);
+            }
+        }
+    }
 #endif
 }

--- a/src/Agent/NewRelic/Agent/Core/Samplers/GcSampler.cs
+++ b/src/Agent/NewRelic/Agent/Core/Samplers/GcSampler.cs
@@ -306,7 +306,7 @@ namespace NewRelic.Agent.Core.Samplers
             var currentPerfCounterInstName = default(string);
             try
             {
-                currentPerfCounterInstName = _pcProxyFactory.GetCurrentProcessInstanceNameForCategory(GCPerfCounterCategoryName);
+                currentPerfCounterInstName = _pcProxyFactory.GetCurrentProcessInstanceNameForCategory(GCPerfCounterCategoryName, _perfCounterInstanceName);
 
                 if (string.IsNullOrWhiteSpace(currentPerfCounterInstName))
                 {

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### New Features
+* **The New Relic AWS Lambda Agent for .NET is now Open Source** <br/>
+* The New Relic AWS Lambda Agent for .NET is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in the repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
+
+### Fixes
+* **Fix Title** <br/>
+Fix Description
+ 
+### Docs Changes
+* [Doc Title](https://urlToDraft)
+
 ## [1.0.0] - 2019-12-10
 ### New Features
 * New SDK providing Open Tracing instrumentation for AWS Lambda. Refer to New Relic's AWS Lambda monitoring documentation to get started https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring.

--- a/src/NewRelic.Core/NewRelic.SystemInterfaces/IProcess.cs
+++ b/src/NewRelic.Core/NewRelic.SystemInterfaces/IProcess.cs
@@ -9,7 +9,6 @@ namespace NewRelic.SystemInterfaces
 {
     public interface IProcessStatic
     {
-
         IProcess GetCurrentProcess();
     }
 

--- a/src/NewRelic.Core/NewRelic.SystemInterfaces/PerformanceCounterProxy.cs
+++ b/src/NewRelic.Core/NewRelic.SystemInterfaces/PerformanceCounterProxy.cs
@@ -11,178 +11,178 @@ using System.Linq;
 
 namespace NewRelic.SystemInterfaces
 {
-	public interface IPerformanceCounterProxy : IDisposable
-	{
-		float NextValue();
-	}
+    public interface IPerformanceCounterProxy : IDisposable
+    {
+        float NextValue();
+    }
 
-	public class PerformanceCounterProxy : IPerformanceCounterProxy
-	{
-		private readonly PerformanceCounter _counter;
-		private bool _counterIsDisposed = false;
+    public class PerformanceCounterProxy : IPerformanceCounterProxy
+    {
+        private readonly PerformanceCounter _counter;
+        private bool _counterIsDisposed = false;
 
-		public PerformanceCounterProxy(string categoryName, string counterName, string instanceName)
-		{
-			_counter = new PerformanceCounter(categoryName, counterName, instanceName);
-		}
+        public PerformanceCounterProxy(string categoryName, string counterName, string instanceName)
+        {
+            _counter = new PerformanceCounter(categoryName, counterName, instanceName);
+        }
 
-		public float NextValue()
-		{
-			return _counter.NextValue();
-		}
-		
-		public void Dispose()
-		{
-			if (_counter != null && !_counterIsDisposed)
-			{
-				_counter.Dispose();
-				_counterIsDisposed = true;
-			}
-		}
-	}
+        public float NextValue()
+        {
+            return _counter.NextValue();
+        }
 
-	public interface IPerformanceCounterCategoryProxy
-	{
-		string[] GetInstanceNames();
-	}
+        public void Dispose()
+        {
+            if (_counter != null && !_counterIsDisposed)
+            {
+                _counter.Dispose();
+                _counterIsDisposed = true;
+            }
+        }
+    }
 
-	public class PerformanceCounterCategoryProxy : IPerformanceCounterCategoryProxy
-	{
-		private readonly PerformanceCounterCategory _performanceCounterCategory;
+    public interface IPerformanceCounterCategoryProxy
+    {
+        string[] GetInstanceNames();
+    }
 
-		public PerformanceCounterCategoryProxy(string categoryName)
-		{
-			_performanceCounterCategory = new PerformanceCounterCategory(categoryName);
-		}
+    public class PerformanceCounterCategoryProxy : IPerformanceCounterCategoryProxy
+    {
+        private readonly PerformanceCounterCategory _performanceCounterCategory;
 
-		public string[] GetInstanceNames()
-		{
-			return _performanceCounterCategory.GetInstanceNames();
-		}
-	}
+        public PerformanceCounterCategoryProxy(string categoryName)
+        {
+            _performanceCounterCategory = new PerformanceCounterCategory(categoryName);
+        }
 
-	public interface IPerformanceCounterProxyFactory
-	{
-		IPerformanceCounterProxy CreatePerformanceCounterProxy(string categoryName, string counterName);
-	}
+        public string[] GetInstanceNames()
+        {
+            return _performanceCounterCategory.GetInstanceNames();
+        }
+    }
 
-	public class PerformanceCounterProxyFactory : IPerformanceCounterProxyFactory
-	{
-		public const string ProcessIdCounterName = "Process ID";
+    public interface IPerformanceCounterProxyFactory
+    {
+        IPerformanceCounterProxy CreatePerformanceCounterProxy(string categoryName, string counterName, string instanceName);
+        string GetCurrentProcessInstanceNameForCategory(string categoryName);
+    }
 
-		private readonly IProcessStatic _processStatic;
+    public class PerformanceCounterProxyFactory : IPerformanceCounterProxyFactory
+    {
+        public const string ProcessIdCounterName = "Process ID";
 
-		/// <summary>
-		/// Function used to create the performance counter category which is used to list the
-		/// instance names of the processes that are reporting information for that performance counter
-		/// category.  This is dependency injected so that we can manipulate its behavior for testing purposes
-		/// </summary>
-		private readonly Func<string, IPerformanceCounterCategoryProxy> _createPerformanceCounterCategory;
+        private readonly IProcessStatic _processStatic;
 
-		/// <summary>
-		/// Function used to create the actual performance counter proxy.
-		/// This is dependency injected so that we can manipulate its behavior for testing purposes
-		/// Func params: categoryName, perfCounterName, instanceName
-		/// </summary>
-		private readonly Func<string, string, string, IPerformanceCounterProxy> _createPerformanceCounter;
+        /// <summary>
+        /// Function used to create the performance counter category which is used to list the
+        /// instance names of the processes that are reporting information for that performance counter
+        /// category.  This is dependency injected so that we can manipulate its behavior for testing purposes
+        /// </summary>
+        private readonly Func<string, IPerformanceCounterCategoryProxy> _createPerformanceCounterCategory;
 
-		//Dictionary that relates the category to the instance name of the current process for that category.
-		private static readonly ConcurrentDictionary<string, string> _currentProcessInstanceNames = new ConcurrentDictionary<string, string>();
+        /// <summary>
+        /// Function used to create the actual performance counter proxy.
+        /// This is dependency injected so that we can manipulate its behavior for testing purposes
+        /// Func params: categoryName, perfCounterName, instanceName
+        /// </summary>
+        private readonly Func<string, string, string, IPerformanceCounterProxy> _createPerformanceCounter;
 
-		public PerformanceCounterProxyFactory(IProcessStatic processStatic, Func<string, IPerformanceCounterCategoryProxy> performanceCounterCategoryProxyFactory, Func<string, string, string, IPerformanceCounterProxy> performanceCounterCreator)
-		{
-			_processStatic = processStatic;
-			_createPerformanceCounterCategory = performanceCounterCategoryProxyFactory;
-			_createPerformanceCounter = performanceCounterCreator;
-		}
+        public PerformanceCounterProxyFactory(IProcessStatic processStatic, Func<string, IPerformanceCounterCategoryProxy> performanceCounterCategoryProxyFactory, Func<string, string, string, IPerformanceCounterProxy> performanceCounterCreator)
+        {
+            _processStatic = processStatic;
+            _createPerformanceCounterCategory = performanceCounterCategoryProxyFactory;
+            _createPerformanceCounter = performanceCounterCreator;
+        }
 
-		/// <summary>
-		/// Used by dependency injection to resolve the factory for creating a perf counter category proxy
-		/// </summary>
-		/// <param name="categoryName"></param>
-		/// <returns></returns>
-		public static IPerformanceCounterCategoryProxy DefaultCreatePerformanceCounterCategoryProxy(string categoryName)
-		{
-			return new PerformanceCounterCategoryProxy(categoryName);
-		}
+        /// <summary>
+        /// Used by dependency injection to resolve the factory for creating a perf counter category proxy
+        /// </summary>
+        /// <param name="categoryName"></param>
+        /// <returns></returns>
+        public static IPerformanceCounterCategoryProxy DefaultCreatePerformanceCounterCategoryProxy(string categoryName)
+        {
+            return new PerformanceCounterCategoryProxy(categoryName);
+        }
 
-		/// <summary>
-		/// Used by dependency injection to resolve the factory for creating a perf counter
-		/// </summary>
-		/// <param name="categoryName"></param>
-		/// <returns></returns>
-		public static IPerformanceCounterProxy DefaultCreatePerformanceCounterProxy(string categoryName, string counterName, string instanceName)
-		{
-			return new PerformanceCounterProxy(categoryName, counterName, instanceName);
-		}
+        /// <summary>
+        /// Used by dependency injection to resolve the factory for creating a perf counter
+        /// </summary>
+        /// <param name="categoryName"></param>
+        /// <returns></returns>
+        public static IPerformanceCounterProxy DefaultCreatePerformanceCounterProxy(string categoryName, string counterName, string instanceName)
+        {
+            return new PerformanceCounterProxy(categoryName, counterName, instanceName);
+        }
 
-		/// <summary>
-		/// Responsible for obtaining the instance name for the current process for a perf counter
-		/// category.
-		/// </summary>
-		/// <returns>the instance name or NULL if one could not be identified.</returns>
-		/// <param name="categoryName"></param>
-		private string GetCurrentProcessInstanceNameForCategory(string categoryName)
-		{
-			var processName = _processStatic.GetCurrentProcess().ProcessName;
-			var pid = _processStatic.GetCurrentProcess().Id;
+        /// <summary>
+        /// Responsible for obtaining the instance name for the current process for a perf counter
+        /// category.
+        /// </summary>
+        /// <returns>the instance name or NULL if one could not be identified.</returns>
+        /// <param name="categoryName"></param>
+        public string GetCurrentProcessInstanceNameForCategory(string categoryName)
+        {
+            var processName = _processStatic.GetCurrentProcess().ProcessName;
+            var pid = _processStatic.GetCurrentProcess().Id;
 
-			var result = GetInstanceNameForProcessAndCategory(categoryName, processName, pid);
+            var result = GetInstanceNameForProcessAndCategory(categoryName, processName, pid);
 
-			return result;
-		}
+            return result;
+        }
 
-		public IPerformanceCounterProxy CreatePerformanceCounterProxy(string categoryName, string counterName)
-		{
-			var instanceName = _currentProcessInstanceNames.GetOrAdd(categoryName, GetCurrentProcessInstanceNameForCategory);
+        public IPerformanceCounterProxy CreatePerformanceCounterProxy(string categoryName, string counterName, string instanceName)
+        {
+            if (string.IsNullOrWhiteSpace(instanceName)) throw new ArgumentException(nameof(instanceName));
+            if (string.IsNullOrWhiteSpace(counterName)) throw new ArgumentException(nameof(counterName));
+            if (string.IsNullOrWhiteSpace(categoryName)) throw new ArgumentException(nameof(categoryName));
 
-			if (instanceName == null)
-			{
-				throw new Exception($"Unable to obtain current process' instance name for category {categoryName} when trying to build counter {counterName}.");
-			}
+            return _createPerformanceCounter(categoryName, counterName, instanceName);
+        }
 
-			return _createPerformanceCounter(categoryName, counterName, instanceName);
-		}
+        /// <summary>
+        /// The instance name of a performance counter is a combination of the process Name and an index id to 
+        /// uniquely identify it when multiple of the same process are running.  For example "TestApp #1" pid=82, "TestApp #2" pid=134
+        /// are two instances of the same executable, TestApp.  In order to determine if an instance matches a process,
+        /// an additional performance counter "Process ID" must be used which returns the PID of the process.
+        /// </summary>
+        /// <param name="perfCategoryName"></param>
+        /// <param name="processName"></param>
+        /// <param name="pid"></param>
+        /// <returns>The instance name that will be used to collect performance counter data for the process</returns>
+        private string GetInstanceNameForProcessAndCategory(string perfCategoryName, string processName, int pid)
+        {
+            var performanceCategory = _createPerformanceCounterCategory(perfCategoryName);
 
-		/// <summary>
-		/// The instance name of a performance counter is a combination of the process Name and an index id to 
-		/// uniquely identify it when multiple of the same process are running.  For example "TestApp #1" pid=82, "TestApp #2" pid=134
-		/// are two instances of the same executable, TestApp.  In order to determine if an instance matches a process,
-		/// an additional performance counter "Process ID" must be used which returns the PID of the process.
-		/// </summary>
-		/// <param name="perfCategoryName"></param>
-		/// <param name="processName"></param>
-		/// <param name="pid"></param>
-		/// <returns>The instance name that will be used to collect performance counter data for the process</returns>
-		private string GetInstanceNameForProcessAndCategory(string perfCategoryName, string processName, int pid)
-		{
-			var performanceCategory = _createPerformanceCounterCategory(perfCategoryName);
+            var instanceNames = performanceCategory.GetInstanceNames();
 
-			var instanceNames = performanceCategory.GetInstanceNames()
-				.Where(x => x.StartsWith(processName, StringComparison.OrdinalIgnoreCase));
+            foreach (var instanceName in instanceNames)
+            {
+                try
+                {
+                    using (var pcPid = _createPerformanceCounter(perfCategoryName, ProcessIdCounterName, instanceName))
+                    {
+                        if ((int)pcPid.NextValue() == pid)
+                        {
+                            return instanceName;
+                        }
+                    }
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    //The caller should handle this specificially.  It indicates that the
+                    //current user does not have access to pull performance counter values.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    //Log a message here and continue because this instance may not be relevant to the process that we are looking for.
+                    Log.Finest($"Error determining if instance '{instanceName}' is process '{processName}'({pid}). Error: {ex}");
+                }
+            }
 
-			foreach (var instanceName in instanceNames)
-			{
-				try
-				{
-					using (var pcPid = _createPerformanceCounter(perfCategoryName, ProcessIdCounterName, instanceName))
-					{
-						if ((int)pcPid.NextValue() == pid)
-						{
-							return instanceName;
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					//Log a message here and continue because this instance may not be relevant to the process that we are looking for.
-					Log.Finest($"Error determining if instance '{instanceName}' is process '{processName}'({pid}). Error: {ex}");
-				}
-			}
-
-			//At this point a match was not found. The caller should handle accordingly
-			return null;
-		}
-	}
+            //At this point a match was not found. The caller should handle accordingly
+            return null;
+        }
+    }
 }
 #endif

--- a/tests/Agent/UnitTests/CompositeTests/Samplers/GcSamplerTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/Samplers/GcSamplerTests.cs
@@ -16,281 +16,368 @@ using Telerik.JustMock;
 
 namespace NewRelic.Agent.Core.Samplers
 {
-	[TestFixture]
-	public class GcSamplerTests
-	{
-		private IPerformanceCounterProxyFactory _perfCounterProxyFactory;
+    [TestFixture]
+    public class GcSamplerTests
+    {
+        private IPerformanceCounterProxyFactory _perfCounterProxyFactory;
 
-		private Action _sampleAction;
+        private Action _sampleAction;
 
-		private CompositeTestAgent _compositeTestAgent;
+        private CompositeTestAgent _compositeTestAgent;
 
-		private IScheduler _scheduler;
+        private IScheduler _scheduler;
 
-		private static readonly GCSampleType[] _expectedSampleTypes = new GCSampleType[]
-		{
-				GCSampleType.Gen0Size,
-				GCSampleType.Gen0Promoted,
-				GCSampleType.Gen1Size,
-				GCSampleType.Gen1Promoted,
-				GCSampleType.Gen2Size,
-				GCSampleType.LOHSize,
-				GCSampleType.HandlesCount,
-				GCSampleType.InducedCount,
-				GCSampleType.PercentTimeInGc,
-				GCSampleType.Gen0CollectionCount,
-				GCSampleType.Gen1CollectionCount,
-				GCSampleType.Gen2CollectionCount
-		};
+        private static readonly GCSampleType[] _expectedSampleTypes = new GCSampleType[]
+        {
+                GCSampleType.Gen0Size,
+                GCSampleType.Gen0Promoted,
+                GCSampleType.Gen1Size,
+                GCSampleType.Gen1Promoted,
+                GCSampleType.Gen2Size,
+                GCSampleType.LOHSize,
+                GCSampleType.HandlesCount,
+                GCSampleType.InducedCount,
+                GCSampleType.PercentTimeInGc,
+                GCSampleType.Gen0CollectionCount,
+                GCSampleType.Gen1CollectionCount,
+                GCSampleType.Gen2CollectionCount
+        };
 
-		private readonly int _countSampleTypes = _expectedSampleTypes.Count();
+        private readonly int _countSampleTypes = _expectedSampleTypes.Count();
 
-		[SetUp]
-		public void SetUp()
-		{
-			_compositeTestAgent = new CompositeTestAgent();
+        [SetUp]
+        public void SetUp()
+        {
+            _compositeTestAgent = new CompositeTestAgent();
 
-			_scheduler = Mock.Create<IScheduler>();
+            _scheduler = Mock.Create<IScheduler>();
 
-			Mock.Arrange(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()))
-				.DoInstead<Action, TimeSpan, TimeSpan?>((action, _, __) => _sampleAction = action);
+            Mock.Arrange(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead<Action, TimeSpan, TimeSpan?>((action, _, __) => _sampleAction = action);
 
-			_perfCounterProxyFactory = Mock.Create<IPerformanceCounterProxyFactory>();
-		}
+            _perfCounterProxyFactory = Mock.Create<IPerformanceCounterProxyFactory>();
+        }
 
-		[TearDown]
-		public void TearDown()
-		{
-			_compositeTestAgent.Dispose();
-		}
+        [TearDown]
+        public void TearDown()
+        {
+            _compositeTestAgent.Dispose();
+        }
 
-		/// <summary>
-		/// Ensures that the sampler calculates the values correctly.  Most are direct pass-through of the value
-		/// obtained from the windows perf counter, but some are deltas from prior value.
-		/// </summary>
-		[Test]
-		public void SamplerCalculatesValuesCorrectly()
-		{
-			const int expectedSampleCount = 2;
-			const float startVal = 3f;
-			const float deltaVal = 10f;
-			var lastPerfCounterValue = 0f;
-			var testPerfCounterValue = startVal;
+        /// <summary>
+        /// Ensures that the sampler calculates the values correctly.  Most are direct pass-through of the value
+        /// obtained from the windows perf counter, but some are deltas from prior value.
+        /// </summary>
+        [Test]
+        public void SamplerCalculatesValuesCorrectly()
+        {
+            const int expectedSampleCount = 2;
+            const float startVal = 3f;
+            const float deltaVal = 10f;
+            var lastPerfCounterValue = 0f;
+            var testPerfCounterValue = startVal;
 
-			//Create a mock proxy that allows us to return a specific value and ensure that the proxy factory returns this proxy.
-			var mockProxy = Mock.Create<IPerformanceCounterProxy>();
-			Mock.Arrange(() => mockProxy.NextValue())
-				.Returns(() => { return testPerfCounterValue; });
-						
-			Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>()))
-				.Returns(mockProxy);
+            //Create a mock proxy that allows us to return a specific value and ensure that the proxy factory returns this proxy.
+            var mockProxy = Mock.Create<IPerformanceCounterProxy>();
+            Mock.Arrange(() => mockProxy.NextValue())
+                .Returns(() => { return testPerfCounterValue; });
 
-			//Holds the results of the perf counter captures so that we may compare them as part of our assertions.
-			List<Dictionary<GCSampleType, float>> perfCounterValues = new List<Dictionary<GCSampleType, float>>();
+            Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns(mockProxy);
 
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+                .Returns("Test Value");
 
-			//Intercept the transform method so that we can collect the values that were sampled from the performance counters
-			var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
-			Mock.Arrange(() => gcSampleTransformer.Transform(Arg.IsAny<Dictionary<GCSampleType, float>>()))
-				.DoInstead<Dictionary<GCSampleType, float>>((sampleValues) => {
-					lastPerfCounterValue = testPerfCounterValue;
-					perfCounterValues.Add(sampleValues);
-					testPerfCounterValue += deltaVal;
-				});
-			
-			var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
-
-			//Act
-			sampler.Start();
-			_sampleAction();	//Collect Sample 1
-			_sampleAction();	//Collect Sample 2
-
-			//Assert
-			NrAssert.Multiple(
-				() => Assert.AreEqual(expectedSampleCount, perfCounterValues.Count, $"There should have been {expectedSampleCount} samples collected"),
-				() => Assert.AreEqual(_countSampleTypes, perfCounterValues[0].Count, $"There should be {_countSampleTypes} in the first sample"),
-				() => Assert.AreEqual(_countSampleTypes, perfCounterValues[1].Count, $"There should be {_countSampleTypes} in the second sample")
-			);
-
-			//Validate the sampled(calculated) value for each counter type.
-			foreach (var gcSampleType in perfCounterValues[0].Keys)
-			{
-				//For the first sample, all should have the same value
-				Assert.AreEqual(startVal, perfCounterValues[0][gcSampleType]);
-
-				//For the second sample...
-				switch (gcSampleType)
-				{
-					//...delta values should represent the size of the delta
-					case GCSampleType.Gen0CollectionCount:
-					case GCSampleType.Gen1CollectionCount:
-					case GCSampleType.Gen2CollectionCount:
-					case GCSampleType.InducedCount:
-						Assert.AreEqual(deltaVal, perfCounterValues[1][gcSampleType]);
-						break;
-
-					//...other measurements should be passed through with the perf counter value
-					default:
-						Assert.AreEqual(lastPerfCounterValue, perfCounterValues[1][gcSampleType]);
-						break;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Test to ensure that if a failure occurs while setting up a proxy to pull values from
-		/// performance counter, the setup process will continue, attempting to create other proxies
-		/// </summary>
-		[Test]
-		public void CreatePerfCounterSingleFailureContinuesToNext()
-		{
-			var countAttempts = 0;
-			var countFails = 0;
-			var countSuccess = 0;
-
-			//Create a mock proxies, one that fails and one that succeeds
-			var mockProxy = Mock.Create<IPerformanceCounterProxy>();
-
-			Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>()))
-				.Returns<string, string>((catName, perfCounterName) =>
-				 {
-					 if ((++countAttempts) % 2 == 0)
-					 {
-						 countSuccess++;
-						 return mockProxy;
-					 }
-					 else
-					 {
-						 countFails++;
-						 throw new Exception();
-					 }
-				 });
-
-			var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
-			var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
-
-			//Intercept the stop call for the scheduler to see if the sampler was shut down.
-			var stopWasCalled = false;
-
-			Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
-				.DoInstead(() => { stopWasCalled = true; });
-
-			//Act
-			Assert.DoesNotThrow(sampler.Start);
-			
-			//Assert
-			Assert.AreEqual(_countSampleTypes, countAttempts);
-			Assert.Greater(countFails, 0);
-			Assert.Greater(countSuccess, 0);
-			Assert.IsFalse(stopWasCalled);
-		}
-
-		/// <summary>
-		/// Test to ensure that if all proxies fail to be created, the Sampler is shut down
-		/// </summary>
-		[Test]
-		public void CreatePerfCounterAllFailuresShutsDownSampler()
-		{
-			var countAttempts = 0;
-
-			Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>()))
-				.Returns<string, string>((catName, perfCounterName) =>
-				{
-					countAttempts++;
-					throw new Exception();
-				});
+            //Holds the results of the perf counter captures so that we may compare them as part of our assertions.
+            List<Dictionary<GCSampleType, float>> perfCounterValues = new List<Dictionary<GCSampleType, float>>();
 
 
-			//Intercept the stop call for the scheduler to see if the sampler was shut down.
-			var stopWasCalled = false;
+            //Intercept the transform method so that we can collect the values that were sampled from the performance counters
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            Mock.Arrange(() => gcSampleTransformer.Transform(Arg.IsAny<Dictionary<GCSampleType, float>>()))
+                .DoInstead<Dictionary<GCSampleType, float>>((sampleValues) =>
+                {
+                    lastPerfCounterValue = testPerfCounterValue;
+                    perfCounterValues.Add(sampleValues);
+                    testPerfCounterValue += deltaVal;
+                });
 
-			Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
-				.DoInstead(() => { stopWasCalled = true; });
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
 
-			var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
-			var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+            //Act
+            sampler.Start();
+            _sampleAction();    //Collect Sample 1
+            _sampleAction();    //Collect Sample 2
 
-			//enabling the sampler will publish 3 configuration updated events which will in-turn,
-			//perform the start actions.   Reset our test values prior to manually trying to start
-			//the sampler
-			countAttempts = 0;
-			stopWasCalled = false;
-			
-			//Act
-			Assert.DoesNotThrow(sampler.Start);
+            //Assert
+            NrAssert.Multiple(
+                () => Assert.AreEqual(expectedSampleCount, perfCounterValues.Count, $"There should have been {expectedSampleCount} samples collected"),
+                () => Assert.AreEqual(_countSampleTypes, perfCounterValues[0].Count, $"There should be {_countSampleTypes} in the first sample"),
+                () => Assert.AreEqual(_countSampleTypes, perfCounterValues[1].Count, $"There should be {_countSampleTypes} in the second sample")
+            );
 
-			//Assert
-			Assert.AreEqual(_countSampleTypes, countAttempts);
-			Assert.IsTrue(stopWasCalled);
-		}
+            //Validate the sampled(calculated) value for each counter type.
+            foreach (var gcSampleType in perfCounterValues[0].Keys)
+            {
+                //For the first sample, all should have the same value
+                Assert.AreEqual(startVal, perfCounterValues[0][gcSampleType]);
 
-		/// <summary>
-		/// Test to ensure that if an exception is thrown when attempting to read 
-		/// the value of a performance counter, the Sampler is shut down
-		/// </summary>
-		[Test]
-		public void FailureOnSampleShutsDownSampler()
-		{
-			var countAttempts = 0;
+                //For the second sample...
+                switch (gcSampleType)
+                {
+                    //...delta values should represent the size of the delta
+                    case GCSampleType.Gen0CollectionCount:
+                    case GCSampleType.Gen1CollectionCount:
+                    case GCSampleType.Gen2CollectionCount:
+                    case GCSampleType.InducedCount:
+                        Assert.AreEqual(deltaVal, perfCounterValues[1][gcSampleType]);
+                        break;
 
-			//Create a mock proxy that throws an exception and that updates a counter
-			//of the number of times it was called.
-			var mockProxy = Mock.Create<IPerformanceCounterProxy>();
-			Mock.Arrange(() => mockProxy.NextValue())
-				.Returns(() =>
-				{
-					countAttempts++;
-					throw new Exception();
-				});
+                    //...other measurements should be passed through with the perf counter value
+                    default:
+                        Assert.AreEqual(lastPerfCounterValue, perfCounterValues[1][gcSampleType]);
+                        break;
+                }
+            }
+        }
 
-			Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>()))
-				.Returns(mockProxy);
+        /// <summary>
+        /// Test to ensure that if a failure occurs while setting up a proxy to pull values from
+        /// performance counter, the setup process will continue, attempting to create other proxies
+        /// </summary>
+        [Test]
+        public void CreatePerfCounterSingleFailureContinuesToNext()
+        {
+            var countAttempts = 0;
+            var countFails = 0;
+            var countSuccess = 0;
 
-			var gcSampleTransformer = Mock.Create<IGcSampleTransformer>(); 
-			var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+            //Create a mock proxies, one that fails and one that succeeds
+            var mockProxy = Mock.Create<IPerformanceCounterProxy>();
 
-			//Intercept the stop call for the scheduler to see if the sampler was shut down.
-			var stopWasCalled = false;
+            Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns<string, string>((catName, perfCounterName) =>
+                 {
+                     if ((++countAttempts) % 2 == 0)
+                     {
+                         countSuccess++;
+                         return mockProxy;
+                     }
+                     else
+                     {
+                         countFails++;
+                         throw new Exception();
+                     }
+                 });
 
-			Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
-				.DoInstead(() => { stopWasCalled = true; });
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+                .Returns("Test Value");
+
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+
+            //Intercept the stop call for the scheduler to see if the sampler was shut down.
+            var stopWasCalled = false;
+
+            Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead(() => { stopWasCalled = true; });
+
+            //Act
+            Assert.DoesNotThrow(sampler.Start);
+            Assert.DoesNotThrow(sampler.Sample);
+
+            //Assert
+            Assert.AreEqual(_countSampleTypes, countAttempts);
+            Assert.Greater(countFails, 0);
+            Assert.Greater(countSuccess, 0);
+            Assert.IsFalse(stopWasCalled);
+        }
+
+        [Test]
+        public void SamplingStopsAfterExceedConsecutiveFailureLimit()
+        {
+            var countAttempts = 0;
+
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+                .Returns<string>((catName) =>
+                {
+                    countAttempts++;
+                    if (countAttempts == 3)
+                    {
+                        return "Test Instance Name";
+                    }
+
+                    throw new Exception();
+                });
+
+            //Intercept the stop call for the scheduler to see if the sampler was shut down.
+            var stopWasCalled = false;
+
+            Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead(() => { stopWasCalled = true; });
+
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+
+            //enabling the sampler will publish 3 configuration updated events which will in-turn,
+            //perform the start actions.   Reset our test values prior to manually trying to start
+            //the sampler
+            countAttempts = 0;
+            stopWasCalled = false;
+
+            Assert.DoesNotThrow(sampler.Start);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //success
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());     //fail
+            Assert.IsTrue(stopWasCalled);
+        }
 
 
-			//Act
-			Assert.DoesNotThrow(sampler.Start);
-			Assert.DoesNotThrow(()=>_sampleAction());
 
-			//Assert
-			Assert.Greater(countAttempts, 0);
-			Assert.IsTrue(stopWasCalled);
-		}
+        /// <summary>
+        /// Test to ensure that if all proxies fail to be created, the Sampler is shut down
+        /// </summary>
+        [Test]
+        public void CreatePerfCounterAllFailuresShutsDownSampler()
+        {
+            var countAttempts = 0;
 
-		/// <summary>
-		/// Ensure that the performance counter proxies get disposed of when Stop() is called on the sampler
-		/// </summary>
-		[Test]
-		public void WhenSamplerIsStopped_PerfCounterProxiesAreDisposed()
-		{
-			var disposeAttempts = 0;
+            Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns<string, string>((catName, perfCounterName) =>
+                {
+                    countAttempts++;
+                    throw new Exception();
+                });
 
-			//Create a mock proxy that updates a counter
-			//of the number of times it is disposed.
-			var mockProxy = Mock.Create<IPerformanceCounterProxy>();
-			Mock.Arrange(() => mockProxy.Dispose()).DoInstead(() => disposeAttempts++);
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+           .Returns("Test Value");
 
-			Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>()))
-				.Returns(mockProxy);
+            //Intercept the stop call for the scheduler to see if the sampler was shut down.
+            var stopWasCalled = false;
 
-			var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
-			var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+            Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead(() => { stopWasCalled = true; });
 
-			//Act
-			sampler.Start();
-			sampler.Dispose(); // calls sampler.Stop()
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
 
-			//Assert
-			Assert.AreEqual(_countSampleTypes, disposeAttempts, "Perf counter proxies were not disposed when the GcSampler was stopped.");
-		}
-	}
+            //enabling the sampler will publish 3 configuration updated events which will in-turn,
+            //perform the start actions.   Reset our test values prior to manually trying to start
+            //the sampler
+            countAttempts = 0;
+            stopWasCalled = false;
+
+            //Act
+            Assert.DoesNotThrow(sampler.Start);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+
+            //Assert
+            Assert.AreEqual(_countSampleTypes * 5, countAttempts);
+            Assert.IsTrue(stopWasCalled);
+        }
+
+        /// <summary>
+        /// Test to ensure that if an exception is thrown when attempting to read 
+        /// the value of a performance counter, the Sampler is shut down
+        /// </summary>
+        [Test]
+        public void FailureOnSampleShutsDownSampler()
+        {
+            var countAttempts = 0;
+
+            //Create a mock proxy that throws an exception and that updates a counter
+            //of the number of times it was called.
+            var mockProxy = Mock.Create<IPerformanceCounterProxy>();
+            Mock.Arrange(() => mockProxy.NextValue())
+                .Returns(() =>
+                {
+                    countAttempts++;
+                    throw new Exception();
+                });
+
+            Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns(mockProxy);
+
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+                .Returns("Test Value");
+
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+
+            //Intercept the stop call for the scheduler to see if the sampler was shut down.
+            var stopWasCalled = false;
+
+            Mock.Arrange(() => _scheduler.StopExecuting(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead(() => { stopWasCalled = true; });
+
+
+            //Act
+            Assert.DoesNotThrow(sampler.Start);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+            Assert.IsFalse(stopWasCalled);
+            Assert.DoesNotThrow(() => _sampleAction());
+
+            //Assert
+            Assert.Greater(countAttempts, 0);
+            Assert.IsTrue(stopWasCalled);
+        }
+
+        /// <summary>
+        /// Ensure that the performance counter proxies get disposed of when Stop() is called on the sampler
+        /// </summary>
+        [Test]
+        public void WhenSamplerIsStopped_PerfCounterProxiesAreDisposed()
+        {
+            var disposeAttempts = 0;
+
+            //Create a mock proxy that updates a counter
+            //of the number of times it is disposed.
+            var mockProxy = Mock.Create<IPerformanceCounterProxy>();
+            Mock.Arrange(() => mockProxy.Dispose()).DoInstead(() => disposeAttempts++);
+
+            Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .Returns(mockProxy);
+
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+                .Returns("Test Value");
+
+            var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
+            var sampler = new GcSampler(_scheduler, gcSampleTransformer, _perfCounterProxyFactory);
+
+            //Act
+            sampler.Start();
+            sampler.Sample();
+            sampler.Dispose(); // calls sampler.Stop()
+
+            //Assert
+            Assert.AreEqual(_countSampleTypes, disposeAttempts, "Perf counter proxies were not disposed when the GcSampler was stopped.");
+        }
+    }
 }
 #endif

--- a/tests/Agent/UnitTests/CompositeTests/Samplers/GcSamplerTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/Samplers/GcSamplerTests.cs
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.Core.Samplers
             Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
                 .Returns(mockProxy);
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
                 .Returns("Test Value");
 
             //Holds the results of the perf counter captures so that we may compare them as part of our assertions.
@@ -170,7 +170,7 @@ namespace NewRelic.Agent.Core.Samplers
                      }
                  });
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
                 .Returns("Test Value");
 
             var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
@@ -198,7 +198,7 @@ namespace NewRelic.Agent.Core.Samplers
         {
             var countAttempts = 0;
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
                 .Returns<string>((catName) =>
                 {
                     countAttempts++;
@@ -261,7 +261,7 @@ namespace NewRelic.Agent.Core.Samplers
                     throw new Exception();
                 });
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
            .Returns("Test Value");
 
             //Intercept the stop call for the scheduler to see if the sampler was shut down.
@@ -318,7 +318,7 @@ namespace NewRelic.Agent.Core.Samplers
             Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
                 .Returns(mockProxy);
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
                 .Returns("Test Value");
 
             var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();
@@ -364,7 +364,7 @@ namespace NewRelic.Agent.Core.Samplers
             Mock.Arrange(() => _perfCounterProxyFactory.CreatePerformanceCounterProxy(Arg.IsAny<string>(), Arg.IsAny<string>(), Arg.IsAny<string>()))
                 .Returns(mockProxy);
 
-            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>()))
+            Mock.Arrange(() => _perfCounterProxyFactory.GetCurrentProcessInstanceNameForCategory(Arg.IsAny<string>(),Arg.IsAny<string>()))
                 .Returns("Test Value");
 
             var gcSampleTransformer = Mock.Create<IGcSampleTransformer>();

--- a/tests/NewRelic.Core.Tests/NewRelic.SystemInterfaces/PerformanceCounterProxyFactoryTests.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.SystemInterfaces/PerformanceCounterProxyFactoryTests.cs
@@ -61,8 +61,11 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 			GivenPerfCategoryHasTheseInstanceNames(instanceNameToIdMap.Keys.ToArray());
 			GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
 
+            var testCategoryName = GetTestCategoryName();
+
 			//Act
-			var performanceCounter = _factory.CreatePerformanceCounterProxy(GetTestCategoryName(), "mycounter");
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+			var performanceCounter = _factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName);
 			
 			//Assert
 			Assert.NotNull(performanceCounter);
@@ -74,7 +77,8 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 		{
 			const string currentProcessName = "myprocess";
 			const int currentProcessId = 1;
-			var instanceNameToIdMap = new Dictionary<string, int>
+
+            var instanceNameToIdMap = new Dictionary<string, int>
 			{
 				{ currentProcessName + "1", currentProcessId }
 			};
@@ -86,15 +90,18 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 			var newCatName1 = GetTestCategoryName();
 			var newCatName2 = GetTestCategoryName();
 
-			_factory.CreatePerformanceCounterProxy(newCatName1, "mycounter1");
-			_factory.CreatePerformanceCounterProxy(newCatName1, "mycounter2");
-			_factory.CreatePerformanceCounterProxy(newCatName2, "mycounter");
+            var processInstanceName1 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName1);
+            var processInstanceName2 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName2);
+
+            _factory.CreatePerformanceCounterProxy(newCatName1, "mycounter1", processInstanceName1);
+			_factory.CreatePerformanceCounterProxy(newCatName1, "mycounter2", processInstanceName1);
+			_factory.CreatePerformanceCounterProxy(newCatName2, "mycounter", processInstanceName2);
 
 			Assert.AreEqual(2, _instanceNameLookupCount);
 		}
 
 		[Test]
-		public void ShouldThrowExceptionIfInstanceNameIsNotFound()
+		public void ShouldThrowExceptionIfCreatePerfCounterWithEmptyInstanceName()
 		{
 			const string currentProcessName = "myprocess";
 			const int currentProcessId = 1;
@@ -108,11 +115,15 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 			GivenPerfCategoryHasTheseInstanceNames(instanceNameToIdMap.Keys.ToArray());
 			GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
 
-			Assert.Throws<Exception>(() => _factory.CreatePerformanceCounterProxy(GetTestCategoryName(), "mycounter"));
+            var testCategoryName = GetTestCategoryName();
+
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+
+            Assert.Throws<ArgumentException>(() => _factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
 		}
 
 		[Test]
-		public void ShouldThrowExceptionIfProcessPerformanceCounterCannotOpen()
+		public void ShouldReturnNullIfCannotObtainPerfCounterInstanceName()
 		{
 			const string currentProcessName = "myprocess";
 			const int currentProcessId = 1;
@@ -126,24 +137,73 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 			GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
 			_createProcessIdPerformanceCounter = (_, __, ___) => throw new Exception("Cannot create process performance counter.");
 
-			Assert.Throws<Exception>(() => _factory.CreatePerformanceCounterProxy(GetTestCategoryName(), "mycounter"));
+            var testCategoryName = GetTestCategoryName();
+
+            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
 		}
 
-		[Test]
-		public void ShouldThrowExceptionIfNoInstanceNamesMatchTheProcessName()
+        [Test]
+        public void ShouldThrowIfObtainPerfCounterInstanceNameIsUnauthorized()
+        {
+            const string currentProcessName = "myprocess";
+            const int currentProcessId = 1;
+            var instanceNameToIdMap = new Dictionary<string, int>
+            {
+                { currentProcessName + "1", currentProcessId }
+            };
+
+            GivenCurrentProcessHasThisNameAndId(currentProcessName, currentProcessId);
+            GivenPerfCategoryHasTheseInstanceNames(instanceNameToIdMap.Keys.ToArray());
+            GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
+            _createProcessIdPerformanceCounter = (_, __, ___) => throw new UnauthorizedAccessException("Cannot create process performance counter.");
+
+            var testCategoryName = GetTestCategoryName();
+
+            Assert.Throws<UnauthorizedAccessException>(()=>_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
+
+            //Assert.Throws<UnauthorizedAccessException>(()=>_factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
+        }
+
+        [Test]
+        public void ShouldThrowIfObtainPerfCounterProxyIsUnauthorized()
+        {
+            const string currentProcessName = "myprocess";
+            const int currentProcessId = 1;
+            var instanceNameToIdMap = new Dictionary<string, int>
+            {
+                { currentProcessName + "1", currentProcessId }
+            };
+
+            GivenCurrentProcessHasThisNameAndId(currentProcessName, currentProcessId);
+            GivenPerfCategoryHasTheseInstanceNames(instanceNameToIdMap.Keys.ToArray());
+            GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
+            _createPerformanceCounter = (_, __, ___) => throw new UnauthorizedAccessException("Test Unauthorized Access");
+
+            var testCategoryName = GetTestCategoryName();
+
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+
+            Assert.Throws<UnauthorizedAccessException>(()=>_factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
+        }
+
+
+        [Test]
+		public void ShouldReturnNullIfNoInstanceNamesMatchTheProcessName()
 		{
 			const string currentProcessName = "myprocess";
 			const int currentProcessId = 1;
 			var instanceNameToIdMap = new Dictionary<string, int>
 			{
-				{ "p1", currentProcessId }
+				{ "p1", 2 }
 			};
 
 			GivenCurrentProcessHasThisNameAndId(currentProcessName, currentProcessId);
 			GivenPerfCategoryHasTheseInstanceNames(instanceNameToIdMap.Keys.ToArray());
 			GivenPerfCategoryHasTheseProcessPerformanceCounters(instanceNameToIdMap);
 
-			Assert.Throws<Exception>(() => _factory.CreatePerformanceCounterProxy(GetTestCategoryName(), "mycounter"));
+            var testCategoryName = GetTestCategoryName();
+
+            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
 		}
 
 		private void GivenCurrentProcessHasThisNameAndId(string processName, int processId)

--- a/tests/NewRelic.Core.Tests/NewRelic.SystemInterfaces/PerformanceCounterProxyFactoryTests.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.SystemInterfaces/PerformanceCounterProxyFactoryTests.cs
@@ -64,7 +64,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
             var testCategoryName = GetTestCategoryName();
 
 			//Act
-            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null);
 			var performanceCounter = _factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName);
 			
 			//Assert
@@ -90,8 +90,8 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 			var newCatName1 = GetTestCategoryName();
 			var newCatName2 = GetTestCategoryName();
 
-            var processInstanceName1 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName1);
-            var processInstanceName2 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName2);
+            var processInstanceName1 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName1, null);
+            var processInstanceName2 = _factory.GetCurrentProcessInstanceNameForCategory(newCatName2, null);
 
             _factory.CreatePerformanceCounterProxy(newCatName1, "mycounter1", processInstanceName1);
 			_factory.CreatePerformanceCounterProxy(newCatName1, "mycounter2", processInstanceName1);
@@ -117,7 +117,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 
             var testCategoryName = GetTestCategoryName();
 
-            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null);
 
             Assert.Throws<ArgumentException>(() => _factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
 		}
@@ -139,7 +139,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 
             var testCategoryName = GetTestCategoryName();
 
-            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
+            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null));
 		}
 
         [Test]
@@ -159,7 +159,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 
             var testCategoryName = GetTestCategoryName();
 
-            Assert.Throws<UnauthorizedAccessException>(()=>_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
+            Assert.Throws<UnauthorizedAccessException>(()=>_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null));
 
             //Assert.Throws<UnauthorizedAccessException>(()=>_factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
         }
@@ -181,7 +181,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 
             var testCategoryName = GetTestCategoryName();
 
-            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName);
+            var processInstanceName = _factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null);
 
             Assert.Throws<UnauthorizedAccessException>(()=>_factory.CreatePerformanceCounterProxy(testCategoryName, "mycounter", processInstanceName));
         }
@@ -203,7 +203,7 @@ namespace NewRelic.Core.Tests.NewRelic.SystemInterfaces
 
             var testCategoryName = GetTestCategoryName();
 
-            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName));
+            Assert.IsNull(_factory.GetCurrentProcessInstanceNameForCategory(testCategoryName, null));
 		}
 
 		private void GivenCurrentProcessHasThisNameAndId(string processName, int processId)


### PR DESCRIPTION
## Summary
Redesigns the GC Sampler for Windows to account for missing performance counters and performance counter instance name changes.

## Details
* **Performance Counter Instance Name can change during the lifetime of the application**
    * Removes caching of this value and pulls it once for every sampling cycle.
    * When Performance Counter Instance Name Changes, recreate performance counters and dispose the old ones.
    * Because a race condition can occur where the instance name changes between the time it is captured and the time the values are collected, the GC Sampler is more resilient when failures occur.  Allows up to 5 consecutive failures before shutting down.

* **Reverse lookup using PID to obtain Performance Counter Instance Name will not work until a GC has been reported**
    * Attempts to obtain the instance name every sample cycle (1x/min).
    * If not able to obtain a perf counter instance name, abort the sampling cycle, but do not shut down sampler.  Allows a 60-second delay before trying again.
    * Exception:  If an instance name had been previously captured and now the name is not available, shut down the sampler, something else is going wrong.

* Modifies Logging to be more consistent.
* Ensures that all possible `UnauthorizedAccessExceptions` will shut down the sampler.

## Links
Issue #56 - GC Perf Counters assumes Instance Name is static.
Issue #60 - GC Perf Counters Unable to obtain Instance Name until 1st GC has occurred.

## Proposed Release Notes
Fixes
* **Garbage Collection Performance Metrics for Windows** <br/>
Fixes an issue where Garbage Collection Performance Metrics may not be reported for Windows Applications
