### PR TITLE
Organize integration test namespaces

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/AutostartDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/AutostartDisabled.cs
@@ -7,7 +7,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class AutoStartDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CallStackFallbackMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CallStackFallbackMvc.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class CallStackFallbackMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
@@ -7,7 +7,7 @@ using System;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     public class ConfigBuilderDeadlock : IClassFixture<ConsoleDynamicMethodFixtureFW>
     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConnectResponseHandlingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConnectResponseHandlingTests.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ConnectResponseHandlingTests : IClassFixture<MvcWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CpuMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CpuMvc.cs
@@ -10,14 +10,14 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class MemoryMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CpuMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public MemoryMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger)
+        public CpuMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger)
         {
             _fixture = fixture;
             _fixture.TestLogger = testLogger;
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.IntegrationTests
                     var startTime = DateTime.Now;
                     while (DateTime.Now <= startTime.AddSeconds(60))
                     {
-                        if (_fixture.AgentLog.GetMetrics().Any(metric => metric.MetricSpec.Name == "Memory/Physical"))
+                        if (_fixture.AgentLog.GetMetrics().Any(metric => metric.MetricSpec.Name == "CPU/User Time"))
                             break;
                         Thread.Sleep(TimeSpan.FromSeconds(5));
                     }
@@ -47,7 +47,8 @@ namespace NewRelic.Agent.IntegrationTests
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric {metricName = @"Memory/Physical"}
+                new Assertions.ExpectedMetric {metricName = @"CPU/User Time"},
+                new Assertions.ExpectedMetric {metricName = @"CPU/User/Utilization"}
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DataTransmissionDefaults.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DataTransmissionDefaults.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class DataTransmissionDefaults : IClassFixture<MvcWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DataTransmissionPutGzip.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DataTransmissionPutGzip.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class DataTransmissionPutGzip : IClassFixture<MvcWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DotNetPerfMetricsTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
 
     [NetFrameworkTest]

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -8,7 +8,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class EnvironmentTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceMvc.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ErrorTraceMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceWebApi.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ErrorTraceWebApi : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ErrorTraceWebService.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ErrorTraceWebService : IClassFixture<RemoteServiceFixtures.BasicWebService>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ExpectedErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ExpectedErrorTests.cs
@@ -6,13 +6,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.Collections.Generic;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetCoreTest]
     public class ExpectedErrorTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/FasterEventHarvestTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/FasterEventHarvestTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class FasterEventHarvestNetFrameworkTests : FasterEventHarvestTests<ConsoleDynamicMethodFixtureFW>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/InstrumentationLoaderTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/InstrumentationLoaderTests.cs
@@ -8,7 +8,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using System.Linq;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class InstrumentationLoaderTests : IClassFixture<RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/NewRelicMetadataEnvTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/NewRelicMetadataEnvTests.cs
@@ -7,7 +7,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class NewRelicMetadataEnvTests : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/RemotingSerialization.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/RemotingSerialization.cs
@@ -6,7 +6,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class RemotingSerialization : IClassFixture<RemoteServiceFixtures.OwinRemotingFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/Rules.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/Rules.cs
@@ -9,7 +9,7 @@ using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     /// <summary>
     /// Tests around transaction renaming using URL rules and transaction segment terms

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileNetCoreTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileNetCoreTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetCoreTest]
     public class ThreadProfileNetCoreTests : IClassFixture<AspNetCoreMvcWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ThreadProfileStressTests : IClassFixture<ThreadProfileStressTestWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class ThreadProfileTests : IClassFixture<MvcWithCollectorFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/TransactionThreshold.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/TransactionThreshold.cs
@@ -7,7 +7,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
     public class TransactionThreshold : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/AgentApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/AgentApiTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Api
 {
     [NetFrameworkTest]
     public class AgentApiTests : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiAppNameChangeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiAppNameChangeTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
@@ -10,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Api
 {
     [NetFrameworkTest]
     public class ApiAppNameChangeTests : IClassFixture<RemoteServiceFixtures.ApiAppNameChangeFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Api
 {
     [NetFrameworkTest]
     public class ApiCallsTestsFW : ApiCallsTests<ConsoleDynamicMethodFixtureFW>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreCollectibleAssemblyContextTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreCollectibleAssemblyContextTests.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetCoreTest]
     public class AspNetCoreCollectibleAssemblyContextTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
@@ -10,16 +10,16 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
-    [NetFrameworkTest]
-    public class AspNetCoreMvcFrameworkAsyncTests : IClassFixture<AspNetCoreMvcFrameworkAsyncTestsFixture>
+    [NetCoreTest]
+    public class AspNetCoreMvcAsyncTests : IClassFixture<AspNetCoreMvcAsyncTestsFixture>
     {
-        private readonly AspNetCoreMvcFrameworkAsyncTestsFixture _fixture;
+        private readonly AspNetCoreMvcAsyncTestsFixture _fixture;
         private const int ExpectedTransactionCount = 7;
-        private const string AssemblyName = "AspNetCoreMvcFrameworkAsyncApplication";
+        private const string AssemblyName = "AspNetCoreMvcAsyncApplication";
 
-        public AspNetCoreMvcFrameworkAsyncTests(AspNetCoreMvcFrameworkAsyncTestsFixture fixture, ITestOutputHelper output)
+        public AspNetCoreMvcAsyncTests(AspNetCoreMvcAsyncTestsFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -42,7 +42,6 @@ namespace NewRelic.Agent.IntegrationTests
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "TaskRunBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualTaskRunBackgroundMethod");
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "TaskFactoryStartNewBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualTaskFactoryStartNewBackgroundMethod");
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "ThreadStartBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualThreadStartBackgroundMethod");
-
                 },
                 exerciseApplication: () =>
                 {
@@ -54,7 +53,6 @@ namespace NewRelic.Agent.IntegrationTests
                     _fixture.GetManualTaskRunBlocked();
                     _fixture.GetManualTaskFactoryStartNewBlocked();
                     _fixture.GetManualNewThreadStartBlocked();
-
                 }
             );
             _fixture.Initialize();
@@ -83,11 +81,11 @@ namespace NewRelic.Agent.IntegrationTests
                 () => Assertions.MetricsExist(_manualTaskFactoryStartNewMetrics, metrics),
                 () => Assertions.MetricsExist(_manualNewThreadStartBlocked, metrics)
             );
-
         }
 
         private readonly List<Assertions.ExpectedMetric> _generalMetrics = new List<Assertions.ExpectedMetric>
         {
+            new Assertions.ExpectedMetric { metricName = @"Supportability/OS/Linux", callCount = 1 },
             new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", callCount = ExpectedTransactionCount },
             new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = ExpectedTransactionCount },
             new Assertions.ExpectedMetric { metricName = @"Apdex"},
@@ -199,6 +197,5 @@ namespace NewRelic.Agent.IntegrationTests
             new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/ManualAsync/NewThreadStartBlocked", callCount = 1 },
             new Assertions.ExpectedMetric { metricName = @"Custom/ManualThreadStartBackgroundMethod", metricScope = @"WebTransaction/MVC/ManualAsync/NewThreadStartBlocked", callCount = 1 }
         };
-
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcCoreFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcCoreFrameworkTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetFrameworkTest]
     public class AspNetCoreMvcCoreFrameworkTests : IClassFixture<AspNetCoreMvcCoreFrameworkFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkAsyncTests.cs
@@ -10,16 +10,16 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
-    [NetCoreTest]
-    public class AspNetCoreMvcAsyncTests : IClassFixture<AspNetCoreMvcAsyncTestsFixture>
+    [NetFrameworkTest]
+    public class AspNetCoreMvcFrameworkAsyncTests : IClassFixture<AspNetCoreMvcFrameworkAsyncTestsFixture>
     {
-        private readonly AspNetCoreMvcAsyncTestsFixture _fixture;
+        private readonly AspNetCoreMvcFrameworkAsyncTestsFixture _fixture;
         private const int ExpectedTransactionCount = 7;
-        private const string AssemblyName = "AspNetCoreMvcAsyncApplication";
+        private const string AssemblyName = "AspNetCoreMvcFrameworkAsyncApplication";
 
-        public AspNetCoreMvcAsyncTests(AspNetCoreMvcAsyncTestsFixture fixture, ITestOutputHelper output)
+        public AspNetCoreMvcFrameworkAsyncTests(AspNetCoreMvcFrameworkAsyncTestsFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -42,6 +42,7 @@ namespace NewRelic.Agent.IntegrationTests
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "TaskRunBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualTaskRunBackgroundMethod");
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "TaskFactoryStartNewBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualTaskFactoryStartNewBackgroundMethod");
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, AssemblyName, $"{AssemblyName}.Controllers.ManualAsyncController", "ThreadStartBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "ManualThreadStartBackgroundMethod");
+
                 },
                 exerciseApplication: () =>
                 {
@@ -53,6 +54,7 @@ namespace NewRelic.Agent.IntegrationTests
                     _fixture.GetManualTaskRunBlocked();
                     _fixture.GetManualTaskFactoryStartNewBlocked();
                     _fixture.GetManualNewThreadStartBlocked();
+
                 }
             );
             _fixture.Initialize();
@@ -81,11 +83,11 @@ namespace NewRelic.Agent.IntegrationTests
                 () => Assertions.MetricsExist(_manualTaskFactoryStartNewMetrics, metrics),
                 () => Assertions.MetricsExist(_manualNewThreadStartBlocked, metrics)
             );
+
         }
 
         private readonly List<Assertions.ExpectedMetric> _generalMetrics = new List<Assertions.ExpectedMetric>
         {
-            new Assertions.ExpectedMetric { metricName = @"Supportability/OS/Linux", callCount = 1 },
             new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", callCount = ExpectedTransactionCount },
             new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = ExpectedTransactionCount },
             new Assertions.ExpectedMetric { metricName = @"Apdex"},
@@ -197,5 +199,6 @@ namespace NewRelic.Agent.IntegrationTests
             new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/ManualAsync/NewThreadStartBlocked", callCount = 1 },
             new Assertions.ExpectedMetric { metricName = @"Custom/ManualThreadStartBackgroundMethod", metricScope = @"WebTransaction/MVC/ManualAsync/NewThreadStartBlocked", callCount = 1 }
         };
+
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetFrameworkTest]
     public class AspNetCoreMvcFrameworkTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/AsyncStreamTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/AsyncStreamTest.cs
@@ -8,7 +8,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetCoreTest]
     public class AsyncStreamTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicAspWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicAspWebService.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class BasicAspWebService : IClassFixture<RemoteServiceFixtures.BasicAspWebService>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplication.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,15 +10,14 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicMvcApplicationWithAsyncDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicMvcApplication : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
-
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public BasicMvcApplicationWithAsyncDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public BasicMvcApplication(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -33,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.GetWithAsyncDisabled();
+                    _fixture.Get();
                 }
             );
             _fixture.Initialize();
@@ -46,21 +44,21 @@ namespace NewRelic.Agent.IntegrationTests
             {
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"HttpDispatcher", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransaction", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DisableAsyncSupportController/Index", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ReleaseRequestState", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/UpdateRequestCache", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ReleaseRequestState", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/UpdateRequestCache", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
@@ -71,7 +69,7 @@ namespace NewRelic.Agent.IntegrationTests
 
 				// The .NET agent does not have the information needed to generate this metric
 				new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
             };
 
             var expectedTransactionTraceSegments = new List<string>
@@ -82,7 +80,7 @@ namespace NewRelic.Agent.IntegrationTests
                 @"MapRequestHandler",
                 @"AcquireRequestState",
                 @"ExecuteRequestHandler",
-                @"DotNet/DisableAsyncSupportController/Index",
+                @"DotNet/DefaultController/Index",
                 @"ReleaseRequestState",
                 @"UpdateRequestCache",
                 @"EndRequest",
@@ -90,7 +88,8 @@ namespace NewRelic.Agent.IntegrationTests
             var expectedTransactionTraceAgentAttributes = new Dictionary<string, object>
             {
                 { "response.status", "200" },
-                { "http.statusCode", 200 }
+                { "http.statusCode", 200 },
+                { "request.uri", "/Default" }
             };
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
@@ -106,14 +105,18 @@ namespace NewRelic.Agent.IntegrationTests
             };
             var expectedTransactionEventAgentAttributes = new Dictionary<string, object>
             {
-                { "response.status", "200"},
-                { "http.statusCode", 200 }
+                { "response.status", "200" },
+                { "http.statusCode", 200 },
+                { "request.uri", "/Default" }
             };
+
+            var connect = _fixture.AgentLog.GetConnectData().Environment.GetPluginList();
+            Assert.DoesNotContain(connect, x => x.Contains("NewRelic.Providers.Wrapper.AspNetCore"));
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples()
-                .Where(sample => sample.Path == @"WebTransaction/MVC/DisableAsyncSupportController/Index")
+                .Where(sample => sample.Path == @"WebTransaction/MVC/DefaultController/Index")
                 .FirstOrDefault();
             var transactionEvent = _fixture.AgentLog.GetTransactionEvents()
                 .FirstOrDefault();

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplicationWithAsyncDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplicationWithAsyncDisabled.cs
@@ -10,14 +10,15 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicMvcApplication : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicMvcApplicationWithAsyncDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
+
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public BasicMvcApplication(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public BasicMvcApplicationWithAsyncDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -31,7 +32,7 @@ namespace NewRelic.Agent.IntegrationTests
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.Get();
+                    _fixture.GetWithAsyncDisabled();
                 }
             );
             _fixture.Initialize();
@@ -44,21 +45,21 @@ namespace NewRelic.Agent.IntegrationTests
             {
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"HttpDispatcher", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransaction", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ReleaseRequestState", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/UpdateRequestCache", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/DisableAsyncSupportController/Index", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ReleaseRequestState", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/UpdateRequestCache", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
@@ -69,7 +70,7 @@ namespace NewRelic.Agent.IntegrationTests
 
 				// The .NET agent does not have the information needed to generate this metric
 				new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"CPU/WebTransaction/MVC/DisableAsyncSupportController/Index", callCount = 1 },
             };
 
             var expectedTransactionTraceSegments = new List<string>
@@ -80,7 +81,7 @@ namespace NewRelic.Agent.IntegrationTests
                 @"MapRequestHandler",
                 @"AcquireRequestState",
                 @"ExecuteRequestHandler",
-                @"DotNet/DefaultController/Index",
+                @"DotNet/DisableAsyncSupportController/Index",
                 @"ReleaseRequestState",
                 @"UpdateRequestCache",
                 @"EndRequest",
@@ -88,8 +89,7 @@ namespace NewRelic.Agent.IntegrationTests
             var expectedTransactionTraceAgentAttributes = new Dictionary<string, object>
             {
                 { "response.status", "200" },
-                { "http.statusCode", 200 },
-                { "request.uri", "/Default" }
+                { "http.statusCode", 200 }
             };
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
@@ -105,18 +105,14 @@ namespace NewRelic.Agent.IntegrationTests
             };
             var expectedTransactionEventAgentAttributes = new Dictionary<string, object>
             {
-                { "response.status", "200" },
-                { "http.statusCode", 200 },
-                { "request.uri", "/Default" }
+                { "response.status", "200"},
+                { "http.statusCode", 200 }
             };
-
-            var connect = _fixture.AgentLog.GetConnectData().Environment.GetPluginList();
-            Assert.DoesNotContain(connect, x => x.Contains("NewRelic.Providers.Wrapper.AspNetCore"));
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples()
-                .Where(sample => sample.Path == @"WebTransaction/MVC/DefaultController/Index")
+                .Where(sample => sample.Path == @"WebTransaction/MVC/DisableAsyncSupportController/Index")
                 .FirstOrDefault();
             var transactionEvent = _fixture.AgentLog.GetTransactionEvents()
                 .FirstOrDefault();

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebApplication.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class BasicWebApplication : IClassFixture<RemoteServiceFixtures.BasicWebApplication>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebForms.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebForms.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class BasicWebForms : IClassFixture<RemoteServiceFixtures.BasicWebFormsApplication>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebService.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class BasicWebService : IClassFixture<RemoteServiceFixtures.BasicWebService>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ConsoleAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ConsoleAsyncTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class ConsoleAsyncTests : IClassFixture<ConsoleAsyncFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MsCorLibTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MsCorLibTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Net;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class MsCorLibTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcAsyncTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class MvcAsyncTests : IClassFixture<MvcAsyncFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcRum.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcRum.cs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class MvcRum : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetCoreTest]
     public class NetCoreAsyncTests : IClassFixture<NetCoreAsyncTestsFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackApplicationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackApplicationTests.cs
@@ -9,7 +9,7 @@ using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class ServiceStackApplicationTests : IClassFixture<ServiceStackApplicationFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisCommands.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisCommands.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     public class ServiceStackRedisCommands
     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisTests.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class ServiceStackRedisTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class WebApiAsyncForceNewTransactionTests_Instrumented : WebApiAsyncForceNewTransactionTests

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
     public class WebApiAsyncTests : IClassFixture<WebApiAsyncFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebForms45Application.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebForms45Application.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,15 +10,14 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicOpenRastaApplication : IClassFixture<RemoteServiceFixtures.BasicOpenRastaApplication>
+    public class WebForms45Application : IClassFixture<RemoteServiceFixtures.WebForms45Application>
     {
+        private readonly RemoteServiceFixtures.WebForms45Application _fixture;
 
-        private readonly RemoteServiceFixtures.BasicOpenRastaApplication _fixture;
-
-        public BasicOpenRastaApplication(RemoteServiceFixtures.BasicOpenRastaApplication fixture, ITestOutputHelper output)
+        public WebForms45Application(RemoteServiceFixtures.WebForms45Application fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,13 +25,15 @@ namespace NewRelic.Agent.IntegrationTests
             (
                 setupConfiguration: () =>
                 {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
+                    var newRelicConfig = _fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(newRelicConfig);
                     configModifier.ForceTransactionTraces();
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.GetWithQueryString();
+                    // Make a request with an invalid query string to ensure that the agent handles it safely
+                    var queryStringParams = new Dictionary<string, string> { { "a", "<b>" } };
+                    _fixture.GetWithQueryString(queryStringParams, true);
                 }
             );
             _fixture.Initialize();
@@ -46,20 +46,22 @@ namespace NewRelic.Agent.IntegrationTests
             {
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransaction/ASP/default.aspx", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"HttpDispatcher", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransaction", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/ReleaseRequestState", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/UpdateRequestCache", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/OpenRasta/home/get", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthenticateRequest", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AuthorizeRequest", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ResolveRequestCache", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/MapRequestHandler", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/AcquireRequestState", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"DotNet/ExecuteRequestHandler", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
+
+				// On hold until we port the Page.PerformPreInit instrumentation to a wrapper
+				//new Assertions.ExpectedMetric { metricName = @"DotNet/System.Web.UI.Page/PerformPreInit", metricScope = @"WebTransaction/ASP/webformslow.aspx", callCount = 1 },
+
+				new Assertions.ExpectedMetric { metricName = @"DotNet/EndRequest", metricScope = @"WebTransaction/ASP/default.aspx", callCount = 1 },
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
@@ -69,7 +71,6 @@ namespace NewRelic.Agent.IntegrationTests
                 new Assertions.ExpectedMetric { metricName = @"OtherTransaction/all" },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/Transactions/allOther" },
             };
-
             var expectedTransactionTraceSegments = new List<string>
             {
                 @"AuthenticateRequest",
@@ -78,24 +79,21 @@ namespace NewRelic.Agent.IntegrationTests
                 @"MapRequestHandler",
                 @"AcquireRequestState",
                 @"ExecuteRequestHandler",
-                @"views/homeview.aspx",
-                @"DotNet/home/get",
-                @"ReleaseRequestState",
-                @"UpdateRequestCache",
-                @"EndRequest"
-            };
+				
+				// On hold until we port the Page.PerformPreInit instrumentation to a wrapper
+				//@"DotNet/System.Web.UI.Page/PerformPreInit",
 
+				@"EndRequest",
+            };
             var expectedTransactionTraceAgentAttributes = new Dictionary<string, object>
             {
-                { "response.status", "200" },
-                { "http.statusCode", 200 }
+                { "response.status", "500" },
+                { "http.statusCode", 500 }
             };
-
             var expectedTransactionEventIntrinsicAttributes1 = new Dictionary<string, string>
             {
                 {"type", "Transaction"}
             };
-
             var expectedTransactionEventIntrinsicAttributes2 = new List<string>
             {
                 "timestamp",
@@ -104,16 +102,15 @@ namespace NewRelic.Agent.IntegrationTests
                 "queueDuration",
                 "totalTime"
             };
-
             var expectedTransactionEventAgentAttributes = new Dictionary<string, object>
             {
-                { "response.status", "200"},
-                { "http.statusCode", 200 }
+                { "response.status", "500"},
+                { "http.statusCode", 500 }
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
             var transactionSample = _fixture.AgentLog.GetTransactionSamples()
-                .Where(sample => sample.Path == @"WebTransaction/OpenRasta/home/get")
+                .Where(sample => sample.Path == @"WebTransaction/ASP/default.aspx")
                 .FirstOrDefault();
             var transactionEvent = _fixture.AgentLog.GetTransactionEvents()
                 .FirstOrDefault();

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
     public class AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -6,14 +6,17 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
-    [NetFrameworkTest]
-    public class HighSecurityModeServerEnabled : IClassFixture<RemoteServiceFixtures.HSMOwinWebApiFixture>
+    [NetCoreTest]
+    public class AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests : IClassFixture<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
     {
-        private readonly RemoteServiceFixtures.HSMOwinWebApiFixture _fixture;
+        private const string QueryStringParameterValue = @"my thing";
 
-        public HighSecurityModeServerEnabled(RemoteServiceFixtures.HSMOwinWebApiFixture fixture, ITestOutputHelper output)
+
+        private readonly RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture _fixture;
+
+        public AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -23,18 +26,12 @@ namespace NewRelic.Agent.IntegrationTests
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.ForceTransactionTraces();
                     configModifier.SetLogLevel("debug");
-                    configModifier.SetHighSecurityMode(false);
                     configModifier.SetEnableRequestParameters(true);
+                    configModifier.SetHighSecurityMode(false);
                 },
-                exerciseApplication: () =>
-                {
-                    _fixture.GetData();
-                    _fixture.Get();
-                    _fixture.Get404();
-                    _fixture.GetId();
-                    _fixture.Post();
-                }
+                exerciseApplication: () => _fixture.GetWithData(QueryStringParameterValue)
             );
             _fixture.Initialize();
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
     public class AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
     public class AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests : IClassFixture<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityAndCustomAttributes.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityAndCustomAttributes.cs
@@ -8,18 +8,18 @@ using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
-    [NetCoreTest]
-    public class AspNetCoreHSMEnabledWithCustomAttributesTests : IClassFixture<HSMAspNetCoreWebApiCustomAttributesFixture>
+    [NetFrameworkTest]
+    public class HighSecurityAndCustomAttributes : IClassFixture<HSMCustomAttributesWebApi>
     {
+        private readonly HSMCustomAttributesWebApi _fixture;
 
-        private readonly HSMAspNetCoreWebApiCustomAttributesFixture _fixture;
-
-        public AspNetCoreHSMEnabledWithCustomAttributesTests(HSMAspNetCoreWebApiCustomAttributesFixture fixture, ITestOutputHelper output)
+        public HighSecurityAndCustomAttributes(HSMCustomAttributesWebApi fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -29,16 +29,14 @@ namespace NewRelic.Agent.IntegrationTests
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level",
-                        "debug");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "highSecurity" },
-                        "enabled", "true");
+                    configModifier.SetHighSecurityMode(true);
+                    configModifier.SetLogLevel("debug");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.Get();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogFile.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(2));
+                    _fixture.GetCustomErrorAttributes();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogFile.ErrorEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
 
                 );
@@ -56,7 +54,22 @@ namespace NewRelic.Agent.IntegrationTests
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
             Assert.NotNull(transactionSample);
+
             Assertions.TransactionTraceDoesNotHaveAttributes(unexpectedTransactionTraceAttributes, TransactionTraceAttributeType.User, transactionSample);
+
+            var errorTrace = _fixture.AgentLog.GetErrorTraces().FirstOrDefault();
+            var errorEventPayload = _fixture.AgentLog.GetErrorEvents().FirstOrDefault();
+
+            var unexpectedErrorCustomAttributes = new List<string>
+            {
+                "hey",
+                "faz"
+            };
+
+            NrAssert.Multiple(
+                () => Assertions.ErrorTraceDoesNotHaveAttributes(unexpectedErrorCustomAttributes, ErrorTraceAttributeType.Intrinsic, errorTrace),
+                () => Assertions.ErrorEventDoesNotHaveAttributes(unexpectedErrorCustomAttributes, EventAttributeType.User, errorEventPayload.Events[0])
+            );
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeDisabled.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
     public class HighSecurityModeDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeEnabled.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -11,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
     public class HighSecurityModeEnabled : IClassFixture<RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeNoTransactionAgentApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeNoTransactionAgentApiTests.cs
@@ -10,14 +10,14 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
     public class HighSecurityModeNoTransactionAgentApiTests : IClassFixture<RemoteServiceFixtures.HSMAgentApiExecutor>
     {
 
         private readonly RemoteServiceFixtures.HSMAgentApiExecutor _fixture;
-        private const string StripExeptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
+        private const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
         public HighSecurityModeNoTransactionAgentApiTests(RemoteServiceFixtures.HSMAgentApiExecutor fixture, ITestOutputHelper output)
         {
@@ -47,7 +47,7 @@ namespace NewRelic.Agent.IntegrationTests
             {
                 { "error.class", "System.Exception" },
                 { "type", "TransactionError" },
-                { "error.message", StripExeptionMessagesMessage }
+                { "error.message", StripExceptionMessagesMessage }
             };
 
             var unexpectedErrorEventCustomAttributes = new List<string>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -2,22 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
-    [NetCoreTest]
-    public class AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests : IClassFixture<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
+    [NetFrameworkTest]
+    public class HighSecurityModeServerDisabled : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
     {
-        private const string QueryStringParameterValue = @"my thing";
 
+        private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
-        private readonly RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture _fixture;
-
-        public AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeServerDisabled(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -26,13 +23,20 @@ namespace NewRelic.Agent.IntegrationTests
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
+
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
                     configModifier.SetLogLevel("debug");
+                    configModifier.SetHighSecurityMode(true);
                     configModifier.SetEnableRequestParameters(true);
-                    configModifier.SetHighSecurityMode(false);
                 },
-                exerciseApplication: () => _fixture.GetWithData(QueryStringParameterValue)
+                exerciseApplication: () =>
+                {
+                    _fixture.GetData();
+                    _fixture.Get();
+                    _fixture.Get404();
+                    _fixture.GetId();
+                    _fixture.Post();
+                }
             );
             _fixture.Initialize();
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -6,15 +6,14 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeServerDisabled : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public class HighSecurityModeServerEnabled : IClassFixture<RemoteServiceFixtures.HSMOwinWebApiFixture>
     {
+        private readonly RemoteServiceFixtures.HSMOwinWebApiFixture _fixture;
 
-        private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
-
-        public HighSecurityModeServerDisabled(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeServerEnabled(RemoteServiceFixtures.HSMOwinWebApiFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -23,10 +22,9 @@ namespace NewRelic.Agent.IntegrationTests
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
-
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.SetLogLevel("debug");
-                    configModifier.SetHighSecurityMode(true);
+                    configModifier.SetHighSecurityMode(false);
                     configModifier.SetEnableRequestParameters(true);
                 },
                 exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveAndCustomAttributesTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveAndCustomAttributesTests.cs
@@ -12,7 +12,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
     public class SecurityPoliciesMostRestrictiveAndCustomAttributesTests : IClassFixture<SecurityPoliciesCustomAttributesWebApi>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
     public class SecurityPoliciesMostRestrictiveTests : IClassFixture<RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnored.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnored.cs
@@ -7,15 +7,15 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
-using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
+
 {
     [NetFrameworkTest]
-    public class CustomAttributesIgnored : IClassFixture<CustomAttributesWebApi>
+    public class CustomAttributesIgnored : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
@@ -7,19 +7,18 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
-using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesIgnoredErrorAttributesNotInTransactionTrace : IClassFixture<CustomAttributesWebApi>
+    public class CustomAttributesIgnoredErrorAttributesNotInTransactionTrace : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
     {
-        private readonly CustomAttributesWebApi _fixture;
+        private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesIgnoredErrorAttributesNotInTransactionTrace(CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesIgnoredErrorAttributesNotInTransactionTrace(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesKeyNull.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesKeyNull.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
     public class CustomAttributesKeyNull : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyDisabled.cs
@@ -7,19 +7,18 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
-using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesLegacyIgnored : IClassFixture<CustomAttributesWebApi>
+    public class CustomAttributesLegacyDisabled : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
     {
-        private readonly CustomAttributesWebApi _fixture;
+        private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesLegacyIgnored(CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesLegacyDisabled(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -30,40 +29,38 @@ namespace NewRelic.Agent.IntegrationTests
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
 
-                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(configPath,
-                        new[] { "configuration", "parameterGroups", "customParameters" }, "ignore", "key");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath,
+                        new[] { "configuration", "parameterGroups", "customParameters" }, "enabled", "false");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.Get();
+                    _fixture.Get404();
                     _fixture.AgentLog.WaitForLogLine(AgentLogFile.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(2));
                 }
-
-                );
+            );
             _fixture.Initialize();
         }
 
         [Fact]
         public void Test()
         {
-            var expectedTransactionTraceAttributes = new Dictionary<string, string>
-            {
-                { "foo", "bar" }
-            };
             var unexpectedTransactionTraceAttributes = new List<string>
             {
-                "key"
+                "key",
+                "foo",
+                "hey",
+                "faz",
             };
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
-            Assert.NotNull(transactionSample);
             var maybeDeprecationMessage = _fixture.AgentLog.TryGetLogLine(AgentLogBase.WarnLogLinePrefixRegex + @"Deprecated configuration property 'parameterGroups.customParameters.ignore'.  Use 'attributes.exclude'.  See http://docs.newrelic.com for details.");
 
+            Assert.NotNull(transactionSample);
             NrAssert.Multiple
             (
-                () => Assertions.TransactionTraceHasAttributes(expectedTransactionTraceAttributes, TransactionTraceAttributeType.User, transactionSample),
                 () => Assertions.TransactionTraceDoesNotHaveAttributes(unexpectedTransactionTraceAttributes, TransactionTraceAttributeType.User, transactionSample),
-                () => Assert.NotNull(maybeDeprecationMessage)
+                () => Assert.Null(maybeDeprecationMessage)
             );
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesMvc.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
     public class CustomAttributesMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesWebApi.cs
@@ -11,14 +11,14 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributes : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesWebApi : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributes(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesWebApi(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/Labels.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/Labels.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
     public class Labels : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentation.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class AttributeInstrumentation : IClassFixture<RemoteServiceFixtures.AttributeInstrumentation>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/BasicCustomInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/BasicCustomInstrumentation.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,14 +9,14 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentation : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicCustomInstrumentation : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public CustomInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public BasicCustomInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ConsoleAsynConsoleAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ConsoleAsynConsoleAsyncForceNewTransactionTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class ConsoleAsyncForceNewTransactionTests_Instrumented : ConsoleAsyncForceNewTransactionTests

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationAsync.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationAsync.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class CustomInstrumentationAsync : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorAgentCommand.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorAgentCommand.cs
@@ -11,14 +11,14 @@ using System.Linq;
 using NewRelic.Testing.Assertions;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentationEditorConnectCommand : IClassFixture<MvcWithCollectorFixture>
+    public class CustomInstrumentationEditorAgentCommand : IClassFixture<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
-        public CustomInstrumentationEditorConnectCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public CustomInstrumentationEditorAgentCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,15 +27,15 @@ namespace NewRelic.Agent.IntegrationTests
                 setupConfiguration: () =>
                 {
                     var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_fixture.DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "autoStart", "false");
                     configModifier.SetLogLevel("finest");
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.SetCustomInstrumentationEditorOnConnect();
                     _fixture.Get();
-                    _fixture.StartAgent();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.TriggerCustomInstrumentationEditorAgentCommand();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationUpdateCommandLogLineRegex, TimeSpan.FromMinutes(3));
+
+                    _fixture.AgentLog.ClearLog(TimeSpan.FromSeconds(5));
                     _fixture.GenerateCallsToCustomInstrumentationEditorMethods();
                 }
             );
@@ -62,4 +62,3 @@ namespace NewRelic.Agent.IntegrationTests
         }
     }
 }
-

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorConnectCommand.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorConnectCommand.cs
@@ -11,14 +11,14 @@ using System.Linq;
 using NewRelic.Testing.Assertions;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentationEditorAgentCommand : IClassFixture<MvcWithCollectorFixture>
+    public class CustomInstrumentationEditorConnectCommand : IClassFixture<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
-        public CustomInstrumentationEditorAgentCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public CustomInstrumentationEditorConnectCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,15 +27,15 @@ namespace NewRelic.Agent.IntegrationTests
                 setupConfiguration: () =>
                 {
                     var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_fixture.DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "autoStart", "false");
                     configModifier.SetLogLevel("finest");
                 },
                 exerciseApplication: () =>
                 {
+                    _fixture.SetCustomInstrumentationEditorOnConnect();
                     _fixture.Get();
-                    _fixture.TriggerCustomInstrumentationEditorAgentCommand();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.InstrumentationUpdateCommandLogLineRegex, TimeSpan.FromMinutes(3));
-
-                    _fixture.AgentLog.ClearLog(TimeSpan.FromSeconds(5));
+                    _fixture.StartAgent();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
                     _fixture.GenerateCallsToCustomInstrumentationEditorMethods();
                 }
             );
@@ -62,3 +62,4 @@ namespace NewRelic.Agent.IntegrationTests
         }
     }
 }
+

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperFrameworkTests.cs
@@ -9,28 +9,31 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     /// <summary>
-    /// This test verifies that our TerminatingSegmentWrapper behaves correctly when running on .NET Core. In particular, we really care
+    /// This test verifies that our TerminatingSegmentWrapper behaves correctly when running on .NET Framework. In particular, we really care
     /// about testing the behavior of removing the transaction data from AsyncLocal storage.
     /// </summary>
-    [NetCoreTest]
-    public class DetachWrapperTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    [NetFrameworkTest]
+    public class DetachWrapperFrameworkTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
     {
-        private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
+        private readonly RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture _fixture;
 
-        public DetachWrapperTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+        public DetachWrapperFrameworkTests(RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
+
+            _fixture.UseLocalConfig = true;
+
             _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
                     var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\TerminatingSegmentInstrumentation.xml";
 
-                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "AspNetCoreMvcBasicRequestsApplication", "AspNetCoreMvcBasicRequestsApplication.Controllers.DetachWrapperController", "AsyncMethodWithExternalCall", "DetachWrapper");
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "AspNetCoreMvcFrameworkApplication", "AspNetCoreMvcFrameworkApplication.Controllers.DetachWrapperController", "AsyncMethodWithExternalCall", "DetachWrapper");
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperTests.cs
@@ -9,31 +9,28 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     /// <summary>
-    /// This test verifies that our TerminatingSegmentWrapper behaves correctly when running on .NET Framework. In particular, we really care
+    /// This test verifies that our TerminatingSegmentWrapper behaves correctly when running on .NET Core. In particular, we really care
     /// about testing the behavior of removing the transaction data from AsyncLocal storage.
     /// </summary>
-    [NetFrameworkTest]
-    public class DetachWrapperFrameworkTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
+    [NetCoreTest]
+    public class DetachWrapperTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
-        private readonly RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture _fixture;
+        private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
-        public DetachWrapperFrameworkTests(RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture fixture, ITestOutputHelper output)
+        public DetachWrapperTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
-
-            _fixture.UseLocalConfig = true;
-
             _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
                     var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\TerminatingSegmentInstrumentation.xml";
 
-                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "AspNetCoreMvcFrameworkApplication", "AspNetCoreMvcFrameworkApplication.Controllers.DetachWrapperController", "AsyncMethodWithExternalCall", "DetachWrapper");
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "AspNetCoreMvcBasicRequestsApplication", "AspNetCoreMvcBasicRequestsApplication.Controllers.DetachWrapperController", "AsyncMethodWithExternalCall", "DetachWrapper");
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/InterfaceDefaultsInstrumentationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/InterfaceDefaultsInstrumentationTests.cs
@@ -8,7 +8,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
     public class InterfaceDefaultsInstrumentationTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/NetCoreAttributeInstrumentationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/NetCoreAttributeInstrumentationTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
     public class NetCoreAttributeInstrumentationTests : IClassFixture<RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransaction.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransaction.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class OtherTransaction : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsync.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsync.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class OtherTransactionAsync : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsyncWithImmediateError.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsyncWithImmediateError.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
     public class OtherTransactionAsyncWithError : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsConsole.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsConsole.cs
@@ -8,15 +8,15 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransactionResponseTimeTestsWebApi : IClassFixture<RemoteServiceFixtures.WebApiAsyncFixture>
+    public class OtherTransactionResponseTimeTestsConsole : IClassFixture<RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture>
     {
-        private readonly RemoteServiceFixtures.WebApiAsyncFixture _fixture;
+        private readonly RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture _fixture;
         private const int _delayDuration = 2;
 
-        public OtherTransactionResponseTimeTestsWebApi(RemoteServiceFixtures.WebApiAsyncFixture fixture, ITestOutputHelper output)
+        public OtherTransactionResponseTimeTestsConsole(RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.ExecuteResponseTimeTestOperation(_delayDuration);
+
                 }
             );
 
@@ -53,18 +53,16 @@ namespace NewRelic.Agent.IntegrationTests
             //It should have the following intrinsic values
             NrAssert.Multiple(
                 () => { Assert.True(trx.IntrinsicAttributes.ContainsKey("totalTime")); },
-                () => { Assert.True(trx.IntrinsicAttributes.ContainsKey("duration")); },
-                () => { Assert.True(trx.IntrinsicAttributes.ContainsKey("webDuration")); });
+                () => { Assert.True(trx.IntrinsicAttributes.ContainsKey("duration")); }
+            );
 
             var trxDuration = (double)trx.IntrinsicAttributes["duration"];
-            var trxWebDuration = (double)trx.IntrinsicAttributes["webDuration"];
             var trxTotalTime = (double)trx.IntrinsicAttributes["totalTime"];
 
             //The times should all be greater than 2x the delay since the InnerMethod, which uses
             //OtherTransactionWrapper should NOT record responsetime
             NrAssert.Multiple(
                 () => { Assert.True(trxDuration > durationShouldBeGreaterThan); },
-                () => { Assert.True(trxWebDuration > durationShouldBeGreaterThan); },
                 () => { Assert.True(trxTotalTime > durationShouldBeGreaterThan); });
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/SerilogSumologicTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/SerilogSumologicTests.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
     public class SerilogSumologicSyncTests : IClassFixture<RemoteServiceFixtures.SerilogSumologicFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -6,11 +6,10 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
-using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests
 {
     /// <summary>
     /// This test runs the python-based W3C validation tests found at https://github.com/w3c/trace-context/tree/master/test

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -64,7 +64,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="AsyncTransactionContextTests\" />
-  </ItemGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
@@ -7,7 +7,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
     public class ChangeLogDirectoryTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogFilenameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogFilenameTests.cs
@@ -7,7 +7,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
     public class ChangeLogFilenameTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogFalseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogFalseTests.cs
@@ -8,14 +8,14 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelOffAndAuditLogTrueTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelInfoAndAuditLogFalseTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelOffAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelInfoAndAuditLogFalseTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,8 +27,8 @@ namespace NewRelic.Agent.IntegrationTests
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "off");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "auditLog", "true");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "info");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "auditLog", "false");
                 },
                 exerciseApplication: () =>
                 {
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.IntegrationTests
             Assert.NotNull(_fixture.AgentLog);
             var auditLogFile = Directory.EnumerateFiles(_fixture.DestinationNewRelicLogFileDirectoryPath, "newrelic_agent_*_audit.log")
                 .FirstOrDefault();
-            Assert.NotNull(auditLogFile);
+            Assert.Null(auditLogFile);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogNotSetTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogNotSetTests.cs
@@ -8,7 +8,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
     public class LogLevelInfoAndAuditLogNotSetTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogTrueTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogTrueTests.cs
@@ -8,7 +8,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
     public class LogLevelInfoAndAuditLogTrueTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelOffAndAuditLogTrueTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelOffAndAuditLogTrueTests.cs
@@ -8,14 +8,14 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelInfoAndAuditLogFalseTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelOffAndAuditLogTrueTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelInfoAndAuditLogFalseTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelOffAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,8 +27,8 @@ namespace NewRelic.Agent.IntegrationTests
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "info");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "auditLog", "false");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "off");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "auditLog", "true");
                 },
                 exerciseApplication: () =>
                 {
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.IntegrationTests
             Assert.NotNull(_fixture.AgentLog);
             var auditLogFile = Directory.EnumerateFiles(_fixture.DestinationNewRelicLogFileDirectoryPath, "newrelic_agent_*_audit.log")
                 .FirstOrDefault();
-            Assert.Null(auditLogFile);
+            Assert.NotNull(auditLogFile);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using System.Collections.Generic;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinCATChainTests : IClassFixture<OwinTracingChainFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
@@ -10,7 +10,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using System.Collections.Generic;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinDTChainTests : IClassFixture<OwinTracingChainFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinMiddlewareExceptionTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
@@ -12,7 +12,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinWebApiAsyncTests : IClassFixture<OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinWebApiStatusCodeRollupTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
@@ -11,7 +11,7 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
     public class OwinWebApiTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentation.cs
@@ -6,19 +6,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
-    public class RestSharpInstrumentationDistributedTracing : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RestSharpInstrumentation : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public RestSharpInstrumentationDistributedTracing(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public RestSharpInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -27,7 +26,6 @@ namespace NewRelic.Agent.IntegrationTests
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
                     configModifier.ForceTransactionTraces();
                 },
                 exerciseApplication: () =>
@@ -49,6 +47,8 @@ namespace NewRelic.Agent.IntegrationTests
         public void Test()
         {
             var myHostname = _fixture.DestinationServerName; // This is needed because we are making "external" calls to ourself to test RestSharp
+            var crossProcessId = _fixture.AgentLog.GetCrossProcessId();
+
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
 
@@ -59,10 +59,10 @@ namespace NewRelic.Agent.IntegrationTests
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/PUT", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
@@ -77,34 +77,16 @@ namespace NewRelic.Agent.IntegrationTests
                 .Where(e => e.IntrinsicAttributes.ContainsKey("externalDuration"))
                 .FirstOrDefault();
 
-            var externalSpanEvents = _fixture.AgentLog.GetSpanEvents()
-                .Where(e => e.AgentAttributes.ContainsKey("http.url"))
-                .ToList();
-
             NrAssert.Multiple
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.NotNull(transactionEventWithExternal),
-                () => Assert.All(externalSpanEvents, AssertSpanEventsContainHttpStatusCodeForCompletedRequests)
+                () => Assert.NotNull(transactionEventWithExternal)
             );
 
             var agentWrapperErrorRegex = AgentLogBase.ErrorLogLinePrefixRegex + @"An exception occurred in a wrapper: (.*)";
             var wrapperError = _fixture.AgentLog.TryGetLogLine(agentWrapperErrorRegex);
 
             Assert.Null(wrapperError);
-
-            void AssertSpanEventsContainHttpStatusCodeForCompletedRequests(SpanEvent spanEvent)
-            {
-                var url = (string)spanEvent.AgentAttributes["http.url"];
-                if (url.Contains("/RestAPI/4"))
-                {
-                    Assert.DoesNotContain("http.statusCode", spanEvent.AgentAttributes.Keys);
-                }
-                else
-                {
-                    Assert.Contains("http.statusCode", spanEvent.AgentAttributes.Keys);
-                }
-            }
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwait.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwait.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
     public class RestSharpInstrumentationAsyncAwait : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResult.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResult.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
     public class RestSharpInstrumentationTaskResult : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Rules.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Rules.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.IntegrationTests
     /// Tests around transaction renaming using URL rules and transaction segment terms
     /// NOTE: These tests depend on the application named "RulesWebApi" having some specific rules in place.
     ///		with prefix "WebTransaction/WebAPI" and whitelist terms "Values Sleep UrlRule".
-    ///		Can be found at https://[staging|rpm].newrelicc.com/account/{accountId}/applications/{applicationId}/segment_terms
+    ///		Can be found at https://[staging|rpm].newrelic.com/account/{accountId}/applications/{applicationId}/segment_terms
     /// </summary>
     [NetFrameworkTest]
     public class Rules : IClassFixture<RulesWebApi>


### PR DESCRIPTION
### Description

This PR is prework for issue #238.  It organizes the integration test classes into subfolders and namespaces (where they weren't already).  The primary motivation is to let us parallelize the running of the integration tests by namespace.  Ideally, each namespace's tests will take ten minutes or less to execute in a GHA workflow.

I did my best to group tests into namespaces logically.

### Testing

I made sure the integration tests still pass as expected locally with these changes.

### Changelog

N/A
