### PR TITLE
remove tooling additions causing a conversion

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicWebService/BasicWebService.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicWebService/BasicWebService.csproj
@@ -14,15 +14,6 @@
     <RootNamespace>BasicWebService</RootNamespace>
     <AssemblyName>BasicWebService</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
-    <UseIISExpress>false</UseIISExpress>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>4.0</OldToolsVersion>
-    <IISExpressSSLPort />
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/OwinRemotingClient.csproj
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/OwinRemotingClient.csproj
@@ -14,15 +14,6 @@
     <AssemblyName>OwinRemotingClient</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
-    <FileUpgradeFlags>40</FileUpgradeFlags>
-    <OldToolsVersion>15.0</OldToolsVersion>
-    <Use64BitIISExpress />
-    <IISExpressSSLPort>44315</IISExpressSSLPort>
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
-    <UseGlobalApplicationHostFile />
-    <UpgradeBackupLocation>C:\git\newrelic-dotnet-agent\tests\Agent\IntegrationTests\Backup\</UpgradeBackupLocation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/OwinRemotingServer.csproj
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/OwinRemotingServer.csproj
@@ -13,16 +13,6 @@
     <RootNamespace>OwinRemotingServer</RootNamespace>
     <AssemblyName>OwinRemotingServer</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileUpgradeFlags>40</FileUpgradeFlags>
-    <OldToolsVersion>15.0</OldToolsVersion>
-    <UseIISExpress>true</UseIISExpress>
-    <UpgradeBackupLocation>C:\git\newrelic-dotnet-agent\tests\Agent\IntegrationTests\Backup\</UpgradeBackupLocation>
-    <Use64BitIISExpress />
-    <IISExpressSSLPort>44369</IISExpressSSLPort>
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
-    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Summary
Recent PR inadvertently altered some .csproj files with unnecessary and undesirable effects in IntegrationTests resulting in a project conversion when opening the solution(s) in Visual Studio.
