### PR TITLE
Dockerized couchbase test dependencies

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
@@ -1,0 +1,4 @@
+FROM couchbase/server:enterprise-4.5.1
+
+COPY configure-server.sh /opt/couchbase
+CMD ["/opt/couchbase/configure-server.sh"]

--- a/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
@@ -1,4 +1,6 @@
 FROM couchbase/server:enterprise-4.5.1
 
+RUN apt-get update && apt-get install -y jq
+
 COPY configure-server.sh /opt/couchbase
 CMD ["/opt/couchbase/configure-server.sh"]

--- a/tests/Agent/IntegrationTests/UnboundedServices/couchbase/configure-server.sh
+++ b/tests/Agent/IntegrationTests/UnboundedServices/couchbase/configure-server.sh
@@ -2,74 +2,85 @@ set -m
  
 /entrypoint.sh couchbase-server &
  
-sleep 15
+sleep 20
  
 echo "Creating node" 
-curl -v http://127.0.0.1:8091/pools/default -d memoryQuota=512 -d indexMemoryQuota=512 -d ftsMemoryQuota=512
+curl http://127.0.0.1:8091/pools/default -d memoryQuota=512 -d indexMemoryQuota=512 -d ftsMemoryQuota=512
  
 echo "Setting up services"
-curl -v http://127.0.0.1:8091/node/controller/setupServices -d services=kv%2cn1ql%2Cindex%2cfts
+curl http://127.0.0.1:8091/node/controller/setupServices -d services=kv%2cn1ql%2Cindex%2cfts
  
 echo "Setting admin user and password" 
-curl -v http://127.0.0.1:8091/settings/web -d port=8091 -d username=$COUCHBASE_ADMINISTRATOR_USERNAME -d password=$COUCHBASE_ADMINISTRATOR_PASSWORD
+curl http://127.0.0.1:8091/settings/web -d port=8091 -d username=$COUCHBASE_ADMINISTRATOR_USERNAME -d password=$COUCHBASE_ADMINISTRATOR_PASSWORD
  
 echo "Setting index storge mode" 
-curl -i -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -X POST http://127.0.0.1:8091/settings/indexes -d 'storageMode=memory_optimized'
+curl -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -X POST http://127.0.0.1:8091/settings/indexes -d 'storageMode=memory_optimized'
 
-echo "Installing travel-sample bucket" 
-curl -v -X POST -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD http://127.0.0.1:8091/sampleBuckets/install -d '["travel-sample"]'
+# Check to see if the travel-sample bucket already exists and if it does, skip the rest of setup
+
+travelSampleBucketNotInstalled=$(curl -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD http://127.0.0.1:8091/pools/default/buckets/travel-sample |grep -c "Requested resource not found")
+
+if [ "$travelSampleBucketNotInstalled" -eq 1 ]; then
+
+    echo "Installing travel-sample bucket" 
+    curl -X POST -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD http://127.0.0.1:8091/sampleBuckets/install -d '["travel-sample"]'
  
-sleep 15
- 
-echo "Create a full text search index on travel-sample"
-curl -X PUT -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -H "Content-Type: application/json" \
- http://localhost:8094/api/index/idx_travel_content \
- -d '{
-  "type": "fulltext-index",
-  "name": "idx_travel_content",
-  "uuid": "52288c8856430609",
-  "sourceType": "couchbase",
-  "sourceName": "travel-sample",
-  "sourceUUID": "11c29f02e9fa2ee577d11451e2d99626",
-  "planParams": {
-    "maxPartitionsPerPIndex": 32,
-    "numReplicas": 0,
-    "hierarchyRules": null,
-    "nodePlanParams": null,
-    "pindexWeights": null,
-    "planFrozen": false
-  },
-  "params": {
-    "mapping": {
-      "byte_array_converter": "json",
-      "default_analyzer": "standard",
-      "default_datetime_parser": "dateTimeOptional",
-      "default_field": "_all",
-      "default_mapping": {
-        "display_order": "0",
-        "dynamic": true,
-        "enabled": true
-      },
-      "default_type": "_default",
-      "index_dynamic": true,
-      "store_dynamic": false,
-      "type_field": "type"
+    sleep 15
+
+    # Get UUID of travel-sample bucket
+    uuid=$(curl -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD http://127.0.0.1:8091/pools/default/buckets/travel-sample |jq '. | .uuid ')
+
+    echo "Create a full text search index on travel-sample"
+    curl -X PUT -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -H "Content-Type: application/json" \
+    http://localhost:8094/api/index/idx_travel_content \
+    -d '{
+    "type": "fulltext-index",
+    "name": "idx_travel_content",
+    "sourceType": "couchbase",
+    "sourceName": "travel-sample",
+    "sourceUUID": '${uuid}',
+    "planParams": {
+        "maxPartitionsPerPIndex": 32,
+        "numReplicas": 0,
+        "hierarchyRules": null,
+        "nodePlanParams": null,
+        "pindexWeights": null,
+        "planFrozen": false
     },
-    "store": {
-      "kvStoreName": "forestdb"
+    "params": {
+        "mapping": {
+        "byte_array_converter": "json",
+        "default_analyzer": "standard",
+        "default_datetime_parser": "dateTimeOptional",
+        "default_field": "_all",
+        "default_mapping": {
+            "display_order": "0",
+            "dynamic": true,
+            "enabled": true
+        },
+        "default_type": "_default",
+        "index_dynamic": true,
+        "store_dynamic": false,
+        "type_field": "type"
+        },
+        "store": {
+        "kvStoreName": "forestdb"
+        }
+    },
+    "sourceParams": {
+        "clusterManagerBackoffFactor": 0,
+        "clusterManagerSleepInitMS": 0,
+        "clusterManagerSleepMaxMS": 2000,
+        "dataManagerBackoffFactor": 0,
+        "dataManagerSleepInitMS": 0,
+        "dataManagerSleepMaxMS": 2000,
+        "feedBufferAckThreshold": 0,
+        "feedBufferSizeBytes": 0
     }
-  },
-  "sourceParams": {
-    "clusterManagerBackoffFactor": 0,
-    "clusterManagerSleepInitMS": 0,
-    "clusterManagerSleepMaxMS": 2000,
-    "dataManagerBackoffFactor": 0,
-    "dataManagerSleepInitMS": 0,
-    "dataManagerSleepMaxMS": 2000,
-    "feedBufferAckThreshold": 0,
-    "feedBufferSizeBytes": 0
-  }
-}'
- 
+    }'
+else
+    echo "travel-sample bucket already installed"
+fi 
+
 fg 1
 echo "Couchbase server is ready"

--- a/tests/Agent/IntegrationTests/UnboundedServices/couchbase/configure-server.sh
+++ b/tests/Agent/IntegrationTests/UnboundedServices/couchbase/configure-server.sh
@@ -1,0 +1,75 @@
+set -m
+ 
+/entrypoint.sh couchbase-server &
+ 
+sleep 15
+ 
+echo "Creating node" 
+curl -v http://127.0.0.1:8091/pools/default -d memoryQuota=512 -d indexMemoryQuota=512 -d ftsMemoryQuota=512
+ 
+echo "Setting up services"
+curl -v http://127.0.0.1:8091/node/controller/setupServices -d services=kv%2cn1ql%2Cindex%2cfts
+ 
+echo "Setting admin user and password" 
+curl -v http://127.0.0.1:8091/settings/web -d port=8091 -d username=$COUCHBASE_ADMINISTRATOR_USERNAME -d password=$COUCHBASE_ADMINISTRATOR_PASSWORD
+ 
+echo "Setting index storge mode" 
+curl -i -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -X POST http://127.0.0.1:8091/settings/indexes -d 'storageMode=memory_optimized'
+
+echo "Installing travel-sample bucket" 
+curl -v -X POST -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD http://127.0.0.1:8091/sampleBuckets/install -d '["travel-sample"]'
+ 
+sleep 15
+ 
+echo "Create a full text search index on travel-sample"
+curl -X PUT -u $COUCHBASE_ADMINISTRATOR_USERNAME:$COUCHBASE_ADMINISTRATOR_PASSWORD -H "Content-Type: application/json" \
+ http://localhost:8094/api/index/idx_travel_content \
+ -d '{
+  "type": "fulltext-index",
+  "name": "idx_travel_content",
+  "uuid": "52288c8856430609",
+  "sourceType": "couchbase",
+  "sourceName": "travel-sample",
+  "sourceUUID": "11c29f02e9fa2ee577d11451e2d99626",
+  "planParams": {
+    "maxPartitionsPerPIndex": 32,
+    "numReplicas": 0,
+    "hierarchyRules": null,
+    "nodePlanParams": null,
+    "pindexWeights": null,
+    "planFrozen": false
+  },
+  "params": {
+    "mapping": {
+      "byte_array_converter": "json",
+      "default_analyzer": "standard",
+      "default_datetime_parser": "dateTimeOptional",
+      "default_field": "_all",
+      "default_mapping": {
+        "display_order": "0",
+        "dynamic": true,
+        "enabled": true
+      },
+      "default_type": "_default",
+      "index_dynamic": true,
+      "store_dynamic": false,
+      "type_field": "type"
+    },
+    "store": {
+      "kvStoreName": "forestdb"
+    }
+  },
+  "sourceParams": {
+    "clusterManagerBackoffFactor": 0,
+    "clusterManagerSleepInitMS": 0,
+    "clusterManagerSleepMaxMS": 2000,
+    "dataManagerBackoffFactor": 0,
+    "dataManagerSleepInitMS": 0,
+    "dataManagerSleepMaxMS": 2000,
+    "feedBufferAckThreshold": 0,
+    "feedBufferSizeBytes": 0
+  }
+}'
+ 
+fg 1
+echo "Couchbase server is ready"

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -25,6 +25,8 @@ couchbase:
         - "8091-8094:8091-8094"
         - "11210:11210"
     environment:
+        # These credentials are only used to configure the Couchbase container for use by the integration tests
+        # You can change these to any value you wish before running the container for the first time
         - COUCHBASE_ADMINISTRATOR_USERNAME=Administrator
         - COUCHBASE_ADMINISTRATOR_PASSWORD=password
     container_name: CouchbaseServer

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -18,7 +18,17 @@ mongodb36:
     ports:
         - "27018:27017"
     container_name: MongoDB36Server
-                
+
+couchbase: 
+    build: ./couchbase
+    ports:
+        - "8091-8094:8091-8094"
+        - "11210:11210"
+    environment:
+        - COUCHBASE_ADMINISTRATOR_USERNAME=Administrator
+        - COUCHBASE_ADMINISTRATOR_PASSWORD=password
+    container_name: CouchbaseServer
+    
 
 
 


### PR DESCRIPTION
### Description

This PR is for issue #120.  It adds a Dockerfile and associated docker-compose.yml entry to run a Couchbase server to be used by the Couchbase unbounded integration tests.

`configure-server.sh` is added to the container image in the Dockerfile and is run when the container is launched to perform the necessary Couchbase server setup steps we used to perform manually when setting up a Couchbase server in our internal environment.

### Testing

I verified that the Couchbase unbounded integration tests pass when run against this local container.
