### PR TITLE
Updates build_profiler.sh to explicitly fail on errors

### DIFF
--- a/src/Agent/NewRelic/Profiler/linux/build_profiler.sh
+++ b/src/Agent/NewRelic/Profiler/linux/build_profiler.sh
@@ -7,9 +7,16 @@ cmake \
 	-DCORECLR_PATH=/root/git/coreclr \
 	.
 make clean && make 
+retVal=$?
 
 if [ -f "libNewRelicProfiler.so" ]
 	then ldd libNewRelicProfiler.so
 	else 
-		echo "libNewRelicProfiler.so was not built"
+		echo "::error libNewRelicProfiler.so was not built"
 fi
+
+if [ $retVal -ne 0 ]; then
+    echo "::error Exit code was $retVal."
+fi
+
+exit $retVal


### PR DESCRIPTION
Resolves #254 

### Description

Fixes a problem where runs of the linux profiler are reported as successful despite the build failing.   Updates build_profiler.sh to include workflow commands to report up errors as well as some scripting to catch errors and return them as the exit code.

### Testing

I ran this in my fork and it failed as expected when errors were manually introduced by editing build_profiler.sh with some bad command and the like.

### Changelog

n/a