### PR TITLE
tid is not always a digit

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 {
     public abstract class AgentLogBase
     {
-        public const string LogLineContextDataRegex = @"\[pid: \d+, tid: \d+\] ";
+        public const string LogLineContextDataRegex = @"\[pid: \d+, tid: [\w-#:(,\/.)]+\] ";
         public const string InfoLogLinePrefixRegex = @"^.*?NewRelic\s+INFO: " + LogLineContextDataRegex;
         public const string DebugLogLinePrefixRegex = @"^.*?NewRelic\s+DEBUG: " + LogLineContextDataRegex;
         public const string ErrorLogLinePrefixRegex = @"^.*?NewRelic\s+ERROR: " + LogLineContextDataRegex;

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 {
     public abstract class AgentLogBase
     {
-        public const string LogLineContextDataRegex = @"\[pid: \d+, tid: [\w-#:(,\/.)]+\] ";
+        public const string LogLineContextDataRegex = @"\[pid: \d+, tid: .+\] ";
         public const string InfoLogLinePrefixRegex = @"^.*?NewRelic\s+INFO: " + LogLineContextDataRegex;
         public const string DebugLogLinePrefixRegex = @"^.*?NewRelic\s+DEBUG: " + LogLineContextDataRegex;
         public const string ErrorLogLinePrefixRegex = @"^.*?NewRelic\s+ERROR: " + LogLineContextDataRegex;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarCoreTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarCoreTests.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
                 {
                     _fixture.PostgresExecuteScalar();
                     _fixture.PostgresExecuteScalarAsync();
-                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.SqlTraceDataLogLineRegex, new TimeSpan(0, 1, 0), 2);
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
                 {
                     _fixture.PostgresExecuteScalar();
                     _fixture.PostgresExecuteScalarAsync();
-                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.SqlTraceDataLogLineRegex, new TimeSpan(0, 1, 0), 2);
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();


### PR DESCRIPTION
### Description
The Integration Test AgentLogBase specifiies regexes for searching lines in the Agent log file. The regex for thread id needs to accommodate more than just digits. This PR fixes the regex to match other kinds of thread ids.

Here is an example log line generated by the Agent that failed to match a "...transform completed." log entry (see part after `tid:`):
```
2020-11-03 01:22:29,897 NewRelic FINEST: [pid: 27596, tid: WorkPool-Session#1:Connection(0073d28b-f109-4e86-9347-a19c7b38634e,amqp://127.0.0.1:5672)] Transaction 6a30542b7a651433 (OtherTransaction/Message/RabbitMQ/Queue/Named/integrationTestQueue-d09f6321-917c-48d9-a7a9-ad89fb360853) transform completed.
```

### Testing
Affects both IntegrationTests and UnboundedIntegrationTests. None should fail due to:
`"Log line did not appear a minimum of {minimumCount} times within {timeout.TotalSeconds} seconds.  Expected line expression: {regularExpression}"`

IntegrationTests run locally do not fail due to this bug.

### Note
Test (RabbitMqReceiveTests) was previously passing due to bug fixed in this [PR](https://github.com/newrelic/newrelic-dotnet-agent/pull/311).

### Changelog
N/A
