### PR TITLE
Proxy Password Obfuscation: rename encryptedPassword to passwordObfuscated

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
-* **Proxy Password Encryption Support** <br/>
+* **Proxy Password Obfuscation Support** <br/>
 Agent configuration supports the obfuscation of the proxy password. [The New Relic Command Line Interface (CLI)](https://github.com/newrelic/newrelic-cli/blob/master/README.md) may be used to obscure the proxy password.  The following [documentation](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#proxy) describes how to use an obscured proxy password in the .NET Agent configuration.
 
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -944,7 +944,7 @@ namespace NewRelic.Agent.Core.Config
         
         private string passwordField;
         
-        private string encryptedPasswordField;
+        private string passwordObfuscatedField;
         
         private string domainField;
         
@@ -1023,15 +1023,15 @@ namespace NewRelic.Agent.Core.Config
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public string encryptedPassword
+        public string passwordObfuscated
         {
             get
             {
-                return this.encryptedPasswordField;
+                return this.passwordObfuscatedField;
             }
             set
             {
-                this.encryptedPasswordField = value;
+                this.passwordObfuscatedField = value;
             }
         }
         

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -113,10 +113,10 @@
                     </xs:annotation>
                   </xs:attribute>
 
-                  <xs:attribute name="encryptedPassword" type="xs:string" use="optional">
+                  <xs:attribute name="passwordObfuscated" type="xs:string" use="optional">
                     <xs:annotation>
                       <xs:documentation>
-                        The encrypted password used to authenticate with the proxy server (optional).
+                        The obfuscated password with which to authenticate to the proxy server (optional).
                       </xs:documentation>
                     </xs:annotation>
                   </xs:attribute>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1333,11 +1333,11 @@ namespace NewRelic.Agent.Core.Configuration
                 if (!_proxyPasswordEvaluated)
                 {
                     var hasObscuringKey = !string.IsNullOrWhiteSpace(ObscuringKey);
-                    var hasEncryptedPassword = !string.IsNullOrWhiteSpace(_localConfiguration.service.proxy.encryptedPassword);
+                    var hasObfuscatedPassword = !string.IsNullOrWhiteSpace(_localConfiguration.service.proxy.passwordObfuscated);
 
-                    if (hasObscuringKey && hasEncryptedPassword)
+                    if (hasObscuringKey && hasObfuscatedPassword)
                     {
-                         _proxyPassword = Strings.Base64Decode(_localConfiguration.service.proxy.encryptedPassword, ObscuringKey);
+                         _proxyPassword = Strings.Base64Decode(_localConfiguration.service.proxy.passwordObfuscated, ObscuringKey);
                     }
                     else
                     {

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1072,13 +1072,13 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("ABCD", null, "123", null, ExpectedResult = "ABCD")]
         [TestCase("ABCD", "   ", "123", null, ExpectedResult = "ABCD")]
         [TestCase("ABCD", "bGxs", "   ", null, ExpectedResult = "ABCD")]
-        public string Encrypting_Decrypting_ProxyPassword_Tests(string password, string encryptedPassword, string localConfigObscuringKey, string envObscuringKey)
+        public string Encrypting_Decrypting_ProxyPassword_Tests(string password, string passwordObfuscated, string localConfigObscuringKey, string envObscuringKey)
         {
             Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_CONFIG_OBSCURING_KEY")).Returns(envObscuringKey);
 
             _localConfig.service.proxy.password = password;
             _localConfig.service.obscuringKey = localConfigObscuringKey;
-            _localConfig.service.proxy.encryptedPassword = encryptedPassword;
+            _localConfig.service.proxy.passwordObfuscated = passwordObfuscated;
             
             CreateDefaultConfiguration();
 


### PR DESCRIPTION
### Description

rename `encryptedPassword` attribute in `<Proxy>` to `passwordObfuscated`

### Testing

Tests already exist, just renamed variables in them

### Changelog

Updated ChangeLog.
Updating Online docs draft.