### PR TITLE
Update GitCommand to support checkouts and W3CValidation to checkout

### DIFF
--- a/tests/Agent/IntegrationTests/ApplicationHelperLibraries/ConsoleMultiFunctionApplicationHelpers/NetStandardLibraries/GitCommand.cs
+++ b/tests/Agent/IntegrationTests/ApplicationHelperLibraries/ConsoleMultiFunctionApplicationHelpers/NetStandardLibraries/GitCommand.cs
@@ -22,5 +22,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
 
             return Repository.Clone(repoUri, fullPath);
         }
+
+        [LibraryMethod]
+        public static string Checkout(string fullPath, string commitOrBranch)
+        {
+            var repo = new Repository(fullPath);
+            var branch = Commands.Checkout(repo, commitOrBranch);
+            return branch.CanonicalName;
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/W3CValidation.cs
@@ -68,6 +68,7 @@ namespace NewRelic.Agent.IntegrationTests
 
                     _fixture.AddCommand($"W3CTestService StartService {_fixture.RemoteApplication.Port}");
                     _fixture.AddCommand($@"GitCommand Clone https://github.com/w3c/trace-context.git {_fixture.RemoteApplication.DestinationApplicationDirectoryPath}\trace-context");
+                    _fixture.AddCommand($@"GitCommand Checkout {_fixture.RemoteApplication.DestinationApplicationDirectoryPath}\trace-context 98f210efd89c63593dce90e2bae0a1bdcb986f51");
                     _fixture.AddCommand("ProcessRunner ProcessName python.exe");
                     _fixture.AddCommand("ProcessRunner AddArgument -m unittest");
                     _fixture.AddCommand("ProcessRunner AddSwitch -v");


### PR DESCRIPTION
### Description

On 8/19/2020 a change was made to the tracecontext tests to perform additional checking prior to running tests to fix an issue they had.
Issue: https://github.com/w3c/trace-context/issues/416
PR: https://github.com/w3c/trace-context/pull/417

This changed a number of tests, including "test_tracestate_empty_header"
https://github.com/w3c/trace-context/pull/417/files#diff-3eb4d995269f8dd7de58cb236d151d7bR505

That change for this test was to ensure that tracestate was null (at least it appears so with my limited Python)
There were a couple of other additional checks added, but we are not hitting them as of yet due to this initila problem.
I am not entirely sure if our agent is doing anything wrong at this point.  It looks like the test is expecting to NOT get back a tracestate, whcich seems incorrect.

Reverting back to the previous commit allows the test to work.
This change adds Checkout support for GitCommand and updates W3CValidation to checkout the appropriate commit.

### Testing

Run the W3CValidation integration test to confirm.


