### PR TITLE
Ms sql windows container

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             # complex password than 'password' and that is why this service does
             # not follow the same pattern as the others.
             - SA_PASSWORD=password0TS
-            - SQLCMDPASSWORD=password0TS
+            - ACCEPT_EULA=Y
         container_name: MssqlServer
 
     

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+    
+    mssql:
+        build: ./mssql
+        ports:
+            - "1433:1433"
+        environment:
+            # The password set here must match the password set in the connection
+            # string being used by the MS SQL tests.  SQL server requires a more
+            # complex password than 'password' and that is why this service does
+            # not follow the same pattern as the others.
+            - SA_PASSWORD=password0TS
+            - SQLCMDPASSWORD=password0TS
+        container_name: MssqlServer
+
+    

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
@@ -3,15 +3,12 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download Links:
 ENV sql_express_download_url "https://go.microsoft.com/fwlink/?linkid=829176"
 
-ENV sa_password="_" \
-    attach_dbs="[]" \
-    ACCEPT_EULA="_" \
-    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
-
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # make install files accessible
 COPY start.ps1 /
+COPY NewRelicDB.bak /
+COPY restore.sql /
 WORKDIR /
 
 RUN Invoke-WebRequest -Uri $env:sql_express_download_url -OutFile sqlexpress.exe ; \
@@ -24,4 +21,4 @@ RUN stop-service MSSQL`$SQLEXPRESS ; \
         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpport -value 1433 ; \
         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\' -name LoginMode -value 2 ;
 
-CMD .\start -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose
+CMD .\start -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -Verbose

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
@@ -1,55 +1,27 @@
-#FROM microsoft/mssql-server-windows-developer:2019-latest
-#FROM mcr.microsoft.com/windows/servercore:10.0.17763.1457
-# same as my Windows host:
-#FROM mcr.microsoft.com/windows/servercore:10.0.19041.508 
-
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
-#USER "NT AUTHORITY\System"
-# RUN NET USER TESTUSER "password0TS" /ADD
-# RUN NET LOCALGROUP "Administrators" "TESTUSER" /ADD
-#USER "TESTUSER"
 
+# Download Links:
 ENV sql_express_download_url "https://go.microsoft.com/fwlink/?linkid=829176"
-ENV ACCEPT_EULA=Y
-ENV SA_PASSWORD=password0TS
-ENV ATTACH_DBS='[{"dbName":"NewRelic","dbFiles":["NewRelic.mdf","NewRelic_log.ldf"]}]'
 
-#COPY NewRelic.mdf .
-#COPY NewRelic_log.ldf .
-COPY NewRelicDB.bak .
-COPY restore.sql .
-COPY start.ps1 /
+ENV sa_password="_" \
+    attach_dbs="[]" \
+    ACCEPT_EULA="_" \
+    sa_password_path="C:\ProgramData\Docker\secrets\sa-password"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# make install files accessible
+COPY start.ps1 /
 WORKDIR /
 
-# RUN Invoke-WebRequest -Uri $env:sql_express_download_url -OutFile .\sqlexpress.exe ; \
-#         Start-Process -Wait -FilePath .\sqlexpress.exe -ArgumentList /qs, /x:setup ; \
-#         .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\System' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; \
-#         Remove-Item -Recurse -Force sqlexpress.exe, setup
-
-#ADD https://go.microsoft.com/fwlink/?linkid=829176 sqlexpress.exe
-COPY sqlexpress.exe .
-
-RUN Start-Process -Wait -Verbose -FilePath .\sqlexpress.exe -ArgumentList '/qs /x:setup' ;
-#RUN .\sqlexpress.exe -ArgumentList '/qs /x:setup' ;
-#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
-#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='TESTUSER' /SQLSVCPASSWORD="password0TS" /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
-#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\System' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
-RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='containeradministrator' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
-#RUN Remove-Item -Recurse -Force sqlexpress.exe, setup
-
-#RUN stop-service MSSQL`$SQLEXPRESS ; \
-# RUN net start MSSQL`$SQLEXPRESS /m ; \
-#         sqlcmd -E -S. -Q 'CREATE LOGIN [USER MANAGER\ContainerAdministrator] FROM WINDOWS WITH DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english]' ; \
-#         sqlcmd -E -S. -Q 'ALTER SERVER ROLE [sysadmin] ADD MEMBER [USER MANAGER\ContainerAdministrator]' ; \
-#         stop-service MSSQL`$SQLEXPRESS ;
+RUN Invoke-WebRequest -Uri $env:sql_express_download_url -OutFile sqlexpress.exe ; \
+        Start-Process -Wait -FilePath .\sqlexpress.exe -ArgumentList /qs, /x:setup ; \
+        .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\System' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; \
+        Remove-Item -Recurse -Force sqlexpress.exe, setup
 
 RUN stop-service MSSQL`$SQLEXPRESS ; \
-         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpdynamicports -value '' ; \
-         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpport -value 1433 ; \
-         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\' -name LoginMode -value 2 ;
+        set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpdynamicports -value '' ; \
+        set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpport -value 1433 ; \
+        set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\' -name LoginMode -value 2 ;
 
-# CMD .\start.ps1 -sa_password $env:SA_PASSWORD -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs $env:ATTACH_DBS -Verbose
-CMD .\start.ps1 -sa_password $env:SA_PASSWORD -ACCEPT_EULA $env:ACCEPT_EULA -Verbose
+CMD .\start -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/Dockerfile
@@ -1,0 +1,55 @@
+#FROM microsoft/mssql-server-windows-developer:2019-latest
+#FROM mcr.microsoft.com/windows/servercore:10.0.17763.1457
+# same as my Windows host:
+#FROM mcr.microsoft.com/windows/servercore:10.0.19041.508 
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+#USER "NT AUTHORITY\System"
+# RUN NET USER TESTUSER "password0TS" /ADD
+# RUN NET LOCALGROUP "Administrators" "TESTUSER" /ADD
+#USER "TESTUSER"
+
+ENV sql_express_download_url "https://go.microsoft.com/fwlink/?linkid=829176"
+ENV ACCEPT_EULA=Y
+ENV SA_PASSWORD=password0TS
+ENV ATTACH_DBS='[{"dbName":"NewRelic","dbFiles":["NewRelic.mdf","NewRelic_log.ldf"]}]'
+
+#COPY NewRelic.mdf .
+#COPY NewRelic_log.ldf .
+COPY NewRelicDB.bak .
+COPY restore.sql .
+COPY start.ps1 /
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /
+
+# RUN Invoke-WebRequest -Uri $env:sql_express_download_url -OutFile .\sqlexpress.exe ; \
+#         Start-Process -Wait -FilePath .\sqlexpress.exe -ArgumentList /qs, /x:setup ; \
+#         .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\System' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; \
+#         Remove-Item -Recurse -Force sqlexpress.exe, setup
+
+#ADD https://go.microsoft.com/fwlink/?linkid=829176 sqlexpress.exe
+COPY sqlexpress.exe .
+
+RUN Start-Process -Wait -Verbose -FilePath .\sqlexpress.exe -ArgumentList '/qs /x:setup' ;
+#RUN .\sqlexpress.exe -ArgumentList '/qs /x:setup' ;
+#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
+#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='TESTUSER' /SQLSVCPASSWORD="password0TS" /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
+#RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\System' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
+RUN .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=SQLEXPRESS /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='containeradministrator' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS ; 
+#RUN Remove-Item -Recurse -Force sqlexpress.exe, setup
+
+#RUN stop-service MSSQL`$SQLEXPRESS ; \
+# RUN net start MSSQL`$SQLEXPRESS /m ; \
+#         sqlcmd -E -S. -Q 'CREATE LOGIN [USER MANAGER\ContainerAdministrator] FROM WINDOWS WITH DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english]' ; \
+#         sqlcmd -E -S. -Q 'ALTER SERVER ROLE [sysadmin] ADD MEMBER [USER MANAGER\ContainerAdministrator]' ; \
+#         stop-service MSSQL`$SQLEXPRESS ;
+
+RUN stop-service MSSQL`$SQLEXPRESS ; \
+         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpdynamicports -value '' ; \
+         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpport -value 1433 ; \
+         set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.SQLEXPRESS\mssqlserver\' -name LoginMode -value 2 ;
+
+# CMD .\start.ps1 -sa_password $env:SA_PASSWORD -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs $env:ATTACH_DBS -Verbose
+CMD .\start.ps1 -sa_password $env:SA_PASSWORD -ACCEPT_EULA $env:ACCEPT_EULA -Verbose

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/entrypoint.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/entrypoint.ps1
@@ -1,0 +1,7 @@
+# start SQL Server - start the script to restore the DB
+# SQL startup MUST be at the end of this line to keep container up
+
+Write-Output "entrypoint.ps1"
+
+.\setup.ps1 
+Start-Process .\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/entrypoint.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/entrypoint.ps1
@@ -1,7 +1,0 @@
-# start SQL Server - start the script to restore the DB
-# SQL startup MUST be at the end of this line to keep container up
-
-Write-Output "entrypoint.ps1"
-
-.\setup.ps1 
-Start-Process .\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/restore.sql
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/restore.sql
@@ -1,0 +1,8 @@
+USE [master]
+GO
+RESTORE DATABASE [NewRelic]
+FROM DISK = 'c:\NewRelicDB.bak'
+WITH
+MOVE 'NewRelic' TO 'c:\NewRelic.mdf',
+MOVE 'NewRelic_log' TO 'c:\NewRelic_log.ldf';
+GO

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/setup.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/setup.ps1
@@ -1,9 +1,0 @@
-Write-Output "setup.ps1"
-# Starts a loop to check if SQL is ready before running setup script.
-DO
-{
-    sqlcmd -S localhost -U sa -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h -1
-    Start-Sleep 1s
-} WHILE ($LASTEXITCODE -ne 0)
-
-.\sqlcmd -S localhost -U sa -i \restore.sql

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/setup.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/setup.ps1
@@ -1,0 +1,9 @@
+Write-Output "setup.ps1"
+# Starts a loop to check if SQL is ready before running setup script.
+DO
+{
+    sqlcmd -S localhost -U sa -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h -1
+    Start-Sleep 1s
+} WHILE ($LASTEXITCODE -ne 0)
+
+.\sqlcmd -S localhost -U sa -i \restore.sql

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/start.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service 
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+[Parameter(Mandatory=$false)]
+[string]$sa_password,
+
+[Parameter(Mandatory=$false)]
+[string]$ACCEPT_EULA,
+
+[Parameter(Mandatory=$false)]
+[string]$attach_dbs
+)
+
+
+if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+	Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+	Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1 
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQL`$SQLEXPRESS
+
+# if($sa_password -eq "_") {
+#     $secretPath = $env:sa_password_path
+#     if (Test-Path $secretPath) {
+#         $sa_password = Get-Content -Raw $secretPath
+#     }
+#     else {
+#         Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+#     }
+# }
+
+if($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" +"'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & "C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd.exe" -Q $sqlcmd
+}
+
+#$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+#$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+# if ($null -ne $dbs -And $dbs.Length -gt 0)
+# {
+#     Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+#     Foreach($db in $dbs) 
+#     {            
+#         $files = @();
+#         Foreach($file in $db.dbFiles)
+#         {
+#             $files += "(FILENAME = N'$($file)')";           
+#         }
+
+#         $files = $files -join ","
+#         $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+#         Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+#         & "C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd.exe" -Q $sqlcmd
+#     }
+# }
+
+& "C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\130\Tools\Binn\sqlcmd.exe" -S localhost -U sa -P $Env:SA_PASSWORD -i c:\restore.sql
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/start.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/Windows/mssql/start.ps1
@@ -7,10 +7,7 @@ param(
 [string]$sa_password,
 
 [Parameter(Mandatory=$false)]
-[string]$ACCEPT_EULA,
-
-[Parameter(Mandatory=$false)]
-[string]$attach_dbs
+[string]$ACCEPT_EULA
 )
 
 
@@ -26,45 +23,11 @@ if($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
 Write-Verbose "Starting SQL Server"
 start-service MSSQL`$SQLEXPRESS
 
-if($sa_password -eq "_") {
-    $secretPath = $env:sa_password_path
-    if (Test-Path $secretPath) {
-        $sa_password = Get-Content -Raw $secretPath
-    }
-    else {
-        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
-    }
-}
-
 if($sa_password -ne "_")
 {
     Write-Verbose "Changing SA login credentials"
     $sqlcmd = "ALTER LOGIN sa with password=" +"'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
     & sqlcmd -Q $sqlcmd
-}
-
-$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
-
-$dbs = $attach_dbs_cleaned | ConvertFrom-Json
-
-if ($null -ne $dbs -And $dbs.Length -gt 0)
-{
-    Write-Verbose "Attaching $($dbs.Length) database(s)"
-	    
-    Foreach($db in $dbs) 
-    {            
-        $files = @();
-        Foreach($file in $db.dbFiles)
-        {
-            $files += "(FILENAME = N'$($file)')";           
-        }
-
-        $files = $files -join ","
-        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
-
-        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
-        & sqlcmd -Q $sqlcmd
-    }
 }
 
 Write-Verbose "Restoring NewRelic database."


### PR DESCRIPTION
Description
Resolves #244. Adds a Windows docker image for MSSQL.

Testing
The mssql unbounded integration tests pass locally, although with occasional flickers. These flickers will be addressed when implementing the Unbounded Test execution in GitHub CI, the intended use case for Windows containers.

Changelog
N/A