### PR TITLE
Add the configuration of distributed tracing to agent settings reported to New Relic

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -36,6 +36,9 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("cross_application_tracer.enabled")]
         public bool CrossApplicationTracerEnabled { get; set; }
 
+        [JsonProperty("distributed_tracing.enabled")]
+        public bool DistributedTracingEnabled { get; set; }
+
         [JsonProperty("error_collector.enabled")]
         public bool ErrorCollectorEnabled { get; set; }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
@@ -323,6 +323,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 UsingServerSideConfig = _configuration.UsingServerSideConfig,
                 ThreadProfilerEnabled = _configuration.ThreadProfilingEnabled,
                 CrossApplicationTracerEnabled = _configuration.CrossApplicationTracingEnabled,
+                DistributedTracingEnabled = _configuration.DistributedTracingEnabled,
                 ErrorCollectorEnabled = _configuration.ErrorCollectorEnabled,
                 ErrorCollectorIgnoreStatusCodes = _configuration.HttpStatusCodesToIgnore.ToList(),
                 ErrorCollectorIgnoreErrors = _configuration.ExceptionsToIgnore.ToList(),

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -23,6 +23,7 @@ namespace NewRelic.Agent.Core.Configuration
         const bool UsingServerSideConfig = false;
         const bool ThreadProfilerEnabled = false;
         const bool CrossApplicationTracerEnabled = false;
+        const bool DistributedTracingEnabled = true;
         const bool ErrorCollectorEnabled = true;
         List<string> ErrorCollectorIgnoreStatusCodes = new List<string> { "401", "404" };
         List<string> ErrorCollectorIgnoreErrors = new List<string>();
@@ -55,6 +56,7 @@ namespace NewRelic.Agent.Core.Configuration
             Mock.Arrange(() => configuration.UsingServerSideConfig).Returns(UsingServerSideConfig);
             Mock.Arrange(() => configuration.ThreadProfilingEnabled).Returns(ThreadProfilerEnabled);
             Mock.Arrange(() => configuration.CrossApplicationTracingEnabled).Returns(CrossApplicationTracerEnabled);
+            Mock.Arrange(() => configuration.DistributedTracingEnabled).Returns(DistributedTracingEnabled);
             Mock.Arrange(() => configuration.ErrorCollectorEnabled).Returns(ErrorCollectorEnabled);
             Mock.Arrange(() => configuration.ExpectedErrorClassesForAgentSettings).Returns(ErrorCollectorExpectedClasses);
             Mock.Arrange(() => configuration.ExpectedErrorMessagesForAgentSettings).Returns(ErrorCollectorExpectedMessages);
@@ -82,6 +84,7 @@ namespace NewRelic.Agent.Core.Configuration
                 UsingServerSideConfig = configuration.UsingServerSideConfig,
                 ThreadProfilerEnabled = configuration.ThreadProfilingEnabled,
                 CrossApplicationTracerEnabled = configuration.CrossApplicationTracingEnabled,
+                DistributedTracingEnabled = configuration.DistributedTracingEnabled,
                 ErrorCollectorEnabled = configuration.ErrorCollectorEnabled,
                 ErrorCollectorIgnoreStatusCodes = configuration.HttpStatusCodesToIgnore.ToList(),
                 ErrorCollectorIgnoreErrors = configuration.ExceptionsToIgnore.ToList(),
@@ -102,7 +105,7 @@ namespace NewRelic.Agent.Core.Configuration
 
             var json = JsonConvert.SerializeObject(agentSettings);
 
-            const string expectedJson = @"{""apdex_t"":10.0,""cross_process_id"":""acctId#appId"",""encoding_key"":""thisistheencodingkey"",""trusted_account_ids"":[123456,98765],""max_stack_trace_lines"":100,""using_server_side_config"":false,""thread_profiler.enabled"":false,""cross_application_tracer.enabled"":false,""error_collector.enabled"":true,""error_collector.ignore_status_codes"":[""401"",""404""],""error_collector.ignore_errors"":[""401"",""404""],""error_collector.expected_classes"":[""ExceptionClass1""],""error_collector.expected_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_status_codes"":""403,500"",""transaction_tracer.stack_trace_threshold"":11.0,""transaction_tracer.explain_enabled"":false,""transaction_tracer.max_sql_statements"":100,""transaction_tracer.max_explain_plans"":10,""transaction_tracer.explain_threshold"":12.0,""transaction_tracer.transaction_threshold"":13.0,""transaction_tracer.record_sql"":""obfuscate"",""slow_sql.enabled"":false,""browser_monitoring.auto_instrument"":true,""transaction_event.max_samples_stored"":10000}";
+            const string expectedJson = @"{""apdex_t"":10.0,""cross_process_id"":""acctId#appId"",""encoding_key"":""thisistheencodingkey"",""trusted_account_ids"":[123456,98765],""max_stack_trace_lines"":100,""using_server_side_config"":false,""thread_profiler.enabled"":false,""cross_application_tracer.enabled"":false,""distributed_tracing.enabled"":true,""error_collector.enabled"":true,""error_collector.ignore_status_codes"":[""401"",""404""],""error_collector.ignore_errors"":[""401"",""404""],""error_collector.expected_classes"":[""ExceptionClass1""],""error_collector.expected_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_status_codes"":""403,500"",""transaction_tracer.stack_trace_threshold"":11.0,""transaction_tracer.explain_enabled"":false,""transaction_tracer.max_sql_statements"":100,""transaction_tracer.max_explain_plans"":10,""transaction_tracer.explain_threshold"":12.0,""transaction_tracer.transaction_threshold"":13.0,""transaction_tracer.record_sql"":""obfuscate"",""slow_sql.enabled"":false,""browser_monitoring.auto_instrument"":true,""transaction_event.max_samples_stored"":10000}";
 
             Assert.AreEqual(expectedJson, json);
         }


### PR DESCRIPTION
This PR adds the configuration value for distributed tracing to the `agent_settings` payload sent to NR when the agent connects.  This lets the value of DT config appear in the agent settings page in the UI, which is helpful to both customers and our support team in troubleshooting DT issues.