### PR TITLE
Create assignproj.yml

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -1,0 +1,22 @@
+name: Auto Assign to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.DOTNET_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to Dotnet Engineering Board
+
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/newrelic/projects/20'
+        column_name: 'Triage'


### PR DESCRIPTION
### Description
Auto-assign projects field in Github so that issues and PR have this field auto-populated.

### Testing

Test by creating a new issue and checking that the Engineering Board is auto-populated with the issue in the correct column.

### Changelog
n/a

