### PR TITLE
Use StringComparison.OrdinalIgnoreCase for case-insensitive searches

### DIFF
--- a/src/Agent/NewRelic/Agent/Parsing/SqlWrapperHelper.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlWrapperHelper.cs
@@ -72,20 +72,19 @@ namespace NewRelic.Parsing
         /// <returns></returns>
         private static DatastoreVendor ExtractVendorNameFromString(string text)
         {
-            text = text.ToLowerInvariant();
-            if (text.Contains("SQL Server".ToLowerInvariant()) || text.Contains("SQLServer".ToLowerInvariant()))
+            if (text.IndexOf("SQL Server", StringComparison.OrdinalIgnoreCase) != -1 || text.IndexOf("SQLServer", StringComparison.OrdinalIgnoreCase) != -1)
                 return DatastoreVendor.MSSQL;
 
-            if (text.Contains("MySql".ToLowerInvariant()))
+            if (text.IndexOf("MySql", StringComparison.OrdinalIgnoreCase) != -1)
                 return DatastoreVendor.MySQL;
 
-            if (text.Contains("Oracle".ToLowerInvariant()))
+            if (text.IndexOf("Oracle", StringComparison.OrdinalIgnoreCase) != -1)
                 return DatastoreVendor.Oracle;
 
-            if (text.Contains("PgSql".ToLowerInvariant()) || text.Contains("Postgres".ToLowerInvariant()))
+            if (text.IndexOf("PgSql", StringComparison.OrdinalIgnoreCase) != -1 || text.IndexOf("Postgres", StringComparison.OrdinalIgnoreCase) != -1)
                 return DatastoreVendor.Postgres;
 
-            if (text.Contains("DB2".ToLowerInvariant()) || text.Contains("IBM".ToLowerInvariant()))
+            if (text.IndexOf("DB2", StringComparison.OrdinalIgnoreCase) != -1 || text.IndexOf("IBM", StringComparison.OrdinalIgnoreCase) != -1)
                 return DatastoreVendor.IBMDB2;
 
             return DatastoreVendor.Other;


### PR DESCRIPTION
## Summary

This reduces the amount of garbage created and should be higher-performance.

## Details

This uses `string.IndexOf(text, StringComparion)` instead of calling `.ToLowerInvariant` then `.Contains`. 

From https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#specifying-string-comparisons-explicitly:

> We recommend that you select an overload that does not use default values, for the following reasons:
> 
> * Some overloads with default parameters (those that search for a Char in the string instance) perform an ordinal comparison, whereas others (those that search for a string in the string instance) are culture-sensitive. It is difficult to remember which method uses which default value, and easy to confuse the overloads.

`string.Contains(String, StringComparison)` is not available on all target frameworks, so `IndexOf` must be used instead.

## Proposed Release Notes

_None._ (This is a minor internal correctness/performance enhancement.)