### PR TITLE
Add dockerized services for both MongoDB test groups

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Xml;
@@ -766,6 +767,26 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             return false;
         }
+
+        public static string NormalizeHostname(string host)
+        {
+            var resolvedHostName = IsLocalHost(host) ? Dns.GetHostName() : host;
+            return resolvedHostName;
+        }
+
+        private static bool IsLocalHost(string host)
+        {
+            var localhost = new[] { ".", "localhost" };
+            var hostIsLocalhost = localhost.Contains(host);
+            if (!hostIsLocalhost)
+            {
+                IPAddress ipAddress;
+                var isIpAddress = IPAddress.TryParse(host, out ipAddress);
+                hostIsLocalhost = isIpAddress && IPAddress.IsLoopback(ipAddress);
+            }
+            return hostIsLocalhost;
+        }
+
     }
 
     public static class EnumerableExtensions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
@@ -1,11 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
-using System;
-using System.Linq;
-using System.Net;
-using System.Text.RegularExpressions;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
@@ -35,7 +39,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [Fact]
         public void CheckForDatastoreInstanceMetrics()
         {
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{MongoDbConfiguration.MongoDb26Server}/{MongoDbConfiguration.MongoDb26Port}");
+            var serverHost = CommonUtils.NormalizeHostname(MongoDbConfiguration.MongoDb26Server);
+            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{MongoDbConfiguration.MongoDb26Port}");
             Assert.NotNull(m);
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_DatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_DatabaseTests.cs
@@ -42,7 +42,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [Fact]
         public void CheckForDatastoreInstanceMetrics()
         {
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{MongoDbConfiguration.MongoDb26Server}/{MongoDbConfiguration.MongoDb26Port}");
+            var serverHost = CommonUtils.NormalizeHostname(MongoDbConfiguration.MongoDb26Server);
+            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{MongoDbConfiguration.MongoDb26Port}");
             Assert.NotNull(m);
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_IndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_IndexManagerTests.cs
@@ -43,7 +43,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [Fact]
         public void CheckForDatastoreInstanceMetrics()
         {
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{MongoDbConfiguration.MongoDb26Server}/{MongoDbConfiguration.MongoDb26Port}");
+            var serverHost = CommonUtils.NormalizeHostname(MongoDbConfiguration.MongoDb26Server);
+            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{MongoDbConfiguration.MongoDb26Port}");
             Assert.NotNull(m);
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoCollectionTests.cs
@@ -67,7 +67,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [Fact]
         public void CheckForDatastoreInstanceMetrics()
         {
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{MongoDbConfiguration.MongoDb26Server}/{MongoDbConfiguration.MongoDb26Port}");
+            var serverHost = CommonUtils.NormalizeHostname(MongoDbConfiguration.MongoDb26Server);
+            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{MongoDbConfiguration.MongoDb26Port}");
             Assert.NotNull(m);
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
@@ -1,7 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
@@ -54,7 +53,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/LinqQueryAsync");
             Assert.NotNull(m);
         }
-
 
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
@@ -35,7 +35,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [Fact]
         public void CheckForDatastoreInstanceMetrics()
         {
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{MongoDbConfiguration.MongoDb26Server}/{MongoDbConfiguration.MongoDb26Port}");
+            var serverHost = CommonUtils.NormalizeHostname(MongoDbConfiguration.MongoDb26Server);
+            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{MongoDbConfiguration.MongoDb26Port}");
             Assert.NotNull(m);
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -7,8 +7,19 @@ rabbitmq:
     hostname: my-rabbit
     container_name: RabbitmqServer
 
+mongodb32: 
+    build: ./mongodb32 
+    ports:
+        - "27017:27017"
+    container_name: MongoDB32Server
 
-#couchbase:
+mongodb36: 
+    build: ./mongodb36 
+    ports:
+        - "27018:27017"
+    container_name: MongoDB36Server
+                
+
 
 
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/mongodb32/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mongodb32/Dockerfile
@@ -1,0 +1,1 @@
+FROM mongo:3.2

--- a/tests/Agent/IntegrationTests/UnboundedServices/mongodb36/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mongodb36/Dockerfile
@@ -1,0 +1,1 @@
+FROM mongo:3.6.4


### PR DESCRIPTION
### Description

This PR adds dockerized MongoDB services for both groups of MongoDB integration tests (one set uses the 1.10 version of the MongoDB .NET client driver and the other uses the 2.6 version).  This is for issues #123 and #125.

### Testing

A change was needed in the assertions for the `Datastore/instance` metrics because the agent has some special-case logic to use the local hostname (from Dns.GetHostname()) if the server's address is "localhost" or "127.0.0.1".

### Changelog

No changelog entry required.
