### PR TITLE
Document use of the containerized services for the unbounded integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/README.md
+++ b/tests/Agent/IntegrationTests/UnboundedServices/README.md
@@ -1,0 +1,40 @@
+# Dockerized Unbounded Integration Test Services
+
+The tests in the [unbounded integration tests solution](../UnboundedIntegrationTests.sln) depend on external resources to function properly, e.g. tests for MySql database instrumentation need to connect to a MySql database.  The assets in this path allow a developer to use Docker Desktop to run the necessary services for the tests.
+
+## Requirements
+
+* Windows 10 
+* [Docker Desktop 2.2+](https://docs.docker.com/docker-for-windows/install/)
+
+Note: while not a hard requirement, the containers will perform better if you use [Docker Desktop's WSL2 (Windows Subsystem for Linux 2) backend](https://docs.docker.com/docker-for-windows/wsl/), so having WSL2 enabled on your Windows 10 system is a good idea.
+
+## Running the containers
+
+### All
+
+To run all services, run the following from a shell (we've tested Powershell and "git-bash") in the same path as this document:
+
+`docker-compose up`
+
+If you don't want to follow the output of the services, you can run them in the background (detached) like this:
+
+`docker-compose up -d`
+
+To stop the services:
+
+`docker-compose down`
+
+**Note**: launching all of the services takes a lot of time (as much as 15 minutes in our testing) and a lot of system resources.  Unless you need to run all of the unbounded integration tests (e.g. if you've made a change to a core part of the test framework as opposed to an individual test or piece of instrumentation) it is not recommended to do this.
+
+### Individually
+
+It is generally best to only the the service for the tests you happen to be working on at the time (see note above).  To run a single service, execute the following:
+
+`docker-compose run --service-ports <service>`
+
+See the docker-compose.yml file for the names of the services provided.
+
+## Configuring user secrets
+
+The integration tests, including the unbounded ones, use `dotnet user-secrets` to manage confuration data, including the connection strings needed to access these external services.  An [example-secrets.json](./example-secrets.json) file has been provided which contains connection strings for all of the containerized unbounded services.  See the [integration test documentation](/docs/integration-tests.md) for how to install the user secrets.

--- a/tests/Agent/IntegrationTests/UnboundedServices/README.md
+++ b/tests/Agent/IntegrationTests/UnboundedServices/README.md
@@ -11,9 +11,14 @@ Note: while not a hard requirement, the containers will perform better if you us
 
 ## Running the containers
 
+**Notes**:
+
+* All commands below should be run from a shell (we've tested Powershell and "git-bash") in the same location as this README.
+* Before Docker containers can be used the first time, they need to be built by executing `docker-compose build`.
+
 ### All
 
-To run all services, run the following from a shell (we've tested Powershell and "git-bash") in the same path as this document:
+To run all services:
 
 `docker-compose up`
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -1,0 +1,72 @@
+{
+    "IntegrationTestConfiguration": {
+      "DefaultSetting": {
+        "LicenseKey": "YOUR_LICENSE_KEY_HERE",
+        "Collector": "collector.newrelic.com",
+        "NewRelicAccountId" : "YOUR_ACCOUNT_ID_HERE"
+      },
+      "TestSettingOverrides": {
+        "PostgresTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "Server=127.0.0.1;Port=5432;User Id=postgres;Password=password;Database=postgres;"
+          }
+        },
+        "MSSQLTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "Server=127.0.0.1;Database=NewRelic;User ID=sa;Password=password;Trusted_Connection=False;Encrypt=False;Connection Timeout=30;"
+          }
+        },
+        "MSSQLOdbcTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;"
+          }
+        },
+        "MSSQLOleDbTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "PROVIDER=SQLNCLI11;Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;Timeout=30;"
+          }
+        },
+        "MySQLTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "Network Address=127.0.0.1;Port=3306;Initial Catalog=newrelic;Persist Security Info=no;User Name=root;Password=password;SslMode=None"
+          }
+        },
+        "OracleTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "Data Source=127.0.0.1:1521/XE;User Id=SYSTEM;Password=password;"
+          }
+        },
+        "StackExchangeRedisTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "127.0.0.1:6379"
+          }
+        },
+        "Db2Tests" : {
+          "CustomSettings": {
+              "ConnectionString" : "Server=127.0.0.1;Database=SAMPLE;UserID=newrelic;Password=password"
+          }
+        },
+        "MongoDBTests" : {
+          "CustomSettings": {
+              "ConnectionString" : "mongodb://127.0.0.1:27017"
+          }
+        },
+        "MongoDB26Tests" : {
+          "CustomSettings": {
+              "ConnectionString" : "mongodb://127.0.0.1:27018"
+          }
+        },
+        "RabbitMqTests" : {
+          "CustomSettings": {
+              "Server" : "127.0.0.1"
+          }
+        },
+        "CouchbaseTests" : {
+          "CustomSettings": {
+              "ServerUrl" : "http://127.0.0.1",
+              "TestBucket" : "travel-sample"
+          }
+        }
+      }
+    }
+  }

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -13,17 +13,17 @@
         },
         "MSSQLTests" : {
           "CustomSettings": {
-              "ConnectionString" : "Server=127.0.0.1;Database=NewRelic;User ID=sa;Password=password;Trusted_Connection=False;Encrypt=False;Connection Timeout=30;"
+              "ConnectionString" : "Server=127.0.0.1;Database=NewRelic;User ID=sa;Password=password0TS;Trusted_Connection=False;Encrypt=False;Connection Timeout=30;"
           }
         },
         "MSSQLOdbcTests" : {
           "CustomSettings": {
-              "ConnectionString" : "DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;"
+              "ConnectionString" : "DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password0TS;Encrypt=no;"
           }
         },
         "MSSQLOleDbTests" : {
           "CustomSettings": {
-              "ConnectionString" : "PROVIDER=SQLNCLI11;Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;Timeout=30;"
+              "ConnectionString" : "PROVIDER=SQLNCLI11;Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password0TS;Encrypt=no;Timeout=30;"
           }
         },
         "MySQLTests" : {

--- a/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
@@ -14,7 +14,7 @@ Param(
     [Switch]
     $Stop,
 
-    [int]$StartDelaySeconds = 300
+    [int]$StartDelaySeconds = 600
 )
 
 Function StartUnboundedServices([string] $scriptPath) {


### PR DESCRIPTION
### Description

Adds a README.md on how to use the unbounded service containers when running unbounded integration tests.

### Testing

N/A

### Changelog

N/A
