### PR TITLE
adds aiohttp install in yml

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -485,6 +485,7 @@ jobs:
       - name: Install dependencies
         run: |
           Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+          pip install aiohttp
         shell: powershell
 
       - name: Run Integration Tests


### PR DESCRIPTION
### Description
Adds aiohttp library installation, a dependency of the W3CValidationTest Integration Test.

### Testing
Run Action  `.NET Agent All Solutions Build`, verify W3CValidationTest passes (in DistributedTracing namespace).
Example output expected:
```
<test name="NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests.W3CValidation.Test" type="NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests.W3CValidation" method="Test" time="26.2680708" result="Pass">
```

### Changelog
N/A

