### PR TITLE
Add/update license in nuspec files to be Apache-2.0

### DIFF
--- a/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
+++ b/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
@@ -6,6 +6,7 @@
     <title>NewRelic.Agent.Api</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://docs.newrelic.com/docs/agents/net-agent/features/net-agent-api</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
+++ b/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
@@ -6,7 +6,7 @@
     <title>New Relic x64 for Windows Azure</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
-    <licenseUrl>http://newrelic.com/terms</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/newrelic/nuget-azure-cloud-services</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
@@ -6,6 +6,7 @@
     <title>New Relic for Windows Azure Web Sites (x64)</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://newrelic.com/windowsazure</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
@@ -6,6 +6,7 @@
     <title>New Relic for Windows Azure Web Sites (x86)</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://newrelic.com/windowsazure</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/build/Packaging/ScriptableInstaller/NewRelic.Net.Agent.nuspec
+++ b/build/Packaging/ScriptableInstaller/NewRelic.Net.Agent.nuspec
@@ -6,6 +6,7 @@
     <title>New Relic .NET Agent</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://newrelic.com/.NET</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/build/Packaging/ScriptableInstaller/NewRelic.Net.Agent.x64.nuspec
+++ b/build/Packaging/ScriptableInstaller/NewRelic.Net.Agent.x64.nuspec
@@ -6,6 +6,7 @@
     <title>New Relic .NET Agent (x64)</title>
     <authors>New Relic</authors>
     <owners>New Relic</owners>
+    <license type="expression">Apache-2.0</license>
     <projectUrl>https://newrelic.com/.NET</projectUrl>
     <iconUrl>http://newrelic.com/images/avatar-newrelic.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Update the `license` element of .nuspec files on the `net35/main` branch to be Apache-2.0.
