### PR TITLE
Set log level to warn for event log appender

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -287,6 +287,7 @@ namespace NewRelic.Agent.Core
 #if NET45
 			var appender = new EventLogAppender();
 			appender.Layout = eventLoggerLayout;
+			appender.Threshold = Level.Warn;
 			appender.Name = EventLogAppenderName;
 			appender.LogName = EventLogName;
 			appender.ApplicationName = EventLogSourceName;
@@ -395,7 +396,7 @@ namespace NewRelic.Agent.Core
             catch (Exception exception)
             {
                 log.ErrorFormat("Unable to write the {0} log to \"{1}\": {2}", appenderName, fileName, exception.Message);
-                throw exception;
+                throw;
             }
 
             try

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -419,7 +419,7 @@ namespace NewRelic.Agent.Core
             catch (Exception exception)
             {
                 log.ErrorFormat("Unable to configure the {0} log file appender for \"{1}\": {2}", appenderName, fileName, exception.Message);
-                throw exception;
+                throw;
             }
         }
     }


### PR DESCRIPTION
When an exception is thrown while the agent is initializing its log4net file appender, the agent falls back to setting up an event log appender. This is only true for .NET Framework applications - not .NET Core.

For example, one way to cause an exception during the file appender initialization is to use the following agent configuration:

```xml
<log level="info" directory="C:\SomeBogusDirectory" />
```

Since the directory does not exist, this code throws an exception:
https://github.com/newrelic/newrelic-dotnet-agent/blob/2b8e8cdc71146b1196e6a455e981be37fe789532/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs#L390-L399.

The exception is caught and the event log appender is set up here:
https://github.com/newrelic/newrelic-dotnet-agent/blob/2b8e8cdc71146b1196e6a455e981be37fe789532/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs#L349-L353

When this occurs, the event log appender uses the `info` log level defined in our example configuration. This causes an unabated blizzard of info-level log messages to appear in the event log.

This PR hard codes the event log appender's log level to `warn` preventing the blizzard, but still enables us to troubleshoot why the file appender failed to initialize (as well as any other warnings and errors from the agent).