### PR TITLE
Preserve newrelic.config on .deb package upgrade

### DIFF
--- a/build/Linux/build/deb/build.sh
+++ b/build/Linux/build/deb/build.sh
@@ -38,6 +38,7 @@ dos2unix *.x* extensions/*.x* *.sh
 
 cp /deb/control ${INSTALL_ROOT}/DEBIAN
 cp /deb/postinst ${INSTALL_ROOT}/DEBIAN
+cp /deb/conffiles ${INSTALL_ROOT}/DEBIAN
 
 dos2unix ${INSTALL_ROOT}/DEBIAN/*
 

--- a/build/Linux/build/deb/conffiles
+++ b/build/Linux/build/deb/conffiles
@@ -1,0 +1,1 @@
+/usr/local/newrelic-netcore20-agent/newrelic.config

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -13,8 +13,8 @@ The New Relic .NET agent is now open source! Now you can view the source code to
 * **Garbage Collection Performance Metrics for Windows** <br/>
 Fixes an issue where Garbage Collection Performance Metrics may not be reported for Windows Applications.
 
-* **Maintaining newrelic.config on RPM (Linux) upgrades** <br/>
-Fixes an issue where `newrelic.config` was being overwritten when upgrading the agent via RPM or YUM on RedHat-based Linux distros.
+* **Maintaining newrelic.config on Linux package upgrades** <br/>
+Fixes an issue where `newrelic.config` was being overwritten when upgrading the agent via either `rpm`/`yum` (RedHat/Centos) or `dpkg`/`apt` (Debian/Ubuntu).
  
 ### Docs Changes
 * [Doc Title](https://urlToDraft)


### PR DESCRIPTION
While issue #81 only mentioned rpm/yum package upgrades, the same issue existed for deb/apt package upgrades on Debian distros.  This PR fixes that.
