### PR TITLE
Integration test fixes

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -96,7 +96,6 @@
       <Version>5.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Razor">
-      <!-- <Version>3.2.0</Version> -->
       <Version>3.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client">
@@ -109,7 +108,6 @@
       <Version>5.2.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Webpages">
-      <!-- <Version>3.2.0</Version> -->
       <Version>3.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -55,27 +55,14 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
-    <Reference Include="System.EnterpriseServices" /> 
-    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.0\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
   <ItemGroup>
     <Content Include="Global.asax" />
     <Content Include="Web.config" />
   </ItemGroup>
-    <ItemGroup>
+  <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
@@ -104,7 +91,6 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.7</Version>
@@ -146,7 +132,6 @@
       <Version>4.0.40</Version>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -96,7 +96,8 @@
       <Version>5.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Razor">
-      <Version>3.2.0</Version>
+      <!-- <Version>3.2.0</Version> -->
+      <Version>3.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client">
       <Version>5.2.3</Version>
@@ -108,7 +109,8 @@
       <Version>5.2.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Webpages">
-      <Version>3.2.0</Version>
+      <!-- <Version>3.2.0</Version> -->
+      <Version>3.2.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
       <Version>2.0.1</Version>

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Web.config
@@ -14,30 +14,6 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
-  <runtime>
-    <!--<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>-->
-  </runtime>
   <system.webServer>
     <modules>
       <remove name="WebDAVModule" />

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Web.config
@@ -15,7 +15,7 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    <!--<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
@@ -36,7 +36,7 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
-    </assemblyBinding>
+    </assemblyBinding>-->
   </runtime>
   <system.webServer>
     <modules>

--- a/tests/Agent/IntegrationTests/Applications/BasicWebApplication/BasicWebApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicWebApplication/BasicWebApplication.csproj
@@ -18,6 +18,8 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,9 +39,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr3.Runtime, Version=3.4.1.9004, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
@@ -57,20 +56,8 @@
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="Microsoft.ScriptManager.MSAjax">
-      <HintPath>..\..\packages\Microsoft.AspNet.ScriptManager.MSAjax.5.0.0\lib\net45\Microsoft.ScriptManager.MSAjax.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb">
-      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.3.0.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin">
-      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-    <ItemGroup>
     <PackageReference Include="EntityFramework">
       <Version>6.1.1</Version>
     </PackageReference>
@@ -126,7 +113,6 @@
       <Version>6.0.4</Version>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="Properties\PublishProfiles\LocalDeploy.pubxml" />
     <Content Include="Default.aspx" />

--- a/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/Program.cs
@@ -1,7 +1,6 @@
-/*
-* Copyright 2020 New Relic Corporation. All rights reserved.
-* SPDX-License-Identifier: Apache-2.0
-*/
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 
 using NewRelic.Agent.IntegrationTests.ApplicationHelpers;
 using NewRelic.Api.Agent;

--- a/tests/Agent/IntegrationTests/Applications/ConsoleMultiFunctionApplicationFW/ConsoleMultiFunctionApplicationFW.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleMultiFunctionApplicationFW/ConsoleMultiFunctionApplicationFW.csproj
@@ -38,39 +38,15 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.4.1.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Hosting.4.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="NewRelic.Api.Agent, Version=8.19.353.0, Culture=neutral, PublicKeyToken=06552fced0b33d87, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NewRelic.Agent.Api.8.19.353\lib\net45\NewRelic.Api.Agent.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.7\lib\net45\System.Web.Http.Owin.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/Web.config
@@ -16,7 +16,7 @@
     <httpModules>
     </httpModules>
   </system.web>
-  <runtime>
+  <!--<runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
@@ -35,7 +35,7 @@
         <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
-  </runtime>
+  </runtime>-->
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <modules>

--- a/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/RejitMvcApplication/Web.config
@@ -16,26 +16,6 @@
     <httpModules>
     </httpModules>
   </system.web>
-  <!--<runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>-->
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <modules>

--- a/tests/Agent/IntegrationTests/Applications/WebForms45Application/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/WebForms45Application/Web.config
@@ -38,24 +38,6 @@
       <remove name="FormsAuthentication" />
     </modules>
   </system.webServer>
-  
-  <!--<runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1"> 
-      <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
-      </dependentAssembly>      
-    </assemblyBinding>
-  </runtime>-->
-
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>

--- a/tests/Agent/IntegrationTests/Applications/WebForms45Application/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/WebForms45Application/Web.config
@@ -39,7 +39,7 @@
     </modules>
   </system.webServer>
   
-  <runtime>
+  <!--<runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1"> 
       <dependentAssembly>
         <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
@@ -54,7 +54,7 @@
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>      
     </assemblyBinding>
-  </runtime>
+  </runtime>-->
 
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">

--- a/tests/Agent/IntegrationTests/Applications/WebForms45Application/WebForms45Application.csproj
+++ b/tests/Agent/IntegrationTests/Applications/WebForms45Application/WebForms45Application.csproj
@@ -58,48 +58,6 @@
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="AspNet.ScriptManager.bootstrap">
-      <HintPath>..\..\packages\AspNet.ScriptManager.bootstrap.3.4.1\lib\net45\AspNet.ScriptManager.bootstrap.dll</HintPath>
-    </Reference>
-    <Reference Include="AspNet.ScriptManager.jQuery">
-      <HintPath>..\..\packages\AspNet.ScriptManager.jQuery.3.4.1\lib\net45\AspNet.ScriptManager.jQuery.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ScriptManager.MSAjax">
-      <HintPath>..\..\packages\Microsoft.AspNet.ScriptManager.MSAjax.5.0.0\lib\net45\Microsoft.ScriptManager.MSAjax.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ScriptManager.WebForms">
-      <HintPath>..\..\packages\Microsoft.AspNet.ScriptManager.WebForms.5.0.0\lib\net45\Microsoft.ScriptManager.WebForms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="WebGrease">
-      <Private>True</Private>
-      <HintPath>..\..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
-    </Reference>
-    <Reference Include="Antlr3.Runtime">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.Web.Optimization.WebForms">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.WebForms.1.1.3\lib\net45\Microsoft.AspNet.Web.Optimization.WebForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.FriendlyUrls">
-      <HintPath>..\..\packages\Microsoft.AspNet.FriendlyUrls.Core.1.0.2\lib\net45\Microsoft.AspNet.FriendlyUrls.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
-      <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="About.aspx" />
@@ -147,10 +105,7 @@
       <DependentUpon>Site.Master</DependentUpon>
     </Compile>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="App_Data\" />
-    <Folder Include="Scripts\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <None Include="Properties\PublishProfiles\LocalDeploy.pubxml" />
     <None Include="Web.Debug.config">

--- a/tests/Agent/IntegrationTests/IntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/IntegrationTests.sln
@@ -132,6 +132,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore3Features", "Appl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore3Collectible", "ApplicationHelperLibraries\NetCore3Collectible\NetCore3Collectible.csproj", "{1F9D5857-EEE4-48FC-B101-2ADFFC88EA4A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleInstrumentationLoaderCore", "Applications\ConsoleInstrumentationLoaderCore\ConsoleInstrumentationLoaderCore.csproj", "{8AC32C1E-2C20-4ECE-8480-700E28C3E43D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -358,6 +360,10 @@ Global
 		{1F9D5857-EEE4-48FC-B101-2ADFFC88EA4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F9D5857-EEE4-48FC-B101-2ADFFC88EA4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F9D5857-EEE4-48FC-B101-2ADFFC88EA4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AC32C1E-2C20-4ECE-8480-700E28C3E43D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AC32C1E-2C20-4ECE-8480-700E28C3E43D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AC32C1E-2C20-4ECE-8480-700E28C3E43D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AC32C1E-2C20-4ECE-8480-700E28C3E43D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -411,6 +417,7 @@ Global
 		{CD2C128F-2A0E-4453-8F85-F6E53F7C8E8A} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
 		{383D35CC-5B34-4ABE-AEB2-B3E2666DD572} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
 		{1F9D5857-EEE4-48FC-B101-2ADFFC88EA4A} = {CB5B7DCD-F949-4435-BC39-C34F4F3D2009}
+		{8AC32C1E-2C20-4ECE-8480-700E28C3E43D} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3830ABDF-4AEA-4D91-83A2-13F091D1DF5F}

--- a/tests/Agent/IntegrationTests/IntegrationTests/CallStackFallbackMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CallStackFallbackMvc.cs
@@ -1,8 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -73,8 +71,8 @@ namespace NewRelic.Agent.IntegrationTests
                 new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Normalized/*" },
                 new Assertions.ExpectedMetric { metricName = @"OtherTransaction/all" },
 
-				// The .NET agent does not have the information needed to generate this metric
-				new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction", callCount = 1 },
+                // The .NET agent does not have the information needed to generate this metric
+                new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
             };
 
@@ -110,8 +108,7 @@ namespace NewRelic.Agent.IntegrationTests
             };
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
-                {"type", "Transaction"},
-                {"nr.apdexPerfZone", "F"}
+                {"type", "Transaction"}
             };
             var expectedTransactionEventIntrinsicAttributes2 = new List<string>
             {
@@ -119,7 +116,8 @@ namespace NewRelic.Agent.IntegrationTests
                 "duration",
                 "webDuration",
                 "queueDuration",
-                "totalTime"
+                "totalTime",
+                "nr.apdexPerfZone"
             };
             var expectedTransactionEventAgentAttributes = new Dictionary<string, object>
             {

--- a/tests/Agent/IntegrationTests/Shared/MsSqlOleDbConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/MsSqlOleDbConfiguration.cs
@@ -9,7 +9,6 @@ namespace NewRelic.Agent.IntegrationTests.Shared
     public class MsSqlOleDbConfiguration
     {
         private static string _msSqlOleDbConnectionString;
-        private static string _msSqlOleDbServer;
 
         // example:  "PROVIDER=SQLXXXX11;Server=1.2.3.4;Database=DBName;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;Timeout=30;"
         public static string MsSqlOleDbConnectionString


### PR DESCRIPTION
### Description

This PR reduces the number of build warnings when building the integration tests solution, primarily by modifying package references in .csproj files and some assembly binding redirections in web.config files.  These warnings were recently introduced by project file changes to support StyleCop.

It also fixes some test failures caused by a) asserting on the value of the ApdexPerfZone attribute rather than just asserting on its presence and b) fixing a copyright header format issue in one file.

### Testing

The integration tests solution builds with fewer warnings, and the tests pass for me locally (as reliably as usual, meaning that out of 900+ tests I typically get 5-15 test flickers (failures which pass upon re-test)).

### Changelog

N/A because no agent functionality changed.