### PR TITLE
Remove is metric name allowed

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -11,7 +11,7 @@ New Feature Description
 Fixes Issue [#XX](https://github.com/newrelic/newrelic-dotnet-agent/issues/XX)
 
 ### Fixes
-Fixes Issue [#XX](https://github.com/newrelic/newrelic-dotnet-agent/issues/XX)
+Fixes Issue [#337](https://github.com/newrelic/newrelic-dotnet-agent/issues/337) by removing obsolete code which was causing memory growth associated with a large number of transaction names.
 
 ## [8.34] - 2020-10-26
 

--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
@@ -24,8 +24,6 @@ namespace NewRelic.Agent.Core.Metrics
         private static readonly TransactionMetricName NormalizedWebTransactionMetricName = new TransactionMetricName(MetricNames.WebTransactionPrefix, "Normalized/*");
         private static readonly TransactionMetricName NormalizedOtherTransactionMetricName = new TransactionMetricName(MetricNames.OtherTransactionPrefix, "Normalized/*");
 
-        private readonly Utils.HashSet<string> _transactionNames = new Utils.HashSet<string>();
-
         #region Public API
 
         public string NormalizeUrl(string url)
@@ -71,9 +69,6 @@ namespace NewRelic.Agent.Core.Metrics
 
             // Renaming rules are not allowed to change the first segment of a transaction name
             var newTransactionName = GetTransactionMetricName(newPrefixedTransactionName, proposedTransactionName, shouldIgnore);
-
-            if (!IsMetricNameAllowed(newPrefixedTransactionName))
-                return proposedTransactionName.IsWebTransactionName ? NormalizedWebTransactionMetricName : NormalizedOtherTransactionMetricName;
 
             return newTransactionName;
         }
@@ -181,28 +176,6 @@ namespace NewRelic.Agent.Core.Metrics
                 return segment;
 
             return "*";
-        }
-
-        /// <summary>
-        /// Checks if the given metric name is whitelisted according to the "black hole"
-        /// 
-        /// This logic is an implementation of the "black hole" rule.
-        /// </summary>
-        /// <param name="metricName"></param>
-        /// <returns>True if the name is on (or is added to) the whitelist, else false</returns>
-        private bool IsMetricNameAllowed(string metricName)
-        {
-            lock (_transactionNames)
-            {
-                // If metric name is already in whitelist, allow it through
-                if (_transactionNames.Contains(metricName))
-                    return true;
-
-                // Otherwise, add the name to the whitelist and then allow it through
-                _transactionNames.Add(metricName);
-
-                return true;
-            }
         }
 
         #endregion

--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
@@ -21,9 +21,6 @@ namespace NewRelic.Agent.Core.Metrics
     /// </summary>
     public class MetricNameService : ConfigurationBasedService, IMetricNameService
     {
-        private static readonly TransactionMetricName NormalizedWebTransactionMetricName = new TransactionMetricName(MetricNames.WebTransactionPrefix, "Normalized/*");
-        private static readonly TransactionMetricName NormalizedOtherTransactionMetricName = new TransactionMetricName(MetricNames.OtherTransactionPrefix, "Normalized/*");
-
         #region Public API
 
         public string NormalizeUrl(string url)


### PR DESCRIPTION
### Description

Fixes #337.  A while back, we removed functionality from the agent that capped the total number of metric names that could be created.  That change made the `IsMetricNameAllowed()` method obsolete, and caused the `_transactionNames` collection to grow without bound.  Since the only reason that collection existed in the first place was to enable the functionality that was removed, it should have been removed at that time as well.

### Testing

All unit tests passed for me locally.  All but two integration tests passed, and those two failures appear to be due to unrelated connectivity issues.

### Changelog

CHANGELOG was updated.
