### PR TITLE
Generates `error.expected` attribute for Error Event, Error Trace and Span Event

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -45,6 +45,8 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> DbStatement { get; }
         AttributeDefinition<string, string> DistributedTraceId { get; }
         AttributeDefinition<TimeSpan, double> Duration { get; }
+        AttributeDefinition<bool, bool> IsErrorExpected { get;}
+        AttributeDefinition<bool, bool> SpanIsErrorExpected { get; }
         AttributeDefinition<string, string> ErrorClass { get; }
         AttributeDefinition<string, string> ErrorDotMessage { get; }
         AttributeDefinition<string, string> ErrorMessage { get; }
@@ -503,10 +505,22 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.TransactionEvent)
                 .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _isError;       //Error Attribute				
+        private AttributeDefinition<bool, bool> _isError;       //Error Attribute
         public AttributeDefinition<bool, bool> IsError => _isError ?? (_isError =
             AttributeDefinitionBuilder.CreateBool("error", AttributeClassification.Intrinsics)
                 .AppliesTo(AttributeDestinations.TransactionEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<bool, bool> _isErrorExpected;
+        public AttributeDefinition<bool, bool> IsErrorExpected => _isErrorExpected ?? (_isErrorExpected =
+            AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.Intrinsics)
+                .AppliesTo(AttributeDestinations.ErrorTrace, AttributeDestinations.ErrorEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<bool, bool> _spanIsErrorExpected;
+        public AttributeDefinition<bool, bool> SpanIsErrorExpected => _spanIsErrorExpected ?? (_spanIsErrorExpected =
+            AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 
         private AttributeDefinition<DateTime, long> _timestamp;

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -231,6 +231,11 @@ namespace NewRelic.Agent.Core.Segments
             {
                 AttribDefs.SpanErrorClass.TrySetValue(attribValues, ErrorData.ErrorTypeName);
                 AttribDefs.SpanErrorMessage.TrySetValue(attribValues, ErrorData.ErrorMessage);
+
+                if (ErrorData.IsExpected)
+                {
+                    AttribDefs.SpanIsErrorExpected.TrySetValue(attribValues, ErrorData.IsExpected);
+                }
             }
 
             Data.SetSpanTypeSpecificAttributes(attribValues);

--- a/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
@@ -71,6 +71,10 @@ namespace NewRelic.Agent.Core.Spans
             {
                 _attribDefs.SpanErrorClass.TrySetValue(spanAttributes, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.ErrorTypeName);
                 _attribDefs.SpanErrorMessage.TrySetValue(spanAttributes, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.ErrorMessage);
+                if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.IsExpected)
+                {
+                    _attribDefs.SpanIsErrorExpected.TrySetValue(spanAttributes, true);
+                }
             }
 
             _attribDefs.Guid.TrySetValue(spanAttributes, rootSpanId);

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -99,6 +99,11 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 _attribDefs.ErrorDotMessage.TrySetValue(attribValues, errorData.ErrorMessage);
                 _attribDefs.IsError.TrySetValue(attribValues, true);
                 _attribDefs.ErrorEventSpanId.TrySetValue(attribValues, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorDataSpanId);
+
+                if (errorData.IsExpected)
+                {
+                    _attribDefs.IsErrorExpected.TrySetValue(attribValues, true);
+                }
             }
 
             var isCatParticipant = IsCatParticipant(immutableTransaction);

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -376,7 +376,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
         }
 
         [TestCase(true)]
-        [TestCase(true)]
+        [TestCase(false)]
         public void GetSpanEvent_Generates_ExpecedErrorAttribute(bool hasExpectedError)
         {
             // ARRANGE
@@ -394,15 +394,20 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             // ACT
             var spanEvents = _spanEventMaker.GetSpanEvents(immutableTransaction, TransactionName, transactionAttributes).ToList();
             var rootSpanEvent = spanEvents[0];
+            var spanEvent = spanEvents[1];
 
             // ASSERT
             if (hasExpectedError)
             {
                 CollectionAssert.Contains(rootSpanEvent.AgentAttributes().Keys, "error.expected");
+                Assert.AreEqual(true, rootSpanEvent.AgentAttributes()["error.expected"]);
+                CollectionAssert.Contains(spanEvent.AgentAttributes().Keys, "error.expected");
+                Assert.AreEqual(true, spanEvent.AgentAttributes()["error.expected"]);
             }
             else
             {
                 CollectionAssert.DoesNotContain(rootSpanEvent.AgentAttributes().Keys, "error.expected");
+                CollectionAssert.DoesNotContain(spanEvent.AgentAttributes().Keys, "error.expected");
             }
         }
 


### PR DESCRIPTION
## Summary

Generates `error.expected` attribute for Error Events, Error Traces and Span Events

## Details
Generates `error.expected` intrinsic attribute for Error Events and Error Traces if error is expected.
Generates `error.expected` agent attribute for Span Events if error is expected.

## Links

<!--
Any relevant links that will help reviewers.
-->

## Proposed Release Notes

<!--
Proposed test of release notes, if applicable.
-->

