### PR TITLE
Attribute Performance - v2

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
@@ -371,7 +371,7 @@ namespace NewRelic.Agent.Core.Api
             if (_configurationService.Configuration.CaptureCustomParameters)
             {
                 var transaction = GetCurrentInternalTransaction();
-                transaction.TransactionMetadata.AddUserAttribute(key, value);
+                transaction.AddCustomAttribute(key, value);
             }
         }
 
@@ -449,15 +449,22 @@ namespace NewRelic.Agent.Core.Api
             {
                 if (_configurationService.Configuration.CaptureCustomParameters)
                 {
-                    var transactionMetadata = GetCurrentInternalTransaction().TransactionMetadata;
+                    //var transactionMetadata = GetCurrentInternalTransaction().TransactionMetadata;
+                    var transaction = GetCurrentInternalTransaction();
                     if (userName != null && !string.IsNullOrEmpty(userName))
-                        transactionMetadata.AddUserAttribute("user", userName.ToString(CultureInfo.InvariantCulture));
+                    {
+                        transaction.AddCustomAttribute("user", userName.ToString(CultureInfo.InvariantCulture));
+                    }
 
                     if (accountName != null && !string.IsNullOrEmpty(accountName))
-                        transactionMetadata.AddUserAttribute("account", accountName.ToString(CultureInfo.InvariantCulture));
+                    {
+                        transaction.AddCustomAttribute("account", accountName.ToString(CultureInfo.InvariantCulture));
+                    }
 
                     if (productName != null && !string.IsNullOrEmpty(productName))
-                        transactionMetadata.AddUserAttribute("product", productName.ToString(CultureInfo.InvariantCulture));
+                    {
+                        transaction.AddCustomAttribute("product", productName.ToString(CultureInfo.InvariantCulture));
+                    }
                 }
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> DbStatement { get; }
         AttributeDefinition<string, string> DistributedTraceId { get; }
         AttributeDefinition<TimeSpan, double> Duration { get; }
-        AttributeDefinition<bool, bool> IsErrorExpected { get;}
+        AttributeDefinition<bool, bool> IsErrorExpected { get; }
         AttributeDefinition<bool, bool> SpanIsErrorExpected { get; }
         AttributeDefinition<string, string> ErrorClass { get; }
         AttributeDefinition<string, string> ErrorDotMessage { get; }
@@ -163,76 +163,104 @@ namespace NewRelic.Agent.Core.Attributes
 
         private readonly ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>> _typeAttributes = new ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>>();
 
+
+        private AttributeDefinition<object, object> CreateCustomAttributeForTransaction(string name)
+        {
+            return AttributeDefinitionBuilder
+                .CreateCustomAttribute(name, AttributeDestinations.All)
+                .Build(_attribFilter);
+        }
+
+        private AttributeDefinition<object, object> CreateCustomAttributeForCustomEvent(string name)
+        {
+            return AttributeDefinitionBuilder
+                .CreateCustomAttribute(name, AttributeDestinations.CustomEvent)
+                .Build(_attribFilter);
+        }
+
+        private AttributeDefinition<object, object> CreateCustomAttributeForError(string name)
+        {
+            return AttributeDefinitionBuilder
+                .CreateCustomAttribute(name, AttributeDestinations.ErrorEvent | AttributeDestinations.ErrorTrace)
+                .Build(_attribFilter);
+        }
+
+        private AttributeDefinition<object, object> CreateCustomAttributeForSpan(string name)
+        {
+            return AttributeDefinitionBuilder
+                .CreateCustomAttribute(name, AttributeDestinations.SpanEvent)
+                .Build(_attribFilter);
+        }
+
+        private AttributeDefinition<string, string> CreateRequestParameterAttribute(string paramName)
+        {
+            var attribName = $"request.parameters.{paramName}";
+
+            return AttributeDefinitionBuilder
+                .CreateString(attribName, AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
+                .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
+                .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
+                .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
+                .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
+                .Build(_attribFilter);
+        }
+
         public AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name)
         {
-            return _trxCustomAttributes.GetOrAdd(name, (n) => AttributeDefinitionBuilder
-                .CreateCustomAttribute(n, AttributeDestinations.All)
-                .Build(_attribFilter));
+            return _trxCustomAttributes.GetOrAdd(name, CreateCustomAttributeForTransaction);
         }
 
         public AttributeDefinition<object, object> GetCustomAttributeForCustomEvent(string name)
         {
-            return _customEventCustomAttributes.GetOrAdd(name, (n) => AttributeDefinitionBuilder
-                .CreateCustomAttribute(n, AttributeDestinations.CustomEvent)
-                .Build(_attribFilter));
+            return _customEventCustomAttributes.GetOrAdd(name, CreateCustomAttributeForCustomEvent);
         }
 
         public AttributeDefinition<object, object> GetCustomAttributeForError(string name)
         {
-            return _errorCustomAttributes.GetOrAdd(name, (n) => AttributeDefinitionBuilder
-                .CreateCustomAttribute(n, AttributeDestinations.ErrorEvent | AttributeDestinations.ErrorTrace)
-                .Build(_attribFilter));
+            return _errorCustomAttributes.GetOrAdd(name, CreateCustomAttributeForError);
         }
 
         public AttributeDefinition<object, object> GetCustomAttributeForSpan(string name)
         {
-            return _spanCustomAttributes.GetOrAdd(name, (n) => AttributeDefinitionBuilder
-                .CreateCustomAttribute(n, AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+            return _spanCustomAttributes.GetOrAdd(name, CreateCustomAttributeForSpan);
         }
 
         public AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName)
         {
-            var attribName = $"request.parameters.{paramName}";
+            return _requestParameterAttributes.GetOrAdd(paramName, CreateRequestParameterAttribute);
+        }
 
-            return _requestParameterAttributes.GetOrAdd(paramName, (pn) => AttributeDefinitionBuilder
-                .CreateString(attribName, AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
-                .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
-                .AppliesTo(AttributeDestinations.ErrorTrace,       _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
-                .AppliesTo(AttributeDestinations.ErrorEvent,       _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
-                .AppliesTo(AttributeDestinations.SpanEvent,        _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
-                .Build(_attribFilter));
+        public AttributeDefinition<TypeAttributeValue, string> CreateTypeAttribute(TypeAttributeValue tm)
+        {
+            var val = EnumNameCache<TypeAttributeValue>.GetName(tm);
+
+            var dest = AttributeDestinations.None;
+            switch (tm)
+            {
+                case TypeAttributeValue.Transaction:
+                    dest = AttributeDestinations.TransactionEvent;
+                    break;
+
+                case TypeAttributeValue.TransactionError:
+                    dest = AttributeDestinations.ErrorEvent;
+                    break;
+
+                case TypeAttributeValue.Span:
+                    dest = AttributeDestinations.SpanEvent;
+                    break;
+            }
+
+            return AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
+                .AppliesTo(dest)
+                .WithDefaultOutputValue(val)
+                .WithConvert((target) => val)
+                .Build(_attribFilter);
         }
 
         public AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue targetModel)
         {
-            return _typeAttributes.GetOrAdd(targetModel, (tm) =>
-            {
-                var val = EnumNameCache<TypeAttributeValue>.GetName(tm);
-
-                var dest = AttributeDestinations.None;
-                switch(tm)
-                {
-                    case TypeAttributeValue.Transaction:
-                        dest = AttributeDestinations.TransactionEvent;
-                        break;
-
-                    case TypeAttributeValue.TransactionError:
-                        dest = AttributeDestinations.ErrorEvent;
-                        break;
-
-                    case TypeAttributeValue.Span:
-                        dest = AttributeDestinations.SpanEvent;
-                        break;
-                }
-
-                return AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
-                    .AppliesTo(dest)
-                    .WithDefaultOutputValue(val)
-                    .WithConvert((target) => val)
-                    .Build(_attribFilter);
-            });
+            return _typeAttributes.GetOrAdd(targetModel, CreateTypeAttribute);
         }
 
         private AttributeDefinition<TimeSpan?, string> _queueWaitTime;
@@ -291,7 +319,7 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .AppliesTo(AttributeDestinations.ErrorEvent)
                 .AppliesTo(AttributeDestinations.TransactionTrace)
-                .WithConvert(x=>x.ToString())
+                .WithConvert(x => x.ToString())
                 .Build(_attribFilter));
 
         private AttributeDefinition<long?, long> _httpStatusCode;
@@ -375,8 +403,8 @@ namespace NewRelic.Agent.Core.Attributes
                         return null;
                     }
 
-                    var hashesArray = hashes.OrderBy(x=>x).ToArray();
-                    if(hashesArray.Length == 0)
+                    var hashesArray = hashes.OrderBy(x => x).ToArray();
+                    if (hashesArray.Length == 0)
                     {
                         return null;
                     }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NewRelic.Agent.Core.Attributes;
 
 namespace NewRelic.Agent.Core.Transactions
 {
@@ -13,8 +14,9 @@ namespace NewRelic.Agent.Core.Transactions
     /// </summary>
     public interface ITransactionAttributeMetadata
     {
-        KeyValuePair<string, string>[] RequestParameters { get; }
-        KeyValuePair<string, object>[] UserAttributes { get; }
+
+        AttributeValueCollection UserAndRequestAttributes { get; }
+
         IReadOnlyTransactionErrorState ReadOnlyTransactionErrorState { get; }
 
         string Uri { get; }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -831,7 +831,8 @@ namespace NewRelic.Agent.Core.Transactions
             {
                 if (parameter.Key != null && parameter.Value != null)
                 {
-                    TransactionMetadata.AddRequestParameter(parameter.Key, parameter.Value);
+                    var paramAttribute = _attribDefs.GetRequestParameterAttribute(parameter.Key);
+                    TransactionMetadata.UserAndRequestAttributes.TrySetValue(paramAttribute, parameter.Value);
                 }
             }
         }
@@ -847,7 +848,8 @@ namespace NewRelic.Agent.Core.Transactions
                 return this;
             }
 
-            TransactionMetadata.AddUserAttribute(key, value);
+            var customAttrib = _attribDefs.GetCustomAttributeForTransaction(key);
+            TransactionMetadata.UserAndRequestAttributes.TrySetValue(customAttrib, value);
 
             return this;
         }

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -192,16 +192,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             _attribDefs.HostDisplayName.TrySetValue(attribValues, _configurationService.Configuration.ProcessHostDisplayName);
 
-            foreach(var reqParam in metadata.RequestParameters)
-            {
-                _attribDefs.GetRequestParameterAttribute(reqParam.Key).TrySetValue(attribValues, reqParam.Value);
-            }
-
-            foreach (var userAttrib in metadata.UserAttributes)
-            {
-                _attribDefs.GetCustomAttributeForTransaction(userAttrib.Key).TrySetValue(attribValues, userAttrib.Value);
-            }
-
+            
             if (_configurationService.Configuration.ErrorCollectorEnabled && metadata.ReadOnlyTransactionErrorState.HasError && metadata.ReadOnlyTransactionErrorState.ErrorData != null && metadata.ReadOnlyTransactionErrorState.ErrorData.CustomAttributes != null)
             {
                 foreach(var errAttrib in metadata.ReadOnlyTransactionErrorState.ErrorData.CustomAttributes)
@@ -210,6 +201,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
                 }
             }
+
+            attribValues.AddRange(metadata.UserAndRequestAttributes);
         }
 
         private static bool IsCatParticipant(ImmutableTransaction immutableTransaction)

--- a/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
@@ -1253,7 +1253,7 @@ namespace CompositeTests
                 new ExpectedAttribute {Key = "key3", Value = "3.1"},
 
 				// Singles should be left as singles
-				new ExpectedAttribute {Key = "key4", Value = 4.0d}
+				new ExpectedAttribute {Key = "key4", Value = 4.0f}
             };
 
             TransactionTraceAssertions.HasAttributes(expectedAttributes, AttributeClassification.UserAttributes, transactionTrace);

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeCollectionTests.cs
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
 
             NrAssert.Multiple
             (
-                () => Assert.AreEqual(2, allAttribs.Count),
+                () => Assert.AreEqual(4, allAttribs.Count),
                 () => Assert.AreEqual(1, agentAttribsDic.Count()),
                 () => Assert.AreEqual("banana2", agentAttribsDic["original_url"]),
                 () => Assert.AreEqual(1, userAttribsDic.Count()),

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
@@ -137,7 +137,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.RumTests
             var priority = 0.5f;
             IInternalTransaction tx = new Transaction(_configuration, name, timer, DateTime.UtcNow, Mock.Create<ICallStackManager>(), Mock.Create<IDatabaseService>(), priority, Mock.Create<IDatabaseStatementParser>(), Mock.Create<IDistributedTracePayloadHandler>(), Mock.Create<IErrorService>(), _attribDefs);
             tx.TransactionMetadata.SetQueueTime(TimeSpan.FromMilliseconds(testCase.QueueTimeMilliseconds));
-            testCase.UserAttributes.ForEach(attr => tx.TransactionMetadata.AddUserAttribute(attr.Key, attr.Value));
+            testCase.UserAttributes.ForEach(attr => tx.AddCustomAttribute(attr.Key, attr.Value));
             tx.TransactionMetadata.SetCrossApplicationReferrerTripId("");
             // ACT
             var browserMonitoringScript = _browserMonitoringScriptMaker.GetScript(tx);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
@@ -16,10 +16,6 @@ namespace NewRelic.Agent.Core.Transactions
 {
     public class TestImmutableTransactionMetadata : IImmutableTransactionMetadata
     {
-        public KeyValuePair<string, string>[] RequestParameters { get; }
-        public KeyValuePair<string, object>[] UserAttributes { get; }
-
-
         public string Uri { get; }
         public string OriginalUri { get; }
         public string ReferrerUri { get; }
@@ -27,6 +23,8 @@ namespace NewRelic.Agent.Core.Transactions
         public TimeSpan? QueueTime { get; }
 
         public int? HttpResponseStatusCode { get; }
+
+        public AttributeValueCollection UserAndRequestAttributes { get; }
 
         public IEnumerable<string> CrossApplicationAlternatePathHashes { get; }
 
@@ -59,8 +57,7 @@ namespace NewRelic.Agent.Core.Transactions
             string originalUri,
             string referrerUri,
             TimeSpan? queueTime,
-            ConcurrentDictionary<string, string> requestParameters,
-            ConcurrentDictionary<string, object> userAttributes,
+            AttributeValueCollection userAndRequestAttributes,
             ITransactionErrorState transactionErrorState,
             int? httpResponseStatusCode,
             int? httpResponseSubStatusCode,
@@ -84,9 +81,7 @@ namespace NewRelic.Agent.Core.Transactions
             ReferrerUri = referrerUri;
             QueueTime = queueTime;
 
-            // The following must use ToArray because ToArray is thread safe on a ConcurrentDictionary.
-            RequestParameters = requestParameters.ToArray();
-            UserAttributes = userAttributes.ToArray();
+            UserAndRequestAttributes = userAndRequestAttributes;
 
             ReadOnlyTransactionErrorState = transactionErrorState;
 
@@ -250,8 +245,7 @@ namespace NewRelic.Agent.Core.Transactions
                 originalUri: "originalUri",
                 referrerUri: "referrerUri",
                 queueTime: new TimeSpan(1),
-                requestParameters: new ConcurrentDictionary<string, string>(),
-                userAttributes: new ConcurrentDictionary<string, object>(),
+                userAndRequestAttributes: new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes),
                 transactionErrorState: _transactionErrorState,
                 httpResponseStatusCode: 200,
                 httpResponseSubStatusCode: 201,
@@ -268,7 +262,7 @@ namespace NewRelic.Agent.Core.Transactions
                 syntheticsMonitorId: "syntheticsMonitorId",
                 isSynthetics: false,
                 hasCatResponseHeaders: false,
-                priority: _priority);
+                priority: _priority);;
 
             var attribDefSvc = new AttributeDefinitionService((f) => new AttributeDefinitions(f));
             return new ImmutableTransaction(_transactionName, _segments, metadata, _startTime, _duration, _responseTime, _transactionGuid, true, true, false, 0.5f, _distributedTraceSampled, _distributedTraceTraceId, _tracingState, attribDefSvc.AttributeDefs);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -279,13 +279,15 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var priority = 0.5f;
             var internalTransaction = new Transaction(Mock.Create<IConfiguration>(), immutableTransaction.TransactionName, _timerFactory.StartNewTimer(), DateTime.UtcNow, Mock.Create<ICallStackManager>(), Mock.Create<IDatabaseService>(), priority, Mock.Create<IDatabaseStatementParser>(), Mock.Create<IDistributedTracePayloadHandler>(), _errorService, _attribDefSvc.AttributeDefs);
             var transactionMetadata = internalTransaction.TransactionMetadata;
-            PopulateTransactionMetadataBuilder(transactionMetadata, uri, statusCode, subStatusCode, referrerCrossProcessId, exceptionData, customErrorData, isSynthetics, isCAT, referrerUri, includeUserAttributes);
+            PopulateTransactionMetadataBuilder(internalTransaction, uri, statusCode, subStatusCode, referrerCrossProcessId, exceptionData, customErrorData, isSynthetics, isCAT, referrerUri, includeUserAttributes);
 
             return internalTransaction;
         }
 
-        private void PopulateTransactionMetadataBuilder(ITransactionMetadata metadata, string uri = null, int? statusCode = null, int? subStatusCode = null, string referrerCrossProcessId = null, ErrorData exceptionData = null, ErrorData customErrorData = null, bool isSynthetics = true, bool isCAT = true, string referrerUri = null, bool includeUserAttributes = false)
+        private void PopulateTransactionMetadataBuilder(IInternalTransaction transaction, string uri = null, int? statusCode = null, int? subStatusCode = null, string referrerCrossProcessId = null, ErrorData exceptionData = null, ErrorData customErrorData = null, bool isSynthetics = true, bool isCAT = true, string referrerUri = null, bool includeUserAttributes = false)
         {
+            var metadata = transaction.TransactionMetadata;
+
             if (uri != null)
                 metadata.SetUri(uri);
             if (statusCode != null)
@@ -315,7 +317,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             if (includeUserAttributes)
             {
-                metadata.AddUserAttribute("sample.user.attribute", "user attribute string");
+                transaction.AddCustomAttribute("sample.user.attribute", "user attribute string");
             }
 
             if (isSynthetics)

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -331,8 +331,13 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[]
+            {
+                new KeyValuePair<string,string>("requestParameterKey", "requestParameterValue"),
+
+            });
+            
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -414,8 +419,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -512,8 +517,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -589,8 +594,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -666,8 +671,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -1255,8 +1260,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -1327,7 +1332,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             var immutableTransaction = transaction.ConvertToImmutableTransaction();
@@ -1390,8 +1395,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -1459,8 +1464,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
-            transaction.TransactionMetadata.AddRequestParameter("requestParameterKey", "requestParameterValue");
-            transaction.TransactionMetadata.AddUserAttribute("userAttributeKey", "userAttributeValue");
+            transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
+            transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -351,9 +351,11 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
             _agent.CurrentTransaction.SetRequestParameters(parameters);
 
-            Assert.AreEqual(1, _transaction.TransactionMetadata.RequestParameters.Length);
-            Assert.AreEqual("key", _transaction.TransactionMetadata.RequestParameters[0].Key);
-            Assert.AreEqual("value", _transaction.TransactionMetadata.RequestParameters[0].Value);
+            var attribValDic = _transaction.TransactionMetadata.UserAndRequestAttributes.ToDictionary();
+
+            Assert.AreEqual(1, attribValDic.Count);
+            Assert.AreEqual("request.parameters.key", attribValDic.First().Key);
+            Assert.AreEqual("value", attribValDic.First().Value);
         }
 
         [Test]
@@ -365,10 +367,10 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
             _agent.CurrentTransaction.SetRequestParameters(parameters);
 
-            var result = _transaction.TransactionMetadata.RequestParameters.ToDictionary();
-            Assert.AreEqual(2, _transaction.TransactionMetadata.RequestParameters.Length);
-            Assert.Contains("firstName", result.Keys);
-            Assert.Contains("lastName", result.Keys);
+            var result = _transaction.TransactionMetadata.UserAndRequestAttributes.ToDictionary();
+            Assert.AreEqual(2, result.Count);
+            Assert.Contains("request.parameters.firstName", result.Keys);
+            Assert.Contains("request.parameters.lastName", result.Keys);
             Assert.Contains("Jane", result.Values);
             Assert.Contains("Doe", result.Values);
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionMetadataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionMetadataTests.cs
@@ -142,44 +142,6 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
                 );
         }
 
-        [Test]
-        public void AddRequestParameter_LastInWins()
-        {
-            var key = "testKey";
-            var valueA = "valueA";
-            var valueB = "valueB";
-
-            var metadata = new TransactionMetadata();
-            metadata.AddRequestParameter(key, valueA);
-            metadata.AddRequestParameter(key, valueB);
-
-            var immutableTransactionMetadata = metadata.ConvertToImmutableMetadata();
-
-            var requestParameters = immutableTransactionMetadata.RequestParameters.ToDictionary();
-
-            var result = requestParameters[key];
-
-            Assert.AreEqual(result, valueB);
-        }
-
-        [Test]
-        public void AddUserAttribute_LastInWins()
-        {
-            var key = "testKey";
-            var valueA = "valueA";
-            var valueB = "valueB";
-
-            var metadata = new TransactionMetadata();
-            metadata.AddUserAttribute(key, valueA);
-            metadata.AddUserAttribute(key, valueB);
-
-            var immutableTransactionMetadata = metadata.ConvertToImmutableMetadata();
-
-            var userAttributes = immutableTransactionMetadata.UserAttributes.ToDictionary();
-
-            var result = userAttributes[key];
-
-            Assert.AreEqual(result, valueB);
-        }
+        
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionTests.cs
@@ -20,6 +20,8 @@ using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.Errors;
 using NewRelic.Agent.Core.DistributedTracing;
 using NewRelic.Agent.Core.Spans;
+using System.Collections.Generic;
+using NewRelic.Agent.TestUtilities;
 
 namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
 {
@@ -249,6 +251,53 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         {
             _transaction.SetWrapperToken(_wrapperToken);
             Assert.AreEqual(_wrapperToken, _transaction.GetWrapperToken());
+        }
+
+        [Test]
+        public void AddRequestParameter_LastInWins()
+        {
+
+            var key = "testKey";
+            var outputKey = "request.parameters." + key;
+            var valueA = "valueA";
+            var valueB = "valueB";
+
+            _transaction.SetRequestParameters(new[]
+            {
+                new KeyValuePair<string,string>(key, valueA),
+                new KeyValuePair<string,string>(key, valueB)
+            });
+
+            var immutableTransactionMetadata = _transaction.TransactionMetadata.ConvertToImmutableMetadata();
+
+            var requestParameters = immutableTransactionMetadata.UserAndRequestAttributes.ToDictionary();
+
+            var result = requestParameters[outputKey];
+
+            Assert.AreEqual(result, valueB);
+        }
+
+        [Test]
+        public void AddUserAttribute_LastInWins()
+        {
+            var key = "testKey";
+            var outputKey = "request.parameters." + key;
+            var valueA = "valueA";
+            var valueB = "valueB";
+
+            _transaction.SetRequestParameters(new[]
+           {
+                new KeyValuePair<string,string>(key, valueA),
+                new KeyValuePair<string,string>(key, valueB)
+            });
+
+            var immutableTransactionMetadata = _transaction.TransactionMetadata.ConvertToImmutableMetadata();
+
+            var userAttributes = immutableTransactionMetadata.UserAndRequestAttributes.ToDictionary();
+
+            var result = userAttributes[outputKey];
+
+            Assert.AreEqual(result, valueB);
         }
     }
 }

--- a/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/AttributeComparer.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/AttributeComparer.cs
@@ -162,14 +162,17 @@ namespace NewRelic.Agent.TestUtilities
                 classifications = new[] { AttributeClassification.Intrinsics, AttributeClassification.AgentAttributes, AttributeClassification.UserAttributes };
             }
 
-            var attribValues = new List<IAttributeValue>();
+            var attribValues = new Dictionary<string, object>();
 
             foreach (var classification in classifications)
             {
-                attribValues.AddRange(attribValueCollection.GetAttributeValues(classification));
+                foreach(var attribVal in attribValueCollection.GetAttributeValues(classification))
+                {
+                    attribValues[attribVal.AttributeDefinition.Name] = attribVal.Value;
+                }
             }
 
-            return attribValues.ToDictionary(x => x.AttributeDefinition.Name, x => x.Value);
+            return attribValues;
         }
 
 


### PR DESCRIPTION
… backing it; Modified AttributeValueCollection to use a list as its backing structure

Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](/CODE_OF_CONDUCT.md).

### Description

* Modifies the Agent to store Request Paramters and Custom Attribute Values (via API) in an AttributeValueCollection, instead of an intermediate dictionaries.
* Modifies AttributeDefintions to not use lambda function for GetOrAdd for Custom Attributes, Request Attributes, and the type attributes.
* Modifies AttributeValueCollection to use a List<AttributeValue> with locks as its backing store instead of ConcurrentDictionary<string,AttributeValue>

### Testing
Existing Test framework should be sufficient to test this performance change

### Changelog

