### PR TITLE
AddNewRelicStartupFilter should only be added once.

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -17,13 +17,10 @@ Enables nullable reference types that are part of the C# 8.0 language specificat
 * **Improved Support for NetTCP Binding in WCF Instrumation**
 When the NetTCP Binding type is used in Windows Communication Foundation (WCF), the Agent will now send and receive trace context information in support of Distributed Tracing (DT) or Cross Application Tracing (CAT).  Implements [#209](https://github.com/newrelic/newrelic-dotnet-agent/issues/209).
 
-* **.NET 5 Prerelease Support**<br/>
-Adds support for .NET 5 prerelease. 
-
 ### Fixes
 * Fixes an issue that may cause `InvalidCastException` due to an assembly version mismatch in Mvc3 instrumentation.
 * Fixes an async timing issue that can cause the end time of `Task`-returning methods to be determined incorrectly.
-* Fixes an issue that causes .NET 5 prerealease incompatability.
+* Fixes [#223](https://github.com/newrelic/newrelic-dotnet-agent/issues/223) that causes the agent incompatible with ASP.NET Core 5 RC1 applications.
 
 ## [8.31] - 2020-08-17
 ### New Features

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -20,7 +20,7 @@ When the NetTCP Binding type is used in Windows Communication Foundation (WCF), 
 ### Fixes
 * Fixes an issue that may cause `InvalidCastException` due to an assembly version mismatch in Mvc3 instrumentation.
 * Fixes an async timing issue that can cause the end time of `Task`-returning methods to be determined incorrectly.
-* Fixes [#223](https://github.com/newrelic/newrelic-dotnet-agent/issues/223) that causes the agent incompatible with ASP.NET Core 5 RC1 applications.
+* Fixes [#223](https://github.com/newrelic/newrelic-dotnet-agent/issues/223) so the agent can be compatible with ASP.NET Core 5 RC1.
 
 ## [8.31] - 2020-08-17
 ### New Features

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -17,9 +17,13 @@ Enables nullable reference types that are part of the C# 8.0 language specificat
 * **Improved Support for NetTCP Binding in WCF Instrumation**
 When the NetTCP Binding type is used in Windows Communication Foundation (WCF), the Agent will now send and receive trace context information in support of Distributed Tracing (DT) or Cross Application Tracing (CAT).  Implements [#209](https://github.com/newrelic/newrelic-dotnet-agent/issues/209).
 
+* **.NET 5 Prerelease Support**<br/>
+Adds support for .NET 5 prerelease. 
+
 ### Fixes
 * Fixes an issue that may cause `InvalidCastException` due to an assembly version mismatch in Mvc3 instrumentation.
 * Fixes an async timing issue that can cause the end time of `Task`-returning methods to be determined incorrectly.
+* Fixes an issue that causes .NET 5 prerealease incompatability.
 
 ## [8.31] - 2020-08-17
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/GenericHostWebHostBuilderExtensionsWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/GenericHostWebHostBuilderExtensionsWrapper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Linq;
+using System.Threading;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using NewRelic.Agent.Api;
@@ -12,7 +13,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
     public class GenericHostWebHostBuilderExtensionsWrapper : IWrapper
     {
         public bool IsTransactionRequired => false;
-        private static bool _isNewRelicStartupFilterAdded;
+        private static int _isNewRelicStartupFilterAdded;
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
@@ -33,11 +34,10 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
         {
             public static void AddStartupFilterToHostBuilder(object hostBuilder, IAgent agent)
             {
-                if (!_isNewRelicStartupFilterAdded)
+                if (0 == Interlocked.CompareExchange(ref _isNewRelicStartupFilterAdded, 1, 0))
                 {
                     var typedHostBuilder = (Microsoft.Extensions.Hosting.IHostBuilder)hostBuilder;
                     typedHostBuilder.ConfigureServices(AddStartupFilter);
-                    _isNewRelicStartupFilterAdded = true;
 
                     void AddStartupFilter(Microsoft.Extensions.Hosting.HostBuilderContext hostBuilderContext, IServiceCollection services)
                     {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/ResolveAppWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/ResolveAppWrapper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Threading;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
@@ -11,7 +12,7 @@ namespace NewRelic.Providers.Wrapper.Owin
     public class ResolveAppWrapper : IWrapper
     {
         public bool IsTransactionRequired => false;
-        private static bool _isNewRelicMiddlewareAdded;
+        private static int _isNewRelicMiddlewareAdded;
         private Func<object, object> _getBuilder;
         public Func<object, object> GetBuilder => _getBuilder ?? (_getBuilder = VisibilityBypasser.Instance.GeneratePropertyAccessor<object>("Microsoft.Owin.Hosting",
                 "Microsoft.Owin.Hosting.Engine.StartContext", "Builder"));
@@ -23,7 +24,7 @@ namespace NewRelic.Providers.Wrapper.Owin
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
-            if (!_isNewRelicMiddlewareAdded)
+            if (0 == Interlocked.CompareExchange(ref _isNewRelicMiddlewareAdded, 1, 0))
             {
                 var context = instrumentedMethodCall.MethodCall.MethodArguments[0];
 
@@ -36,7 +37,6 @@ namespace NewRelic.Providers.Wrapper.Owin
                 typeof(OwinStartupMiddleware), new object[] { agent }
                 });
 
-                _isNewRelicMiddlewareAdded = true;
             }
 
             return Delegates.NoOp;


### PR DESCRIPTION
### Description
The current agent is not compatible with .Net 5.0 RC1. This is due to an introduction of a new method overload of the ConfigureWebHost method in .Net 5.0 RC1. The agent currently subscribes to any of this method overload to add the custom AddNewRelicStartupFilter startup filter into the application pipeline in order to instrument Asp.net core calls. Since introduction of the new method overload, the agent subscribed to two method overloads and they were both executed. As a result, the agent added more than one AddNewRelicStartupFilter startup filter into the pipeline. It should add only one. This PR fixes this.

