### PR TITLE
Instrument MySqlConnector

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 * **Proxy Password Obfuscation Support** <br/>
 Agent configuration supports the obfuscation of the proxy password. [The New Relic Command Line Interface (CLI)](https://github.com/newrelic/newrelic-cli/blob/master/README.md) may be used to obscure the proxy password.  The following [documentation](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#proxy) describes how to use an obscured proxy password in the .NET Agent configuration.
+* **MySqlConnector Support** <br/>
+The MySqlConnector ADO.NET driver is instrumented by default. Fixes [#85](https://github.com/newrelic/newrelic-dotnet-agent/issues/85) and implements [this suggestion](https://discuss.newrelic.com/t/feature-idea-support-mysqlconnector-driver-for-db-instrumentation/63414).
 
 ### Fixes
 * Fixes an issue that may cause `InvalidCastException` due to an assembly version mismatch in Mvc3 instrumentation.

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -87,6 +87,22 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteNonQuery" />
       </match>
 
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlCommand">
+        <exactMethodMatcher methodName="ExecuteDbDataReader" parameters="System.Data.CommandBehavior" />
+        <exactMethodMatcher methodName="ExecuteReader" />
+        <exactMethodMatcher methodName="ExecuteNonQuery" />
+        <exactMethodMatcher methodName="ExecuteScalar" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlCommand">
+        <exactMethodMatcher methodName="ExecuteDbDataReader" parameters="System.Data.CommandBehavior" />
+        <exactMethodMatcher methodName="ExecuteReader" />
+        <exactMethodMatcher methodName="ExecuteNonQuery" />
+        <exactMethodMatcher methodName="ExecuteScalar" />
+      </match>
+
       <!-- IBM DB2 driver -->
       <match assemblyName="IBM.Data.DB2" className="IBM.Data.DB2.DB2Command">
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior"/>
@@ -127,6 +143,24 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteXmlReaderAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlCommand">
+        <exactMethodMatcher methodName="ExecuteDbDataReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlCommand">
+        <exactMethodMatcher methodName="ExecuteDbDataReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />
       </match>
 
       <!-- Postgres SQL Driver-->
@@ -182,6 +216,18 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="Read" />
       </match>
 
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlDataReader">
+        <exactMethodMatcher methodName="NextResult" />
+        <exactMethodMatcher methodName="Read" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlDataReader">
+        <exactMethodMatcher methodName="NextResult" />
+        <exactMethodMatcher methodName="Read" />
+      </match>
+
       <!-- IBM DB2 driver -->
       <match assemblyName="IBM.Data.DB2" className="IBM.Data.DB2.DB2DataReader">
         <exactMethodMatcher methodName="NextResult" />
@@ -212,7 +258,19 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="NextResultAsync" />
         <exactMethodMatcher methodName="ReadAsync" />
       </match>
-      
+
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlDataReader">
+        <exactMethodMatcher methodName="NextResultAsync" />
+        <exactMethodMatcher methodName="ReadAsync" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlDataReader">
+        <exactMethodMatcher methodName="NextResultAsync" />
+        <exactMethodMatcher methodName="ReadAsync" />
+      </match>
+
       <!-- Postgres data provider -->
       <match assemblyName="Npgsql" className="Npgsql.NpgsqlDataReader">
         <exactMethodMatcher methodName="NextResultAsync" />
@@ -256,6 +314,16 @@ SPDX-License-Identifier: Apache-2.0
       <!-- MySql (official) driver -->
       <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlConnection">
         <exactMethodMatcher methodName="Open"/>
+      </match>
+
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlConnection">
+        <exactMethodMatcher methodName="Open" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlConnection">
+        <exactMethodMatcher methodName="Open" />
       </match>
 
       <!-- IBM DB2 driver -->


### PR DESCRIPTION
### Description

Fixes #85.

This causes MySqlConnector to be instrumented by default; it supports the namespaces for both MySqlConnector v0.x (`MySql.Data.MySqlClient`) and v1.x (`MySqlConnector`).

### Testing

I've performed local ad-hoc testing with MySqlConnector 0.69.9 and 1.0.1 in a local ASP.NET Web API project under IIS. Results were logged to this project: https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLW5lcmRsZXRzLmRpc3RyaWJ1dGVkLXRyYWNlLWxpc3QiLCJlbnRpdHlJZCI6Ik9UazNOelY4UVZCTmZFRlFVRXhKUTBGVVNVOU9mRGczTXprME5UQTFOZyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJPVGszTnpWOFFWQk5mRUZRVUV4SlEwRlVTVTlPZkRnM016azBOVEExTmciLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoiZGlzdHJpYnV0ZWQtdHJhY2luZy1uZXJkbGV0cy5kaXN0cmlidXRlZC10cmFjZS1saXN0In19&platform[timeRange][duration]=1800000 (don't know if that works 

