### PR TITLE
Gather additional data and consolidate integration test results

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -487,7 +487,14 @@ jobs:
 
       - name: Run Integration Tests
         run: |
+          Write-Host "List ports in use"
+          netstat -no
+
+          Write-Host "Run tests"
           ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xml ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
+          
+          Write-Host "Get HostableWebCore errors (if any)"
+          Get-EventLog -LogName Application -Source HostableWebCore
         shell: powershell
 
       - name: Archive Test Results
@@ -514,6 +521,15 @@ jobs:
 
       - name: Combine Integration Results
         run: |
-          Get-ChildItem . -Recurse
+          mkdir all-integration-test-results
+
+          Get-ChildItem -Path .\integration-test-results* -Include *.xml -Recurse | ForEach-Object { cp $_.FullName .\all-integration-test-results }
         shell: powershell
+
+      - name: Upload combined artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: all-integration-test-results-${{ github.run_id }}
+          path: ./all-integration-test-results
+          if-no-files-found: error
 

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -491,7 +491,7 @@ jobs:
           netstat -no
 
           Write-Host "Run tests"
-          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xml ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
+          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xmlv1 ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
           
           Write-Host "Get HostableWebCore errors (if any)"
           Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -454,6 +454,8 @@ jobs:
       integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
       xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
       integration_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net461/NewRelic.Agent.IntegrationTests.dll
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: true
 
     steps:
       - name: Checkout
@@ -487,17 +489,21 @@ jobs:
 
       - name: Run Integration Tests
         run: |
-          Write-Host "List ports in use"
-          netstat -no
+          if ($Env:enhanced_logging) {
+            Write-Host "List ports in use"
+            netstat -no  
+          }
 
           Write-Host "Run tests"
           ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xmlv1 ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
           
-          Write-Host "Get HostableWebCore errors (if any)"
-          Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
-
-          Write-Host "Get .NET Runtime errors (if any)"
-          Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
+          if ($Env:enhanced_logging) {
+            Write-Host "Get HostableWebCore errors (if any)"
+            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+  
+            Write-Host "Get .NET Runtime errors (if any)"
+            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+          }
         shell: powershell
 
       - name: Archive Test Results

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -487,7 +487,7 @@ jobs:
 
       - name: Run Integration Tests
         run: |
-          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -html ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.html
+          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xml ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
         shell: powershell
 
       - name: Archive Test Results
@@ -497,3 +497,23 @@ jobs:
           name: integration-test-results-${{ matrix.namespace }}-${{ github.run_id }}
           path: ${{ github.workspace }}/TestResults
           if-no-files-found: error
+
+  combine-integration-test-results:
+    needs: run-integration-tests
+    if: ${{ always() }}
+    name: Combine Integration Test Results
+
+    runs-on: windows-2019
+
+    env:
+      results_name: ""
+
+    steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Combine Integration Results
+        run: |
+          Get-ChildItem . -Recurse
+        shell: powershell
+

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -494,7 +494,10 @@ jobs:
           ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -xml ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.xml
           
           Write-Host "Get HostableWebCore errors (if any)"
-          Get-EventLog -LogName Application -Source HostableWebCore
+          Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+
+          Write-Host "Get .NET Runtime errors (if any)"
+          Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore
         shell: powershell
 
       - name: Archive Test Results


### PR DESCRIPTION
### Description

In order to make troubleshooting our integration test failures easier, this PR does the following:
1. XUnit outputs XML instead of HTML reports
2. These reports are consolidated into a single downloadable artifact for easier processing of all test results.
3. Some additional data is gathered before and after running the integration tests - ports in use, and Windows event log errors and warnings for HostableWebCore and the .NET Runtime.

### Testing

N/A

### Changelog

N/A