### PR TITLE
Add repository documentation for net35 branch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+### Hello! We're glad you've joined us. 
+
+We believe participation in our community should be a harassment free experience for everyone. 
+
+Learn more about our guidelines and principles by reading our [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) on our Open Source Website.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Before submitting an Issue, please search for similar ones in the
 
 ### Version Support
 
-When contributing, please keep in mind that New Relic customers (that's you!) are running many different versions of .NET, some of them pretty old. Changes that depend on the newest version of .NET Framework or Core will probably be rejected, especially if they replace something backwards compatible.  Code in `src/Agent` or `src/NewRelic.Core` needs to be compatible with .NET Framework 3.5.  Backwards compatibility is less important for code that lives in `tests`, but still should not gratuitously require features only available in the latest .NET Framework or Core.
+When contributing, please keep in mind that New Relic customers (that's you!) are running many different versions of .NET, some of them pretty old. Changes that depend on the newest version of .NET Framework or Core will probably be rejected, especially if they replace something backwards compatible.  Code in `src/Agent` needs to be compatible with .NET Framework 3.5.  Backwards compatibility is less important for code that lives in `tests`, but still should not gratuitously require features only available in the latest .NET Framework or Core.
 
 Be aware that the instrumentation needs to work with a wide range of versions of the instrumented modules, and that code that looks nonsensical or overcomplicated may be that way for compatibility-related reasons. Read all the comments and check the related tests before deciding whether existing code is incorrect.
 
@@ -38,7 +38,7 @@ This project is licensed under the Apache-2.0 license.  Any third party librarie
 
 ### Coding Style Guidelines
 
-Our repository includes an [.editorconfig](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/.editorconfig) which will be used automatically by Visual Studio to maintain consistent code formatting.
+Our repository includes an [.editorconfig](/.editorconfig) which will be used automatically by Visual Studio to maintain consistent code formatting.
 
 #### Variable naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+## Contributing to the net35/main branch
+
+This branch is maintained for backwards compatibility with .NET Framework 3.5 and corresponds to the 6.x agent release version line.  It gets security patches and critical bug fixes, but no new features.  If you believe you have found a security flaw in this branch of the agent, please see the section about vulnerabilities in our top-level [README](./README.md).
+
+Contributions are always welcome. Before contributing please read the
+[code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](../../issues); your issue may have already been discussed or fixed in `main`. To contribute,
+[fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
+
+Note that our [code of conduct](./CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
+
+## Feature Requests
+
+**Note**: since this is a maintenance branch, it is unlikely that we will prioritize any feature requests on this branch. 
+
+Feature requests should be submitted in the [Issue tracker](../../issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](../../issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
+Before submitting an Issue, please search for similar ones in the
+[closed issues](../../issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+
+## Pull Requests
+
+**Note**: in order to enable the correct CI to run on PRs into `net35/main`, add the `net35` tag to the PR after submitting it in GitHub.
+
+### Version Support
+
+When contributing, please keep in mind that New Relic customers (that's you!) are running many different versions of .NET, some of them pretty old. Changes that depend on the newest version of .NET Framework or Core will probably be rejected, especially if they replace something backwards compatible.  Code in `src/Agent` or `src/NewRelic.Core` needs to be compatible with .NET Framework 3.5.  Backwards compatibility is less important for code that lives in `tests`, but still should not gratuitously require features only available in the latest .NET Framework or Core.
+
+Be aware that the instrumentation needs to work with a wide range of versions of the instrumented modules, and that code that looks nonsensical or overcomplicated may be that way for compatibility-related reasons. Read all the comments and check the related tests before deciding whether existing code is incorrect.
+
+If you’re planning on contributing a new feature or an otherwise complex contribution, we kindly ask you to start a conversation with the maintainer team by opening up a GitHub issue first.
+
+### General Guidelines
+
+A primary goal of the agent is to adhere to the Hippocratic oath for the applications it instruments: “first, do no harm”.  The code in the agent will execute inside the process space of our customers’ applications and must not crash them, destabilize them, change their behavior, or significantly degrade their performance.  Another important consideration is that the data the agent gathers must not leak any personally identifying information (PII) from customer apps, e.g. usernames or credit card numbers.
+
+This project is licensed under the Apache-2.0 license.  Any third party libraries added as dependencies of the project must have a similarly permissive open source license, e.g. MIT.
+
+### Coding Style Guidelines
+
+Our repository includes an [.editorconfig](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/.editorconfig) which will be used automatically by Visual Studio to maintain consistent code formatting.
+
+#### Variable naming conventions
+
+| Format      | Use For | Example |
+| ----------- | ------- | ------- |
+| PascalCase  | Constant fields, public class level fields | `private const string MyConst = "NewRelic";` |
+| camelCase  | Local variables (note: we prefer the use of the `var` implicit definition keyword whenever possible) | `var myId = 12345;` |
+| _camelcase  | Private class-level fields, including static and/or read-only | `private int _myId;` |
+
+#### Class naming conventions
+
+- All class names should be written in PascalCase and should be singular, e.g. `TransactionName`.  If it is a collection, it should be pluralized e.g. `TransactionNames`.  Code files can contain multiple classes if the classes are tightly coupled, but this should be rare.
+- All class declarations should have access modifiers.
+
+#### Interface naming conventions
+
+- All interfaces names should be written in PascalCase and prefixed with the letter "I", e.g. `ITransactionName`.
+
+#### Method naming conventions
+
+- Methods should be named using PascalCase and parameters should be named using camelCase, e.g `private string GetUserNameFromId(int userId)`.
+
+#### Class file layout
+
+- The preferred order of declarations within a class is:
+  - Fields
+  - Properties
+  - Methods (with constructors grouped at the beginning)
+  - Events
+
+### Testing Guidelines
+
+See our [development](/docs/development.md) and [integration testing](/docs/integration-tests.md) documentation to run tests, including required setup steps.
+
+For most contributions it is strongly recommended to add additional tests which exercise your changes. This helps us efficiently incorporate your changes into our mainline codebase and provides a safeguard that your change won't be broken by future development. Because of this, we require that all changes come with tests. You are welcome to submit pull requests with untested changes, but they won't be merged until you or the development team have an opportunity to write tests for them.
+
+There are some rare cases where code changes do not result in changed functionality (e.g. a performance optimization) and new tests are not required. In general, including tests with your pull request dramatically increases the chances it will be accepted.
+
+Integration tests are used to test the functionality of [agent instrumentation](/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper).  PRs that add or modify instrumentation should include new or updated integration tests.
+
+## Contributor License Agreement
+
+Keep in mind that when you submit your Pull Request, you'll need to sign the CLA via the click-through using CLA-Assistant. If you'd like to execute our corporate CLA, or if you have any questions, please drop us an email at opensource@newrelic.com.
+
+For more information about CLAs, please check out Alex Russell’s excellent post,
+[“Why Do I Need to Sign This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
+
+## Slack
+
+We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic.  If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace.  To request access, see https://newrelicusers-signup.herokuapp.com/.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,64 @@
 
 # New Relic Monitoring for .NET
 
-You are viewing a previous version of the New Relic .NET agent repository. While the code here should be buildable, it may require some manual modifications or additional tooling in order to do so. This previous version is primarily for reference purposes.
+#### .NET Agent
+New Relic's .NET agent monitors your .NET app, giving you an end-to-end view of your app's performance. It works with all .NET compatible languages, such as C#, VB.NET and CLI.
+
+Note: this branch, `net35/main`, is maintained for backwards compatibility with .NET Framework 3.5 and corresponds to the 6.x versions of the New Relic .NET agent.  It primarily only recieves security patches and critical bug fixes.
 
 ## Support
 
-New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorers Hub. You can find this project's topic/threads here:
+## Installation
 
-https://discuss.newrelic.com/c/support-products-agents/net-agent
+See our [agent installation documentation](https://docs.newrelic.com/docs/agents/net-agent/installation/introduction-net-agent-install).
+
+## Getting Started
+
+* See our [introduction to New Relic for .NET](https://docs.newrelic.com/docs/agents/net-agent/getting-started/introduction-new-relic-net) to learn how to use the .NET agent with your application.
+* See our [changelog](src/Agent/CHANGELOG.md) for release notes.
+
+## Building and Testing
+
+Get started by reviewing our instructions for how to [build and test](docs/development.md).
+
+## Support
+
+Should you need assistance with New Relic products, you are in good hands with several support diagnostic tools and support channels.
+
+This [troubleshooting framework](https://discuss.newrelic.com/t/troubleshooting-frameworks/108787) steps you through common troubleshooting questions. 
+
+New Relic offers NRDiag, [a client-side diagnostic utility](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) that automatically detects common problems with New Relic agents. If NRDiag detects a problem, it suggests troubleshooting steps. NRDiag can also automatically attach troubleshooting data to a New Relic Support ticket.
+
+If the issue has been confirmed as a bug or is a Feature request, please file a Github issue.
+
+**Support Channels**
+
+* [New Relic Documentation](https://docs.newrelic.com/docs/agents/net-agent): Comprehensive guidance for using our agent
+* [New Relic Community](https://discuss.newrelic.com/c/support-products-agents/net-agent): The best place to engage in troubleshooting questions
+* [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
+* [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
+* [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 
+
+## Privacy
+At New Relic we take your privacy and the security of your information seriously, and are committed to protecting your information. We must emphasize the importance of not sharing personal data in public forums, and ask all users to scrub logs and diagnostic information for sensitive information, whether personal, proprietary, or otherwise.
+
+We define “Personal Data” as any information relating to an identified or identifiable individual, including, for example, your name, phone number, post code or zip code, Device ID, IP address and email address.
+
+Please review [New Relic’s General Data Privacy Notice](https://newrelic.com/termsandconditions/privacy) for more information.
+
+## Roadmap
+
+The `net35/main` branch of this repository corresponds to the 6.x release version line, which is maintained for backwards compatibility with .NET Framework 3.5 and only receives security patches and critical bug fixes.  As such, there is no roadmap for this branch.
 
 ## Contributing
 We encourage your contributions to improve New Relic's .NET monitoring products! Keep in mind that when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
 To execute our corporate CLA, which is required if your contribution is on behalf of a company, or if you have any questions, please drop us an email at open-source@newrelic.com.
+
+**A note about vulnerabilities**
+
+As noted in our [security policy](https://github.com/newrelic/.github/blob/master/SECURITY.md), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
+
+If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
 
 ## License
 The .NET Agent is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 #### .NET Agent
 New Relic's .NET agent monitors your .NET app, giving you an end-to-end view of your app's performance. It works with all .NET compatible languages, such as C#, VB.NET and CLI.
 
-Note: this branch, `net35/main`, is maintained for backwards compatibility with .NET Framework 3.5 and corresponds to the 6.x versions of the New Relic .NET agent.  It primarily only recieves security patches and critical bug fixes.
+Note: this branch, `net35/main`, is maintained for backwards compatibility with .NET Framework 3.5 and corresponds to the 6.x versions of the New Relic .NET agent.  It primarily receives security patches and critical bug fixes.
 
 ## Support
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
+
+* **The .NET Agent is now open source!** <br/>
+The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
+
 ### Fixes
 
 ## [6.25]


### PR DESCRIPTION
This adds and/or updates some of the standard repository documentation assets to the net35/main branch:

* Add CONTRIBUTING.md
  * This has been modified from the main branch version to call out specific guidelines for this branch.
* Add CODE_OF_CONDUCT.md
* Modify README.md to match the version from the `main` branch, except for places where it calls out specific details of this branch, such as the lack of a roadmap.
