### PR TITLE
Dockerized oracle test dependencies

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -31,11 +31,20 @@ couchbase:
         - "8091-8094:8091-8094"
         - "11210:11210"
     environment:
-        # These credentials are only used to configure the Couchbase container for use by the integration tests
-        # You can change these to any value you wish before running the container for the first time
+        # These credentials are only used to configure the Couchbase container 
+        # for use by the integration tests. You can change these to any value 
+        # you wish before running the container for the first time
         - COUCHBASE_ADMINISTRATOR_USERNAME=Administrator
         - COUCHBASE_ADMINISTRATOR_PASSWORD=password
     container_name: CouchbaseServer
 
-
-
+oracle:
+    build: ./oracle
+    shm_size: 1g
+    ports:
+        - "1521:1521"
+        #- "8080:8080"
+    environment:
+        # The password set here must match the password set in the connection 
+        # string being used by the Oracle unbounded integration tests
+        - ORACLE_PWD=password

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -43,8 +43,9 @@ oracle:
     shm_size: 1g
     ports:
         - "1521:1521"
-        #- "8080:8080"
     environment:
         # The password set here must match the password set in the connection 
         # string being used by the Oracle unbounded integration tests
         - ORACLE_PWD=password
+    container_name: OracleServer
+    

--- a/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
@@ -1,1 +1,1 @@
-FROM oracle/database:11.2.0.2-xe
+FROM docker.pkg.github.com/newrelic/newrelic-dotnet-agent/oracledb:11.2.0.2-xe

--- a/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
@@ -1,0 +1,1 @@
+FROM oracle/database:11.2.0.2-xe

--- a/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/newrelic/newrelic-dotnet-agent/oracledb:11.2.0.2-xe
+FROM newrelic/test-oracle-db:11.2.0.2-xe


### PR DESCRIPTION
### Description

Resolves issue #129.  Adds a Dockerfile and docker-compose.yml entry to provide an Oracle 11 express edition database for use by the unbounded tests that test our Oracle DB instrumentation wrapper.

### Testing

I've verified that the unbounded tests for Oracle pass when using this service, and we'll make sure our CI job for the unbounded tests pass before merging this.

### Changelog

N/A
