### PR TITLE
Save Profiler artifacts for later use in workflow

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -282,6 +282,13 @@ jobs:
         docker-compose run build
       shell: bash
 
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: linuxprofiler-${{ github.run_id }}
+        path: |
+          ${{ github.workspace }}\src\Agent\NewRelic\Profiler\libNewRelicProfiler.so
+
   build-integration-tests:
     needs: [build-test-fullagent-msi, build-test-windows-profiler, build-test-linux-profiler]
     name: Build IntegrationTests

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -252,12 +252,18 @@ jobs:
         MSBuild.exe -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
       shell: powershell
 
-    - name: Archive Artifacts
+    - name: Archive Artifacts x64
       uses: actions/upload-artifact@v2
       with:
-        name: windowsprofiler-${{ github.run_id }}
+        name: windowsprofiler-x64-${{ github.run_id }}
         path: |
           ${{ github.workspace }}\src\Agent\_profilerBuild\x64-Release
+
+    - name: Archive Artifacts x86
+      uses: actions/upload-artifact@v2
+      with:
+        name: windowsprofiler-x86-${{ github.run_id }}
+        path: |
           ${{ github.workspace }}\src\Agent\_profilerBuild\x86-Release
 
   build-test-linux-profiler:

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -293,7 +293,7 @@ jobs:
       with:
         name: linuxprofiler-${{ github.run_id }}
         path: |
-          ${{ github.workspace }}\src\Agent\NewRelic\Profiler\libNewRelicProfiler.so
+          ${{ github.workspace }}/src/Agent/NewRelic/Profiler/libNewRelicProfiler.so
 
   build-integration-tests:
     needs: [build-test-fullagent-msi, build-test-windows-profiler, build-test-linux-profiler]

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -203,7 +203,8 @@ jobs:
           branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}    
 
-      - uses: LouisBrunner/checks-action@v1.0.0
+      - name: Create Check-run with test results
+        uses: LouisBrunner/checks-action@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
@@ -250,6 +251,14 @@ jobs:
         Write-Host "MSBuild.exe -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}"
         MSBuild.exe -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
       shell: powershell
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: windowsprofiler-${{ github.run_id }}
+        path: |
+          ${{ github.workspace }}\src\Agent\_profilerBuild\x64-Release
+          ${{ github.workspace }}\src\Agent\_profilerBuild\x86-Release
 
   build-test-linux-profiler:
     name: Build Linux Profiler


### PR DESCRIPTION
Resolves #237 

### Description

Saves the linux and windows profiler artifacts so that they can be used later on in the workflow during the integration tests.  Will create 3 artifact packages, 2 for windows and 1 for linux:

- `windowsprofiler-x86-<github.run_id>`
- `windowsprofiler-x64-<github.run_id>`
- `linuxprofiler-<github.run_id>`

### Testing

Workflow completes.  

Windows artifacts will come in two packages, one for x86 and one for x64 to avoid confusion since the names are all the same. Both packages should have the follow files at a minimum:
- NewRelic.Profiler.dll
- NewRelic.Profiler.pdb

Linux: 
- libNewRelicProfiler.so

### Changelog

Please remember to update our [changelog](/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),

