### PR TITLE
Dockerized rabbitmq test dependencies

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -1,0 +1,14 @@
+rabbitmq: 
+    build: ./rabbitmq 
+    ports:
+        - "4369:4369"
+        - "5671-5672:5671-5672"
+        - "25672:25672"
+    hostname: my-rabbit
+    container_name: RabbitmqServer
+
+
+#couchbase:
+
+
+

--- a/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
@@ -1,0 +1,1 @@
+FROM rabbitmq:3.5

--- a/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
@@ -1,1 +1,1 @@
-FROM rabbitmq:3.5
+FROM rabbitmq:3.8


### PR DESCRIPTION
### Description

This adds a docker-compose file and associated Dockerfile for hosting a RabbitMq service locally to be used by the unbounded integration tests.

### Testing

We manually tested running the RabbitMq unbounded tests against this local service and they passed.  Otherwise, no agent or test code changes are made by this PR.

### Changelog

No changelog entry required.
