### PR TITLE
Add new overloading public api calls to expect errors

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/NewRelic.cs
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.cs
@@ -312,6 +312,92 @@ namespace NewRelic.Api.Agent
             System.Diagnostics.Trace.WriteLine(string.Format("NewRelic.NoticeError({0},{1})", message, parameters));
         }
 
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only.
+        /// </summary>
+        /// <param name="message">The message to be displayed in the traced error.
+        /// Only the first 1000 characters are retained.
+        /// </param>
+        /// <param name="parameters">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combbined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">
+        /// Mark an error as expected.
+        /// </param>>
+        /// <example>
+        /// <code>
+        ///  try
+        /// {
+        ///    var ImNotABool = "43";
+        ///    bool.Parse(ImNotABool);
+        /// }
+        /// catch (Exception ex)
+        /// {
+        ///    var quotes = new Dictionary&lt;string,string&gt;();
+        ///    quotes.Add("1", "They had a large chunk of the garbage file? How much do they know?");
+        ///    quotes.Add("2", "I'll hack the Gibson.");
+        ///    quotes.Add("3", "Zero Cool? Crashed fifteen hundred and seven systems in one day?");
+        ///    quotes.Add("4", "Turn on your laptop. Set it to receive a file.");
+        ///    quotes.Add("5", "Listen you guys, help yourself to anything in the fridge. Cereal has.");
+        ///    NewRelic.Api.Agent.NewRelic.NoticeError(ex.Message, quotes, true);
+        /// }
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void NoticeError(string message, IDictionary<string, string> parameters, bool isExpected)
+        {
+            System.Diagnostics.Trace.WriteLine(string.Format("NewRelic.NoticeError({0},{1},{2})", message, parameters, isExpected));
+        }
+
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only.
+        /// </summary>
+        /// <param name="message">The message to be displayed in the traced error.
+        /// Only the first 1000 characters are retained.
+        /// </param>
+        /// <param name="parameters">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combbined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">
+        /// Mark an error as expected.
+        /// </param>>
+        /// <example>
+        /// <code>
+        ///  try
+        /// {
+        ///    var ImNotABool = "43";
+        ///    bool.Parse(ImNotABool);
+        /// }
+        /// catch (Exception ex)
+        /// {
+        ///    var quotes = new Dictionary&lt;string,string&gt;();
+        ///    quotes.Add("1", "They had a large chunk of the garbage file? How much do they know?");
+        ///    quotes.Add("2", "I'll hack the Gibson.");
+        ///    quotes.Add("3", "Zero Cool? Crashed fifteen hundred and seven systems in one day?");
+        ///    quotes.Add("4", "Turn on your laptop. Set it to receive a file.");
+        ///    quotes.Add("5", "Listen you guys, help yourself to anything in the fridge. Cereal has.");
+        ///    NewRelic.Api.Agent.NewRelic.NoticeError(ex.Message, quotes, true);
+        /// }
+        /// </code>
+        /// </example>
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void NoticeError(string message, IDictionary<string, object> parameters, bool isExpected)
+        {
+            System.Diagnostics.Trace.WriteLine(string.Format("NewRelic.NoticeError({0},{1},{2})", message, parameters, isExpected));
+        }
+
         #endregion
 
         #region Transaction APIs

--- a/src/Agent/NewRelic.Api.Agent/NewRelic.cs
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.cs
@@ -245,7 +245,7 @@ namespace NewRelic.Api.Agent
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
-        /// Only 10,000 characters of combbined key/value data is retained.
+        /// Only 10,000 characters of combined key/value data is retained.
         /// </param>
         /// <example>
         /// <code>
@@ -285,7 +285,7 @@ namespace NewRelic.Api.Agent
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
-        /// Only 10,000 characters of combbined key/value data is retained.
+        /// Only 10,000 characters of combined key/value data is retained.
         /// </param>
         /// <example>
         /// <code>
@@ -325,7 +325,7 @@ namespace NewRelic.Api.Agent
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
-        /// Only 10,000 characters of combbined key/value data is retained.
+        /// Only 10,000 characters of combined key/value data is retained.
         /// </param>
         /// <param name="isExpected">
         /// Mark an error as expected.
@@ -368,7 +368,7 @@ namespace NewRelic.Api.Agent
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
-        /// Only 10,000 characters of combbined key/value data is retained.
+        /// Only 10,000 characters of combined key/value data is retained.
         /// </param>
         /// <param name="isExpected">
         /// Mark an error as expected.

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
@@ -278,6 +278,17 @@ namespace NewRelic.Agent.Core
             TryInvoke(work, apiName, apiMetric);
         }
 
+        public static void NoticeError(string message, IDictionary<string, string> customAttributes, bool isExpected)
+        {
+            const ApiMethod apiMetric = ApiMethod.NoticeError;
+            const string apiName = nameof(NoticeError);
+            void work()
+            {
+                InternalApi.NoticeError(message, customAttributes, isExpected);
+            }
+            TryInvoke(work, apiName, apiMetric);
+        }
+
         /// <summary>
         /// Notice an error identified by a simple message and report it to the New Relic service.
         /// If this method is called within a transaction,
@@ -300,6 +311,17 @@ namespace NewRelic.Agent.Core
             void work()
             {
                 InternalApi.NoticeError(message, customAttributes);
+            }
+            TryInvoke(work, apiName, apiMetric);
+        }
+
+        public static void NoticeError(string message, IDictionary<string, object> customAttributes, bool isExpected)
+        {
+            const ApiMethod apiMetric = ApiMethod.NoticeError;
+            const string apiName = nameof(NoticeError);
+            void work()
+            {
+                InternalApi.NoticeError(message, customAttributes, isExpected);
             }
             TryInvoke(work, apiName, apiMetric);
         }

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
@@ -250,18 +250,10 @@ namespace NewRelic.Agent.Core.Api
         /// null. Only 10,000 characters of combined key/value data is retained. </param>
         public void NoticeError(string message, IDictionary<string, string> customAttributes)
         {
-            message = message ?? throw new ArgumentNullException(nameof(message));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsErrorMessageIgnored(message)) return;
-                var errorData = _errorService.FromMessage(message, customAttributes);
-                ProcessNoticedError(errorData, transaction);
-            }
+            NoticeError(message, customAttributes, false);
         }
 
-        public void NoticeError(string message, IDictionary<string, object> customAttributes)
+        public void NoticeError(string message, IDictionary<string, string> customAttributes, bool isExpected)
         {
             message = message ?? throw new ArgumentNullException(nameof(message));
 
@@ -269,7 +261,25 @@ namespace NewRelic.Agent.Core.Api
             {
                 var transaction = TryGetCurrentInternalTransaction();
                 if (IsErrorMessageIgnored(message)) return;
-                var errorData = _errorService.FromMessage(message, customAttributes);
+                var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
+                ProcessNoticedError(errorData, transaction);
+            }
+        }
+
+        public void NoticeError(string message, IDictionary<string, object> customAttributes)
+        {
+            NoticeError(message, customAttributes, false);
+        }
+
+        public void NoticeError(string message, IDictionary<string, object> customAttributes, bool isExpected)
+        {
+            message = message ?? throw new ArgumentNullException(nameof(message));
+
+            using (new IgnoreWork())
+            {
+                var transaction = TryGetCurrentInternalTransaction();
+                if (IsErrorMessageIgnored(message)) return;
+                var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
                 ProcessNoticedError(errorData, transaction);
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
@@ -21,8 +21,8 @@ namespace NewRelic.Agent.Core.Errors
         ErrorData FromException(Exception exception);
         ErrorData FromException(Exception exception, IDictionary<string, string> customAttributes);
         ErrorData FromException(Exception exception, IDictionary<string, object> customAttributes);
-        ErrorData FromMessage(string errorMessage, IDictionary<string, string> customAttributes);
-        ErrorData FromMessage(string errorMessage, IDictionary<string, object> customAttributes);
+        ErrorData FromMessage(string errorMessage, IDictionary<string, string> customAttributes, bool isExpected);
+        ErrorData FromMessage(string errorMessage, IDictionary<string, object> customAttributes, bool isExpected);
         ErrorData FromErrorHttpStatusCode(int statusCode, int? subStatusCode, DateTime noticedAt);
     }
 
@@ -69,16 +69,16 @@ namespace NewRelic.Agent.Core.Errors
             return FromExceptionInternal(exception, CaptureAttributes(customAttributes));
         }
 
-        public ErrorData FromMessage(string errorMessage, IDictionary<string, string> customAttributes)
+        public ErrorData FromMessage(string errorMessage, IDictionary<string, string> customAttributes, bool isExpected)
         {
             var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : errorMessage;
-            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes));
+            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes), isExpected);
         }
 
-        public ErrorData FromMessage(string errorMessage, IDictionary<string, object> customAttributes)
+        public ErrorData FromMessage(string errorMessage, IDictionary<string, object> customAttributes, bool isExpected)
         {
             var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : errorMessage;
-            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes));
+            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes), isExpected);
         }
 
         public ErrorData FromErrorHttpStatusCode(int statusCode, int? subStatusCode, DateTime noticedAt)

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
@@ -91,6 +91,25 @@ namespace NewRelic.Agent.Api
 
         void NoticeError(string message, IDictionary<string, object> customAttributes);
 
+        /// <summary> Notice an error identified by a simple message and report it to the New Relic
+        /// service. If this method is called within a transaction, the exception will be reported with
+        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        ///
+        /// <param name="message">    The message to be displayed in the traced error. Only the
+        /// first 1000 characters are retained. </param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
+        /// <param name="isExpected"> Marks the error expected.
+        /// </param>
+        void NoticeError(string message, IDictionary<string, string> customAttributes, bool isExpected);
+
+        void NoticeError(string message, IDictionary<string, object> customAttributes, bool isExpected);
+
         /// <summary> Add a key/value pair to the current transaction.  These are reported in errors and
         /// transaction traces. Supports web applications only. </summary>
         ///

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
@@ -137,6 +137,11 @@ namespace NewRelic.Agent.Api
             _agentApiImplementation?.NoticeError(message, customAttributes);
         }
 
+        public static void NoticeError(string message, IDictionary<string, string> customAttributes, bool isExpected)
+        {
+            _agentApiImplementation?.NoticeError(message, customAttributes, isExpected);
+        }
+
         /// <summary> Notice an error identified by a simple message and report it to the New Relic
         /// service. If this method is called within a transaction, the exception will be reported with
         /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
@@ -153,6 +158,11 @@ namespace NewRelic.Agent.Api
         public static void NoticeError(string message, IDictionary<string, object> customAttributes)
         {
             _agentApiImplementation?.NoticeError(message, customAttributes);
+        }
+
+        public static void NoticeError(string message, IDictionary<string, object> customAttributes, bool isExpected)
+        {
+            _agentApiImplementation?.NoticeError(message, customAttributes, isExpected);
         }
 
         /// <summary> Add a key/value pair to the current transaction.  These are reported in errors and

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         [Test]
         public void GetErrorTrace_ReturnsErrorTrace_IfExceptionIsNoticed()
         {
-            var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null);
+            var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorDataIn });
             var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
@@ -80,8 +80,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         [Test]
         public void GetErrorTrace_ReturnsFirstException_IfMultipleExceptionsNoticed()
         {
-            var errorData1 = _errorService.FromMessage("My message", (Dictionary<string, object>)null);
-            var errorData2 = _errorService.FromMessage("My message2", (Dictionary<string, object>)null);
+            var errorData1 = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
+            var errorData2 = _errorService.FromMessage("My message2", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorData1, errorData2 });
             var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
@@ -100,7 +100,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         [Test]
         public void GetErrorTrace_ReturnsExceptionsBeforeStatusCodes()
         {
-            var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null);
+            var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(statusCode: 404, uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorDataIn });
             var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
@@ -121,7 +121,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         {
             Mock.Arrange(() => _configurationService.Configuration.StripExceptionMessages).Returns(true);
 
-            var errorData = _errorService.FromMessage("This message should be stripped.", (Dictionary<string, object>)null);
+            var errorData = _errorService.FromMessage("This message should be stripped.", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorData });
             var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
* Where applicable, a CHANGELOG entry should be included.
-->

## Summary

Add `NoticeError(string message, IDictionary<string, string> parameters, bool isExpected)` and `NoticeError(string message, IDictionary<string, object> parameters, bool isExpected)` calls to the public apis.

## Details

<!--
In-depth description of changes, other technical notes, etc.
-->

## Links

<!--
Any relevant links that will help reviewers.
-->

## Proposed Release Notes

<!--
Proposed test of release notes, if applicable.
-->

