### PR TITLE
Changes obscuring key environment variable name.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -41,6 +41,7 @@ namespace NewRelic.Agent.Core.Configuration
         private const string ServerConfigSource = "Server Configuration";
         private const int MaxExptectedErrorConfigEntries = 50;
         private const int MaxIgnoreErrorConfigEntries = 50;
+        private const string NewRelicConfigObscuringKey = "NEW_RELIC_CONFIG_OBSCURING_KEY";
 
         private static long _currentConfigurationVersion;
         private const int DefaultSpanEventsMaxSamplesStored = 1000;
@@ -1316,7 +1317,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (!_obscuringKeyEvaluated)
                 {
-                    _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, "OBSCURING_KEY");
+                    _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, NewRelicConfigObscuringKey);
                     _obscuringKeyEvaluated = true;
                 }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -41,7 +41,6 @@ namespace NewRelic.Agent.Core.Configuration
         private const string ServerConfigSource = "Server Configuration";
         private const int MaxExptectedErrorConfigEntries = 50;
         private const int MaxIgnoreErrorConfigEntries = 50;
-        private const string NewRelicConfigObscuringKey = "NEW_RELIC_CONFIG_OBSCURING_KEY";
 
         private static long _currentConfigurationVersion;
         private const int DefaultSpanEventsMaxSamplesStored = 1000;
@@ -1317,7 +1316,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (!_obscuringKeyEvaluated)
                 {
-                    _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, NewRelicConfigObscuringKey);
+                    _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, "NEW_RELIC_CONFIG_OBSCURING_KEY");
                     _obscuringKeyEvaluated = true;
                 }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Xml.Serialization;
 using NewRelic.Agent.Core.Config;
 using NewRelic.Agent.Core.DataTransport;
-using NewRelic.Core;
 using NewRelic.SystemInterfaces;
 using NewRelic.SystemInterfaces.Web;
 using NewRelic.Testing.Assertions;

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1075,7 +1075,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("ABCD", "bGxs", "   ", null, ExpectedResult = "ABCD")]
         public string Encrypting_Decrypting_ProxyPassword_Tests(string password, string encryptedPassword, string localConfigObscuringKey, string envObscuringKey)
         {
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("OBSCURING_KEY")).Returns(envObscuringKey);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_CONFIG_OBSCURING_KEY")).Returns(envObscuringKey);
 
             _localConfig.service.proxy.password = password;
             _localConfig.service.obscuringKey = localConfigObscuringKey;


### PR DESCRIPTION
### Description

New Relic specific environment variables should have "NEW_RELIC" prefix. This PR changes the obscuring key environment variable name from "OBSCURING_KEY" to "NEW_RELIC_CONFIG_OBSCURING_KEY".

