### PR TITLE
Integration Tests - Modifies Output Folder to be Test Class Name

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/ConsoleMultiFunctionApplicationCore/README.md
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleMultiFunctionApplicationCore/README.md
@@ -112,7 +112,7 @@ In the example below, an abstract base test fixture has been designed.  Specific
 
 ```Csharp
 
-public abstract class DotNetPerfMetricsTests<TFixture> : IClassFixture<TFixture> where TFixture:ConsoleDynamicMethodFixture
+public abstract class DotNetPerfMetricsTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture:ConsoleDynamicMethodFixture
 {
 
 	public DotNetPerfMetricsTests(TFixture fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicIntegrationTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicIntegrationTest.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 
-namespace NewRelic.Agent.IntegrationTests
+namespace NewRelic.Agent.IntegrationTestHelpers
 {
     public abstract class NewRelicIntegrationTest<TFixture> : IClassFixture<TFixture>
             where TFixture : RemoteApplicationFixture

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -125,7 +125,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         /// actual process to the fixture.  This ensures that the remote application
         /// is managed internally.
         /// </summary>
-
+        ///
         protected abstract string ApplicationDirectoryName { get; }
 
         protected abstract string SourceApplicationDirectoryPath { get; }
@@ -135,6 +135,14 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         public abstract void Start(string commandLineArguments, bool captureStandardOutput = false, bool doProfile = true);
 
         #endregion
+
+        private Type _testClassType;
+        public RemoteApplication SetTestClassType(Type testClassType)
+        {
+            _testClassType = testClassType;
+            return this;
+        }
+
 
         protected IDictionary<string, string> AdditionalEnvironmentVariables;
         public RemoteApplication SetAdditionalEnvironmentVariable(string key, string value)
@@ -164,7 +172,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         {
             get
             {
-                return _uniqueFolderName ?? (_uniqueFolderName = ApplicationDirectoryName + "_" + Guid.NewGuid().ToString());
+                return _uniqueFolderName ?? (_uniqueFolderName = (_testClassType?.Name ?? ApplicationDirectoryName) + "_" + Guid.NewGuid().ToString());
             }
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -21,8 +21,14 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
         private Action _setupConfiguration;
         private Action _exerciseApplication;
+        
 
         private bool _initialized;
+
+        public void SetTestClassType(Type testClassType)
+        {
+            RemoteApplication?.SetTestClassType(testClassType);
+        }
 
         public int? ExitCode => RemoteApplication?.ExitCode;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/AutostartDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/AutostartDisabled.cs
@@ -10,12 +10,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class AutoStartDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class AutoStartDisabled : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public AutoStartDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CallStackFallbackMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/CallStackFallbackMvc.cs
@@ -12,12 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class CallStackFallbackMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CallStackFallbackMvc : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public CallStackFallbackMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using System;
 using Xunit;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
@@ -9,11 +9,11 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
-    public class ConfigBuilderDeadlock : IClassFixture<ConsoleDynamicMethodFixtureFW>
+    public class ConfigBuilderDeadlock : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW>
     {
         protected readonly ConsoleDynamicMethodFixtureFW _fixture;
 
-        public ConfigBuilderDeadlock(ConsoleDynamicMethodFixtureFW fixture, ITestOutputHelper output)
+        public ConfigBuilderDeadlock(ConsoleDynamicMethodFixtureFW fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -11,12 +11,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class EnvironmentTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class EnvironmentTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public EnvironmentTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/GetBrowserTimingHeader.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/GetBrowserTimingHeader.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class GetBrowserTimingHeader : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class GetBrowserTimingHeader : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -19,6 +19,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
         private string _browserTimingHeader;
 
         public GetBrowserTimingHeader(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/GetBrowserTimingHeaderAutoOn.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/GetBrowserTimingHeaderAutoOn.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class GetBrowserTimingHeaderAutoOn : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class GetBrowserTimingHeaderAutoOn : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
@@ -19,6 +19,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
         private string _htmlContentAfterCallToGetBrowserTiming;
 
         public GetBrowserTimingHeaderAutoOn(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/InstrumentationLoaderTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/InstrumentationLoaderTests.cs
@@ -11,12 +11,12 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class InstrumentationLoaderTests : IClassFixture<RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture>
+    public class InstrumentationLoaderTests : NewRelicIntegrationTest<RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture>
     {
         private readonly RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture _fixture;
         private readonly ITestOutputHelper _output;
 
-        public InstrumentationLoaderTests(RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture fixture, ITestOutputHelper output)
+        public InstrumentationLoaderTests(RemoteServiceFixtures.ConsoleInstrumentationLoaderFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -59,11 +59,11 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
     }
 
     [NetCoreTest]
-    public class InstrumentationLoaderTestsCore : IClassFixture<RemoteServiceFixtures.ConsoleInstrumentationLoaderFixtureCore>
+    public class InstrumentationLoaderTestsCore : NewRelicIntegrationTest<RemoteServiceFixtures.ConsoleInstrumentationLoaderFixtureCore>
     {
         private readonly RemoteServiceFixtures.ConsoleInstrumentationLoaderFixtureCore _fixture;
 
-        public InstrumentationLoaderTestsCore(RemoteServiceFixtures.ConsoleInstrumentationLoaderFixtureCore fixture, ITestOutputHelper output)
+        public InstrumentationLoaderTestsCore(RemoteServiceFixtures.ConsoleInstrumentationLoaderFixtureCore fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/NewRelicMetadataEnvTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/NewRelicMetadataEnvTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class NewRelicMetadataEnvTests : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>
+    public class NewRelicMetadataEnvTests : NewRelicIntegrationTest<RemoteServiceFixtures.AgentApiExecutor>
     {
         private readonly RemoteServiceFixtures.AgentApiExecutor _fixture;
         private readonly Dictionary<string, string> _envs = new Dictionary<string, string>
@@ -23,6 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
         };
 
         public NewRelicMetadataEnvTests(RemoteServiceFixtures.AgentApiExecutor fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/RemotingSerialization.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/RemotingSerialization.cs
@@ -9,14 +9,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class RemotingSerialization : IClassFixture<RemoteServiceFixtures.OwinRemotingFixture>
+    public class RemotingSerialization : NewRelicIntegrationTest<RemoteServiceFixtures.OwinRemotingFixture>
     {
         private readonly RemoteServiceFixtures.OwinRemotingFixture _fixture;
 
         string _tcpResponse;
         string _httpResponse;
 
-        public RemotingSerialization(RemoteServiceFixtures.OwinRemotingFixture fixture, ITestOutputHelper output)
+        public RemotingSerialization(RemoteServiceFixtures.OwinRemotingFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/Rules.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/Rules.cs
@@ -18,11 +18,11 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
     ///		Can be found at https://[staging|rpm].newrelic.com/account/{accountId}/applications/{applicationId}/segment_terms
     /// </summary>
     [NetFrameworkTest]
-    public class Rules : IClassFixture<RulesWebApi>
+    public class Rules : NewRelicIntegrationTest<RulesWebApi>
     {
         private readonly RulesWebApi _fixture;
 
-        public Rules(RulesWebApi fixture, ITestOutputHelper output)
+        public Rules(RulesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileNetCoreTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileNetCoreTests.cs
@@ -14,12 +14,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetCoreTest]
-    public class ThreadProfileNetCoreTests : IClassFixture<AspNetCoreMvcWithCollectorFixture>
+    public class ThreadProfileNetCoreTests : NewRelicIntegrationTest<AspNetCoreMvcWithCollectorFixture>
     {
         private readonly AspNetCoreMvcWithCollectorFixture _fixture;
         private string _threadProfileString;
 
         public ThreadProfileNetCoreTests(AspNetCoreMvcWithCollectorFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class ThreadProfileStressTests : IClassFixture<ThreadProfileStressTestWithCollectorFixture>
+    public class ThreadProfileStressTests : NewRelicIntegrationTest<ThreadProfileStressTestWithCollectorFixture>
     {
         private string _threadProfileString;
 
-        public ThreadProfileStressTests(ThreadProfileStressTestWithCollectorFixture fixture, ITestOutputHelper output)
+        public ThreadProfileStressTests(ThreadProfileStressTestWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             fixture.TestLogger = output;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileTests.cs
@@ -14,13 +14,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class ThreadProfileTests : IClassFixture<MvcWithCollectorFixture>
+    public class ThreadProfileTests : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
 
         private readonly MvcWithCollectorFixture _fixture;
         private string _threadProfileString;
 
-        public ThreadProfileTests(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public ThreadProfileTests(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/TransactionThreshold.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/TransactionThreshold.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class TransactionThreshold : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public class TransactionThreshold : NewRelicIntegrationTest<RemoteServiceFixtures.OwinWebApiFixture>
     {
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
-        public TransactionThreshold(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public TransactionThreshold(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/CpuMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/CpuMvc.cs
@@ -13,11 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 {
     [NetFrameworkTest]
-    public class CpuMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CpuMvc : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public CpuMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = testLogger;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
@@ -112,7 +112,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
         };
     }
 
-    public abstract class DotNetPerfMetricsTests<TFixture> : IClassFixture<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    public abstract class DotNetPerfMetricsTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         private const ulong COUNT_GC_INDUCED = 5;
         private const int THREADPOOL_WORKER_MAX = 275;
@@ -140,7 +140,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
             "Threadpool/Throughput/QueueLength"
         };
 
-        public DotNetPerfMetricsTests(TFixture fixture, ITestOutputHelper output)
+        public DotNetPerfMetricsTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             Fixture = fixture;
             Fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/MemoryMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/MemoryMvc.cs
@@ -13,11 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 {
     [NetFrameworkTest]
-    public class MemoryMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class MemoryMvc : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public MemoryMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = testLogger;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/RequiredSupportabilityMetrics.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/RequiredSupportabilityMetrics.cs
@@ -14,11 +14,12 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 {
     // This test verifies that all supportability metrics are generated that are required by APM.
     [NetFrameworkTest]
-    public class RequiredSupportabilityMetrics : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RequiredSupportabilityMetrics : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public RequiredSupportabilityMetrics(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/AgentApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/AgentApiTests.cs
@@ -13,12 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Api
 {
     [NetFrameworkTest]
-    public class AgentApiTests : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>
+    public class AgentApiTests : NewRelicIntegrationTest<RemoteServiceFixtures.AgentApiExecutor>
     {
 
         private readonly RemoteServiceFixtures.AgentApiExecutor _fixture;
 
         public AgentApiTests(RemoteServiceFixtures.AgentApiExecutor fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiAppNameChangeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiAppNameChangeTests.cs
@@ -12,12 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Api
 {
     [NetFrameworkTest]
-    public class ApiAppNameChangeTests : IClassFixture<RemoteServiceFixtures.ApiAppNameChangeFixture>
+    public class ApiAppNameChangeTests : NewRelicIntegrationTest<RemoteServiceFixtures.ApiAppNameChangeFixture>
     {
 
         private readonly RemoteServiceFixtures.ApiAppNameChangeFixture _fixture;
 
         public ApiAppNameChangeTests(RemoteServiceFixtures.ApiAppNameChangeFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
         }
     }
 
-    public abstract class ApiCallsTests<TFixture> : IClassFixture<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    public abstract class ApiCallsTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly string[] ApiCalls = new string[]
             {
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
 
         protected readonly TFixture Fixture;
 
-        public ApiCallsTests(TFixture fixture, ITestOutputHelper output)
+        public ApiCallsTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             Fixture = fixture;
             Fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreCollectibleAssemblyContextTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreCollectibleAssemblyContextTests.cs
@@ -12,13 +12,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetCoreTest]
-    public class AspNetCoreCollectibleAssemblyContextTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
+    public class AspNetCoreCollectibleAssemblyContextTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCore3FeaturesFixture _fixture;
 
         private const int ExpectedTransactionCount = 2;
 
         public AspNetCoreCollectibleAssemblyContextTests(RemoteServiceFixtures.AspNetCore3FeaturesFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreGenericWebHostTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreGenericWebHostTests.cs
@@ -14,13 +14,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetCoreTest]
-    public class AspNetCoreGenericWebHostTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
+    public class AspNetCoreGenericWebHostTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCore3FeaturesFixture _fixture;
 
         private const int ExpectedTransactionCount = 2;
 
         public AspNetCoreGenericWebHostTests(RemoteServiceFixtures.AspNetCore3FeaturesFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
@@ -13,13 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetCoreTest]
-    public class AspNetCoreMvcAsyncTests : IClassFixture<AspNetCoreMvcAsyncTestsFixture>
+    public class AspNetCoreMvcAsyncTests : NewRelicIntegrationTest<AspNetCoreMvcAsyncTestsFixture>
     {
         private readonly AspNetCoreMvcAsyncTestsFixture _fixture;
         private const int ExpectedTransactionCount = 7;
         private const string AssemblyName = "AspNetCoreMvcAsyncApplication";
 
         public AspNetCoreMvcAsyncTests(AspNetCoreMvcAsyncTestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
@@ -14,13 +14,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetCoreTest]
-    public class AspNetCoreMvcBasicRequestsTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    public class AspNetCoreMvcBasicRequestsTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
         private const int ExpectedTransactionCount = 2;
 
         public AspNetCoreMvcBasicRequestsTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcCoreFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcCoreFrameworkTests.cs
@@ -13,11 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetFrameworkTest]
-    public class AspNetCoreMvcCoreFrameworkTests : IClassFixture<AspNetCoreMvcCoreFrameworkFixture>
+    public class AspNetCoreMvcCoreFrameworkTests : NewRelicIntegrationTest<AspNetCoreMvcCoreFrameworkFixture>
     {
         private readonly AspNetCoreMvcCoreFrameworkFixture _fixture;
 
         public AspNetCoreMvcCoreFrameworkTests(AspNetCoreMvcCoreFrameworkFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkAsyncTests.cs
@@ -13,13 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetFrameworkTest]
-    public class AspNetCoreMvcFrameworkAsyncTests : IClassFixture<AspNetCoreMvcFrameworkAsyncTestsFixture>
+    public class AspNetCoreMvcFrameworkAsyncTests : NewRelicIntegrationTest<AspNetCoreMvcFrameworkAsyncTestsFixture>
     {
         private readonly AspNetCoreMvcFrameworkAsyncTestsFixture _fixture;
         private const int ExpectedTransactionCount = 7;
         private const string AssemblyName = "AspNetCoreMvcFrameworkAsyncApplication";
 
         public AspNetCoreMvcFrameworkAsyncTests(AspNetCoreMvcFrameworkAsyncTestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcFrameworkTests.cs
@@ -13,12 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AspNetCore
 {
     [NetFrameworkTest]
-    public class AspNetCoreMvcFrameworkTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
+    public class AspNetCoreMvcFrameworkTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
     {
 
         private readonly RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture _fixture;
 
         public AspNetCoreMvcFrameworkTests(RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/AsyncStreamTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/AsyncStreamTest.cs
@@ -11,13 +11,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetCoreTest]
-    public class AsyncStreamTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
+    public class AsyncStreamTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCore3FeaturesFixture _fixture;
 
         private const int ExpectedTransactionCount = 2;
 
         public AsyncStreamTests(RemoteServiceFixtures.AspNetCore3FeaturesFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicAspWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicAspWebService.cs
@@ -12,12 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicAspWebService : IClassFixture<RemoteServiceFixtures.BasicAspWebService>
+    public class BasicAspWebService : NewRelicIntegrationTest<RemoteServiceFixtures.BasicAspWebService>
     {
 
         private readonly RemoteServiceFixtures.BasicAspWebService _fixture;
 
         public BasicAspWebService(RemoteServiceFixtures.BasicAspWebService fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplication.cs
@@ -14,11 +14,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicMvcApplication : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicMvcApplication : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public BasicMvcApplication(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplicationWithAsyncDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicMvcApplicationWithAsyncDisabled.cs
@@ -13,12 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicMvcApplicationWithAsyncDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicMvcApplicationWithAsyncDisabled : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public BasicMvcApplicationWithAsyncDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicOpenRastaApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicOpenRastaApplication.cs
@@ -13,12 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicOpenRastaApplication : IClassFixture<RemoteServiceFixtures.BasicOpenRastaApplication>
+    public class BasicOpenRastaApplication : NewRelicIntegrationTest<RemoteServiceFixtures.BasicOpenRastaApplication>
     {
 
         private readonly RemoteServiceFixtures.BasicOpenRastaApplication _fixture;
 
-        public BasicOpenRastaApplication(RemoteServiceFixtures.BasicOpenRastaApplication fixture, ITestOutputHelper output)
+        public BasicOpenRastaApplication(RemoteServiceFixtures.BasicOpenRastaApplication fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebApplication.cs
@@ -12,12 +12,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicWebApplication : IClassFixture<RemoteServiceFixtures.BasicWebApplication>
+    public class BasicWebApplication : NewRelicIntegrationTest<RemoteServiceFixtures.BasicWebApplication>
     {
 
         private readonly RemoteServiceFixtures.BasicWebApplication _fixture;
 
-        public BasicWebApplication(RemoteServiceFixtures.BasicWebApplication fixture, ITestOutputHelper output)
+        public BasicWebApplication(RemoteServiceFixtures.BasicWebApplication fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebForms.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebForms.cs
@@ -13,12 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicWebForms : IClassFixture<RemoteServiceFixtures.BasicWebFormsApplication>
+    public class BasicWebForms : NewRelicIntegrationTest<RemoteServiceFixtures.BasicWebFormsApplication>
     {
 
         private readonly RemoteServiceFixtures.BasicWebFormsApplication _fixture;
 
-        public BasicWebForms(RemoteServiceFixtures.BasicWebFormsApplication fixture, ITestOutputHelper output)
+        public BasicWebForms(RemoteServiceFixtures.BasicWebFormsApplication fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/BasicWebService.cs
@@ -12,12 +12,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicWebService : IClassFixture<RemoteServiceFixtures.BasicWebService>
+    public class BasicWebService : NewRelicIntegrationTest<RemoteServiceFixtures.BasicWebService>
     {
 
         private readonly RemoteServiceFixtures.BasicWebService _fixture;
 
-        public BasicWebService(RemoteServiceFixtures.BasicWebService fixture, ITestOutputHelper output)
+        public BasicWebService(RemoteServiceFixtures.BasicWebService fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ConsoleAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ConsoleAsyncTests.cs
@@ -14,12 +14,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class ConsoleAsyncTests : IClassFixture<ConsoleAsyncFixture>
+    public class ConsoleAsyncTests : NewRelicIntegrationTest<ConsoleAsyncFixture>
     {
         private readonly ConsoleAsyncFixture _fixture;
         private const int ExpectedTransactionCount = 7;
 
-        public ConsoleAsyncTests(ConsoleAsyncFixture fixture, ITestOutputHelper output)
+        public ConsoleAsyncTests(ConsoleAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MsCorLibTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MsCorLibTests.cs
@@ -12,11 +12,12 @@ using System.Net;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class MsCorLibTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class MsCorLibTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public MsCorLibTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcAsyncTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class MvcAsyncTests : IClassFixture<MvcAsyncFixture>
+    public class MvcAsyncTests : NewRelicIntegrationTest<MvcAsyncFixture>
     {
         private readonly MvcAsyncFixture _fixture;
         private const int ExpectedTransactionCount = 3;
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
         private const string MetricNameFrameworkName = "MVC";
         private const string MetricNameAsyncAwaitControllerName = "AsyncAwaitController";
 
-        public MvcAsyncTests(MvcAsyncFixture fixture, ITestOutputHelper output)
+        public MvcAsyncTests(MvcAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcRum.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/MvcRum.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class MvcRum : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class MvcRum : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
@@ -19,6 +19,7 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
         private string _responseBodyForNonHtmlContent;
 
         public MvcRum(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
@@ -13,12 +13,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetCoreTest]
-    public class NetCoreAsyncTests : IClassFixture<NetCoreAsyncTestsFixture>
+    public class NetCoreAsyncTests : NewRelicIntegrationTest<NetCoreAsyncTestsFixture>
     {
         private readonly NetCoreAsyncTestsFixture _fixture;
         private const int ExpectedTransactionCount = 3;
 
-        public NetCoreAsyncTests(NetCoreAsyncTestsFixture fixture, ITestOutputHelper output)
+        public NetCoreAsyncTests(NetCoreAsyncTestsFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
@@ -35,13 +35,13 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
     /// </summary>
     /// <typeparam name="TFixture"></typeparam>
     public abstract class NetStandardLibraryInstrumentation<TFixture>
-        : IClassFixture<TFixture> where TFixture : ConsoleDynamicMethodFixture
+        : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         private TFixture _fixture;
 
         private const int COUNT_ITERATIONS = 10;
 
-        public NetStandardLibraryInstrumentation(TFixture fixture, ITestOutputHelper output)
+        public NetStandardLibraryInstrumentation(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackApplicationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackApplicationTests.cs
@@ -12,13 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class ServiceStackApplicationTests : IClassFixture<ServiceStackApplicationFixture>
+    public class ServiceStackApplicationTests : NewRelicIntegrationTest<ServiceStackApplicationFixture>
     {
 
         private readonly ServiceStackApplicationFixture _fixture;
         private const int ExpectedTransactionCount = 1;
 
-        public ServiceStackApplicationTests(ServiceStackApplicationFixture fixture, ITestOutputHelper output)
+        public ServiceStackApplicationTests(ServiceStackApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/ServiceStackRedisTests.cs
@@ -12,12 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class ServiceStackRedisTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class ServiceStackRedisTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         public ServiceStackRedisTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
@@ -188,14 +188,14 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
         }
     }
 
-    public abstract class WebApiAsyncForceNewTransactionTests : IClassFixture<WebApiAsyncFixture>
+    public abstract class WebApiAsyncForceNewTransactionTests : NewRelicIntegrationTest<WebApiAsyncFixture>
     {
         protected readonly WebApiAsyncFixture _fixture;
         protected const string AssemblyName = "WebApiAsyncApplication";
 
         protected abstract void SetupConfiguration(string instrumentationFilePath);
 
-        protected WebApiAsyncForceNewTransactionTests(WebApiAsyncFixture fixture, ITestOutputHelper output)
+        protected WebApiAsyncForceNewTransactionTests(WebApiAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncTests.cs
@@ -14,13 +14,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class WebApiAsyncTests : IClassFixture<WebApiAsyncFixture>
+    public class WebApiAsyncTests : NewRelicIntegrationTest<WebApiAsyncFixture>
     {
         private readonly WebApiAsyncFixture _fixture;
         private const int ExpectedTransactionCount = 6;
         private const string AssemblyName = "WebApiAsyncApplication";
 
-        public WebApiAsyncTests(WebApiAsyncFixture fixture, ITestOutputHelper output)
+        public WebApiAsyncTests(WebApiAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebForms45Application.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebForms45Application.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 {
     [NetFrameworkTest]
-    public class WebForms45Application : IClassFixture<RemoteServiceFixtures.WebForms45Application>
+    public class WebForms45Application : NewRelicIntegrationTest<RemoteServiceFixtures.WebForms45Application>
     {
         private readonly RemoteServiceFixtures.WebForms45Application _fixture;
 
-        public WebForms45Application(RemoteServiceFixtures.WebForms45Application fixture, ITestOutputHelper output)
+        public WebForms45Application(RemoteServiceFixtures.WebForms45Application fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreHSMEnabledWithCustomAttributesTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreHSMEnabledWithCustomAttributesTests.cs
@@ -14,13 +14,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
-    public class AspNetCoreHSMEnabledWithCustomAttributesTests : IClassFixture<HSMAspNetCoreWebApiCustomAttributesFixture>
+    public class AspNetCoreHSMEnabledWithCustomAttributesTests : NewRelicIntegrationTest<HSMAspNetCoreWebApiCustomAttributesFixture>
     {
-
         private readonly HSMAspNetCoreWebApiCustomAttributesFixture _fixture;
 
-        public AspNetCoreHSMEnabledWithCustomAttributesTests(HSMAspNetCoreWebApiCustomAttributesFixture fixture, ITestOutputHelper output)
-        {
+        public AspNetCoreHSMEnabledWithCustomAttributesTests(HSMAspNetCoreWebApiCustomAttributesFixture fixture, ITestOutputHelper output) : base(fixture)
+        { 
             _fixture = fixture;
             _fixture.TestLogger = output;
             _fixture.Actions(

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
-    public class AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    public class AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
@@ -20,6 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public AspNetCoreLocalHSMDisabledAndServerSideHSMDisabledTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -9,14 +9,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
-    public class AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests : IClassFixture<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
+    public class AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests : NewRelicIntegrationTest<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
 
         private readonly RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture _fixture;
 
-        public AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+        public AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
-    public class AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    public class AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
@@ -17,6 +17,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetCoreTest]
-    public class AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests : IClassFixture<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
+    public class AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests : NewRelicIntegrationTest<RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
 
         private readonly RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture _fixture;
 
-        public AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+        public AspNetCoreLocalHSMEnabledAndServerSideHSMEnabledTests(RemoteServiceFixtures.HSMAspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityAndCustomAttributes.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityAndCustomAttributes.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityAndCustomAttributes : IClassFixture<HSMCustomAttributesWebApi>
+    public class HighSecurityAndCustomAttributes : NewRelicIntegrationTest<HSMCustomAttributesWebApi>
     {
         private readonly HSMCustomAttributesWebApi _fixture;
 
-        public HighSecurityAndCustomAttributes(HSMCustomAttributesWebApi fixture, ITestOutputHelper output)
+        public HighSecurityAndCustomAttributes(HSMCustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeDisabled.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeDisabled : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class HighSecurityModeDisabled : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public HighSecurityModeDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeDisabled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeEnabled.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeEnabled : IClassFixture<RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture>
+    public class HighSecurityModeEnabled : NewRelicIntegrationTest<RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
 
         private readonly RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture _fixture;
 
         private const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
-        public HighSecurityModeEnabled(RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeEnabled(RemoteServiceFixtures.HSMBasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeNoTransactionAgentApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeNoTransactionAgentApiTests.cs
@@ -13,13 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeNoTransactionAgentApiTests : IClassFixture<RemoteServiceFixtures.HSMAgentApiExecutor>
+    public class HighSecurityModeNoTransactionAgentApiTests : NewRelicIntegrationTest<RemoteServiceFixtures.HSMAgentApiExecutor>
     {
 
         private readonly RemoteServiceFixtures.HSMAgentApiExecutor _fixture;
         private const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
-        public HighSecurityModeNoTransactionAgentApiTests(RemoteServiceFixtures.HSMAgentApiExecutor fixture, ITestOutputHelper output)
+        public HighSecurityModeNoTransactionAgentApiTests(RemoteServiceFixtures.HSMAgentApiExecutor fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -9,12 +9,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeServerDisabled : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public class HighSecurityModeServerDisabled : NewRelicIntegrationTest<RemoteServiceFixtures.OwinWebApiFixture>
     {
 
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
-        public HighSecurityModeServerDisabled(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeServerDisabled(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -9,11 +9,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class HighSecurityModeServerEnabled : IClassFixture<RemoteServiceFixtures.HSMOwinWebApiFixture>
+    public class HighSecurityModeServerEnabled : NewRelicIntegrationTest<RemoteServiceFixtures.HSMOwinWebApiFixture>
     {
         private readonly RemoteServiceFixtures.HSMOwinWebApiFixture _fixture;
 
-        public HighSecurityModeServerEnabled(RemoteServiceFixtures.HSMOwinWebApiFixture fixture, ITestOutputHelper output)
+        public HighSecurityModeServerEnabled(RemoteServiceFixtures.HSMOwinWebApiFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveAndCustomAttributesTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveAndCustomAttributesTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class SecurityPoliciesMostRestrictiveAndCustomAttributesTests : IClassFixture<SecurityPoliciesCustomAttributesWebApi>
+    public class SecurityPoliciesMostRestrictiveAndCustomAttributesTests : NewRelicIntegrationTest<SecurityPoliciesCustomAttributesWebApi>
     {
         private readonly SecurityPoliciesCustomAttributesWebApi _fixture;
 
-        public SecurityPoliciesMostRestrictiveAndCustomAttributesTests(SecurityPoliciesCustomAttributesWebApi fixture, ITestOutputHelper output)
+        public SecurityPoliciesMostRestrictiveAndCustomAttributesTests(SecurityPoliciesCustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/SecurityPoliciesMostRestrictiveTests.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CSP
 {
     [NetFrameworkTest]
-    public class SecurityPoliciesMostRestrictiveTests : IClassFixture<RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture>
+    public class SecurityPoliciesMostRestrictiveTests : NewRelicIntegrationTest<RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture>
     {
         private const string QueryStringParameterValue = @"my thing";
         private const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
         private readonly RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture _fixture;
 
-        public SecurityPoliciesMostRestrictiveTests(RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public SecurityPoliciesMostRestrictiveTests(RemoteServiceFixtures.SecurityPoliciesBasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatDisabledHeaderPresent.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatDisabledHeaderPresent.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatDisabledHeaderPresent : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatDisabledHeaderPresent : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -21,6 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.CatInbound
         private HttpResponseHeaders _responseHeaders;
 
         public CatDisabledHeaderPresent(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledDoesStatusCodeRollupNaming.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledDoesStatusCodeRollupNaming.cs
@@ -13,12 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledDoesStatusCodeRollupNaming : IClassFixture<BasicMvcApplicationTestFixture>
+    public class CatEnabledDoesStatusCodeRollupNaming : NewRelicIntegrationTest<BasicMvcApplicationTestFixture>
     {
         private BasicMvcApplicationTestFixture _fixture;
         private HttpResponseHeaders _responseHeaders;
 
         public CatEnabledDoesStatusCodeRollupNaming(BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderMissing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderMissing.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledHeaderMissing : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledHeaderMissing : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -21,6 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.CatInbound
         private HttpResponseHeaders _responseHeaders;
 
         public CatEnabledHeaderMissing(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingAbsent.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingAbsent.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledHeaderPresentDistributedTraceSettingAbsent : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledHeaderPresentDistributedTraceSettingAbsent : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -22,6 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.CatInbound
         private HttpResponseHeaders _responseHeaders;
 
         public CatEnabledHeaderPresentDistributedTraceSettingAbsent(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingFalse.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingFalse.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledHeaderPresentDistributedTraceSettingFalse : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledHeaderPresentDistributedTraceSettingFalse : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -22,6 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.CatInbound
         private HttpResponseHeaders _responseHeaders;
 
         public CatEnabledHeaderPresentDistributedTraceSettingFalse(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingTrue.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledHeaderPresentDistributedTraceSettingTrue.cs
@@ -12,12 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledHeaderPresentDistributedTraceSettingTrue : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledHeaderPresentDistributedTraceSettingTrue : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
         private HttpResponseHeaders _responseHeaders;
 
         public CatEnabledHeaderPresentDistributedTraceSettingTrue(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithFullInboundHeaders.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithFullInboundHeaders.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledWithFullInboundHeaders : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledWithFullInboundHeaders : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.CatInbound
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledWithFullInboundHeaders(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledWithFullInboundHeaders(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithServerRedirect.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithServerRedirect.cs
@@ -13,13 +13,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledWithServerRedirect : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledWithServerRedirect : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledWithServerRedirect(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledWithServerRedirect(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithUntrustedAccountId.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatInbound/CatEnabledWithUntrustedAccountId.cs
@@ -12,13 +12,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatInbound
 {
     [NetFrameworkTest]
-    public class CatEnabledWithUntrustedAccountId : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledWithUntrustedAccountId : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledWithUntrustedAccountId(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledWithUntrustedAccountId(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatDisabledChainedRequests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatDisabledChainedRequests.cs
@@ -16,13 +16,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatOutbound
 {
     [NetFrameworkTest]
-    public class CatDisabledChainedRequests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatDisabledChainedRequests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatDisabledChainedRequests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatDisabledChainedRequests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedAsyncAwaitRestSharp.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedAsyncAwaitRestSharp.cs
@@ -15,13 +15,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatOutbound
 {
     [NetFrameworkTest]
-    public class CatEnabledChainedAsyncAwaitRestSharp : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledChainedAsyncAwaitRestSharp : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledChainedAsyncAwaitRestSharp(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledChainedAsyncAwaitRestSharp(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatOutbound
 {
     [NetFrameworkTest]
-    public class CatEnabledChainedRequests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledChainedRequests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledChainedRequests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledChainedRequests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsHttpClient.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsHttpClient.cs
@@ -15,13 +15,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatOutbound
 {
     [NetFrameworkTest]
-    public class CatEnabledChainedRequestsHttpClient : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledChainedRequestsHttpClient : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledChainedRequestsHttpClient(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledChainedRequestsHttpClient(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedTaskResultRestSharp.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedTaskResultRestSharp.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CatOutbound
 {
     [NetFrameworkTest]
-    public class CatEnabledChainedTaskResultRestSharp : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CatEnabledChainedTaskResultRestSharp : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
 
         private HttpResponseHeaders _responseHeaders;
 
-        public CatEnabledChainedTaskResultRestSharp(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CatEnabledChainedTaskResultRestSharp(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnored.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnored.cs
@@ -15,11 +15,11 @@ namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 
 {
     [NetFrameworkTest]
-    public class CustomAttributesIgnored : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesIgnored : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesIgnored(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesIgnored(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesIgnoredErrorAttributesNotInTransactionTrace : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesIgnoredErrorAttributesNotInTransactionTrace : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesIgnoredErrorAttributesNotInTransactionTrace(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesIgnoredErrorAttributesNotInTransactionTrace(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesKeyNull.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesKeyNull.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesKeyNull : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesKeyNull : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesKeyNull(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesKeyNull(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyDisabled.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesLegacyDisabled : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesLegacyDisabled : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesLegacyDisabled(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesLegacyDisabled(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyIgnored.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesLegacyIgnored.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesLegacyIgnored : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesLegacyIgnored : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesLegacyIgnored(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesLegacyIgnored(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesMvc.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CustomAttributesMvc : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public CustomAttributesMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CustomAttributesMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesWebApi.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class CustomAttributesWebApi : IClassFixture<RemoteServiceFixtures.CustomAttributesWebApi>
+    public class CustomAttributesWebApi : NewRelicIntegrationTest<RemoteServiceFixtures.CustomAttributesWebApi>
     {
         private readonly RemoteServiceFixtures.CustomAttributesWebApi _fixture;
 
-        public CustomAttributesWebApi(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output)
+        public CustomAttributesWebApi(RemoteServiceFixtures.CustomAttributesWebApi fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/Labels.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/Labels.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomAttributes
 {
     [NetFrameworkTest]
-    public class Labels : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class Labels : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public Labels(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public Labels(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentation.cs
@@ -13,11 +13,12 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class AttributeInstrumentation : IClassFixture<RemoteServiceFixtures.AttributeInstrumentation>
+    public class AttributeInstrumentation : NewRelicIntegrationTest<RemoteServiceFixtures.AttributeInstrumentation>
     {
         private readonly RemoteServiceFixtures.AttributeInstrumentation _fixture;
 
         public AttributeInstrumentation(RemoteServiceFixtures.AttributeInstrumentation fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/BasicCustomInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/BasicCustomInstrumentation.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class BasicCustomInstrumentation : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class BasicCustomInstrumentation : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public BasicCustomInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public BasicCustomInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ConsoleAsynConsoleAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ConsoleAsynConsoleAsyncForceNewTransactionTests.cs
@@ -175,14 +175,14 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 
     }
 
-    public abstract class ConsoleAsyncForceNewTransactionTests : IClassFixture<ConsoleAsyncFixture>
+    public abstract class ConsoleAsyncForceNewTransactionTests : NewRelicIntegrationTest<ConsoleAsyncFixture>
     {
         protected readonly ConsoleAsyncFixture Fixture;
         protected const string AssemblyName = "ConsoleAsyncApplication";
 
         protected abstract void SetupConfiguration(string instrumentationFilePath);
 
-        public ConsoleAsyncForceNewTransactionTests(ConsoleAsyncFixture fixture, ITestOutputHelper output)
+        public ConsoleAsyncForceNewTransactionTests(ConsoleAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             Fixture = fixture;
             Fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationAsync.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationAsync.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentationAsync : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class CustomInstrumentationAsync : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public CustomInstrumentationAsync(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public CustomInstrumentationAsync(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorAgentCommand.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorAgentCommand.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentationEditorAgentCommand : IClassFixture<MvcWithCollectorFixture>
+    public class CustomInstrumentationEditorAgentCommand : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
-        public CustomInstrumentationEditorAgentCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public CustomInstrumentationEditorAgentCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorConnectCommand.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/CustomInstrumentationEditorConnectCommand.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class CustomInstrumentationEditorConnectCommand : IClassFixture<MvcWithCollectorFixture>
+    public class CustomInstrumentationEditorConnectCommand : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
-        public CustomInstrumentationEditorConnectCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public CustomInstrumentationEditorConnectCommand(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperFrameworkTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperFrameworkTests.cs
@@ -16,11 +16,12 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
     /// about testing the behavior of removing the transaction data from AsyncLocal storage.
     /// </summary>
     [NetFrameworkTest]
-    public class DetachWrapperFrameworkTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
+    public class DetachWrapperFrameworkTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture _fixture;
 
         public DetachWrapperFrameworkTests(RemoteServiceFixtures.AspNetCoreMvcFrameworkFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/DetachWrapperTests.cs
@@ -16,11 +16,12 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
     /// about testing the behavior of removing the transaction data from AsyncLocal storage.
     /// </summary>
     [NetCoreTest]
-    public class DetachWrapperTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    public class DetachWrapperTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public DetachWrapperTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/InterfaceDefaultsInstrumentationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/InterfaceDefaultsInstrumentationTests.cs
@@ -11,13 +11,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
-    public class InterfaceDefaultsInstrumentationTests : IClassFixture<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
+    public class InterfaceDefaultsInstrumentationTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCore3FeaturesFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCore3FeaturesFixture _fixture;
 
         private const int ExpectedTransactionCount = 2;
 
         public InterfaceDefaultsInstrumentationTests(RemoteServiceFixtures.AspNetCore3FeaturesFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/NetCoreAttributeInstrumentationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/NetCoreAttributeInstrumentationTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
-    public class NetCoreAttributeInstrumentationTests : IClassFixture<RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture>
+    public class NetCoreAttributeInstrumentationTests : NewRelicIntegrationTest<RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture>
     {
         private readonly RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture _fixture;
 
-        public NetCoreAttributeInstrumentationTests(RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture fixture, ITestOutputHelper output)
+        public NetCoreAttributeInstrumentationTests(RemoteServiceFixtures.NetCoreAttributeInstrumentationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransaction.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransaction.cs
@@ -12,11 +12,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransaction : IClassFixture<RemoteServiceFixtures.AgentApiExecutor>
+    public class OtherTransaction : NewRelicIntegrationTest<RemoteServiceFixtures.AgentApiExecutor>
     {
         private readonly RemoteServiceFixtures.AgentApiExecutor _fixture;
 
         public OtherTransaction(RemoteServiceFixtures.AgentApiExecutor fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsync.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsync.cs
@@ -12,12 +12,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransactionAsync : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class OtherTransactionAsync : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
 
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public OtherTransactionAsync(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public OtherTransactionAsync(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsyncWithImmediateError.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionAsyncWithImmediateError.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransactionAsyncWithError : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class OtherTransactionAsyncWithError : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public OtherTransactionAsyncWithError(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public OtherTransactionAsyncWithError(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsConsole.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsConsole.cs
@@ -11,12 +11,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransactionResponseTimeTestsConsole : IClassFixture<RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture>
+    public class OtherTransactionResponseTimeTestsConsole : NewRelicIntegrationTest<RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture>
     {
         private readonly RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture _fixture;
         private const int _delayDuration = 2;
 
-        public OtherTransactionResponseTimeTestsConsole(RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture fixture, ITestOutputHelper output)
+        public OtherTransactionResponseTimeTestsConsole(RemoteServiceFixtures.ConsoleOtherTransactionWrapperFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/OtherTransactionResponseTimeTestsWebApi.cs
@@ -11,12 +11,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetFrameworkTest]
-    public class OtherTransactionResponseTimeTestsWebApi : IClassFixture<RemoteServiceFixtures.WebApiAsyncFixture>
+    public class OtherTransactionResponseTimeTestsWebApi : NewRelicIntegrationTest<RemoteServiceFixtures.WebApiAsyncFixture>
     {
         private readonly RemoteServiceFixtures.WebApiAsyncFixture _fixture;
         private const int _delayDuration = 2;
 
-        public OtherTransactionResponseTimeTestsWebApi(RemoteServiceFixtures.WebApiAsyncFixture fixture, ITestOutputHelper output)
+        public OtherTransactionResponseTimeTestsWebApi(RemoteServiceFixtures.WebApiAsyncFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/SerilogSumologicTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/SerilogSumologicTests.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
     [NetCoreTest]
-    public class SerilogSumologicSyncTests : IClassFixture<RemoteServiceFixtures.SerilogSumologicFixture>
+    public class SerilogSumologicSyncTests : NewRelicIntegrationTest<RemoteServiceFixtures.SerilogSumologicFixture>
     {
         private readonly RemoteServiceFixtures.SerilogSumologicFixture _fixture;
 
-        public SerilogSumologicSyncTests(RemoteServiceFixtures.SerilogSumologicFixture fixture, ITestOutputHelper output, bool synchronousMethodFirst = true)
+        public SerilogSumologicSyncTests(RemoteServiceFixtures.SerilogSumologicFixture fixture, ITestOutputHelper output, bool synchronousMethodFirst = true) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectResponseHandlingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectResponseHandlingTests.cs
@@ -15,13 +15,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DataTransmission
 {
     [NetFrameworkTest]
-    public class ConnectResponseHandlingTests : IClassFixture<MvcWithCollectorFixture>
+    public class ConnectResponseHandlingTests : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
         private IEnumerable<CollectedRequest> _collectedRequests = null;
         private HeaderValidationData _requestHeaderMapValidationData = new HeaderValidationData();
 
-        public ConnectResponseHandlingTests(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public ConnectResponseHandlingTests(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/DataTransmissionDefaults.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/DataTransmissionDefaults.cs
@@ -14,13 +14,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DataTransmission
 {
     [NetFrameworkTest]
-    public class DataTransmissionDefaults : IClassFixture<MvcWithCollectorFixture>
+    public class DataTransmissionDefaults : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
         private IEnumerable<CollectedRequest> _collectedRequests = null;
 
-        public DataTransmissionDefaults(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public DataTransmissionDefaults(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/DataTransmissionPutGzip.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/DataTransmissionPutGzip.cs
@@ -14,13 +14,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DataTransmission
 {
     [NetFrameworkTest]
-    public class DataTransmissionPutGzip : IClassFixture<MvcWithCollectorFixture>
+    public class DataTransmissionPutGzip : NewRelicIntegrationTest<MvcWithCollectorFixture>
     {
         private readonly MvcWithCollectorFixture _fixture;
 
         private IEnumerable<CollectedRequest> _collectedRequests = null;
 
-        public DataTransmissionPutGzip(MvcWithCollectorFixture fixture, ITestOutputHelper output)
+        public DataTransmissionPutGzip(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
@@ -27,11 +27,11 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
         }
     }
 
-    public abstract class FasterEventHarvestTests<TFixture> : IClassFixture<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    public abstract class FasterEventHarvestTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         protected readonly TFixture Fixture;
 
-        public FasterEventHarvestTests(TFixture fixture, ITestOutputHelper output)
+        public FasterEventHarvestTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             Fixture = fixture;
             Fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetCoreTest]
-    public class AspNetCoreDistTraceRequestChainTests : IClassFixture<AspNetCoreDistTraceRequestChainFixture>
+    public class AspNetCoreDistTraceRequestChainTests : NewRelicIntegrationTest<AspNetCoreDistTraceRequestChainFixture>
     {
         private readonly AspNetCoreDistTraceRequestChainFixture _fixture;
 
@@ -24,6 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
         public const string TransportType = "HTTP"; //All calls are Http for the distributed traces
 
         public AspNetCoreDistTraceRequestChainTests(AspNetCoreDistTraceRequestChainFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTSupportabilityMetricTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTSupportabilityMetricTests.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetFrameworkTest]
-    public class DTSupportabilityMetricTests : IClassFixture<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
+    public class DTSupportabilityMetricTests : NewRelicIntegrationTest<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
     {
         readonly RemoteServiceFixtures.DTBasicMVCApplicationFixture _fixture;
 
-        public DTSupportabilityMetricTests(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public DTSupportabilityMetricTests(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DtApiTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DtApiTestBase.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
-    public abstract class DtApiTestBase : IClassFixture<RemoteServiceFixtures.DistributedTracingApiFixture>
+    public abstract class DtApiTestBase : NewRelicIntegrationTest<RemoteServiceFixtures.DistributedTracingApiFixture>
     {
         public enum TracingTestOption
         {
@@ -22,9 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 
         protected readonly TracingTestOption _tracingTestOption;
 
-        public DtApiTestBase(DistributedTracingApiFixture fixture, ITestOutputHelper output,
-            TracingTestOption tracingTestOption
-        )
+        public DtApiTestBase(DistributedTracingApiFixture fixture, ITestOutputHelper output, TracingTestOption tracingTestOption) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/InitiateDTAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/InitiateDTAttributesTest.cs
@@ -14,12 +14,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetFrameworkTest]
-    public class InitiateDTAttributesTest : IClassFixture<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
+    public class InitiateDTAttributesTest : NewRelicIntegrationTest<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
     {
 
         private readonly RemoteServiceFixtures.DTBasicMVCApplicationFixture _fixture;
 
-        public InitiateDTAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public InitiateDTAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/ReceiveDTAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/ReceiveDTAttributesTest.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetFrameworkTest]
-    public class ReceiveDTAttributesTest : IClassFixture<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
+    public class ReceiveDTAttributesTest : NewRelicIntegrationTest<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.DTBasicMVCApplicationFixture _fixture;
 
-        public ReceiveDTAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public ReceiveDTAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/SpanEventsAreCreatedAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/SpanEventsAreCreatedAttributesTest.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetFrameworkTest]
-    public class SpanEventsAreCreatedAttributesTest : IClassFixture<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
+    public class SpanEventsAreCreatedAttributesTest : NewRelicIntegrationTest<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.DTBasicMVCApplicationFixture _fixture;
 
-        public SpanEventsAreCreatedAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public SpanEventsAreCreatedAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/SpanEventsNotCreatedAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/SpanEventsNotCreatedAttributesTest.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing
 {
     [NetFrameworkTest]
-    public class SpanEventsNotCreatedAttributesTest : IClassFixture<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
+    public class SpanEventsNotCreatedAttributesTest : NewRelicIntegrationTest<RemoteServiceFixtures.DTBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.DTBasicMVCApplicationFixture _fixture;
 
-        public SpanEventsNotCreatedAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public SpanEventsNotCreatedAttributesTest(RemoteServiceFixtures.DTBasicMVCApplicationFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
     /// Instrumentations occur in this test are AspNetCore and HttpClient.
     /// </summary>
     [NetCoreTest]
-    public class HttpClientW3CTestsNetCore : IClassFixture<AspNetCoreDistTraceRequestChainFixture>
+    public class HttpClientW3CTestsNetCore : NewRelicIntegrationTest<AspNetCoreDistTraceRequestChainFixture>
     {
         private readonly AspNetCoreDistTraceRequestChainFixture _fixture;
 
@@ -30,6 +30,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         private const string TestOtherVendorEntries = "rojo=1,congo=2";
 
         public HttpClientW3CTestsNetCore(AspNetCoreDistTraceRequestChainFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
     /// Instrumentations occur in this test are AspNetCore and HttpClient.
     /// </summary>
     [NetCoreTest]
-    public class HttpWebRequestW3CTestsNetCore : IClassFixture<AspNetCoreDistTraceRequestChainFixture>
+    public class HttpWebRequestW3CTestsNetCore : NewRelicIntegrationTest<AspNetCoreDistTraceRequestChainFixture>
     {
         private readonly AspNetCoreDistTraceRequestChainFixture _fixture;
 
@@ -29,6 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         private const string TestOtherVendorEntries = "rojo=1,congo=2";
 
         public HttpWebRequestW3CTestsNetCore(AspNetCoreDistTraceRequestChainFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/TraceIdTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/TraceIdTests.cs
@@ -12,12 +12,13 @@ using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests
 {
     [NetFrameworkTest]
-    public class TraceIdTests : IClassFixture<AspNetCore3BasicWebApiApplicationFixture>
+    public class TraceIdTests : NewRelicIntegrationTest<AspNetCore3BasicWebApiApplicationFixture>
     {
         private readonly AspNetCore3BasicWebApiApplicationFixture _fixture;
         private string _traceId;
 
         public TraceIdTests(AspNetCore3BasicWebApiApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CTestBase.cs
@@ -13,7 +13,7 @@ using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests
 {
-    public abstract class W3CTestBase<T> : IClassFixture<T> where T : TracingChainFixture
+    public abstract class W3CTestBase<T> : NewRelicIntegrationTest<T> where T : TracingChainFixture
     {
         protected T _fixture;
         protected const string TestTraceId = "12345678901234567890123456789012";
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
                 new KeyValuePair<string, string> ("tracestate", TestOtherVendorEntries)
             };
 
-        public W3CTestBase(T fixture, ITestOutputHelper output)
+        public W3CTestBase(T fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -46,11 +46,11 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
     /// This makes troubleshooting a bit more difficult since you have to dig through the output for the test and find the failures.
     /// </summary>
     [NetFrameworkTest]
-    public class W3CValidation : IClassFixture<ConsoleDynamicMethodFixtureFW>
+    public class W3CValidation : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW>
     {
         protected readonly ConsoleDynamicMethodFixtureFW _fixture;
 
-        public W3CValidation(ConsoleDynamicMethodFixtureFW fixture, ITestOutputHelper output)
+        public W3CValidation(ConsoleDynamicMethodFixtureFW fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Errors
 {
     [NetFrameworkTest]
-    public class ErrorTraceMvc : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class ErrorTraceMvc : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public ErrorTraceMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger)
+        public ErrorTraceMvc(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper testLogger) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = testLogger;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Errors
 {
     [NetFrameworkTest]
-    public class ErrorTraceWebApi : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public class ErrorTraceWebApi : NewRelicIntegrationTest<RemoteServiceFixtures.OwinWebApiFixture>
     {
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
-        public ErrorTraceWebApi(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper testLogger)
+        public ErrorTraceWebApi(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper testLogger) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = testLogger;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Errors
 {
     [NetFrameworkTest]
-    public class ErrorTraceWebService : IClassFixture<RemoteServiceFixtures.BasicWebService>
+    public class ErrorTraceWebService : NewRelicIntegrationTest<RemoteServiceFixtures.BasicWebService>
     {
         private const string ExpectedExceptionType = "System.Exception";
 
 
         private readonly RemoteServiceFixtures.BasicWebService _fixture;
 
-        public ErrorTraceWebService(RemoteServiceFixtures.BasicWebService fixture, ITestOutputHelper output)
+        public ErrorTraceWebService(RemoteServiceFixtures.BasicWebService fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
@@ -14,11 +14,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Errors
 {
     [NetCoreTest]
-    public class ExpectedErrorTests : IClassFixture<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    public class ExpectedErrorTests : NewRelicIntegrationTest<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
     {
         private readonly RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public ExpectedErrorTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNet5.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNet5.cs
@@ -15,11 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetCore
 {
     [NetCoreTest]
-    public class HttpClientInstrumentationNet5 : IClassFixture<AspNet5BasicWebApiApplicationFixture>
+    public class HttpClientInstrumentationNet5 : NewRelicIntegrationTest<AspNet5BasicWebApiApplicationFixture>
     {
         private readonly AspNet5BasicWebApiApplicationFixture _fixture;
 
         public HttpClientInstrumentationNet5(AspNet5BasicWebApiApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNetCore.cs
@@ -15,11 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetCore
 {
     [NetCoreTest]
-    public class HttpClientInstrumentationNetCore : IClassFixture<AspNetCoreMvcBasicRequestsFixture>
+    public class HttpClientInstrumentationNetCore : NewRelicIntegrationTest<AspNetCoreMvcBasicRequestsFixture>
     {
         private readonly AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public HttpClientInstrumentationNetCore(AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientViaFactoryNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientViaFactoryNetCore.cs
@@ -12,11 +12,12 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetCore
 {
-    public class HttpClientViaFactoryNetCore : IClassFixture<AspNetCoreMvcBasicRequestsFixture>
+    public class HttpClientViaFactoryNetCore : NewRelicIntegrationTest<AspNetCoreMvcBasicRequestsFixture>
     {
         private readonly AspNetCoreMvcBasicRequestsFixture _fixture;
 
         public HttpClientViaFactoryNetCore(AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetFramework/HttpClientInstrumentationDisablesForLegacyPipeline.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetFramework/HttpClientInstrumentationDisablesForLegacyPipeline.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetFramework
 {
     [NetFrameworkTest]
-    public class HttpClientInstrumentationDisablesForLegacyPipeline : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class HttpClientInstrumentationDisablesForLegacyPipeline : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public HttpClientInstrumentationDisablesForLegacyPipeline(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public HttpClientInstrumentationDisablesForLegacyPipeline(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetFramework/HttpClientInstrumentationNetFramework.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetFramework/HttpClientInstrumentationNetFramework.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetFramework
 {
     [NetFrameworkTest]
-    public class HttpClientInstrumentationNetFramework : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class HttpClientInstrumentationNetFramework : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public HttpClientInstrumentationNetFramework(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public HttpClientInstrumentationNetFramework(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class ChangeLogDirectoryTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class ChangeLogDirectoryTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public ChangeLogDirectoryTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public ChangeLogDirectoryTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogFilenameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogFilenameTests.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class ChangeLogFilenameTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class ChangeLogFilenameTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public ChangeLogFilenameTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public ChangeLogFilenameTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogFalseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogFalseTests.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelInfoAndAuditLogFalseTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelInfoAndAuditLogFalseTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelInfoAndAuditLogFalseTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelInfoAndAuditLogFalseTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogNotSetTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogNotSetTests.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelInfoAndAuditLogNotSetTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelInfoAndAuditLogNotSetTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelInfoAndAuditLogNotSetTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelInfoAndAuditLogNotSetTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogTrueTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelInfoAndAuditLogTrueTests.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelInfoAndAuditLogTrueTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelInfoAndAuditLogTrueTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelInfoAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelInfoAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelOffAndAuditLogTrueTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelOffAndAuditLogTrueTests.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Logging
 {
     [NetFrameworkTest]
-    public class LogLevelOffAndAuditLogTrueTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class LogLevelOffAndAuditLogTrueTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public LogLevelOffAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public LogLevelOffAndAuditLogTrueTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/NewRelicIntegrationTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/NewRelicIntegrationTest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests
+{
+    public abstract class NewRelicIntegrationTest<TFixture> : IClassFixture<TFixture>
+            where TFixture : RemoteApplicationFixture
+    {
+
+        public NewRelicIntegrationTest(TFixture fixture)
+        {
+            fixture.SetTestClassType(this.GetType());
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
@@ -14,11 +14,11 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinCATChainTests : IClassFixture<OwinTracingChainFixture>
+    public class OwinCATChainTests : NewRelicIntegrationTest<OwinTracingChainFixture>
     {
         private readonly OwinTracingChainFixture _fixture;
 
-        public OwinCATChainTests(OwinTracingChainFixture fixture, ITestOutputHelper output)
+        public OwinCATChainTests(OwinTracingChainFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
@@ -13,11 +13,11 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinDTChainTests : IClassFixture<OwinTracingChainFixture>
+    public class OwinDTChainTests : NewRelicIntegrationTest<OwinTracingChainFixture>
     {
         private readonly OwinTracingChainFixture _fixture;
 
-        public OwinDTChainTests(OwinTracingChainFixture fixture, ITestOutputHelper output)
+        public OwinDTChainTests(OwinTracingChainFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
@@ -14,12 +14,13 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinMiddlewareExceptionTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public abstract class OwinMiddlewareExceptionTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture: RemoteServiceFixtures.OwinWebApiFixture
     {
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinMiddlewareExceptionTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public OwinMiddlewareExceptionTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -92,14 +93,23 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         }
     }
 
-    public class Owin3MiddlewareExceptionTests : OwinMiddlewareExceptionTests, IClassFixture<RemoteServiceFixtures.Owin3WebApiFixture>
+    public class OwinMiddlewareExceptionTests : OwinMiddlewareExceptionTestsBase<RemoteServiceFixtures.OwinWebApiFixture>
+    {
+        public OwinMiddlewareExceptionTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class Owin3MiddlewareExceptionTests : OwinMiddlewareExceptionTestsBase<RemoteServiceFixtures.Owin3WebApiFixture>
     {
         public Owin3MiddlewareExceptionTests(RemoteServiceFixtures.Owin3WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-    public class Owin4MiddlewareExceptionTests : OwinMiddlewareExceptionTests, IClassFixture<RemoteServiceFixtures.Owin4WebApiFixture>
+
+    public class Owin4MiddlewareExceptionTests : OwinMiddlewareExceptionTestsBase<RemoteServiceFixtures.Owin4WebApiFixture>
     {
         public Owin4MiddlewareExceptionTests(RemoteServiceFixtures.Owin4WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinMiddlewareExceptionTests.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinMiddlewareExceptionTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected OwinMiddlewareExceptionTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
@@ -15,13 +15,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinWebApiAsyncTests : IClassFixture<OwinWebApiFixture>
+    public abstract class OwinWebApiAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : OwinWebApiFixture
     {
         private readonly OwinWebApiFixture _fixture;
         private const int ExpectedTransactionCount = 8;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiAsyncTests(OwinWebApiFixture fixture, ITestOutputHelper output)
+        public OwinWebApiAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             var assemblyName = _fixture.AssemblyName;
@@ -258,19 +259,27 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         }
     }
 
-    public class Owin3WebApiAsyncTests : OwinWebApiAsyncTests, IClassFixture<Owin3WebApiFixture>
+    public class OwinWebApiAsyncTests : OwinWebApiAsyncTestsBase<OwinWebApiFixture>
+    {
+        public OwinWebApiAsyncTests(OwinWebApiFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class Owin3WebApiAsyncTests : OwinWebApiAsyncTestsBase<Owin3WebApiFixture>
     {
         public Owin3WebApiAsyncTests(Owin3WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-    public class Owin4WebApiAsyncTests : OwinWebApiAsyncTests, IClassFixture<Owin4WebApiFixture>
+
+    public class Owin4WebApiAsyncTests : OwinWebApiAsyncTestsBase<Owin4WebApiFixture>
     {
         public Owin4WebApiAsyncTests(Owin4WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         private const int ExpectedTransactionCount = 8;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected OwinWebApiAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             var assemblyName = _fixture.AssemblyName;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
@@ -13,14 +13,15 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinWebApiStatusCodeRollupTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public abstract class OwinWebApiStatusCodeRollupTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : RemoteServiceFixtures.OwinWebApiFixture
     {
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
         private readonly List<string> bogusPaths = new List<string> { "no/such/path", "foo/bar/baz", "fizz/buzz", "one/two/red/blue" };
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiStatusCodeRollupTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public OwinWebApiStatusCodeRollupTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -76,19 +77,27 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         }
     }
 
-    public class Owin3WebApiStatusCodeRollupTests : OwinWebApiTests, IClassFixture<RemoteServiceFixtures.Owin3WebApiFixture>
+    public class OwinWebApiStatusCodeRollupTests : OwinWebApiStatusCodeRollupTestsBase<RemoteServiceFixtures.OwinWebApiFixture>
+    {
+        public OwinWebApiStatusCodeRollupTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class Owin3WebApiStatusCodeRollupTests : OwinWebApiStatusCodeRollupTestsBase<RemoteServiceFixtures.Owin3WebApiFixture>
     {
         public Owin3WebApiStatusCodeRollupTests(RemoteServiceFixtures.Owin3WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-    public class Owin4WebApiStatusCodeRollupTests : OwinWebApiTests, IClassFixture<RemoteServiceFixtures.Owin4WebApiFixture>
+
+    public class Owin4WebApiStatusCodeRollupTests : OwinWebApiStatusCodeRollupTestsBase<RemoteServiceFixtures.Owin4WebApiFixture>
     {
         public Owin4WebApiStatusCodeRollupTests(RemoteServiceFixtures.Owin4WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiStatusCodeRollupTests.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         private readonly List<string> bogusPaths = new List<string> { "no/such/path", "foo/bar/baz", "fizz/buzz", "one/two/red/blue" };
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiStatusCodeRollupTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected OwinWebApiStatusCodeRollupTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
@@ -182,6 +182,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         {
         }
     }
+
     public class Owin4WebApiTests : OwinWebApiTestsBase<RemoteServiceFixtures.Owin4WebApiFixture>
     {
         public Owin4WebApiTests(RemoteServiceFixtures.Owin4WebApiFixture fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected OwinWebApiTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiTests.cs
@@ -14,12 +14,13 @@ using NewRelic.Testing.Assertions;
 namespace NewRelic.Agent.IntegrationTests.Owin
 {
     [NetFrameworkTest]
-    public class OwinWebApiTests : IClassFixture<RemoteServiceFixtures.OwinWebApiFixture>
+    public abstract class OwinWebApiTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : RemoteServiceFixtures.OwinWebApiFixture
     {
         private readonly RemoteServiceFixtures.OwinWebApiFixture _fixture;
 
         // The base test class runs tests for Owin 2; the derived classes test Owin 3 and 4
-        public OwinWebApiTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+        public OwinWebApiTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -166,14 +167,22 @@ namespace NewRelic.Agent.IntegrationTests.Owin
         }
     }
 
-    public class Owin3WebApiTests : OwinWebApiTests, IClassFixture<RemoteServiceFixtures.Owin3WebApiFixture>
+    public class OwinWebApiTests : OwinWebApiTestsBase<RemoteServiceFixtures.OwinWebApiFixture>
+    {
+        public OwinWebApiTests(RemoteServiceFixtures.OwinWebApiFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class Owin3WebApiTests : OwinWebApiTestsBase<RemoteServiceFixtures.Owin3WebApiFixture>
     {
         public Owin3WebApiTests(RemoteServiceFixtures.Owin3WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
-    public class Owin4WebApiTests : OwinWebApiTests, IClassFixture<RemoteServiceFixtures.Owin4WebApiFixture>
+    public class Owin4WebApiTests : OwinWebApiTestsBase<RemoteServiceFixtures.Owin4WebApiFixture>
     {
         public Owin4WebApiTests(RemoteServiceFixtures.Owin4WebApiFixture fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddAttribute.cs
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitAddAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitAddAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddAttribute.cs
@@ -20,11 +20,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.AddAttributeTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitAddAttribute : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitAddAttributeBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture: AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitAddAttribute(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitAddAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -97,7 +98,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitAddAttributeWithTieredCompilation : RejitAddAttribute, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitAddAttribute : RejitAddAttributeBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitAddAttribute(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitAddAttributeWithTieredCompilation : RejitAddAttributeBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitAddAttributeWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddFile.cs
@@ -20,11 +20,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.AddXmlFileTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitAddFile : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitAddFileBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitAddFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        protected RejitAddFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -82,7 +83,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitAddFileWithTieredCompilation : RejitAddFile, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitAddFile : RejitAddFileBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitAddFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitAddFileWithTieredCompilation : RejitAddFileBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitAddFileWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddNode.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitAddNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitAddNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitAddNode.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.AddNodeTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitAddNode : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitAddNodeBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture: AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitAddNode(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitAddNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -86,7 +87,16 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitAddNodeWithTieredCompilation : RejitAddNode, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitAddNode : RejitAddNodeBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitAddNode(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+
+    }
+
+    public class RejitAddNodeWithTieredCompilation : RejitAddNodeBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitAddNodeWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.ChangeAttributeTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitChangeAttributeValue : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitChangeAttributeValueBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitChangeAttributeValue(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitChangeAttributeValueBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -93,7 +94,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitChangeAttributeValueWithTieredCompilation : RejitChangeAttributeValue, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitChangeAttributeValue : RejitChangeAttributeValueBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitChangeAttributeValue(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitChangeAttributeValueWithTieredCompilation : RejitChangeAttributeValueBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitChangeAttributeValueWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
@@ -96,7 +96,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
 
     public class RejitChangeAttributeValue : RejitChangeAttributeValueBase<AspNetCoreReJitMvcApplicationFixture>
     {
-        public RejitChangeAttributeValue(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
+        public RejitChangeAttributeValue(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitChangeAttributeValue.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitChangeAttributeValueBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitChangeAttributeValueBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteAttribute.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitDeleteAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteAttribute.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.DeleteAttributeTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitDeleteAttribute : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitDeleteAttributeBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture: AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteAttribute(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitDeleteAttributeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -82,7 +83,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitDeleteAttributeWithTieredCompilation : RejitDeleteAttribute, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitDeleteAttribute : RejitDeleteAttributeBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitDeleteAttribute(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitDeleteAttributeWithTieredCompilation : RejitDeleteAttributeBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitDeleteAttributeWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteFile.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitDeleteFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteFile.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.DeleteXmlFileTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitDeleteFile : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitDeleteFileBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitDeleteFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -82,12 +83,19 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitDeleteFileWithTieredCompilation : RejitDeleteFile, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitDeleteFile : RejitDeleteFileBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitDeleteFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitDeleteFileWithTieredCompilation : RejitDeleteFileBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitDeleteFileWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
-
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteNode.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.DeleteNodeTest.xml 
     /// </summary>
     [NetCoreTest]
-    public class RejitDeleteNode : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitDeleteNodeBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteNode(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitDeleteNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -96,7 +97,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitDeleteNodeWithTieredCompilation : RejitDeleteNode, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitDeleteNode : RejitDeleteNodeBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitDeleteNode(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitDeleteNodeWithTieredCompilation : RejitDeleteNodeBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitDeleteNodeWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitDeleteNode.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
-        public RejitDeleteNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitDeleteNodeBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitRenameFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitRenameFile.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
 
         private readonly string _renameOriginalFileFilePath;
 
-        public RejitRenameFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        protected RejitRenameFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitRenameFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetCore/RejitRenameFile.cs
@@ -19,13 +19,14 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
     /// Files: Integration.Testing.RenameOriginalXmlFileTest.xml, Integration.Testing.RenameTargetXmlFileTest.xml
     /// </summary>
     [NetCoreTest]
-    public class RejitRenameFile : IClassFixture<AspNetCoreReJitMvcApplicationFixture>
+    public abstract class RejitRenameFileBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:AspNetCoreReJitMvcApplicationFixture
     {
         private readonly AspNetCoreReJitMvcApplicationFixture _fixture;
 
         private readonly string _renameOriginalFileFilePath;
 
-        public RejitRenameFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+        public RejitRenameFileBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
 
@@ -93,7 +94,15 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetCore
         }
     }
 
-    public class RejitRenameFileWithTieredCompilation : RejitRenameFile, IClassFixture<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
+    public class RejitRenameFile : RejitRenameFileBase<AspNetCoreReJitMvcApplicationFixture>
+    {
+        public RejitRenameFile(AspNetCoreReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class RejitRenameFileWithTieredCompilation : RejitRenameFileBase<AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation>
     {
         public RejitRenameFileWithTieredCompilation(AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation fixture, ITestOutputHelper output)
             : base(fixture, output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddAttribute.cs
@@ -20,11 +20,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.AddAttributeTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitAddAttribute : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitAddAttribute : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitAddAttribute(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddFile.cs
@@ -20,11 +20,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.AddXmlFileTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitAddFile : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitAddFile : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitAddFile(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitAddNode.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.AddNodeTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitAddNode : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitAddNode : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitAddNode(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitChangeAttributeValue.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitChangeAttributeValue.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.ChangeAttributeTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitChangeAttributeValue : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitChangeAttributeValue : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitChangeAttributeValue(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteAttribute.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteAttribute.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.DeleteAttributeTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitDeleteAttribute : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitDeleteAttribute : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitDeleteAttribute(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteFile.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.DeleteXmlFileTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitDeleteFile : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitDeleteFile : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitDeleteFile(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteNode.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitDeleteNode.cs
@@ -19,11 +19,12 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.DeleteNodeTest.xml 
     /// </summary>
     [NetFrameworkTest]
-    public class RejitDeleteNode : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitDeleteNode : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         public RejitDeleteNode(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitRenameFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/ReJit/NetFramework/RejitRenameFile.cs
@@ -19,13 +19,14 @@ namespace NewRelic.Agent.IntegrationTests.ReJit.NetFramework
     /// Files: Integration.Testing.RenameOriginalXmlFileTest.xml, Integration.Testing.RenameTargetXmlFileTest.xml
     /// </summary>
     [NetFrameworkTest]
-    public class RejitRenameFile : IClassFixture<AspNetFrameworkReJitMvcApplicationFixture>
+    public class RejitRenameFile : NewRelicIntegrationTest<AspNetFrameworkReJitMvcApplicationFixture>
     {
         private readonly AspNetFrameworkReJitMvcApplicationFixture _fixture;
 
         private readonly string _renameOriginalFileFilePath;
 
         public RejitRenameFile(AspNetFrameworkReJitMvcApplicationFixture fixture, ITestOutputHelper output)
+            : base(fixture)
         {
             _fixture = fixture;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/ConsoleInstrumentationLoaderFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/ConsoleInstrumentationLoaderFixture.cs
@@ -18,8 +18,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             : base(new RemoteConsoleApplication(ApplicationDirectoryName, ExecutableName, ApplicationType.Bounded)
                 .SetTimeout(TimeSpan.FromMinutes(2)))
         {
-
-
         }
 
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentation.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
-    public class RestSharpInstrumentation : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RestSharpInstrumentation : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public RestSharpInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public RestSharpInstrumentation(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwait.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwait.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
-    public class RestSharpInstrumentationAsyncAwait : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RestSharpInstrumentationAsyncAwait : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public RestSharpInstrumentationAsyncAwait(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public RestSharpInstrumentationAsyncAwait(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
-    public class RestSharpInstrumentationDistributedTracing : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RestSharpInstrumentationDistributedTracing : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public RestSharpInstrumentationDistributedTracing(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public RestSharpInstrumentationDistributedTracing(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResult.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResult.cs
@@ -12,11 +12,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
     [NetFrameworkTest]
-    public class RestSharpInstrumentationTaskResult : IClassFixture<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class RestSharpInstrumentationTaskResult : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
-        public RestSharpInstrumentationTaskResult(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public RestSharpInstrumentationTaskResult(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFTestBase.cs
@@ -5,6 +5,7 @@
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.ApplicationLibraries.Wcf;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
@@ -16,7 +17,7 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.WCF
 {
-    public abstract class WCFTestBase : IClassFixture<ConsoleDynamicMethodFixtureFW>
+    public abstract class WCFTestBase : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW>
     {
         public enum TracingTestOption
         {
@@ -108,7 +109,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF
             HostingModel hostingModelOption,
             ASPCompatibilityMode aspCompatModeOption,
             IWCFLogHelpers logHelpersImpl
-            )
+            ) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncGetTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncGetTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncGetTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncGetTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncGetTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncGetTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncInsertTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncInsertTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncInsertTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncInsertTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncInsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncInsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncMiscTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncMiscTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncMiscTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncMiscTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncMiscTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncMiscTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncQueryRequestTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncQueryRequestTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncQueryRequestTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncQueryRequestTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncQueryRequestTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncQueryRequestTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncQueryTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncRemoveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncRemoveTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncRemoveTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncRemoveTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncRemoveTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncRemoveTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncReplaceTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncReplaceTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncReplaceTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncReplaceTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncReplaceTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncReplaceTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncSearchQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncSearchQueryTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncSearchQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncSearchQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncSearchQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncSearchQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncUpsertTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncUpsertTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncUpsertTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncUpsertTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncUpsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncUpsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncViewQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseAsyncViewQueryTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseAsyncViewQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseAsyncViewQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseAsyncViewQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseAsyncViewQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseGetTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseGetTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseGetTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseGetTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseGetTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseGetTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseInsertTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseInsertTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseInsertTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseInsertTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseInsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseInsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseMiscTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseMiscTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseMiscTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseMiscTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseMiscTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseMiscTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseQueryRequestTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseQueryRequestTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseQueryRequestTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseQueryRequestTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseQueryRequestTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseQueryRequestTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseQueryTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseRemoveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseRemoveTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseRemoveTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseRemoveTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseRemoveTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseRemoveTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseReplaceTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseReplaceTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseReplaceTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseReplaceTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseReplaceTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseReplaceTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseSearchQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseSearchQueryTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseSearchQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseSearchQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseSearchQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseSearchQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseUpsertTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseUpsertTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseUpsertTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseUpsertTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseUpsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseUpsertTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseViewQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/CouchbaseViewQueryTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Couchbase
 {
     [NetFrameworkTest]
-    public class CouchbaseViewQueryTests : IClassFixture<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
+    public class CouchbaseViewQueryTests : NewRelicIntegrationTest<RemoteServiceFixtures.CouchbaseBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.CouchbaseBasicMvcFixture _fixture;
 
-        public CouchbaseViewQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)
+        public CouchbaseViewQueryTests(RemoteServiceFixtures.CouchbaseBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2AsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2AsyncTests.cs
@@ -15,11 +15,11 @@
 //namespace NewRelic.Agent.UnboundedIntegrationTests.IbmDb2
 //{
 //    [NetFrameworkTest]
-//    public class IbmDb2AsyncTests : IClassFixture<RemoteServiceFixtures.IbmDb2BasicMvcFixture>
+//    public class IbmDb2AsyncTests : NewRelicIntegrationTest<RemoteServiceFixtures.IbmDb2BasicMvcFixture>
 //    {
 //        private readonly RemoteServiceFixtures.IbmDb2BasicMvcFixture _fixture;
 
-//        public IbmDb2AsyncTests(RemoteServiceFixtures.IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)
+//        public IbmDb2AsyncTests(RemoteServiceFixtures.IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
 //        {
 //            _fixture = fixture;
 //            _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2StoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2StoredProcedureTests.cs
@@ -15,12 +15,12 @@
 //namespace NewRelic.Agent.UnboundedIntegrationTests.IbmDb2
 //{
 //    [NetFrameworkTest]
-//    public class IbmDb2StoredProcedureTests : IClassFixture<IbmDb2BasicMvcFixture>
+//    public class IbmDb2StoredProcedureTests : NewRelicIntegrationTest<IbmDb2BasicMvcFixture>
 //    {
 //        private readonly IbmDb2BasicMvcFixture _fixture;
 //        private readonly string _procedureName = $"IbmDb2TestStoredProc{Guid.NewGuid():N}";
 
-//        public IbmDb2StoredProcedureTests(IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)
+//        public IbmDb2StoredProcedureTests(IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
 //        {
 //            _fixture = fixture;
 //            _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2Tests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/IbmDb2/IbmDb2Tests.cs
@@ -15,11 +15,11 @@
 //namespace NewRelic.Agent.UnboundedIntegrationTests.IbmDb2
 //{
 //    [NetFrameworkTest]
-//    public class IbmDb2Tests : IClassFixture<RemoteServiceFixtures.IbmDb2BasicMvcFixture>
+//    public class IbmDb2Tests : NewRelicIntegrationTest<RemoteServiceFixtures.IbmDb2BasicMvcFixture>
 //    {
 //        private readonly RemoteServiceFixtures.IbmDb2BasicMvcFixture _fixture;
 
-//        public IbmDb2Tests(RemoteServiceFixtures.IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)
+//        public IbmDb2Tests(RemoteServiceFixtures.IbmDb2BasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
 //        {
 //            _fixture = fixture;
 //            _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_AsyncCursorTests.cs
@@ -9,13 +9,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDB2_6_AsyncCursorTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
+    public class MongoDB2_6_AsyncCursorTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6ApplicationFixture _fixture;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
 
-        public MongoDB2_6_AsyncCursorTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_AsyncCursorTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_CoreSmokeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_CoreSmokeTests.cs
@@ -9,13 +9,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetCoreTest]
-    public class MongoDB2_6_CoreSmokeTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6CoreApplicationFixture>
+    public class MongoDB2_6_CoreSmokeTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6CoreApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6CoreApplicationFixture _fixture;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCoreCollection";
 
-        public MongoDB2_6_CoreSmokeTests(RemoteServiceFixtures.MongoDB2_6CoreApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_CoreSmokeTests(RemoteServiceFixtures.MongoDB2_6CoreApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_DatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_DatabaseTests.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDB2_6_DatabaseTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
+    public class MongoDB2_6_DatabaseTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6ApplicationFixture _fixture;
 
-        public MongoDB2_6_DatabaseTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_DatabaseTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_IndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_IndexManagerTests.cs
@@ -10,13 +10,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDB2_6_IndexManagerTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
+    public class MongoDB2_6_IndexManagerTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6ApplicationFixture _fixture;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
 
-        public MongoDB2_6_IndexManagerTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_IndexManagerTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoCollectionTests.cs
@@ -10,13 +10,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDB2_6_MongoCollectionTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
+    public class MongoDB2_6_MongoCollectionTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6ApplicationFixture _fixture;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
 
-        public MongoDB2_6_MongoCollectionTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_MongoCollectionTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDB2_6_MongoQueryProviderTests.cs
@@ -9,13 +9,13 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDB2_6_MongoQueryProviderTests : IClassFixture<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
+    public class MongoDB2_6_MongoQueryProviderTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDB2_6ApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDB2_6ApplicationFixture _fixture;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
 
-        public MongoDB2_6_MongoQueryProviderTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDB2_6_MongoQueryProviderTests(RemoteServiceFixtures.MongoDB2_6ApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBTests.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
 {
     [NetFrameworkTest]
-    public class MongoDBTests : IClassFixture<RemoteServiceFixtures.MongoDbApplicationFixture>
+    public class MongoDBTests : NewRelicIntegrationTest<RemoteServiceFixtures.MongoDbApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MongoDbApplicationFixture _fixture;
 
-        public MongoDBTests(RemoteServiceFixtures.MongoDbApplicationFixture fixture, ITestOutputHelper output)
+        public MongoDBTests(RemoteServiceFixtures.MongoDbApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     [NetFrameworkTest]
-    public class EnterpriseLibraryMsSqlTests : IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class EnterpriseLibraryMsSqlTests : NewRelicIntegrationTest<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.MsSqlBasicMvcFixture _fixture;
 
-        public EnterpriseLibraryMsSqlTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
+        public EnterpriseLibraryMsSqlTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncLegacyAspPipelineTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncLegacyAspPipelineTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     [NetFrameworkTest]
-    public class MsSqlAsyncLegacyAspPipelineTests : IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlAsyncLegacyAspPipelineTests : NewRelicIntegrationTest<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.MsSqlBasicMvcFixture _fixture;
 
-        public MsSqlAsyncLegacyAspPipelineTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
+        public MsSqlAsyncLegacyAspPipelineTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -13,13 +14,14 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlAsyncTestsParameterizedQueryBase
+    public abstract class MsSqlAsyncTestsParameterizedQueryBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
         private readonly bool _paramsWithAtSign;
 
-        public MsSqlAsyncTestsParameterizedQueryBase(RemoteServiceFixtures.IMsSqlClientFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSign)
+        public MsSqlAsyncTestsParameterizedQueryBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSign) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -177,7 +179,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlAsyncTestsParameterizedQuery(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlAsync_WithParameterizedQuery", true)
@@ -186,7 +188,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlAsyncTestsParameterizedQuery_ParamsWithoutAtSign(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlAsync_WithParameterizedQuery", false)
@@ -195,7 +197,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientAsyncTestsParameterizedQuery(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", true)
@@ -204,7 +206,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSign(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", false)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -13,12 +14,13 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlAsyncTestsBase
+    public abstract class MsSqlAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
 
-        public MsSqlAsyncTestsBase(RemoteServiceFixtures.IMsSqlClientFixture fixture, ITestOutputHelper output, string expectedTransactionName)
+        public MsSqlAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -168,7 +170,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlAsyncTests : MsSqlAsyncTestsBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlAsyncTests : MsSqlAsyncTestsBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlAsyncTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlAsync")
@@ -177,7 +179,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTests : MsSqlAsyncTestsBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientAsyncTests : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientAsyncTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync/{tableName}")

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
@@ -14,13 +15,14 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlStoredProcedureTestsBase
+    public abstract class MsSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:RemoteApplicationFixture, IMsSqlClientFixture
     {
         private readonly IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
         private readonly bool _paramsWithAtSigns;
 
-        public MsSqlStoredProcedureTestsBase(IMsSqlClientFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSigns)
+        public MsSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSigns) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -106,16 +108,16 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests : MsSqlStoredProcedureTestsBase, IClassFixture<MsSqlBasicMvcFixture>
+    public class MsSqlStoredProcedureTests : MsSqlStoredProcedureTestsBase<MsSqlBasicMvcFixture>
     {
-        public MsSqlStoredProcedureTests(MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests(MsSqlBasicMvcFixture fixture, ITestOutputHelper output) 
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlParameterizedStoredProcedure", true)
         {
         }
     }
 
     [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase, IClassFixture<MsSqlBasicMvcFixture>
+    public class MsSqlStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<MsSqlBasicMvcFixture>
     {
         public MsSqlStoredProcedureTests_ParamsWithoutAtSigns(MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlParameterizedStoredProcedure", false)
@@ -125,7 +127,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests : MsSqlStoredProcedureTestsBase, IClassFixture<MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientStoredProcedureTests : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientStoredProcedureTests(MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", true)
@@ -134,7 +136,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase, IClassFixture<MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns(MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", false)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
 
-    public abstract class MsSqlStoredProcedureUsingOdbcDriverTestsBase : IClassFixture<OdbcBasicMvcFixture>
+    public abstract class MsSqlStoredProcedureUsingOdbcDriverTestsBase : NewRelicIntegrationTest<OdbcBasicMvcFixture>
     {
         private readonly OdbcBasicMvcFixture _fixture;
         private readonly bool _paramsWithAtSigns;
-        public MsSqlStoredProcedureUsingOdbcDriverTestsBase(OdbcBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns)
+        public MsSqlStoredProcedureUsingOdbcDriverTestsBase(OdbcBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns) : base(fixture)
         {
             _paramsWithAtSigns = paramsWithAtSigns;
 
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOdbcDriverTests : MsSqlStoredProcedureUsingOdbcDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests(OdbcBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, true)
+        public MsSqlStoredProcedureUsingOdbcDriverTests(OdbcBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, true)
         {
         }
     }
@@ -116,7 +116,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns : MsSqlStoredProcedureUsingOdbcDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns(OdbcBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, false)
+        public MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns(OdbcBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, false)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
@@ -12,12 +12,12 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlStoredProcedureUsingOleDbDriverTestsBase : IClassFixture<OleDbBasicMvcFixture>
+    public abstract class MsSqlStoredProcedureUsingOleDbDriverTestsBase : NewRelicIntegrationTest<OleDbBasicMvcFixture>
     {
         private readonly OleDbBasicMvcFixture _fixture;
         private readonly bool _paramsWithAtSigns;
 
-        public MsSqlStoredProcedureUsingOleDbDriverTestsBase(OleDbBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns)
+        public MsSqlStoredProcedureUsingOleDbDriverTestsBase(OleDbBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns) : base(fixture)
         {
             _paramsWithAtSigns = paramsWithAtSigns;
 
@@ -103,7 +103,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOleDbDriverTests : MsSqlStoredProcedureUsingOleDbDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOleDbDriverTests(OleDbBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, true)
+        public MsSqlStoredProcedureUsingOleDbDriverTests(OleDbBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, true)
         {
         }
     }
@@ -111,7 +111,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns : MsSqlStoredProcedureUsingOleDbDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns(OleDbBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, false)
+        public MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns(OleDbBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, false)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -14,12 +15,13 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlTestsBase
+    public abstract class MsSqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
 
-        public MsSqlTestsBase(RemoteServiceFixtures.IMsSqlClientFixture fixture, ITestOutputHelper output, string expectedTransactionName)
+        public MsSqlTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName) :  base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -169,7 +171,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlTests : MsSqlTestsBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlTests : MsSqlTestsBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSql")
@@ -178,7 +180,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientTests : MsSqlTestsBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientTests : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql/{tableName}")

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -13,13 +14,14 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlQueryParameterCaptureTestsBase
+    public abstract class MsSqlQueryParameterCaptureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
         private readonly bool _paramsWithAtSigns;
 
-        public MsSqlQueryParameterCaptureTestsBase(RemoteServiceFixtures.IMsSqlClientFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSigns)
+        public MsSqlQueryParameterCaptureTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName, bool paramsWithAtSigns) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -144,7 +146,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlQueryParameterCaptureTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSql_WithParameterizedQuery", true)
@@ -153,7 +155,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase, IClassFixture<RemoteServiceFixtures.MsSqlBasicMvcFixture>
+    public class MsSqlQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MsSqlBasicMvcFixture>
     {
         public MsSqlQueryParameterCaptureTests_ParamsWithoutAtSigns(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSql_WithParameterizedQuery", false)
@@ -162,7 +164,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientQueryParameterCaptureTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", true)
@@ -171,7 +173,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase, IClassFixture<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
     {
         public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", false)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
@@ -20,11 +20,11 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
     /// in order to separately test the existence of a Consume segment in the transaction trace. Only a single TT is being saved per test.
     /// </remarks>
     [NetFrameworkTest]
-    public class MsmqConsumeTests : IClassFixture<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
+    public class MsmqConsumeTests : NewRelicIntegrationTest<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MSMQBasicMVCApplicationFixture _fixture;
 
-        public MsmqConsumeTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public MsmqConsumeTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {
     [NetFrameworkTest]
-    public class MsmqPeekTests : IClassFixture<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
+    public class MsmqPeekTests : NewRelicIntegrationTest<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MSMQBasicMVCApplicationFixture _fixture;
 
-        public MsmqPeekTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public MsmqPeekTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {
     [NetFrameworkTest]
-    public class MsmqPurgeTests : IClassFixture<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
+    public class MsmqPurgeTests : NewRelicIntegrationTest<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MSMQBasicMVCApplicationFixture _fixture;
 
-        public MsmqPurgeTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public MsmqPurgeTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {
     [NetFrameworkTest]
-    public class MsmqSendTests : IClassFixture<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
+    public class MsmqSendTests : NewRelicIntegrationTest<RemoteServiceFixtures.MSMQBasicMVCApplicationFixture>
     {
         private readonly RemoteServiceFixtures.MSMQBasicMVCApplicationFixture _fixture;
 
-        public MsmqSendTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)
+        public MsmqSendTests(RemoteServiceFixtures.MSMQBasicMVCApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
 {
     [NetFrameworkTest]
-    public class MySqlAsyncTests : IClassFixture<RemoteServiceFixtures.MySqlBasicMvcFixture>
+    public class MySqlAsyncTests : NewRelicIntegrationTest<RemoteServiceFixtures.MySqlBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.MySqlBasicMvcFixture _fixture;
 
-        public MySqlAsyncTests(RemoteServiceFixtures.MySqlBasicMvcFixture fixture, ITestOutputHelper output)
+        public MySqlAsyncTests(RemoteServiceFixtures.MySqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -14,12 +14,12 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
 {
-    public abstract class MySqlConnectorTestBase : IClassFixture<RemoteServiceFixtures.MySqlConnectorBasicMvcFixture>
+    public abstract class MySqlConnectorTestBase : NewRelicIntegrationTest<RemoteServiceFixtures.MySqlConnectorBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.MySqlConnectorBasicMvcFixture _fixture;
         private readonly string _transactionName;
 
-        protected MySqlConnectorTestBase(RemoteServiceFixtures.MySqlConnectorBasicMvcFixture fixture, ITestOutputHelper output, Action<RemoteServiceFixtures.MySqlConnectorBasicMvcFixture> exerciseApplication, string transactionName)
+        protected MySqlConnectorTestBase(RemoteServiceFixtures.MySqlConnectorBasicMvcFixture fixture, ITestOutputHelper output, Action<RemoteServiceFixtures.MySqlConnectorBasicMvcFixture> exerciseApplication, string transactionName) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
@@ -14,12 +14,12 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
 {
-    public abstract class MySqlStoredProcedureTestsBase : IClassFixture<MySqlBasicMvcFixture>
+    public abstract class MySqlStoredProcedureTestsBase : NewRelicIntegrationTest<MySqlBasicMvcFixture>
     {
         private readonly MySqlBasicMvcFixture _fixture;
         private readonly bool _paramsWithAtSigns;
 
-        protected MySqlStoredProcedureTestsBase(MySqlBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns)
+        protected MySqlStoredProcedureTestsBase(MySqlBasicMvcFixture fixture, ITestOutputHelper output, bool paramsWithAtSigns) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -113,7 +113,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
     [NetFrameworkTest]
     public class MySqlStoredProcedureTestsWithAtSigns : MySqlStoredProcedureTestsBase
     {
-        public MySqlStoredProcedureTestsWithAtSigns(MySqlBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, true)
+        public MySqlStoredProcedureTestsWithAtSigns(MySqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, true)
         {
 
         }
@@ -122,7 +122,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
     [NetFrameworkTest]
     public class MySqlStoredProcedureTestsWithoutAtSigns : MySqlStoredProcedureTestsBase
     {
-        public MySqlStoredProcedureTestsWithoutAtSigns(MySqlBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, false)
+        public MySqlStoredProcedureTestsWithoutAtSigns(MySqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, false)
         {
 
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
 {
     [NetFrameworkTest]
-    public class MySqlTests : IClassFixture<RemoteServiceFixtures.MySqlBasicMvcFixture>
+    public class MySqlTests : NewRelicIntegrationTest<RemoteServiceFixtures.MySqlBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.MySqlBasicMvcFixture _fixture;
 
-        public MySqlTests(RemoteServiceFixtures.MySqlBasicMvcFixture fixture, ITestOutputHelper output)
+        public MySqlTests(RemoteServiceFixtures.MySqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NServiceBusReceiveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NServiceBusReceiveTests.cs
@@ -15,11 +15,11 @@ using Assert = Xunit.Assert;
 namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 {
     [NetFrameworkTest]
-    public class NServiceBusReceiveTests : IClassFixture<NServiceBusReceiverFixture>
+    public class NServiceBusReceiveTests : NewRelicIntegrationTest<NServiceBusReceiverFixture>
     {
         private readonly NServiceBusReceiverFixture _fixture;
 
-        public NServiceBusReceiveTests(NServiceBusReceiverFixture fixture, ITestOutputHelper output)
+        public NServiceBusReceiveTests(NServiceBusReceiverFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NServiceBusTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NServiceBusTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 {
     [NetFrameworkTest]
-    public class NServiceBusTests : IClassFixture<RemoteServiceFixtures.NServiceBusBasicMvcApplicationFixture>
+    public class NServiceBusTests : NewRelicIntegrationTest<RemoteServiceFixtures.NServiceBusBasicMvcApplicationFixture>
     {
         private readonly RemoteServiceFixtures.NServiceBusBasicMvcApplicationFixture _fixture;
 
-        public NServiceBusTests(RemoteServiceFixtures.NServiceBusBasicMvcApplicationFixture fixture, ITestOutputHelper output)
+        public NServiceBusTests(RemoteServiceFixtures.NServiceBusBasicMvcApplicationFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/EnterpriseLibraryOracleTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/EnterpriseLibraryOracleTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
 {
     [NetFrameworkTest]
-    public class EnterpriseLibraryOracleTests : IClassFixture<RemoteServiceFixtures.OracleBasicMvcFixture>
+    public class EnterpriseLibraryOracleTests : NewRelicIntegrationTest<RemoteServiceFixtures.OracleBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.OracleBasicMvcFixture _fixture;
 
-        public EnterpriseLibraryOracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)
+        public EnterpriseLibraryOracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
 {
     [NetFrameworkTest]
-    public class OracleAsyncTests : IClassFixture<RemoteServiceFixtures.OracleBasicMvcFixture>
+    public class OracleAsyncTests : NewRelicIntegrationTest<RemoteServiceFixtures.OracleBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.OracleBasicMvcFixture _fixture;
 
-        public OracleAsyncTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)
+        public OracleAsyncTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleStoredProcedureTests.cs
@@ -15,12 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
 {
     [NetFrameworkTest]
-    public class OracleStoredProcedureTests : IClassFixture<OracleBasicMvcFixture>
+    public class OracleStoredProcedureTests : NewRelicIntegrationTest<OracleBasicMvcFixture>
     {
         private readonly OracleBasicMvcFixture _fixture;
         private readonly string _procedureName = $"OracleTestStoredProc{Guid.NewGuid():N}".Substring(0, 30);
 
-        public OracleStoredProcedureTests(OracleBasicMvcFixture fixture, ITestOutputHelper output)
+        public OracleStoredProcedureTests(OracleBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
 {
     [NetFrameworkTest]
-    public class OracleTests : IClassFixture<RemoteServiceFixtures.OracleBasicMvcFixture>
+    public class OracleTests : NewRelicIntegrationTest<RemoteServiceFixtures.OracleBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.OracleBasicMvcFixture _fixture;
 
-        public OracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)
+        public OracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncCoreTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresAsyncCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresAsyncCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
 
-        public PostgresAsyncCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresAsyncCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncLegacyAspPipelineTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncLegacyAspPipelineTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresAsyncLegacyAspPipelineTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresAsyncLegacyAspPipelineTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
 
-        public PostgresAsyncLegacyAspPipelineTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresAsyncLegacyAspPipelineTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresAsyncTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresAsyncTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresAsyncTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
 
-        public PostgresAsyncTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresAsyncTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresCoreTests.cs
@@ -16,10 +16,10 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
-        public PostgresCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarCoreTests.cs
@@ -16,11 +16,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresExecuteScalarCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresExecuteScalarCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
 
-        public PostgresExecuteScalarCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresExecuteScalarCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
@@ -16,11 +16,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresExecuteScalarTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresExecuteScalarTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
 
-        public PostgresExecuteScalarTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresExecuteScalarTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorCoreTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresIteratorCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresIteratorCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
 
-        public PostgresIteratorCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresIteratorCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresIteratorTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresIteratorTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
 
-        public PostgresIteratorTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresIteratorTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncCoreTests.cs
@@ -15,12 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresStoredProcedureAsyncCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresStoredProcedureAsyncCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
         private readonly string _procedureName = $"PostgresTestStoredProcAsync{Guid.NewGuid():N}";
 
-        public PostgresStoredProcedureAsyncCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresStoredProcedureAsyncCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
@@ -15,12 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresStoredProcedureAsyncTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresStoredProcedureAsyncTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
         private readonly string _procedureName = $"PostgresTestStoredProcAsync{Guid.NewGuid():N}";
 
-        public PostgresStoredProcedureAsyncTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresStoredProcedureAsyncTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureCoreTests.cs
@@ -15,12 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetCoreTest]
-    public class PostgresStoredProcedureCoreTests : IClassFixture<PostgresBasicMvcCoreFixture>
+    public class PostgresStoredProcedureCoreTests : NewRelicIntegrationTest<PostgresBasicMvcCoreFixture>
     {
         private readonly PostgresBasicMvcCoreFixture _fixture;
         private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
 
-        public PostgresStoredProcedureCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)
+        public PostgresStoredProcedureCoreTests(PostgresBasicMvcCoreFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
@@ -15,12 +15,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresStoredProcedureTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresStoredProcedureTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
         private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
 
-        public PostgresStoredProcedureTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresStoredProcedureTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresTests.cs
@@ -16,10 +16,10 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 {
     [NetFrameworkTest]
-    public class PostgresTests : IClassFixture<PostgresBasicMvcFixture>
+    public class PostgresTests : NewRelicIntegrationTest<PostgresBasicMvcFixture>
     {
         private readonly PostgresBasicMvcFixture _fixture;
-        public PostgresTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)
+        public PostgresTests(PostgresBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqDistributedTracingTests : IClassFixture<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
+    public class RabbitMqDistributedTracingTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
     {
         // regex for payload
         private const string PayloadRegex = "{\"v\":\\[\\d,\\d\\],\"d\":{\"ty\":\"App\",\"ac\":\"\\d{1,9}\",\"ap\":\"\\d{1,9}\",\"tr\":\"\\w{16,32}\",\"pr\":\\d.\\d{5,6},\"sa\":true,\"ti\":\\d{10,16},\"tk\":\"\\w{0,16}\",\"tx\":\"\\w{16,16}\",\"id\":\"\\w{16,16}\"}}";
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
         private string _headerValue;
         private RabbitMqBasicMvcFixture _fixture;
 
-        public RabbitMqDistributedTracingTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)
+        public RabbitMqDistributedTracingTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyDistributedTracingTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqLegacyDistributedTracingTests : IClassFixture<RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture>
+    public class RabbitMqLegacyDistributedTracingTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture>
     {
         // regex for payload
         private const string PayloadRegex = "{\"v\":\\[\\d,\\d\\],\"d\":{\"ty\":\"App\",\"ac\":\"\\d{1,9}\",\"ap\":\"\\d{1,9}\",\"tr\":\"\\w{16,32}\",\"pr\":\\d.\\d{5,6},\"sa\":true,\"ti\":\\d{10,16},\"tk\":\"\\w{0,16}\",\"tx\":\"\\w{16,16}\",\"id\":\"\\w{16,16}\"}}";
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
         private string _headerValue;
         private RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture _fixture;
 
-        public RabbitMqLegacyDistributedTracingTests(RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture fixture, ITestOutputHelper output)
+        public RabbitMqLegacyDistributedTracingTests(RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyReceiveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyReceiveTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqLegacyReceiveTests : IClassFixture<RemoteServiceFixtures.RabbitMqLegacyReceiverFixture>
+    public class RabbitMqLegacyReceiveTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqLegacyReceiverFixture>
     {
         private readonly RemoteServiceFixtures.RabbitMqLegacyReceiverFixture _fixture;
 
-        public RabbitMqLegacyReceiveTests(RemoteServiceFixtures.RabbitMqLegacyReceiverFixture fixture, ITestOutputHelper output)
+        public RabbitMqLegacyReceiveTests(RemoteServiceFixtures.RabbitMqLegacyReceiverFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqLegacyTests.cs
@@ -13,14 +13,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqLegacyTests : IClassFixture<RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture>
+    public class RabbitMqLegacyTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture _fixture;
 
         private string _sendReceiveQueue;
         private string _purgeQueue;
 
-        public RabbitMqLegacyTests(RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture fixture, ITestOutputHelper output)
+        public RabbitMqLegacyTests(RemoteServiceFixtures.RabbitMqLegacyBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqReceiveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqReceiveTests.cs
@@ -13,11 +13,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqReceiveTests : IClassFixture<RemoteServiceFixtures.RabbitMqReceiverFixture>
+    public class RabbitMqReceiveTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqReceiverFixture>
     {
         private readonly RemoteServiceFixtures.RabbitMqReceiverFixture _fixture;
 
-        public RabbitMqReceiveTests(RemoteServiceFixtures.RabbitMqReceiverFixture fixture, ITestOutputHelper output)
+        public RabbitMqReceiveTests(RemoteServiceFixtures.RabbitMqReceiverFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
@@ -12,14 +12,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public class RabbitMqTests : IClassFixture<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
+    public class RabbitMqTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
     {
         private readonly RemoteServiceFixtures.RabbitMqBasicMvcFixture _fixture;
 
         private string _sendReceiveQueue;
         private string _purgeQueue;
 
-        public RabbitMqTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)
+        public RabbitMqTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqW3cTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqW3cTracingTests.cs
@@ -16,9 +16,9 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
 {
     [NetFrameworkTest]
-    public abstract class RabbitMqW3cTracingTests : IClassFixture<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
+    public abstract class RabbitMqW3cTracingTests : NewRelicIntegrationTest<RemoteServiceFixtures.RabbitMqBasicMvcFixture>
     {
-        public RabbitMqW3cTracingTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)
+        public RabbitMqW3cTracingTests(RemoteServiceFixtures.RabbitMqBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
         {
             fixture.TestLogger = output;
             fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisStrongNameTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisStrongNameTests.cs
@@ -16,11 +16,11 @@ using Assert = Xunit.Assert;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Redis
 {
     [NetFrameworkTest]
-    public class StackExchangeRedisStrongNameTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplication>
+    public class StackExchangeRedisStrongNameTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplication>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplication _fixture;
 
-        public StackExchangeRedisStrongNameTests(RemoteServiceFixtures.BasicMvcApplication fixture, ITestOutputHelper output)
+        public StackExchangeRedisStrongNameTests(RemoteServiceFixtures.BasicMvcApplication fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
@@ -15,11 +15,11 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.Redis
 {
     [NetFrameworkTest]
-    public class StackExchangeRedisTests : IClassFixture<RemoteServiceFixtures.BasicMvcApplication>
+    public class StackExchangeRedisTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplication>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplication _fixture;
 
-        public StackExchangeRedisTests(RemoteServiceFixtures.BasicMvcApplication fixture, ITestOutputHelper output)
+        public StackExchangeRedisTests(RemoteServiceFixtures.BasicMvcApplication fixture, ITestOutputHelper output)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;


### PR DESCRIPTION
* Modifies the integration test framework to use the Class Name of the Test to be the output folder name.

* Establishes `NewRelicIntegrationTest<TFixture>` as the base from which new relic tests are derived.  This replaces `IClassFixture<T>`.
    * Allows us to set the Test Class' name on the Fixture.
    * Allows the fixture to set the RemoteApplication's TestClassName
    * UniqueFolderName uses the TestClassName instead of the `ApplicationDirectory`

### Description

The what, the why and the how of your PR.

### Testing

What unit or integration tests were added or modified, or why no testing changes were required.

### Changelog

Please remember to update our [changelog](/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),

