### PR TITLE
Fix assembly version mismatch

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+Fixes issue that may cause InvalidCastException due to an assembly version mismatch in Mvc3 instrumentation.
 
 ## [8.31] - 2020-08-17
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/AsyncBeginInvokeActionWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/AsyncBeginInvokeActionWrapper.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-//using System.Web.Mvc;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/AsyncBeginInvokeActionWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/AsyncBeginInvokeActionWrapper.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Web.Mvc;
+//using System.Web.Mvc;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
@@ -27,20 +27,23 @@ namespace NewRelic.Providers.Wrapper.Mvc3
         {
             transaction.AttachToAsync();
 
-            var controllerContext = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<ControllerContext>(0);
-            var controllerName = MvcRouteNamingHelper.TryGetControllerNameFromObject(controllerContext);
-            var actionName = MvcRouteNamingHelper.TryGetActionNameFromRouteParameters(instrumentedMethodCall.MethodCall, controllerContext.RouteData);
+            var controllerContext = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<dynamic>(0);
+            if (controllerContext != null)
+            {
+                var controllerName = MvcRouteNamingHelper.TryGetControllerNameFromObject(controllerContext);
+                var actionName = MvcRouteNamingHelper.TryGetActionNameFromRouteParameters(instrumentedMethodCall.MethodCall, controllerContext.RouteData);
 
-            var httpContext = controllerContext.HttpContext;
-            if (httpContext == null)
-                throw new NullReferenceException("httpContext");
+                var httpContext = controllerContext.HttpContext;
+                if (httpContext == null)
+                    throw new NullReferenceException("httpContext");
 
-            var transactionName = string.Format("{0}/{1}", controllerName, actionName);
-            transaction.SetWebTransactionName(WebTransactionType.MVC, transactionName, TransactionNamePriority.FrameworkHigh);
+                var transactionName = string.Format("{0}/{1}", controllerName, actionName);
+                transaction.SetWebTransactionName(WebTransactionType.MVC, transactionName, TransactionNamePriority.FrameworkHigh);
 
-            var segment = transaction.StartMethodSegment(instrumentedMethodCall.MethodCall, controllerName, actionName);
+                var segment = transaction.StartMethodSegment(instrumentedMethodCall.MethodCall, controllerName, actionName);
 
-            httpContext.Items[HttpContextSegmentKey] = segment;
+                httpContext.Items[HttpContextSegmentKey] = segment;
+            }
 
             return Delegates.NoOp;
         }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/Mvc3.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/Mvc3.csproj
@@ -1,16 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFramework>net45</TargetFramework>
         <AssemblyName>NewRelic.Providers.Wrapper.Mvc3</AssemblyName>
         <RootNamespace>NewRelic.Providers.Wrapper.Mvc3</RootNamespace>
         <Description>Mvc3 Wrapper Provider for New Relic .NET Agent</Description>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNet.Mvc" Version="3.0.50813.1" />
-        <PackageReference Include="Microsoft.AspNet.Razor" Version="1.0.20105.408" />
-        <PackageReference Include="Microsoft.AspNet.WebPages" Version="1.0.20105.408" />
-        <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
-    </ItemGroup>
     <ItemGroup>
         <Reference Include="System" />
         <Reference Include="System.Core" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
@@ -1,9 +1,8 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//using System.Collections.Generic;
-//using System.Linq;
-//using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
 using System.Web.Routing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
@@ -28,16 +27,9 @@ namespace NewRelic.Providers.Wrapper.Mvc3
             if (actionName != null)
                 return actionName;
 
-            //var directRouteMatches = routeData.Values.GetValueOrDefault("MS_DirectRouteMatches") as IEnumerable<RouteData> ?? Enumerable.Empty<RouteData>();
-            //routeData = directRouteMatches.FirstOrDefault() ?? routeData;
-            //actionName = routeData.Values.GetValueOrDefault("action") as string;
-
-            //var a = routeData.Values;
-            //var b = a["MS_DirectRouteMatches"];
-            //var c = b[0];
-            //actionName = c.Values["action"];
-          
-            actionName = routeData?.Values?["MS_DirectRouteMatches"]?[0]?.Values?["action"];
+            var directRouteMatches = routeData?.Values?["MS_DirectRouteMatches"] as IEnumerable<RouteData> ?? Enumerable.Empty<RouteData>();
+            routeData = directRouteMatches?.FirstOrDefault() ?? routeData;
+            actionName = routeData?.Values?["action"];
 
             return actionName ?? "Unknown Action";
         }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
@@ -3,17 +3,17 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Web.Mvc;
+//using System.Web.Mvc;
 using System.Web.Routing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
-using NewRelic.SystemExtensions.Collections.Generic;
+//using NewRelic.SystemExtensions.Collections.Generic;
 
 namespace NewRelic.Providers.Wrapper.Mvc3
 {
     public static class MvcRouteNamingHelper
     {
-        public static string TryGetControllerNameFromObject(ControllerContext controllerContext)
+        public static string TryGetControllerNameFromObject(dynamic controllerContext)
         {
             var controller = controllerContext.Controller;
             if (controller == null)
@@ -23,7 +23,7 @@ namespace NewRelic.Providers.Wrapper.Mvc3
             return controllerType.Name;
         }
 
-        public static string TryGetActionNameFromRouteParameters(MethodCall methodCall, RouteData routeData)
+        public static string TryGetActionNameFromRouteParameters(MethodCall methodCall, dynamic routeData)
         {
             var actionName = methodCall.MethodArguments.ExtractAs<string>(1);
             if (actionName != null)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
@@ -1,8 +1,9 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
-using System.Linq;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Threading;
 using System.Web.Routing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
@@ -27,9 +28,16 @@ namespace NewRelic.Providers.Wrapper.Mvc3
             if (actionName != null)
                 return actionName;
 
-            var directRouteMatches = routeData.Values.GetValueOrDefault("MS_DirectRouteMatches") as IEnumerable<RouteData> ?? Enumerable.Empty<RouteData>();
-            routeData = directRouteMatches.FirstOrDefault() ?? routeData;
-            actionName = routeData.Values.GetValueOrDefault("action") as string;
+            //var directRouteMatches = routeData.Values.GetValueOrDefault("MS_DirectRouteMatches") as IEnumerable<RouteData> ?? Enumerable.Empty<RouteData>();
+            //routeData = directRouteMatches.FirstOrDefault() ?? routeData;
+            //actionName = routeData.Values.GetValueOrDefault("action") as string;
+
+            //var a = routeData.Values;
+            //var b = a["MS_DirectRouteMatches"];
+            //var c = b[0];
+            //actionName = c.Values["action"];
+          
+            actionName = routeData?.Values?["MS_DirectRouteMatches"]?[0]?.Values?["action"];
 
             return actionName ?? "Unknown Action";
         }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/MvcRouteNamingHelper.cs
@@ -3,11 +3,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-//using System.Web.Mvc;
 using System.Web.Routing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
-//using NewRelic.SystemExtensions.Collections.Generic;
 
 namespace NewRelic.Providers.Wrapper.Mvc3
 {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/SyncInvokeActionWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/SyncInvokeActionWrapper.cs
@@ -21,19 +21,25 @@ namespace NewRelic.Providers.Wrapper.Mvc3
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
             transaction.AttachToAsync();
-
             var controllerContext = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<dynamic>(0);
-            var controllerName = MvcRouteNamingHelper.TryGetControllerNameFromObject(controllerContext);
-            var actionName = MvcRouteNamingHelper.TryGetActionNameFromRouteParameters(instrumentedMethodCall.MethodCall, controllerContext.RouteData);
 
-            var transactionName = string.Format("{0}/{1}", controllerName, actionName);
-            transaction.SetWebTransactionName(WebTransactionType.MVC, transactionName, TransactionNamePriority.FrameworkHigh);
+            if (controllerContext != null)
+            {
+                var controllerName = MvcRouteNamingHelper.TryGetControllerNameFromObject(controllerContext);
+                var actionName = MvcRouteNamingHelper.TryGetActionNameFromRouteParameters(instrumentedMethodCall.MethodCall, controllerContext.RouteData);
 
-            var segment = transaction.StartMethodSegment(instrumentedMethodCall.MethodCall, controllerName, actionName);
-            if (segment == null)
-                return Delegates.NoOp;
+                var transactionName = string.Format("{0}/{1}", controllerName, actionName);
+                transaction.SetWebTransactionName(WebTransactionType.MVC, transactionName, TransactionNamePriority.FrameworkHigh);
 
-            return Delegates.GetDelegateFor(segment);
+                var segment = transaction.StartMethodSegment(instrumentedMethodCall.MethodCall, controllerName, actionName);
+
+                if (segment != null)
+                {
+                    return Delegates.GetDelegateFor(segment);
+                }
+            }
+
+            return Delegates.NoOp;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/SyncInvokeActionWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Mvc3/SyncInvokeActionWrapper.cs
@@ -1,7 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Web.Mvc;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.SystemExtensions;
@@ -23,7 +22,7 @@ namespace NewRelic.Providers.Wrapper.Mvc3
         {
             transaction.AttachToAsync();
 
-            var controllerContext = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<ControllerContext>(0);
+            var controllerContext = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<dynamic>(0);
             var controllerName = MvcRouteNamingHelper.TryGetControllerNameFromObject(controllerContext);
             var actionName = MvcRouteNamingHelper.TryGetActionNameFromRouteParameters(instrumentedMethodCall.MethodCall, controllerContext.RouteData);
 


### PR DESCRIPTION
### Description
Removes dependency on `System.Web.Mvc` in the Agent's Mvc3 instrumentation to avoid exceptions such as `System.InvalidCastException: Expected argument 0 to be of type System.Web.Mvc.ControllerContext (v3.0.0.1), but was of type System.Web.Mvc.ControllerContext (v4.0.0.1)` .
This was accomplished using `<dynamic>` instead of specific `System.Web.Mvc` type `ContextController`.

### Testing
Use of `ControllerContext` in `System.Web.Mvc` was checked via decompilervfor use by restricted methods (internal, private) and none were found, so use of it in the Agent should not pose a problem.
Attempts were made to create an Mvc4 test app, as in the reporting customer's case, but the exception was not reproducible.
Removal of Agent instrumentation dependency on the dll should prevent the assembly version mismatch error encountered by the customer.



