### PR TITLE
Dockerized db2 test dependencies

### DIFF
--- a/build/Scripts/run-integration-tests.ps1
+++ b/build/Scripts/run-integration-tests.ps1
@@ -9,7 +9,8 @@ Param (
     [string]$testSuite,
     [string]$xunitParams = "",
     [switch]$saveWorkingFolders = $false,
-    [string]$secretsFilePath = ""
+    [string]$secretsFilePath = "",
+    [int]$unboundedServicesStartDelaySeconds = 300
 )
 
 if ($saveWorkingFolders) {
@@ -35,7 +36,7 @@ if ($secretsFilePath -ne "") {
 }
 
 if ($testSuite -eq "unbounded") {
-    Invoke-Expression "$unboundedServicesControlPath -Start"
+    Invoke-Expression "$unboundedServicesControlPath -Start -StartDelaySeconds $unboundedServicesStartDelaySeconds"
 }
 
 $expression = "$xUnitPath" + " " + "$testSuiteDll" + " " +  $xunitParams

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2AsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2AsyncTests.cs
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 4 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/IBMDB2/all", callCount = 4 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/IBMDB2/allWeb", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/instance/IBMDB2/{Db2Configuration.Db2Server}/default", callCount = 4},
+                new Assertions.ExpectedMetric { metricName = $"Datastore/instance/IBMDB2/{CommonUtils.NormalizeHostname(Db2Configuration.Db2Server)}/default", callCount = 4},
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/IBMDB2/select", callCount = 2 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/IBMDB2/employee/select", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/IBMDB2/employee/select", callCount = 1, metricScope = "WebTransaction/MVC/IbmDb2Controller/InvokeIbmDb2QueryAsync"},
@@ -94,7 +94,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests
 
             var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
             {
-                new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "host", parameterValue = $"{Db2Configuration.Db2Server}"},
+                new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(Db2Configuration.Db2Server)},
                 new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "port_path_or_id", parameterValue = "default"},
                 new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "database_name", parameterValue = "SAMPLE"}
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2Tests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2Tests.cs
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 4 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/IBMDB2/all", callCount = 4 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/IBMDB2/allWeb", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/instance/IBMDB2/{Db2Configuration.Db2Server}/default", callCount = 4},
+                new Assertions.ExpectedMetric { metricName = $"Datastore/instance/IBMDB2/{CommonUtils.NormalizeHostname(Db2Configuration.Db2Server)}/default", callCount = 4},
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/IBMDB2/select", callCount = 2 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/IBMDB2/employee/select", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/IBMDB2/employee/select", callCount = 1, metricScope = "WebTransaction/MVC/IbmDb2Controller/InvokeIbmDb2Query"},
@@ -94,7 +94,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests
 
             var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
             {
-                new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "host", parameterValue = $"{Db2Configuration.Db2Server}"},
+                new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(Db2Configuration.Db2Server)},
                 new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "port_path_or_id", parameterValue = "default"},
                 new Assertions.ExpectedSegmentParameter { segmentName = @"Datastore/statement/IBMDB2/employee/select", parameterName = "database_name", parameterValue = "SAMPLE"}
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/db2/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/db2/Dockerfile
@@ -1,0 +1,1 @@
+FROM ibmcom/db2:11.5.0.0

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -56,6 +56,8 @@ db2:
         - "50000:50000"
     environment:
         - LICENSE=accept
+        # These credentials are only used to configure the Db2 container for use by the integration tests
+        # They must match the values from the connection string used by those tests
         - DB2INSTANCE=newrelic
         - DB2INST1_PASSWORD=password
         - SAMPLEDB=true

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -37,5 +37,15 @@ couchbase:
         - COUCHBASE_ADMINISTRATOR_PASSWORD=password
     container_name: CouchbaseServer
 
-
+db2:
+    build: ./db2
+    privileged: true
+    ports:
+        - "50000:50000"
+    environment:
+        - LICENSE=accept
+        - DB2INSTANCE=newrelic
+        - DB2INST1_PASSWORD=password
+        - SAMPLEDB=true
+    container_name: Db2Server
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
@@ -14,16 +14,14 @@ Param(
     [Switch]
     $Stop,
 
-    [Parameter(Manadatory=$false)]
-    [Int32]
-    $StartDelaySeconds = 300
+    [int]$StartDelaySeconds = 300
 )
 
 Function StartUnboundedServices([string] $scriptPath) {
     Push-Location "$scriptPath"
     Write-Host "Launching docker services"
     docker-compose up -d
-    Write-Host "Waiting $StartDelaySeconds for services to be ready"
+    Write-Host "Waiting $StartDelaySeconds seconds for services to be ready"
     Start-Sleep $StartDelaySeconds #TODO: something smarter than this
     Pop-Location
 }

--- a/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
@@ -12,15 +12,19 @@ Param(
     [Parameter(Mandatory=$true,
     ParameterSetName="Stop")]
     [Switch]
-    $Stop
+    $Stop,
+
+    [Parameter(Manadatory=$false)]
+    [Int32]
+    $StartDelaySeconds = 300
 )
 
 Function StartUnboundedServices([string] $scriptPath) {
     Push-Location "$scriptPath"
     Write-Host "Launching docker services"
     docker-compose up -d
-    Write-Host "Waiting for services to be ready"
-    sleep 30 #TODO: something smarter than this
+    Write-Host "Waiting $StartDelaySeconds for services to be ready"
+    Start-Sleep $StartDelaySeconds #TODO: something smarter than this
     Pop-Location
 }
 


### PR DESCRIPTION
### Description

Resolves issue #118.  Adds a dockerfile and docker-compose.yml entry to host IBM Db2 in a docker container for use by our integration tests for the Db2 instrumentation wrapper.

### Testing

Some assertions in the Db2 tests were updated to use the `NormalizeHostname` method to get the correct database instance metric string based on local vs. remote db host.  I verified the Db2 tests pass when pointed at the local service in Docker.

### Changelog

N/A
