### PR TITLE
Use Base64 to store key in secrets and then recreate the key as needed.

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -663,6 +663,12 @@ jobs:
           fileName: 'gpg.tar.bz2'
           encodedString: ${{ secrets.GPG_KEY }}
 
+      - name: Copy GPG Key to keys
+        run: |
+          mkdir ${{ github.workspace }}/build/Linux/keys
+          cp -f ${{ steps.write_gpgkey.outputs.filePath }} ${{ github.workspace }}/build/Linux/keys/gpg.tar.bz2
+        shell: bash
+
       - name: Build RPM
         run: |
           sudo apt install dos2unix -y
@@ -671,7 +677,7 @@ jobs:
           agentVersion=${agentVersion/$'\r\n\t'}
           cd ${{ github.workspace }}/build/Linux
           docker-compose build
-          docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=${{ steps.write_gpgkey.outputs.filePath }} build_rpm
+          docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
         shell: bash
       
       - name: Archive Package Artifacts

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -656,6 +656,13 @@ jobs:
           name: agent-version
           path: ${{ github.workspace }}
 
+      - name: Get GPG Key
+        id: write_gpgkey
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'gpg.tar.bz2'
+          encodedString: ${{ secrets.GPG_KEY }}
+
       - name: Build RPM
         run: |
           sudo apt install dos2unix -y
@@ -664,8 +671,7 @@ jobs:
           agentVersion=${agentVersion/$'\r\n\t'}
           cd ${{ github.workspace }}/build/Linux
           docker-compose build
-          docker-compose run -e AGENT_VERSION=$agentVersion build_rpm
-          #docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
+          docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=${{ steps.write_gpgkey.outputs.filePath }} build_rpm
         shell: bash
       
       - name: Archive Package Artifacts


### PR DESCRIPTION
Resolves #334 

### Description

 - Adds step to rebuild gpg key from secret
- Passes in the key zip from rebuild step to docker-compose
- Removes previous step that had no gpg
- Creates keys dir
- Copies GPG to keys

### Testing

With the key being provided it should use that to succeed. However, this code will not run since it only runs on release.  See [here ](https://github.com/jaffinito/newrelic-dotnet-agent/actions/runs/344856818)for a run that shows the key being used.  Starting [here ](https://github.com/jaffinito/newrelic-dotnet-agent/runs/1351113936?check_suite_focus=true#step:8:973)is the log you can see the key being applied with the passphrase.

### Changelog

n/a

