### PR TITLE
Fixes the expectedStatusCodes configuration

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -3855,7 +3855,7 @@ namespace NewRelic.Agent.Core.Config
         
         private List<configurationErrorCollectorErrorClass> expectedMessagesField;
         
-        private configurationErrorCollectorExpectedStatusCodes expectedStatusCodesField;
+        private string expectedStatusCodesField;
         
         private configurationErrorCollectorAttributes attributesField;
         
@@ -3873,7 +3873,6 @@ namespace NewRelic.Agent.Core.Config
         public configurationErrorCollector()
         {
             this.attributesField = new configurationErrorCollectorAttributes();
-            this.expectedStatusCodesField = new configurationErrorCollectorExpectedStatusCodes();
             this.expectedMessagesField = new List<configurationErrorCollectorErrorClass>();
             this.expectedClassesField = new configurationErrorCollectorExpectedClasses();
             this.ignoreStatusCodesField = new configurationErrorCollectorIgnoreStatusCodes();
@@ -3932,7 +3931,7 @@ namespace NewRelic.Agent.Core.Config
             }
         }
         
-        public configurationErrorCollectorExpectedStatusCodes expectedStatusCodes
+        public string expectedStatusCodes
         {
             get
             {
@@ -4220,47 +4219,6 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationErrorCollectorErrorClass Clone()
         {
             return ((configurationErrorCollectorErrorClass)(this.MemberwiseClone()));
-        }
-        #endregion
-    }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
-    [System.SerializableAttribute()]
-    [System.ComponentModel.DesignerCategoryAttribute("code")]
-    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
-    public partial class configurationErrorCollectorExpectedStatusCodes
-    {
-        
-        private List<float> codeField;
-        
-        /// <summary>
-        /// configurationErrorCollectorExpectedStatusCodes class constructor
-        /// </summary>
-        public configurationErrorCollectorExpectedStatusCodes()
-        {
-            this.codeField = new List<float>();
-        }
-        
-        [System.Xml.Serialization.XmlElementAttribute("code")]
-        public List<float> code
-        {
-            get
-            {
-                return this.codeField;
-            }
-            set
-            {
-                this.codeField = value;
-            }
-        }
-        
-        #region Clone method
-        /// <summary>
-        /// Create a clone of this configurationErrorCollectorExpectedStatusCodes object
-        /// </summary>
-        public virtual configurationErrorCollectorExpectedStatusCodes Clone()
-        {
-            return ((configurationErrorCollectorExpectedStatusCodes)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1291,25 +1291,12 @@
                   </xs:complexType>
               </xs:element>
 
-              <xs:element name="expectedStatusCodes">
-                  <xs:complexType>
-                      <xs:annotation>
-                          <xs:documentation>
-                              A comma separated list of status codes to be marked as expected.
-                          </xs:documentation>
-                      </xs:annotation>
-  
-                      <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                          <xs:element name="code" type="xs:float">
-                              <xs:annotation>
-                                  <xs:documentation>
-                                      You may use standard integral HTTP errorcodes, such as just 401, or may use Microsoft FullStatusCodes, with decimal points, such as 401.4 or 403.18.
-                                  </xs:documentation>
-                              </xs:annotation>
-                          </xs:element>
-                      </xs:sequence>
-  
-                  </xs:complexType>
+              <xs:element name="expectedStatusCodes" minOccurs="0" maxOccurs="1" type="xs:string">
+                  <xs:annotation>
+                      <xs:documentation>
+                              A comma separated list of status codes to be marked as expected. You may use standard integral HTTP errorcodes, such as just 401, or may use Microsoft FullStatusCodes, with decimal points, such as 401.4 or 403.18.
+                      </xs:documentation>
+                  </xs:annotation>
               </xs:element>
 
               <xs:element name="attributes" minOccurs="0" maxOccurs="1">

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1173,31 +1173,12 @@ namespace NewRelic.Agent.Core.Configuration
                 }
             }
 
-            var localStatusCodesToIgnore = new List<string>();
-
-            foreach (var localCode in _localConfiguration.errorCollector.expectedStatusCodes.code)
-            {
-                localStatusCodesToIgnore.Add(localCode.ToString(CultureInfo.InvariantCulture));
-            }
-
-            var expectedStatusCodes = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes, localStatusCodesToIgnore);
-
-            foreach (var statusCode in expectedStatusCodes)
-            {
-                if (expectedErrorInfo.ContainsKey(statusCode))
-                {
-                    Log.Warn($"{statusCode} status code is already specified once in the errorCollector.expectedStatusCodes configuration.");
-                }
-                else
-                {
-                    expectedErrorInfo.Add(statusCode, Enumerable.Empty<string>());
-                }
-            }
+            var expectedStatusCodes = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes, _localConfiguration.errorCollector.expectedStatusCodes);
 
             ExpectedErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
             ExpectedErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedMessages);
             ExpectedErrorClassesForAgentSettings = expectedClasses;
-            ExpectedErrorStatusCodesForAgentSettings = string.Join(",", expectedStatusCodes);
+            ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodes;
         }
 
         public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; private set; }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
@@ -206,7 +206,7 @@ namespace NewRelic.Agent.Core.Configuration
             public IEnumerable<KeyValuePair<string, IEnumerable<string>>> ErrorCollectorExpectedMessages { get; set; }
 
             [JsonProperty("error_collector.expected_status_codes")]
-            public IEnumerable<string> ErrorCollectorExpectedStatusCodes { get; set; }
+            public string ErrorCollectorExpectedStatusCodes { get; set; }
 
             [JsonProperty("ignored_params")]
             public IEnumerable<string> ParametersToIgnore { get; set; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -895,9 +895,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         <errorClass>ErrorClass1</errorClass>
         <errorClass>ErrorClass2</errorClass>
     </expectedClasses>
-    <expectedStatusCodes>
-        <code>404</code>
-    </expectedStatusCodes>
+    <expectedStatusCodes>404,500</expectedStatusCodes>
     <expectedMessages>
         <errorClass name=""ErrorClass2"">
             <message>error message 1 in ErrorClass2</message>
@@ -920,7 +918,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             _defaultConfig = new TestableDefaultConfiguration(_environment, localConfiguration, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
-            Assert.That(_defaultConfig.ExpectedErrorsConfiguration.ContainsKey("404"));
+            Assert.That(_defaultConfig.ExpectedErrorStatusCodesForAgentSettings == "404,500");
 
             var expectedMessages = _defaultConfig.ExpectedErrorsConfiguration;
 
@@ -949,16 +947,16 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.ExpectedErrorsConfiguration.FirstOrDefault().Key;
         }
 
-        [TestCase(new[] { 401f }, new[] { "405" }, ExpectedResult = "405")]
-        [TestCase(new[] { 401f }, null, ExpectedResult = "401")]
-        public string ExpectedStatusCodesSetFromLocalAndServerOverrides(float[] local, string[] server)
+        [TestCase( "401", "405", ExpectedResult = "405")]
+        [TestCase( "401", null, ExpectedResult = "401")]
+        public string ExpectedStatusCodesSetFromLocalAndServerOverrides(string local, string server)
         {
             _serverConfig.RpmConfig.ErrorCollectorExpectedStatusCodes = server;
-            _localConfig.errorCollector.expectedStatusCodes.code = new List<float>(local);
+            _localConfig.errorCollector.expectedStatusCodes = (local);
 
             CreateDefaultConfiguration();
 
-            return _defaultConfig.ExpectedErrorsConfiguration.Keys.FirstOrDefault();
+            return _defaultConfig.ExpectedErrorStatusCodesForAgentSettings;
         }
 
         [TestCase(true, ExpectedResult = "server")]
@@ -986,7 +984,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [Test]
         public void ExpectedErrorSettingsForAgentSettingsReportedCorrectly()
         {
-            _localConfig.errorCollector.expectedStatusCodes.code = new List<float> { 404, 500 };
+            _localConfig.errorCollector.expectedStatusCodes = "404,500";
             _localConfig.errorCollector.expectedClasses.errorClass = new List<string> { "ErrorClass1", "ErrorClass2" };
             _localConfig.errorCollector.expectedMessages = new List<configurationErrorCollectorErrorClass>
             {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry should be included.
-->

## Summary

`expectedStatusCodes` configuration should accept a comma separated list of status codes string. The current implementation made it to accept a list of individual status codes. 
## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Proposed Release Notes

<!--
Proposed test of release notes, if applicable.
-->

