### PR TITLE
Package rpm (without GPG signing) and make available to artifactbuilder

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -627,7 +627,7 @@ jobs:
           if-no-files-found: error
   
   run-artifactbuilder:
-    needs: build-test-fullagent-msi
+    needs: [ create-package-rpm ]
     name: Run ArtifactBuilder
     runs-on: windows-2019
 
@@ -677,4 +677,52 @@ jobs:
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}\build\BuildArtifacts
+          if-no-files-found: error
+
+  create-package-rpm:
+    needs: build-test-fullagent-msi
+    name: Create RPM Package
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Download _build Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-folder-artifacts
+          path: src/_build
+
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@v2
+        with:
+          name: homefolders
+          path: src/Agent
+      
+      - name: Download Agent Version
+        uses: actions/download-artifact@v2
+        with:
+          name: agent-version
+          path: ${{ github.workspace }}
+
+      - name: Build RPM
+        run: |
+          sudo apt install dos2unix -y
+          dos2unix ${{ github.workspace }}/agent_version.txt
+          agentVersion=$(head -n 1 ${{ github.workspace }}/agent_version.txt)
+          agentVersion=${agentVersion/$'\r\n\t'}
+          cd ${{ github.workspace }}/build/Linux
+          docker-compose build
+          docker-compose run -e AGENT_VERSION=$agentVersion build_rpm
+          #docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
+        shell: bash
+      
+      - name: Archive Package Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-folder-artifacts
+          path: ${{ github.workspace }}/src/_build
           if-no-files-found: error

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -628,6 +628,7 @@ jobs:
   
   run-artifactbuilder:
     needs: [ create-package-rpm ]
+    if: ${{ github.event.release }}
     name: Run ArtifactBuilder
     runs-on: windows-2019
 
@@ -681,6 +682,7 @@ jobs:
 
   create-package-rpm:
     needs: build-test-fullagent-msi
+    if: ${{ github.event.release }}
     name: Create RPM Package
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -625,7 +625,56 @@ jobs:
           name: integration-test-artifacts
           path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
           if-no-files-found: error
-  
+
+  create-package-rpm:
+    needs: build-test-fullagent-msi
+    if: ${{ github.event.release }}
+    name: Create RPM Package
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Download _build Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-folder-artifacts
+          path: src/_build
+
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@v2
+        with:
+          name: homefolders
+          path: src/Agent
+      
+      - name: Download Agent Version
+        uses: actions/download-artifact@v2
+        with:
+          name: agent-version
+          path: ${{ github.workspace }}
+
+      - name: Build RPM
+        run: |
+          sudo apt install dos2unix -y
+          dos2unix ${{ github.workspace }}/agent_version.txt
+          agentVersion=$(head -n 1 ${{ github.workspace }}/agent_version.txt)
+          agentVersion=${agentVersion/$'\r\n\t'}
+          cd ${{ github.workspace }}/build/Linux
+          docker-compose build
+          docker-compose run -e AGENT_VERSION=$agentVersion build_rpm
+          #docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
+        shell: bash
+      
+      - name: Archive Package Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-folder-artifacts
+          path: ${{ github.workspace }}/src/_build
+          if-no-files-found: error
+
   run-artifactbuilder:
     needs: [ create-package-rpm ]
     if: ${{ github.event.release }}
@@ -678,53 +727,4 @@ jobs:
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}\build\BuildArtifacts
-          if-no-files-found: error
-
-  create-package-rpm:
-    needs: build-test-fullagent-msi
-    if: ${{ github.event.release }}
-    name: Create RPM Package
-    runs-on: ubuntu-18.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: Download _build Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: build-folder-artifacts
-          path: src/_build
-
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@v2
-        with:
-          name: homefolders
-          path: src/Agent
-      
-      - name: Download Agent Version
-        uses: actions/download-artifact@v2
-        with:
-          name: agent-version
-          path: ${{ github.workspace }}
-
-      - name: Build RPM
-        run: |
-          sudo apt install dos2unix -y
-          dos2unix ${{ github.workspace }}/agent_version.txt
-          agentVersion=$(head -n 1 ${{ github.workspace }}/agent_version.txt)
-          agentVersion=${agentVersion/$'\r\n\t'}
-          cd ${{ github.workspace }}/build/Linux
-          docker-compose build
-          docker-compose run -e AGENT_VERSION=$agentVersion build_rpm
-          #docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
-        shell: bash
-      
-      - name: Archive Package Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: build-folder-artifacts
-          path: ${{ github.workspace }}/src/_build
           if-no-files-found: error

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -46,7 +46,7 @@ if [ -z "$AGENT_VERSION" ]; then
         exit -1
     fi
 fi
-echo "AGENT_VERSION=$AGENT_VERSION"
+echo "AGENT_VERSION=|$AGENT_VERSION|"
 TARGET_SYSTEM_INSTALL_PATH="/usr/local/${PACKAGE_NAME}"
 SPECFILE="/rpm/${PACKAGE_NAME}.spec"
 

--- a/build/Linux/docker-compose.yml
+++ b/build/Linux/docker-compose.yml
@@ -1,6 +1,6 @@
 build_deb: 
     build: ./build/deb 
-    command: bash -c "dos2unix /deb/build.sh && /deb/build.sh"
+    command: bash -c "dos2unix /deb/build.sh && chmod 777 /deb/build.sh && /deb/build.sh"
     volumes: 
         - ../../src/_build/CoreArtifacts:/release
         - ../../src/Agent:/data
@@ -11,7 +11,7 @@ build_deb:
 
 build_rpm: 
     build: ./build/rpm
-    command: bash -c "dos2unix /rpm/build.sh && /rpm/build.sh"
+    command: bash -c "dos2unix /rpm/build.sh && chmod 777 /rpm/build.sh && /rpm/build.sh"
     volumes: 
         - ../../src/_build/CoreArtifacts:/release
         - ../../src/Agent:/data
@@ -23,7 +23,7 @@ build_rpm:
 
 test_debian: 
     build: ./test/distros/debian
-    command: bash -c "dos2unix /test/test.sh &>/dev/null && /test/test.sh"
+    command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
     volumes:
         - ../../src/_build/CoreArtifacts:/release
         - ./test/scripts:/test
@@ -32,7 +32,7 @@ test_debian:
 
 test_centos: 
     build: ./test/distros/centos
-    command: bash -c "dos2unix /test/test.sh &>/dev/null && /test/test.sh"
+    command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
     volumes:
         - ../../src/_build/CoreArtifacts:/release
         - ./test/scripts:/test

--- a/build/Linux/docker-compose.yml
+++ b/build/Linux/docker-compose.yml
@@ -1,6 +1,6 @@
 build_deb: 
     build: ./build/deb 
-    command: bash -c "dos2unix /deb/build.sh && chmod 777 /deb/build.sh && /deb/build.sh"
+    command: bash -c "dos2unix /deb/build.sh && chmod 755 /deb/build.sh && /deb/build.sh"
     volumes: 
         - ../../src/_build/CoreArtifacts:/release
         - ../../src/Agent:/data


### PR DESCRIPTION
Resolves #327 

### Description

**Very Important Notes**: 
- The jobs and steps added here will not run until a release occurs. 
- Until the Debian packaging is done, the artifact builder will fail since it needs all the packages.  If you look at the error [here](https://github.com/jaffinito/newrelic-dotnet-agent/runs/1349858453?check_suite_focus=true#step:8:64) you will see that it is not missing the RPM package.
- The GPG version of the build command is commented out since it will not work until the GPG work in #334 is completed.  This was left in as a comment to be clear that this not the final version.

Changes:
- Updated rpm/build.sh to make agent version defects clearer (wraps it in pipes '|')
- Updated Linux/docker-compose.yml to chomd 777 the sh files
- Added create-package-rpm to build RPM package
- Updated run-artifactbuilder to need create-package-rpm not build-test-fullagent-msi
- Added if to allow artifactbuilder and rpmbuilder to only run on release

### Testing

Workflow should complete as normal and the `create-package-rpm` and `run-artifactbuilder` jobs should not run.  See [here](https://github.com/jaffinito/newrelic-dotnet-agent/actions/runs/344362598) for a truncated run showing things work as described.

### Changelog

n/a

