### PR TITLE
Adds Running Unbounded Integration Tests to workflow

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -32,13 +32,27 @@ jobs:
       profiler_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler
       profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
       output_path: ${{ github.workspace }}\src\Agent\_profilerBuild
-      #<other env vars here>
+      profiler_md5: ""
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: MD5 Profiler
+      run: |
+        pip install checksumdir
+        $profsum = checksumdir -a md5 ${{ env.profiler_path }}
+        echo "profiler_md5=${profsum}" >> $GITHUB_ENV
+      shell: powershell
+
+    - name: Cache Profiler  https://unix.stackexchange.com/questions/35832/how-do-i-get-the-md5-sum-of-a-directorys-contents-as-one-sum
+      id: cache-profiler-win
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}\src\Agent\_profilerBuild\**\*
+        key: ${{ runner.os }}-primes
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.1
@@ -73,8 +87,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: profiler
-        path: |
-          ${{ github.workspace }}\src\Agent\_profilerBuild\**\*
+        path: ${{ github.workspace }}\src\Agent\_profilerBuild\**\*
         if-no-files-found: error
 
   build-test-linux-profiler:
@@ -613,7 +626,16 @@ jobs:
       
     - name: Combine Integration Results
       run: |
-        mkdir all-integration-test-results
+        Write-Host "Create all-integration-test-results"
+        Get-ChildItem
+        mkdir ${{ github.workspace }}\all-integration-test-results
+
+        Write-Host "Check all-integration-test-results"
+        Get-ChildItem -Path ${{ github.workspace }}
+
+        Write-Host "Check ${{ github.workspace }}\integration-test-artifacts"
+        Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts
+
         Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts -Include *.xml -Recurse | ForEach-Object { cp $_.FullName ${{ github.workspace }}\all-integration-test-results }
       shell: powershell
       

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -10,7 +10,6 @@ env:
   scripts_path: ${{ github.workspace }}\build\scripts
   tools_path: ${{ github.workspace }}\build\Tools
   DOTNET_NOLOGO: true
-  #<other env vars here>
 
 jobs:
 

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -612,7 +612,7 @@ jobs:
         if-no-files-found: error
         
   combine-integration-test-results:
-    needs: run-integration-tests
+    needs: [ run-integration-tests, run-unbounded-tests ]
     if: ${{ always() }}
     name: Combine Integration Test Results
         
@@ -623,19 +623,11 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: integration-test-artifacts
+        path: ${{ github.workspace }}\integration-test-artifacts
       
     - name: Combine Integration Results
       run: |
-        Write-Host "Create all-integration-test-results"
-        Get-ChildItem
         mkdir ${{ github.workspace }}\all-integration-test-results
-
-        Write-Host "Check all-integration-test-results"
-        Get-ChildItem -Path ${{ github.workspace }}
-
-        Write-Host "Check ${{ github.workspace }}\integration-test-artifacts"
-        Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts
-
         Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts -Include *.xml -Recurse | ForEach-Object { cp $_.FullName ${{ github.workspace }}\all-integration-test-results }
       shell: powershell
       

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -649,7 +649,7 @@ jobs:
           netstat -no  
         }
 
-        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -html ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.html
+        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.html
 
         if ($Env:enhanced_logging) {
           Write-Host "Get HostableWebCore errors (if any)"

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1,9 +1,8 @@
 name: .NET Agent All Solutions Build
 
+# Does not run on PUSH since we have already ran all the test
 on:
   pull_request:
-    branches: [ main ]
-  push:
     branches: [ main ]
   workflow_dispatch:
 
@@ -264,75 +263,75 @@ jobs:
       results_name: ""
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          fetch-depth: 0
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        fetch-depth: 0
 
-      - name: Download Test Results Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: test-results-${{ github.run_id }}
-          path: testresults
+    - name: Download Test Results Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: test-results-${{ github.run_id }}
+        path: testresults
 
-      - name: Move Test Results
-        run: |
-          Write-Host "Change to testresults"
-          cd testresults
+    - name: Move Test Results
+      run: |
+        Write-Host "Change to testresults"
+        cd testresults
 
-          Write-Host "Create the folder"
-          $resultname = "fullagent_msi-${{ github.run_id }}".ToLower().Replace(" ", "")
-          Write-Host "::set-env name=results_name::$resultname"
+        Write-Host "Create the folder"
+        $resultname = "fullagent_msi-${{ github.run_id }}".ToLower().Replace(" ", "")
+        Write-Host "::set-env name=results_name::$resultname"
 
-          Write-Host "Check if testresults folder exists, create if not."
-          if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults" )) {
-            New-Item -Path "${{ github.workspace }}\docs" -Name "testresults" -ItemType "directory" }
-          
-          Write-Host "Check if test run results ($resultname) folder exists, create if not."
-          if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults\$resultname" )) {
-            New-Item -Path "${{ github.workspace }}\docs\testresults" -Name "$resultname" -ItemType "directory" }
+        Write-Host "Check if testresults folder exists, create if not."
+        if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults" )) {
+          New-Item -Path "${{ github.workspace }}\docs" -Name "testresults" -ItemType "directory" }
+        
+        Write-Host "Check if test run results ($resultname) folder exists, create if not."
+        if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults\$resultname" )) {
+          New-Item -Path "${{ github.workspace }}\docs\testresults" -Name "$resultname" -ItemType "directory" }
 
-          Write-Host "Copy the files and overwrite if already exists"
-          Copy-Item .\* -Destination ${{ github.workspace }}\docs\testresults\$resultname\ -Force
+        Write-Host "Copy the files and overwrite if already exists"
+        Copy-Item .\* -Destination ${{ github.workspace }}\docs\testresults\$resultname\ -Force
 
-          Write-Host "Confirm Folder Exists"
-          Test-Path "${{ github.workspace }}\docs\testresults\$resultname"
-        shell: powershell
+        Write-Host "Confirm Folder Exists"
+        Test-Path "${{ github.workspace }}\docs\testresults\$resultname"
+      shell: powershell
 
-      - name: Commit files
-        run: |
-          Write-Host "git config"
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+    - name: Commit files
+      run: |
+        Write-Host "git config"
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
 
-          Write-Host "Stage files in git"
-          $ErrorActionPreference = 'Continue'
-          git add -A
+        Write-Host "Stage files in git"
+        $ErrorActionPreference = 'Continue'
+        git add -A
 
-          Write-Host "git commit"
-          git commit -am "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
+        Write-Host "git commit"
+        git commit -am "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
 
-          Write-Host "git pull"
-          git pull
-        shell: powershell
+        Write-Host "git pull"
+        git pull
+      shell: powershell
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}    
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}    
 
-      - name: Create Check-run with test results
-        uses: LouisBrunner/checks-action@v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
-          status: completed
-          conclusion: neutral
-          output: |
-            { "summary": "${{ steps.test.outputs.summary }}",
-            "text_description": "[FullAgent Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/agent-results.html) [AWS Lambda Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/lambda-results.html" }
+    - name: Create Check-run with test results
+      uses: LouisBrunner/checks-action@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
+        status: completed
+        conclusion: neutral
+        output: |
+          { "summary": "${{ steps.test.outputs.summary }}",
+          "text_description": "[FullAgent Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/agent-results.html) [AWS Lambda Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/lambda-results.html" }
 
   build-integration-tests:
     needs: build-test-fullagent-msi
@@ -405,6 +404,17 @@ jobs:
         MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
       shell: powershell
 
+    - name: Archive Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: unboundedintegrationtests-${{ github.run_id }}
+        path: |
+          ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+          ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+          !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+        if-no-files-found: error
+
   build-platform-tests: 
     needs: build-test-fullagent-msi
     name: Build PlatformTests
@@ -458,63 +468,203 @@ jobs:
       NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY : 1
       
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-      - name: Set up secrets
-        env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-        run: |
-          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+    - name: Set up secrets
+      env:
+        INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+      run: |
+        "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+      shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@v2
-        with:
-          name: homefolders-${{ github.run_id }}
-          path: src/Agent
+    - name: Download Agent Home Folders
+      uses: actions/download-artifact@v2
+      with:
+        name: homefolders-${{ github.run_id }}
+        path: src/Agent
 
-      - name: Download Integration Test Artifacts
-        uses: actions/download-artifact/@v2
-        with:
-          name: integrationtests-${{ github.run_id }}
-          # Should not need a path because the integration test artifacts are archived with the full directory structure
+    - name: Download Integration Test Artifacts
+      uses: actions/download-artifact/@v2
+      with:
+        name: integrationtests-${{ github.run_id }}
+        # Should not need a path because the integration test artifacts are archived with the full directory structure
 
-      - name: Install dependencies
-        run: |
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-          pip install aiohttp
-        shell: powershell
+    - name: Install dependencies
+      run: |
+        Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+        pip install aiohttp
+      shell: powershell
 
-      - name: Run Integration Tests
-        run: |
-          if ($Env:enhanced_logging) {
-            Write-Host "List ports in use"
-            netstat -no  
-          }
+    - name: Run Integration Tests
+      run: |
+        if ($Env:enhanced_logging) {
+          Write-Host "List ports in use"
+          netstat -no  
+        }
 
-          Write-Host "Run tests"
-          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
-          
-          if ($Env:enhanced_logging) {
-            Write-Host "Get HostableWebCore errors (if any)"
-            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
-  
-            Write-Host "Get .NET Runtime errors (if any)"
-            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
-          }
-        shell: powershell
+        Write-Host "Run tests"
+        ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+        
+        if ($Env:enhanced_logging) {
+          Write-Host "Get HostableWebCore errors (if any)"
+          Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+          Write-Host "Get .NET Runtime errors (if any)"
+          Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+        }
+      shell: powershell
+
+    - name: Archive IntegrationTestWorkingDirectory on Failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
-            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-          if-no-files-found: error
-          
+        if-no-files-found: error
+
+    - name: Archive Test Artifacts
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        path: |
+          C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+        if-no-files-found: error
+
+  run-unbounded-tests:
+    needs: [build-unbounded-tests]
+    name: Run Unbounded Tests
+
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
+      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+
+    env:
+      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
+      unbounded_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net461/NewRelic.Agent.UnboundedIntegrationTests.dll
+      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: true
+
+    steps:
+    - name: My IP
+      run: (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
+      shell: powershell
+      
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Download Agent Home Folders
+      uses: actions/download-artifact@v2
+      with:
+        name: homefolders-${{ github.run_id }}
+        path: src/Agent
+
+    - name: Download Unbounded Integration Test Artifacts
+      uses: actions/download-artifact/@v2
+      with:
+        name: unboundedintegrationtests-${{ github.run_id }}
+        # Should not need a path because the integration test artifacts are archived with the full directory structure
+    
+    - name: Setup TLS
+      run: |
+        $registryRootPath = "HKCU:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
+        $tls10 = "TLS 1.0"
+        $tls11 = "TLS 1.1"
+        $tls12 = "TLS 1.2"
+        $client = "Client"
+        $server = "Server"
+        $registryPaths = @(
+        "$registryRootPath\$tls10\$client",
+        "$registryRootPath\$tls10\$server",
+        "$registryRootPath\$tls11\$client",
+        "$registryRootPath\$tls11\$server",
+        "$registryRootPath\$tls12\$client",
+        "$registryRootPath\$tls12\$server"
+        )
+        $name = "Enabled"
+        $value = "1"
+        foreach ($registryPath in $registryPaths) {
+          if(!(Test-Path $registryPath)) {
+            New-Item -Path $registryPath -Force | Out-Null
+            New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+          }
+          else {
+            New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+          }
+        }  
+      shell: powershell
+
+    - name: Install dependencies
+      run: |
+        Write-Host "Installing HostableWebCore Feature"
+        Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+
+        if ("${{ matrix.namespace }}" -eq "Msmq") {
+          Write-Host "Installing Msmq Features"
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
+        }
+
+        if ("${{ matrix.namespace }}" -eq "MsSql") {
+          Write-Host "Installing MSSQL CLI"
+          msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
+          Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
+        }
+      shell: powershell
+
+    - name: Set up secrets
+      env:
+        INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
+      run: |
+        "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+      shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+
+    - name: Run Unbounded Integration Tests
+      run: |
+        if ($Env:enhanced_logging) {
+          Write-Host "List ports in use"
+          netstat -no  
+        }
+
+        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -html ${{ github.workspace }}/TestResults/${{ matrix.namespace }}_testResults.html
+
+        if ($Env:enhanced_logging) {
+          Write-Host "Get HostableWebCore errors (if any)"
+          Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+
+          Write-Host "Get .NET Runtime errors (if any)"
+          Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+        }
+      shell: powershell
+
+    - name: Archive IntegrationTestWorkingDirectory on Failure
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\**\*.config
+        if-no-files-found: error
+
+    - name: Archive Test Artifacts
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        path: |
+          C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+        if-no-files-found: error
+        

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -614,12 +614,12 @@ jobs:
     - name: Combine Integration Results
       run: |
         mkdir all-integration-test-results
-        Get-ChildItem -Path .\integration-test-artifacts* -Include *.xml -Recurse | ForEach-Object { cp $_.FullName .\all-integration-test-results }
+        Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts -Include *.xml -Recurse | ForEach-Object { cp $_.FullName ${{ github.workspace }}\all-integration-test-results }
       shell: powershell
       
     - name: Upload combined artifacts
       uses: actions/upload-artifact@v2
       with:
         name: all-integration-test-results
-        path: ./all-integration-test-results
+        path: ${{ github.workspace }}/all-integration-test-results
         if-no-files-found: error

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -449,7 +449,7 @@ jobs:
         }
 
         Write-Host "Run tests"
-        ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+        ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
         
         if ($Env:enhanced_logging -eq $True) {
           Write-Host "Get HostableWebCore errors (if any)"
@@ -578,7 +578,7 @@ jobs:
           netstat -no  
         }
 
-        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
 
         if ($Env:enhanced_logging -eq $True) {
           Write-Host "Get HostableWebCore errors (if any)"

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -533,9 +533,9 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
+        path: |
+          C:\IntegrationTestWorkingDirectory\**\*.log
+          C:\IntegrationTestWorkingDirectory\**\*.config
         if-no-files-found: error
 
     - name: Archive Test Artifacts

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -24,6 +24,7 @@ jobs:
 
   build-test-windows-profiler:
     needs: cancel-previous-workflow-runs
+    if: ${{ always() }}
     name: Build Windows Profiler
 
     runs-on: windows-2019
@@ -79,6 +80,7 @@ jobs:
 
   build-test-linux-profiler:
     needs: cancel-previous-workflow-runs
+    if: ${{ always() }}
     name: Build Linux Profiler
 
     runs-on: ubuntu-18.04

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -552,13 +552,10 @@ jobs:
       run: |
         Write-Host "Installing HostableWebCore Feature"
         Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-
-        if ("${{ matrix.namespace }}" -eq "Msmq") {
-          Write-Host "Installing Msmq Features"
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
-        }
+        Write-Host "Installing Msmq Features"
+        Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+        Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+        Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
 
         if ("${{ matrix.namespace }}" -eq "MsSql") {
           Write-Host "Installing MSSQL CLI"
@@ -609,31 +606,4 @@ jobs:
         name: integration-test-artifacts
         path: |
           C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-        if-no-files-found: error
-        
-  combine-integration-test-results:
-    needs: [ run-integration-tests, run-unbounded-tests ]
-    if: ${{ always() }}
-    name: Combine Integration Test Results
-        
-    runs-on: windows-2019
-        
-    steps:
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: integration-test-artifacts
-        path: ${{ github.workspace }}\integration-test-artifacts
-      
-    - name: Combine Integration Results
-      run: |
-        mkdir ${{ github.workspace }}\all-integration-test-results
-        Get-ChildItem -Path ${{ github.workspace }}\integration-test-artifacts -Include *.xml -Recurse | ForEach-Object { cp $_.FullName ${{ github.workspace }}\all-integration-test-results }
-      shell: powershell
-      
-    - name: Upload combined artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: all-integration-test-results
-        path: ${{ github.workspace }}/all-integration-test-results
         if-no-files-found: error

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -568,7 +568,7 @@ jobs:
           netstat -no  
         }
 
-        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.html
+        ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xmlv1 C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
 
         if ($Env:enhanced_logging -eq $True) {
           Write-Host "Get HostableWebCore errors (if any)"

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -665,9 +665,9 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
+        path: |
+          C:\IntegrationTestWorkingDirectory\**\*.log
+          C:\IntegrationTestWorkingDirectory\**\*.config
         if-no-files-found: error
 
     - name: Archive Test Artifacts

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -14,7 +14,16 @@ env:
 
 jobs:
 
+  cancel-previous-workflow-runs:
+    name: Cancel Previous Runs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-test-windows-profiler:
+    needs: cancel-previous-workflow-runs
     name: Build Windows Profiler
 
     runs-on: windows-2019
@@ -69,6 +78,7 @@ jobs:
         if-no-files-found: error
 
   build-test-linux-profiler:
+    needs: cancel-previous-workflow-runs
     name: Build Linux Profiler
 
     runs-on: ubuntu-18.04

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Archive Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: profiler-${{ github.run_id }}
+        name: profiler
         path: |
           ${{ github.workspace }}\src\Agent\_profilerBuild\**\*
         if-no-files-found: error
@@ -118,7 +118,7 @@ jobs:
     - name: Archive Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: profiler-${{ github.run_id }}
+        name: profiler
         path: |
           ${{ github.workspace }}/src/Agent/_profilerBuild/
         if-no-files-found: error
@@ -157,7 +157,7 @@ jobs:
     - name: Download Profiler Artifacts Before Agent Build
       uses: actions/download-artifact@v2
       with:
-        name: profiler-${{ github.run_id }}
+        name: profiler
         path: ${{ github.workspace }}/src/Agent/_profilerBuild/
     
     - name: Install dependencies for FullAgent.sln
@@ -181,7 +181,7 @@ jobs:
     - name: Archive FullAgent Home folders
       uses: actions/upload-artifact@v2
       with:
-        name: homefolders-${{ github.run_id }}
+        name: homefolders
         path: |
           ${{ github.workspace }}\src\Agent\newrelichome_x64
           ${{ github.workspace }}\src\Agent\newrelichome_x64_coreclr
@@ -259,90 +259,9 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
-        name: test-results-${{ github.run_id }}
+        name: test-results
         path: ${{ github.workspace }}\TestResults
         if-no-files-found: error
-
-  publish-test-results:
-    needs: build-test-fullagent-msi
-    if: ${{ always() }}
-    name: Publish Test Results
-
-    runs-on: windows-2019
-
-    env:
-      results_name: ""
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: gh-pages
-        fetch-depth: 0
-
-    - name: Download Test Results Artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: test-results-${{ github.run_id }}
-        path: testresults
-
-    - name: Move Test Results
-      run: |
-        Write-Host "Change to testresults"
-        cd testresults
-
-        Write-Host "Create the folder"
-        $resultname = "fullagent_msi-${{ github.run_id }}".ToLower().Replace(" ", "")
-        Write-Host "::set-env name=results_name::$resultname"
-
-        Write-Host "Check if testresults folder exists, create if not."
-        if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults" )) {
-          New-Item -Path "${{ github.workspace }}\docs" -Name "testresults" -ItemType "directory" }
-        
-        Write-Host "Check if test run results ($resultname) folder exists, create if not."
-        if ( -Not (Test-Path "${{ github.workspace }}\docs\testresults\$resultname" )) {
-          New-Item -Path "${{ github.workspace }}\docs\testresults" -Name "$resultname" -ItemType "directory" }
-
-        Write-Host "Copy the files and overwrite if already exists"
-        Copy-Item .\* -Destination ${{ github.workspace }}\docs\testresults\$resultname\ -Force
-
-        Write-Host "Confirm Folder Exists"
-        Test-Path "${{ github.workspace }}\docs\testresults\$resultname"
-      shell: powershell
-
-    - name: Commit files
-      run: |
-        Write-Host "git config"
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-
-        Write-Host "Stage files in git"
-        $ErrorActionPreference = 'Continue'
-        git add -A
-
-        Write-Host "git commit"
-        git commit -am "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
-
-        Write-Host "git pull"
-        git pull
-      shell: powershell
-
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        branch: gh-pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}    
-
-    - name: Create Check-run with test results
-      uses: LouisBrunner/checks-action@v1.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: "Test Results for ${{ github.workflow }} ${{ github.run_id }}"
-        status: completed
-        conclusion: neutral
-        output: |
-          { "summary": "${{ steps.test.outputs.summary }}",
-          "text_description": "[FullAgent Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/agent-results.html) [AWS Lambda Test Results](https://newrelic.github.io/newrelic-dotnet-agent/testresults/${{ env.results_name }}/lambda-results.html" }
 
   build-integration-tests:
     needs: build-test-fullagent-msi
@@ -377,7 +296,7 @@ jobs:
     - name: Archive Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: integrationtests-${{ github.run_id }}
+        name: integrationtests
         path: |
           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
@@ -418,7 +337,7 @@ jobs:
     - name: Archive Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: unboundedintegrationtests-${{ github.run_id }}
+        name: unboundedintegrationtests
         path: |
           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
@@ -494,13 +413,13 @@ jobs:
     - name: Download Agent Home Folders
       uses: actions/download-artifact@v2
       with:
-        name: homefolders-${{ github.run_id }}
+        name: homefolders
         path: src/Agent
 
     - name: Download Integration Test Artifacts
       uses: actions/download-artifact/@v2
       with:
-        name: integrationtests-${{ github.run_id }}
+        name: integrationtests
         # Should not need a path because the integration test artifacts are archived with the full directory structure
 
     - name: Install dependencies
@@ -532,7 +451,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        name: integration-test-artifacts
         path: |
           C:\IntegrationTestWorkingDirectory\**\*.log
           C:\IntegrationTestWorkingDirectory\**\*.config
@@ -542,7 +461,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
-        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        name: integration-test-artifacts
         path: |
           C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
         if-no-files-found: error
@@ -578,13 +497,13 @@ jobs:
     - name: Download Agent Home Folders
       uses: actions/download-artifact@v2
       with:
-        name: homefolders-${{ github.run_id }}
+        name: homefolders
         path: src/Agent
 
     - name: Download Unbounded Integration Test Artifacts
       uses: actions/download-artifact/@v2
       with:
-        name: unboundedintegrationtests-${{ github.run_id }}
+        name: unboundedintegrationtests
         # Should not need a path because the integration test artifacts are archived with the full directory structure
     
     - name: Setup TLS
@@ -664,7 +583,7 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        name: integration-test-artifacts
         path: |
           C:\IntegrationTestWorkingDirectory\**\*.log
           C:\IntegrationTestWorkingDirectory\**\*.config
@@ -674,7 +593,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v2
       with:
-        name: integration-test-artifacts-${{ matrix.namespace }}-${{ github.run_id }}
+        name: integration-test-artifacts
         path: |
           C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
         if-no-files-found: error
@@ -689,6 +608,8 @@ jobs:
     steps:
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v2
+      with:
+        name: integration-test-artifacts
       
     - name: Combine Integration Results
       run: |
@@ -699,6 +620,6 @@ jobs:
     - name: Upload combined artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: all-integration-test-results-${{ github.run_id }}
+        name: all-integration-test-results
         path: ./all-integration-test-results
         if-no-files-found: error

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnboundedIntegrationTests",
 	ProjectSection(ProjectDependencies) = postProject
 		{5CF71C91-EE5E-4F8D-8FEE-AE497A32BF8B} = {5CF71C91-EE5E-4F8D-8FEE-AE497A32BF8B}
 		{EA98CDD2-655D-4239-9B9F-44EB806DEE53} = {EA98CDD2-655D-4239-9B9F-44EB806DEE53}
+		{F4F32DD5-910F-4AC7-85CE-17C72A4847C9} = {F4F32DD5-910F-4AC7-85CE-17C72A4847C9}
+		{8F6605E4-7801-4ADF-AD8F-144517608000} = {8F6605E4-7801-4ADF-AD8F-144517608000}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTestHelpers", "IntegrationTestHelpers\IntegrationTestHelpers.csproj", "{9AABBBB0-32FC-4DA3-A38C-96A50A7ABAC1}"
@@ -142,7 +144,7 @@ Global
 		{F4F32DD5-910F-4AC7-85CE-17C72A4847C9} = {03BAC949-FAD7-4EE6-A2BD-45E3DE2407F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 		SolutionGuid = {656848E2-BFD2-4092-9328-C6CDF39B1274}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 	EndGlobalSection
 EndGlobal

--- a/tests/Agent/IntegrationTests/UnboundedServices/linux/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/linux/docker-compose.yml
@@ -4,6 +4,7 @@ rabbitmq:
         - "4369:4369"
         - "5671-5672:5671-5672"
         - "25672:25672"
+        - "15691-15692"
     hostname: my-rabbit
     container_name: RabbitmqServer
 
@@ -30,6 +31,10 @@ couchbase:
     ports:
         - "8091-8094:8091-8094"
         - "11210:11210"
+        - "8095-8096"
+        - "11207"
+        - "11211"
+        - "18091-18096"
     environment:
         # These credentials are only used to configure the Couchbase container 
         # for use by the integration tests. You can change these to any value 
@@ -78,6 +83,9 @@ db2:
     privileged: true
     ports:
         - "50000:50000"
+        - "22"
+        - "55000"
+        - "60006-60007"
     environment:
         - LICENSE=accept
         # These credentials are only used to configure the Db2 container for 
@@ -93,6 +101,7 @@ mysql:
     command: mysqld --default-authentication-plugin=mysql_native_password
     ports:
         - "3306:3306"
+        - "33060"
     environment:
         # These credentials are only used to configure the MySql container 
         # for use by the integration tests. They must match the values from 


### PR DESCRIPTION
Resolves #299 

### Description

If you have questions about any change please reach out!

 Adds job to run unbounded integration tests as a matrix
- Updated docker-compose.yml to properly map all exposed ports instead of a subset.
- docker-compose.yml and linux container folders are already copied to linux server and running
- This PR does not remove the Windows containers, saving that for a cleanup PR
- Updated build-unbounded-tests to save artifacts
- Added run-unbounded-tests matrix job to run tests
- Unbounded tests havce many dependencies so the steps for these items have been expanded
- Artifacts for both run-unbounded-tests and run-integration-tests have been synced and updated to only save working folders on failure
- Due to how GHA hosts servers we may see some failures due to how the firewall on the linux server is restricted. I am working on a better way.

Workflow Job limit handling
- Removes the "push" event from the list of workflow triggers since everything runs during the PR acceptance process.  This will eliminate a source of extra workflow runs.
- Added a job that calls an action that will cancel other previous runs of the same PR that may be active. 
- "cancel-previous-workflow-runs" job is run before all others
- The Profiler build jobs are set to "need" the cancel job so that it runs first.  The Profiler jobs were the first first jobs that ran so they were the only ones that needed the change.
- Added `if: ${{ always() }}` to Profiler jobs so that "cancel-previous-workflow-runs"  job errors don't block runs.

### Testing

Individual datastores have all be tested and pass.
Cancellation Job tested and passed.

To confirm testing, unbounded tests need to pass without real errors.  There can and likely will some failure due to the ip ranges being blocked.  This will be corrected via server changes in the future (still working out a good way to do this, I have ideas.).

### Changelog

n/a
