### PR TITLE
Save integration test artifacts

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -65,6 +65,7 @@ jobs:
           ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr_linux
           ${{ github.workspace }}\src\Agent\newrelichome_x86
           ${{ github.workspace }}\src\Agent\newrelichome_x86_coreclr
+        if-no-files-found: error
 
     - name: Create Self-signed code signing cert
       run: |
@@ -138,6 +139,7 @@ jobs:
       with:
         name: test-results-${{ github.run_id }}
         path: ${{ github.workspace }}\TestResults
+        if-no-files-found: error
 
   publish-test-results:
     needs: build-test-fullagent-msi
@@ -265,6 +267,7 @@ jobs:
         name: windowsprofiler-x86-${{ github.run_id }}
         path: |
           ${{ github.workspace }}\src\Agent\_profilerBuild\x86-Release
+        if-no-files-found: error
 
   build-test-linux-profiler:
     name: Build Linux Profiler
@@ -294,6 +297,7 @@ jobs:
         name: linuxprofiler-${{ github.run_id }}
         path: |
           ${{ github.workspace }}/src/Agent/NewRelic/Profiler/libNewRelicProfiler.so
+        if-no-files-found: error
 
   build-integration-tests:
     needs: [build-test-fullagent-msi, build-test-windows-profiler, build-test-linux-profiler]
@@ -324,6 +328,17 @@ jobs:
         Write-Host "MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_soluition_path }}"
         MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_soluition_path }}
       shell: powershell
+
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: integrationtests-${{ github.run_id }}
+        path: |
+          ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+          !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+        if-no-files-found: error
 
   build-unbounded-tests:
     needs: [build-test-fullagent-msi, build-test-windows-profiler, build-test-linux-profiler]


### PR DESCRIPTION
Resolves #236

### Description

Add a step to archive the integration test artifacts.
- Only save the bin and Deploy folders since the checkout will have the rest of the files
- Relies on the checkout to pull the code (won't be needed most of the time, bit its already getting pulled in)
- Artifacts are currently ~400mb in size and take ~5 minutes to upload (full download should be about the same)
- Artifacts have been built to have the repo root as the root of the package to make overlaying the files easier.  (Was done by adding `test.runsettings` to artifacts -- also noted in yml).

The idea is that after checking out the branch, the artifacts can be pulled down on top of the branch resulting in all the required files being in place.

#### Addendum

Adds `if-no-files-found: error` to all the artifacts uploads so that jobs will fail if the upload has no files.  It defaults to warning.  This will cause PRs with missing artifacts to not be mergable which is correct.

### Testing

The initial test is that the workflow builds AND produces an integration test artifact that is around ~400mb in size. As we being to get the integration test matrix jobs running we will likely need to adjust the artifacts slightly.

### Changelog

n/a

