### PR TITLE
Fix two bugs in core installer script

### DIFF
--- a/build/Packaging/CoreInstaller/installAgent.ps1
+++ b/build/Packaging/CoreInstaller/installAgent.ps1
@@ -42,7 +42,7 @@ Function InstallAgent() {
 
     $locationExists = Test-Path $Destination
 	$locationIsEmpty = $False
-	if ($locaitonExists) {
+	if ($locationExists) {
 	   $locationIsEmpty = (Get-ChildItem $Destination).Length -eq 0
 	}
 
@@ -91,7 +91,7 @@ must back them up to another location prior to forcing an over-install.
         
     else {
         Get-ChildItem $resolvedPath | Remove-Item -Recurse
-        Copy-Item "$x86Filepath\*" $resolvedPath - Recurse
+        Copy-Item "$x86Filepath\*" $resolvedPath -Recurse
     }
 
     if ( $installType -eq "global") {


### PR DESCRIPTION
1. On the -X86 install path, there was a space between `-` and `Recurse` in the command to copy the agent files to the supplied destination, which broke any attempt to use this script to install the 32-bit core agent on Windows.
2. There was a typo in a variable name which broke the logic which should allow the user to install the agent to an existing folder as long as it was empty.