### PR TITLE
Fixes the test results publishing issue with re-running a workflow

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -173,13 +173,16 @@ jobs:
           $resultname = "fullagent_msi-${{ github.run_id }}".ToLower().Replace(" ", "")
           Write-Host "::set-env name=results_name::$resultname"
 
+          Write-Host "Check if testresults folder exists, create if not."
           if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults" )) {
             New-Item -Path "${{ github.workspace }}\docs" -Name "testresults" -ItemType "directory" }
+          
+          Write-Host "Check if test run results ($resultname) folder exists, create if not."
+          if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults\$resultname" )) {
+            New-Item -Path "${{ github.workspace }}\docs\testresults" -Name "$resultname" -ItemType "directory" }
 
-          New-Item -Path "${{ github.workspace }}\docs\testresults" -Name "$resultname" -ItemType "directory"
-
-          Write-Host "Copy the files"
-          Copy-Item .\* -Destination ${{ github.workspace }}\docs\testresults\$resultname\
+          Write-Host "Copy the files and overwrite if already exists"
+          Copy-Item .\* -Destination ${{ github.workspace }}\docs\testresults\$resultname\ -Force
 
           Write-Host "Confirm Folder Exists"
           Test-Path "${{ github.workspace }}\docs\testresults\$resultname"


### PR DESCRIPTION
Resolves #256

### Description

- The publishing of the test results is failing if the workflow is re-run due to the folder structure already existing.
- Updates the script that moves the results to also check if the run folder exists before attempting to create it.

### Testing

First run passed as expected so I re-ran the workflow and that also ran fine, no publishing issues.

### Changelog
n/a

