### PR TITLE
remove unnecessary confusing env vars

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/linux/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/linux/docker-compose.yml
@@ -60,7 +60,6 @@ mssql:
         # complex password than 'password' and that is why this service does
         # not follow the same pattern as the others.
         - SA_PASSWORD=password0TS
-        - SQLCMDPASSWORD=password0TS
     container_name: MssqlServer
 
 oracle:

--- a/tests/Agent/IntegrationTests/UnboundedServices/linux/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/linux/mssql/Dockerfile
@@ -1,8 +1,6 @@
 FROM microsoft/mssql-server-linux:2017-latest
 
 ENV ACCEPT_EULA=Y
-ENV MSSQL_SA_PASSWORD=password0TS
-ENV SQLCMDPASSWORD=password0TS
 ENV SA_PASSWORD=password0TS
 
 COPY setup.sh /var/


### PR DESCRIPTION
### Description
Removes unused environment variables leftover from initial development and testing.

### Testing
Unbounded MsSql tests pass locally without them.

### Changelog
N/A

