### PR TITLE
Script changes for dockerized unbounded services

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
@@ -1,0 +1,39 @@
+############################################################
+# Copyright 2020 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+############################################################
+
+Param(
+    [Parameter(Mandatory=$true,
+    ParameterSetName="Start")]
+    [Switch]
+    $Start,
+
+    [Parameter(Mandatory=$true,
+    ParameterSetName="Stop")]
+    [Switch]
+    $Stop
+)
+
+Function StartUnboundedServices([string] $scriptPath) {
+    Push-Location "$scriptPath"
+    Write-Host "Launching docker services"
+    docker-compose up -d
+    Write-Host "Waiting for services to be ready"
+    sleep 30 #TODO: something smarter than this
+    Pop-Location
+}
+
+Function StopUnboundedServices([string] $scriptPath) {
+    Push-Location "$scriptPath"
+    docker-compose down
+    Pop-Location
+}
+
+$scriptPath = Resolve-Path "$(Split-Path -Parent $PSCommandPath)"
+
+if ($Start) {
+    StartUnboundedServices($scriptPath)
+} elseif ($Stop) {
+    StopUnboundedServices($scriptPath)
+}


### PR DESCRIPTION
### Description

This PR introduces a script for starting and stopping the dockerized unbounded services, `unbounded-services-control.ps1`.  At the moment it is essentially a wrapper around `docker-compose up/down`.  However, we anticipate needing to add some setup commands for some services after they are started; they should be added to this new script.

This PR also modifies `run-integration-tests.ps1` to call this new script to start the services before running the unbounded tests and then stop the services after the tests finish.

### Testing

I tested the scripts locally; our CI for the unbounded tests calls the `run-integration-tests.ps1` script so it will get tested on PR merge.  There are no agent behavior changes in this PR.

### Changelog

No changelog entry needed.

