### PR TITLE
Change how EndSegment is called for Tasks

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -14,6 +14,7 @@ Enables nullable reference types that are part of the C# 8.0 language specificat
 
 ### Fixes
 * Fixes an issue that may cause `InvalidCastException` due to an assembly version mismatch in Mvc3 instrumentation.
+* Fixes an async timing issue that can cause the end time of `Task`-returning methods to be determined incorrectly.
 
 ## [8.31] - 2020-08-17
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Delegates.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Delegates.cs
@@ -152,22 +152,18 @@ namespace NewRelic.Agent.Extensions.Providers.Wrapper
                 transaction.Hold();
             }
 
-            if (options == TaskContinueWithOption.None)
+            if (task.IsCompleted)
+            {
+                EndSegment(task);
+            }
+            else if (options == TaskContinueWithOption.None)
             {
                 if (!continuationOptions.HasValue) task.ContinueWith(EndSegment);
                 else task.ContinueWith(EndSegment, continuationOptions.Value);
             }
             else
             {
-                var context = SynchronizationContext.Current;
-                if (context != null)
-                {
-                    task.ContinueWith(EndSegment, TaskScheduler.FromCurrentSynchronizationContext());
-                }
-                else
-                {
-                    task.ContinueWith(EndSegment, TaskContinuationOptions.ExecuteSynchronously);
-                }
+                task.ContinueWith(EndSegment, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             }
 
             void EndSegment(Task completedTask)


### PR DESCRIPTION
### Description

If the `Task` has already completed, we call `EndSegment` (synchronously) immediately. Otherwise, we always continue with `TaskContinuationOptions.ExecuteSynchronously` on the default `TaskScheduler`, which runs our continuation as soon as possible (on the thread that completed the task).

This avoids task continuations being delayed until much later in the ASP.NET pipeline (due to when `AspNetSynchronizationContext` posts them), which causes inaccurate timings.

### Testing

Tested in prod as per https://github.com/newrelic/newrelic-dotnet-agent/issues/85#issuecomment-690669280.

