### PR TITLE
Update example secrets file

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -44,11 +44,26 @@ Tests the integration of the New Relic .NET agent with various .NET applications
   * The data server client installer can be downloaded from [here](https://www.ibm.com/support/pages/ibm-data-server-client-packages-version-111-mod-4-fix-pack-4).
 
 ### Set up test secrets
-You must have a New Relic license key to run the tests. Some tests require special New Relic license keys for high security mode (HSM) and configurable security policies (CSP). Follow the steps below to set these license keys.
+* You must have a valid New Relic license key to run the tests. 
+* The license key and other settings are accessed by the tests in a `secrets.json` file. [Here](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json) is an example.
+* The [example](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json) includes placeholders for values unique to a user's environment.
+* The [example](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json) includes values needed for all Integration Tests and Unbounded Integration Tests.
+  * Not all values in the `secrets.json` are required if a user is running a subset of tests, and can be omitted for irrelevant tests.
 
-1. Create a `secrets.json` file using the template below.  **Do *not* place the `secrets.json` file within your local repo folder.**
-2. Replace the license key placeholders in the `secrets.json` template with actual license keys. The `REPLACE_WITH_HIGH_SECURITY_LICENSE_KEY` and `REPLACE_WITH_SECURITY_POLICIES_CONFIGURABLE_LICENSE_KEY` are placeholders for license keys from a [High Security Mode](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode) enabled account and a [Configurable Security Policies](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies) enabled account respectively. To find your license keys, visit [this page](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key).
-3. Open a Windows command prompt and run this command: `type {SECRET_FILE_PATH}\secrets.json | dotnet user-secrets set --project {DOTNET_AGENT_REPO_PATH}\tests\Agent\IntegrationTests\Shared`. Replace `{SECRET_FILE_PATH}` and `{DOTNET_AGENT_REPO_PATH}` with the location of the `secrets.json` file and the location of the repo respectively. You'll get a "successful" message if all the secrets are successfully installed. 
+* Some tests require special New Relic license keys for High Security Mode (HSM) or Configurable Security Policies (CSP). Follow the steps below to set these license keys:
+
+  1. Create a `secrets.json` file using the template below or copy the [example](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json).  **Do *not* place the `secrets.json` file within your local repo folder.**
+  2. Replace the license key placeholders in the `secrets.json` template with actual license keys. 
+      * The `REPLACE_WITH_HIGH_SECURITY_LICENSE_KEY` and `REPLACE_WITH_SECURITY_POLICIES_CONFIGURABLE_LICENSE_KEY` are placeholders for license keys from a [HSM](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode)-enabled account and a [CSP](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies)-enabled account, respectively. 
+      * To find your license keys, visit [this page](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key).
+
+* Once placeholder values have been replaced with actual values:
+
+  * Open a Windows command prompt and run this command: 
+    * ```type {SECRET_FILE_PATH}\secrets.json | dotnet user-secrets set --project {DOTNET_AGENT_REPO_PATH}\tests\Agent\IntegrationTests\Shared```
+      * Replacing `{SECRET_FILE_PATH}` with the location of the edited `secrets.json` file
+      * Replacing `{DOTNET_AGENT_REPO_PATH}`with the location of the local repo
+    * A "successful" message indicates if all the secrets are successfully installed. 
 
 ### `secrets.json` file template:
 ```

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -76,6 +76,46 @@
               "ServerUrl" : "http://127.0.0.1",
               "TestBucket" : "travel-sample"
           }
+        },
+        "AwsLambdaAwsSdkTests" : {
+          "CustomSettings": {
+              "ApplicationGatewayResourceId" : "YOUR_APP_GATEWAY_RESOURCE_ID_HERE"
+          }
+        },
+        "AwsLambdaSmokeTests" : {
+          "CustomSettings": {
+              "ApplicationGatewayResourceId" : "YOUR_APP_GATEWAY_RESOURCE_ID_HERE"
+          }
+        },
+        "AwsLambdaErrorTests" : {
+          "CustomSettings": {
+              "ApplicationGatewayResourceId" : "YOUR_APP_GATEWAY_RESOURCE_ID_HERE"
+          }
+        },
+        "AwsLambdaDTTestCallee" : {
+          "CustomSettings": {
+              "ApplicationGatewayResourceId" : "YOUR_APP_GATEWAY_RESOURCE_ID_HERE"
+          }
+        },
+        "AwsLambdaDTTestCaller" : {
+          "CustomSettings": {
+              "ApplicationGatewayResourceId" : "YOUR_APP_GATEWAY_RESOURCE_ID_HERE"
+          }
+        },
+        "ServiceFabricTests" : {
+          "CustomSettings": {
+              "ServerCertThumbprint" : "YOUR_SERVER_CERT_THUMBPRINT_HERE",
+              "ConnectionEndpoint" : "YOUR_CONNECTION_ENDPOINT_HERE",
+              "TestUrl" : "YOUR_AZURE_TEST_URL_HERE"
+          }
+        },
+        "AzureWebApplicationTests" : {
+          "CustomSettings": {
+              "NewRelicLogFilesUri" : "YOUR_LOG_FILES_URI_HERE",
+              "UserName" : "YOUR_AZURE_USER_NAME_HERE",
+              "Password" : "YOUR_AZURE_PW_HERE",
+              "TestUrl" : "YOUR_AZURE_TEST_URL_HERE"
+          }
         }
       }
     }

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -1,11 +1,21 @@
 {
     "IntegrationTestConfiguration": {
       "DefaultSetting": {
-        "LicenseKey": "YOUR_LICENSE_KEY_HERE",
+        "LicenseKey": "YOUR_NEW_RELIC_LICENSE_KEY_HERE",
         "Collector": "collector.newrelic.com",
-        "NewRelicAccountId" : "YOUR_ACCOUNT_ID_HERE"
+        "NewRelicAccountId" : "YOUR_ACCOUNT_ID_HERE",
+        "AwsTestRoleArn" : "YOUR_AWS_TEST_ROLE_ARN_HERE",
+        "AwsAccessKeyId" : "YOUR_AWS_ACCESS_KEY_ID_HERE",
+        "AwsSecretAccessKey" : "YOUR_AWS_SECRET_ACCESS_KEY_HERE",
+        "AwsAccountNumber" : "YOUR_AWS_ACCOUNT_NUMBER_HERE"
       },
       "TestSettingOverrides": {
+        "HSM": {
+          "LicenseKey": "YOUR_NEW_RELIC_HSM_KEY_HERE"
+        },
+        "CSP" : {
+          "LicenseKey": "YOUR_NEW_RELIC_CSP_KEY_HERE"
+        },
         "PostgresTests" : {
           "CustomSettings": {
               "ConnectionString" : "Server=127.0.0.1;Port=5432;User Id=postgres;Password=password;Database=postgres;"


### PR DESCRIPTION
### Description
Updates `example-secrets.json` file to include HSM & CSP keys, and AWS credentials, providing an example for all possible secrets.
Updates docs file to point to example-secrets.json.

### Testing
No testing as this is just an example/documentation and has placeholders for the actual values.

### Changelog
N/A

