### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflow/stale.yml
+++ b/.github/workflow/stale.yml
@@ -12,8 +12,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This has been marked stale after 30 days with no activity. It will be closed in 5 days if there is no activity.'
         stale-pr-message: 'Stale pull request message'
-        days-before-stale: 1
-        days-before-close: 2
+        days-before-stale: 30
+        days-before-close: 5
         stale-issue-label: 'stale'
         exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review'
         stale-pr-label: 'stale'

--- a/.github/workflow/stale.yml
+++ b/.github/workflow/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This has been marked stale after 30 days with no activity. It will be closed in 5 days if there is no activity.'
+        stale-pr-message: 'Stale pull request message'
+        days-before-stale: 1
+        days-before-close: 2
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review'
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'on hold,in review'


### PR DESCRIPTION
## Summary
Adds stale.yml GitHub action to check for abandoned/stale PRs and Issues.


## Details
Current configuration adds `stale` label after 30 days, closes 5 days after that if no action taken.

## Links
Same behavior as in [Ruby Agent](https://github.com/newrelic/newrelic-ruby-agent/blob/dev/.github/workflows/stale.yml).
Uses [this GitHub action](https://github.com/actions/stale).

## Testing
Currently testing the yaml in a test repo, but implementation `days-before-stale` and `days-before-close` smallest period is 1 day, so waiting 1 day for the label to appear, then another day for the close to occur.
