### PR TITLE
Deployment workflow

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -682,7 +682,7 @@ jobs:
           agentVersion=$(head -n 1 ${{ github.workspace }}/agent_version.txt)
           agentVersion=${agentVersion/$'\r\n\t'}
           cd ${{ github.workspace }}/build/Linux
-          docker-compose build
+          docker-compose build build_rpm
           docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
         shell: bash
       
@@ -730,7 +730,7 @@ jobs:
           agentVersion=$(head -n 1 ${{ github.workspace }}/agent_version.txt)
           agentVersion=${agentVersion/$'\r\n\t'}
           cd ${{ github.workspace }}/build/Linux
-          docker-compose build
+          docker-compose build build_deb
           docker-compose run -e AGENT_VERSION=$agentVersion build_deb
         shell: bash
         

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -792,5 +792,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: deploy-artifacts
-          path: ${{ github.workspace }}\build\BuildArtifacts
+          path: |
+            ${{ github.workspace }}\build\BuildArtifacts
+            ${{ github.workspace }}\deploy
           if-no-files-found: error

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,215 @@
+name: Deploy the .NET Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent_version:
+        description: 'Agent Version to RELEASE. Format: X.X.X'
+        required: true
+      run_id:
+        description: 'Run ID of the Release Workflow (all_solutions.yml) triggered but creating a release.'
+        required: true
+
+env:
+  DOTNET_NOLOGO: true
+
+jobs:
+
+  get-external-artifacts:
+    name: Get Deploy Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Deploy Artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: all_solutions.yml
+          run_id: ${{ github.event.inputs.run_id }}
+          name: deploy-artifacts
+          path: ${{ github.workspace }}
+          repo: ${{ github.repository }}
+      
+      - name: Upload Deploy Artifacts Locally
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}/build/BuildArtifacts
+          if-no-files-found: error
+
+      - name: Upload Deploy Tooling Locally
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-tooling
+          path: ${{ github.workspace }}/deploy/
+          if-no-files-found: error
+
+
+  deploy-downloadsite:
+    needs: get-external-artifacts
+    name: Deploy MSI and Scriptable to Download Site
+    runs-on: windows-2019
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Download Deploy Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}\working_dir
+
+      - name: Deploy to Download Site
+        run: |
+          Copy-Item .\working_dir\newrelic-agent-win-x64-*.msi .\working_dir\NewRelicDotNetAgent_x64.msi -Force -Recurse
+          Copy-Item .\working_dir\newrelic-agent-win-x86-*.msi .\working_dir\NewRelicDotNetAgent_x86.msi -Force -Recurse
+          Copy-Item .\working_dir\newrelic-agent-*-scriptable-installer.zip .\working_dir\NewRelic.Agent.Installer.zip -Force -Recurse
+
+          New-Item -ItemType directory -Path .\latest_release -Force
+          Copy-Item .\working_dir\* .\latest_release\ -Force -Recurse
+          cd .\latest_release
+          aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+          cd ..
+
+          New-Item -Force -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }}
+          Copy-Item .\working_dir\* ".\previous_releases\${{ github.event.inputs.agent_version }}\" -Force -Recurse
+
+          cd .\previous_releases\${{ github.event.inputs.agent_version }}
+          aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+        shell: powershell
+
+  deploy-nuget:
+    needs: get-external-artifacts
+    name: Deploy Agent to NuGet
+    runs-on: windows-2019
+
+    env:
+      nuget_source: https://www.nuget.org
+
+    steps:
+      - name: Download Deploy Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}\working_dir
+
+      - name: Setup NuGet API Key
+        run: |
+          nuget.exe setApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }}
+        shell: powershell
+
+      - name: Deploy Agent to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgent\NewRelic.Agent.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgent\$packageName
+          $version = $packageName.TrimStart('NewRelic.Agent').TrimStart('.').TrimEnd('.nupkg')
+          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+        shell: powershell
+
+      - name: Deploy Agent API to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgentApi\NewRelic.Agent.Api.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgentApi\$packageName
+          $version = $packageName.TrimStart('NewRelic.Agent.Api').TrimStart('.').TrimEnd('.nupkg')
+          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+        shell: powershell
+
+      - name: Deploy Azure Cloud Services to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureCloudServices\NewRelicWindowsAzure.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureCloudServices\$packageName
+          $version = $packageName.TrimStart('NewRelicWindowsAzure').TrimStart('.').TrimEnd('.nupkg')
+          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+        shell: powershell
+
+      - name: Deploy Azure WebSites-x64 to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\NewRelic.Azure.WebSites.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\$packageName
+          $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
+          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+        shell: powershell
+
+      - name: Deploy Azure WebSites-x86 to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\NewRelic.Azure.WebSites.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\$packageName
+          $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
+          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+        shell: powershell
+
+  deploy-linux:
+    name: Deploy Linux to APT and YUM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Download Deploy Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}/
+
+      - name: Download Deploy Tooling
+        uses: actions/download-artifact@v2
+        with:
+          name: deploy-tooling
+          path: ${{ github.workspace }}/
+
+      - name: Get GPG Key
+        id: write_gpgkey
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'gpg.tar.bz2'
+          encodedString: ${{ secrets.GPG_KEY }}
+
+      - name: Move Artifacts an GPG Key to Staging Location
+        run: |
+          cp *.rpm ${{ github.workspace }}/deploy/linux/packages
+          cp *.deb ${{ github.workspace }}/deploy/linux/packages
+          cp -f ${{ steps.write_gpgkey.outputs.filePath }} ${{ github.workspace }}/deploy/linux/deploy_scripts/gpg.tar.bz2
+        shell: bash
+
+      - name: Build Container
+        run: |
+          # Confirm that the version is in the proper format.
+          IFS='.' read -ra agent_version_array <<< "${{ github.event.inputs.agent_version }}"
+          agent_version_count=${#agent_version_array[@]}
+          if [ $agent_version_count -lt 3 ] || [ $agent_version_count -gt 4 ] ; then
+            echo "::error Supplied agent version from Workflow (${{ github.event.inputs.agent_version }}) is malformed.  It needs to be like 8.29.0 or 8.29.0.0"
+            exit 1
+          elif[] ; then
+            AGENT_VERSION=${{ github.event.inputs.agent_version }}
+          else
+            AGENT_VERSION=${{ github.event.inputs.agent_version }}.0
+          fi
+
+          # Build the docker.env
+          cd ${{ github.workspace }}/deploy/linux/
+          touch docker.env
+          echo "AGENT_VERSION=$AGENT_VERSION" >> docker.env
+          echo "ACTION=release" >> docker.env
+          echo "S3_BUCKET=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> docker.env
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> docker.env
+          echo "GPG_KEYS=/deployscripts/gpg.tar.bz2" >> docker.env
+          echo "PROD_MAIN_S3=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
+          echo "PROD_TEST_S3=${{ secrets.PROD_TEST_S3 }}" >> docker.env
+          echo "TEST_TEST_S3=${{ secrets.TEST_TEST_S3 }}" >> docker.env
+          echo "TEST_PRIV_S3=${{ secrets.TEST_PRIV_S3 }}" >> docker.env
+
+          # Run docker-compose
+          docker-compose build
+          docker-compose run deploy_packages
+        shell: bash
+
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,14 +77,25 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deploy-artifacts
-          path: ${{ github.workspace }}\working_dir
+          path: ${{ github.workspace }}\staging_dir
 
-      - name: Deploy to Download Site
+      - name: Move Artifacts to working_dir
+        run: |
+          $installers = Get-ChildItem -Path .\staging_dir -Include *.msi,*.zip -Recurse
+          foreach ($installer in $installers) {
+            Copy-Item -Path $installer.FullName -Destination .\working_dir\
+          }
+        shell: powershell
+
+      - name: Create Version-less Installers
         run: |
           Copy-Item .\working_dir\newrelic-agent-win-x64-*.msi .\working_dir\NewRelicDotNetAgent_x64.msi -Force -Recurse
           Copy-Item .\working_dir\newrelic-agent-win-x86-*.msi .\working_dir\NewRelicDotNetAgent_x86.msi -Force -Recurse
           Copy-Item .\working_dir\newrelic-agent-*-scriptable-installer.zip .\working_dir\NewRelic.Agent.Installer.zip -Force -Recurse
+        shell: powershell
 
+      - name: Deploy latest_release to Download Site
+        run: |
           New-Item -ItemType directory -Path .\latest_release -Force
           Copy-Item .\working_dir\* .\latest_release\ -Force -Recurse
           cd .\latest_release
@@ -93,19 +104,21 @@ jobs:
           }
           else {
             Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
-            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete"
+            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include `"*`" --exclude `".DS_Store`" --delete"
           }
+        shell: powershell
 
-          cd ..
-          New-Item -Force -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }}
+      - name: Deploy previous_release to Download Site
+        run: |
+          New-Item -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }} -Force
           Copy-Item .\working_dir\* ".\previous_releases\${{ github.event.inputs.agent_version }}\" -Force -Recurse
           cd .\previous_releases\${{ github.event.inputs.agent_version }}
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
-            aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+            aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/ --include "*" --exclude ".DS_Store" --delete --profile $profileName
           }
           else {
             Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
-            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete"
+            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/ --include `"*`" --exclude `".DS_Store`" --delete --profile $profileName"
           }
         shell: powershell
 
@@ -232,7 +245,7 @@ jobs:
           cp -f ${{ steps.write_gpgkey.outputs.filePath }} ${{ github.workspace }}/deploy/linux/deploy_scripts/gpg.tar.bz2
         shell: bash
 
-      - name: Build Container
+      - name: Prepare docker.env
         run: |
           # Confirm that the version is in the proper format.
           IFS='.' read -ra agent_version_array <<< "${{ github.event.inputs.agent_version }}"
@@ -259,8 +272,11 @@ jobs:
           echo "PROD_TEST_S3=${{ secrets.PROD_TEST_S3 }}" >> docker.env
           echo "TEST_TEST_S3=${{ secrets.TEST_TEST_S3 }}" >> docker.env
           echo "TEST_PRIV_S3=${{ secrets.TEST_PRIV_S3 }}" >> docker.env
+        shell: bash
 
-          # Run docker-compose
+      - name: Build and Run Container
+        run: |
+          cd ${{ github.workspace }}/deploy/linux/
           docker-compose build
           if [ "${{ github.event.inputs.deploy }}" == "true" ] ; then
             docker-compose run deploy_packages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,10 @@ jobs:
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
           }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete"
+          }
           cd ..
 
           New-Item -Force -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }}
@@ -86,6 +90,10 @@ jobs:
           cd .\previous_releases\${{ github.event.inputs.agent_version }}
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+          }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete"
           }
         shell: powershell
 
@@ -117,6 +125,10 @@ jobs:
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
+          }
         shell: powershell
 
       - name: Deploy Agent API to Nuget
@@ -126,6 +138,10 @@ jobs:
           $version = $packageName.TrimStart('NewRelic.Agent.Api').TrimStart('.').TrimEnd('.nupkg')
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
           }
         shell: powershell
 
@@ -137,6 +153,10 @@ jobs:
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
+          }
         shell: powershell
 
       - name: Deploy Azure WebSites-x64 to Nuget
@@ -147,6 +167,10 @@ jobs:
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
+          }
         shell: powershell
 
       - name: Deploy Azure WebSites-x86 to Nuget
@@ -156,6 +180,10 @@ jobs:
           $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
           }
         shell: powershell
 
@@ -222,6 +250,9 @@ jobs:
           docker-compose build
           if [ "${{ github.event.inputs.deploy }}" == "true" ] ; then
             docker-compose run deploy_packages
+          else
+            echo "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            echo "docker-compose run deploy_packages"
           fi
         shell: bash
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,13 +146,6 @@ jobs:
     name: Deploy Linux to APT and YUM
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
       - name: Download Deploy Artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,15 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       agent_version:
-        description: 'Agent Version to RELEASE. Format: X.X.X'
+        description: 'Agent Version to deploy.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
       run_id:
-        description: 'Run ID of the Release Workflow (all_solutions.yml) triggered but creating a release.'
+        description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
       deploy:
-        description: 'If "true", deploy the Artifacts. If "false", do everything except deploy.'
+        description: 'If "true", deploy the artifacts. If "false", do everything except deploy.'
         required: true
         default: 'false'
+      downloadsite:
+        description: 'If "true", will run the deploy-downloadsite job. If "false", will not.'
+        required: true
+        default: 'true'
+      nuget:
+        description: 'If "true", will run the deploy-nuget job. If "false", will not.'
+        required: true
+        default: 'true'
+      linux:
+        description: 'If "true", will run the deploy-linux job. If "false", will not.'
+        required: true
+        default: 'true'
 
 env:
   DOTNET_NOLOGO: true
@@ -49,6 +61,7 @@ jobs:
 
   deploy-downloadsite:
     needs: get-external-artifacts
+    if: ${{ github.event.inputs.downloadsite == 'true' }}
     name: Deploy MSI and Scriptable to Download Site
     runs-on: windows-2019
 
@@ -75,7 +88,6 @@ jobs:
           New-Item -ItemType directory -Path .\latest_release -Force
           Copy-Item .\working_dir\* .\latest_release\ -Force -Recurse
           cd .\latest_release
-
           if ("${{ github.event.inputs.deploy }}" -eq "true") {
             aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
           }
@@ -83,8 +95,8 @@ jobs:
             Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
             Write-Host "aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete"
           }
-          cd ..
 
+          cd ..
           New-Item -Force -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }}
           Copy-Item .\working_dir\* ".\previous_releases\${{ github.event.inputs.agent_version }}\" -Force -Recurse
           cd .\previous_releases\${{ github.event.inputs.agent_version }}
@@ -99,6 +111,7 @@ jobs:
 
   deploy-nuget:
     needs: get-external-artifacts
+    if: ${{ github.event.inputs.nuget == 'true' }}
     name: Deploy Agent to NuGet
     runs-on: windows-2019
 
@@ -189,6 +202,7 @@ jobs:
 
   deploy-linux:
     needs: get-external-artifacts
+    if: ${{ github.event.inputs.linux == 'true' }}
     name: Deploy Linux to APT and YUM
     runs-on: ubuntu-latest
     steps:
@@ -213,8 +227,8 @@ jobs:
 
       - name: Move Artifacts an GPG Key to Staging Location
         run: |
-          cp *.rpm ${{ github.workspace }}/deploy/linux/packages
-          cp *.deb ${{ github.workspace }}/deploy/linux/packages
+          cp LinuxRpm/*.rpm ${{ github.workspace }}/deploy/linux/packages
+          cp LinuxDeb/*.deb ${{ github.workspace }}/deploy/linux/packages
           cp -f ${{ steps.write_gpgkey.outputs.filePath }} ${{ github.workspace }}/deploy/linux/deploy_scripts/gpg.tar.bz2
         shell: bash
 
@@ -226,7 +240,7 @@ jobs:
           if [ $agent_version_count -lt 3 ] || [ $agent_version_count -gt 4 ] ; then
             echo "::error Supplied agent version from Workflow (${{ github.event.inputs.agent_version }}) is malformed.  It needs to be like 8.29.0 or 8.29.0.0"
             exit 1
-          elif[] ; then
+          elif [ $agent_version_count -eq 4 ] ; then
             AGENT_VERSION=${{ github.event.inputs.agent_version }}
           else
             AGENT_VERSION=${{ github.event.inputs.agent_version }}.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
       run_id:
         description: 'Run ID of the Release Workflow (all_solutions.yml) triggered but creating a release.'
         required: true
+      deploy:
+        description: 'If "true", deploy the Artifacts. If "false", do everything except deploy.'
+        required: true
+        default: 'false'
 
 env:
   DOTNET_NOLOGO: true
@@ -16,7 +20,7 @@ env:
 jobs:
 
   get-external-artifacts:
-    name: Get Deploy Artifacts
+    name: Get and Publish Deploy Artifacts Locally
     runs-on: ubuntu-latest
     steps:
       - name: Download Deploy Artifacts
@@ -42,7 +46,6 @@ jobs:
           name: deploy-tooling
           path: ${{ github.workspace }}/deploy/
           if-no-files-found: error
-
 
   deploy-downloadsite:
     needs: get-external-artifacts
@@ -72,14 +75,18 @@ jobs:
           New-Item -ItemType directory -Path .\latest_release -Force
           Copy-Item .\working_dir\* .\latest_release\ -Force -Recurse
           cd .\latest_release
-          aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+          }
           cd ..
 
           New-Item -Force -ItemType directory -Path .\previous_releases\${{ github.event.inputs.agent_version }}
           Copy-Item .\working_dir\* ".\previous_releases\${{ github.event.inputs.agent_version }}\" -Force -Recurse
-
           cd .\previous_releases\${{ github.event.inputs.agent_version }}
-          aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ github.event.inputs.agent_version }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
+          }
         shell: powershell
 
   deploy-nuget:
@@ -107,7 +114,9 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgent\NewRelic.Agent.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgent\$packageName
           $version = $packageName.TrimStart('NewRelic.Agent').TrimStart('.').TrimEnd('.nupkg')
-          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
         shell: powershell
 
       - name: Deploy Agent API to Nuget
@@ -115,7 +124,9 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgentApi\NewRelic.Agent.Api.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgentApi\$packageName
           $version = $packageName.TrimStart('NewRelic.Agent.Api').TrimStart('.').TrimEnd('.nupkg')
-          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
         shell: powershell
 
       - name: Deploy Azure Cloud Services to Nuget
@@ -123,7 +134,9 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureCloudServices\NewRelicWindowsAzure.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureCloudServices\$packageName
           $version = $packageName.TrimStart('NewRelicWindowsAzure').TrimStart('.').TrimEnd('.nupkg')
-          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
         shell: powershell
 
       - name: Deploy Azure WebSites-x64 to Nuget
@@ -131,7 +144,9 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\NewRelic.Azure.WebSites.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\$packageName
           $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
-          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
         shell: powershell
 
       - name: Deploy Azure WebSites-x86 to Nuget
@@ -139,10 +154,13 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\NewRelic.Azure.WebSites.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\$packageName
           $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
-          C:\nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
         shell: powershell
 
   deploy-linux:
+    needs: get-external-artifacts
     name: Deploy Linux to APT and YUM
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +174,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: deploy-tooling
-          path: ${{ github.workspace }}/
+          path: ${{ github.workspace }}/deploy
 
       - name: Get GPG Key
         id: write_gpgkey
@@ -202,7 +220,9 @@ jobs:
 
           # Run docker-compose
           docker-compose build
-          docker-compose run deploy_packages
+          if [ "${{ github.event.inputs.deploy }}" == "true" ] ; then
+            docker-compose run deploy_packages
+          fi
         shell: bash
 
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,10 +81,7 @@ jobs:
 
       - name: Move Artifacts to working_dir
         run: |
-          $installers = Get-ChildItem -Path .\staging_dir -Include *.msi,*.zip -Recurse
-          foreach ($installer in $installers) {
-            Copy-Item -Path $installer.FullName -Destination .\working_dir\
-          }
+          Copy-Item -Path .\staging_dir\build\BuildArtifacts\DownloadSite -Destination .\working_dir -Recurse
         shell: powershell
 
       - name: Create Version-less Installers

--- a/build/Linux/build/deb/build.sh
+++ b/build/Linux/build/deb/build.sh
@@ -58,3 +58,7 @@ cp /common/agentinfo.json .
 
 # create tar ball
 tar cvfz /release/${PACKAGE_FILE_BASENAME}.tar.gz -C ${INSTALL_LOCATION} ..
+
+if [ $? -gt 0 ] ; then
+    echo "::error Docker run exited with code: $?"
+fi

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -99,3 +99,6 @@ if [[ ! -z "$GPG_KEYS" ]]; then
     sign_rpm "$rpm_file"
 fi
 
+if [ $? -gt 0 ] ; then
+    echo "::error Docker run exited with code: $?"
+fi

--- a/build/Linux/docker-compose.yml
+++ b/build/Linux/docker-compose.yml
@@ -1,41 +1,42 @@
-build_deb: 
-    build: ./build/deb 
-    command: bash -c "dos2unix /deb/build.sh && chmod 755 /deb && /deb/build.sh"
-    volumes: 
-        - ../../src/_build/CoreArtifacts:/release
-        - ../../src/Agent:/data
-        - ../../src/Agent/Miscellaneous:/docs
-        - ./build/deb:/deb
-        - ./build/common:/common
-    working_dir: /data
+version: "3.8"
+services:
+    build_deb: 
+        build: ./build/deb 
+        command: bash -c "dos2unix /deb/build.sh && chmod 755 -R /deb && chmod 777 /deb/build.sh && /deb/build.sh"
+        volumes: 
+            - ../../src/_build/CoreArtifacts:/release
+            - ../../src/Agent:/data
+            - ../../src/Agent/Miscellaneous:/docs
+            - ./build/deb:/deb
+            - ./build/common:/common
+        working_dir: /data
 
-build_rpm: 
-    build: ./build/rpm
-    command: bash -c "dos2unix /rpm/build.sh && chmod 777 /rpm/build.sh && /rpm/build.sh"
-    volumes: 
-        - ../../src/_build/CoreArtifacts:/release
-        - ../../src/Agent:/data
-        - ../../src/Agent/Miscellaneous:/docs
-        - ./build/rpm:/rpm
-        - ./build/common:/common
-        - ./keys:/keys
-    working_dir: /data
+    build_rpm: 
+        build: ./build/rpm
+        command: bash -c "dos2unix /rpm/build.sh && chmod 777 /rpm/build.sh && /rpm/build.sh"
+        volumes: 
+            - ../../src/_build/CoreArtifacts:/release
+            - ../../src/Agent:/data
+            - ../../src/Agent/Miscellaneous:/docs
+            - ./build/rpm:/rpm
+            - ./build/common:/common
+            - ./keys:/keys
+        working_dir: /data
 
-test_debian: 
-    build: ./test/distros/debian
-    command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
-    volumes:
-        - ../../src/_build/CoreArtifacts:/release
-        - ./test/scripts:/test
-        - ./test/applications:/apps
-    working_dir: /data
+    test_debian: 
+        build: ./test/distros/debian
+        command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
+        volumes:
+            - ../../src/_build/CoreArtifacts:/release
+            - ./test/scripts:/test
+            - ./test/applications:/apps
+        working_dir: /data
 
-test_centos: 
-    build: ./test/distros/centos
-    command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
-    volumes:
-        - ../../src/_build/CoreArtifacts:/release
-        - ./test/scripts:/test
-        - ./test/applications:/apps
-    working_dir: /data
-
+    test_centos: 
+        build: ./test/distros/centos
+        command: bash -c "dos2unix /test/test.sh &>/dev/null && chmod 777 /test/test.sh && /test/test.sh"
+        volumes:
+            - ../../src/_build/CoreArtifacts:/release
+            - ./test/scripts:/test
+            - ./test/applications:/apps
+        working_dir: /data

--- a/deploy/linux/README.md
+++ b/deploy/linux/README.md
@@ -1,0 +1,29 @@
+# .NET Core Agent Linux Package Deployment
+
+The assets in this path are used to deploy the Linux packages (.deb and .rpm) for the .NET Core Agent to New Relic's public package sources (apt.newrelic.com and yum.newrelic.com).
+
+## Requirements
+1. Docker, with the ability to run Linux containers
+2. AWS S3 access keys with read/write access to the bucket(s) you are updating
+
+To deploy the .rpm and .deb packages for a particular release version (e.g. 6.18.123.0), run the following commands from this directory (same directory as this README):
+
+1. `cp <packages_to_be_released> ./packages`
+2. `docker-compose build`
+3. The following environment variables MUST be set in the environment that `deploy.bash` executes in inside the container:
+    - `AGENT_VERSION` (e.g. 6.18.123.0)
+    - `AWS_ACCESS_KEY_ID`
+    - `AWS_SECRET_ACCESS_KEY`
+4. These environment variables can be passed to the container in a few ways:
+    - In a file, specified in the `docker-compose.yml` file (currently `docker.env`), one name/val pair per line with no quoting
+    - You can set them explicity in the `docker-compose run` command, like so:
+    `docker-compose run -e AGENT_VERSION=6.18.123.0 -e AWS_ACCESS_KEY_ID=AKAKAKAKAKAKAKA -e AWS_SECRET_ACCESS_KEY=6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ deploy_packages`
+5. The following environment variables MAY be passed to the container, but are not required:
+    - `AWS_DEFAULT_REGION` (defaults to `us-west-2`)
+    - `AWS_DEFAULT_OUTPUT` (defaults to `text`)
+    - `RELEASE_ACTION` (defaults to `release-2-fake-production`; set to `release-2-production` to REALLY release new agent packages for Linux)
+6. `docker-compose run deploy_packages`
+
+Note that the scripts in ./deploy_scripts came from the PHP agent team and have a lot of logic in them to support their particular build/test/release processes, not all of which
+we are using.  However, since we are sharing the same public package sources with the PHP agent, anything this script does needs to be cautious to avoid breaking their repos.
+In particular, before we attempt to deploy a version of our agent to the main public repos, we should make sure the PHP agent team isn't also trying to deploy at the same time.

--- a/deploy/linux/container/Dockerfile
+++ b/deploy/linux/container/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    dpkg-dev \
+    createrepo \
+    awscli \
+    curl \
+    dos2unix \
+    bsdmainutils \
+    rsync \
+    && rm -rf /var/lib/apt/lists/*

--- a/deploy/linux/deploy.bash
+++ b/deploy/linux/deploy.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e # for initial debugging purposes, halt the build script on any error.  This should be removed before release, probably
+
+if [ -z "$AGENT_VERSION" ]; then
+    echo "AGENT_VERSION is not set"
+    exit -1
+fi
+
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "AWS_ACCESS_KEY_ID is not set"
+    exit -1
+fi
+
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "AWS_SECRET_ACCESS_KEY is not set"
+    exit -1
+fi
+
+AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
+AWS_DEFAULT_OUTPUT=${AWS_DEFAULT_OUTPUT:-text}
+
+
+## Actions
+# 'release' => release new packages
+# 'rollback' => roll back/remove an existing set of packages
+
+ACTION=${ACTION:-release}
+S3_BUCKET=${S3_BUCKET:-$}
+
+/deployscripts/deploy-packages.bash -p /data/s3 -i /packages -a "$ACTION" -s "$S3_BUCKET" -v "$AGENT_VERSION"

--- a/deploy/linux/deploy_scripts/conf/apt-generate-config.in
+++ b/deploy/linux/deploy_scripts/conf/apt-generate-config.in
@@ -1,0 +1,30 @@
+Dir {
+  ArchiveDir ".";
+  CacheDir ".";
+};
+
+Default::Packages {
+  Extensions ".deb";
+  Compress ". gzip bzip2";
+};
+
+Default::Sources::Compress "gzip bzip2";
+Default::Contents::Compress "gzip bzip2";
+
+BinDirectory "dists/@TARGETREPO@/non-free/binary-amd64" {
+  Packages "dists/@TARGETREPO@/non-free/binary-amd64/Packages";
+  Contents "dists/@TARGETREPO@/Contents-amd64";
+  SrcPackages "dists/@TARGETREPO@/non-free/source/Sources";
+};
+
+BinDirectory "dists/@TARGETREPO@/non-free/binary-i386" {
+  Packages "dists/@TARGETREPO@/non-free/binary-i386/Packages";
+  Contents "dists/@TARGETREPO@/Contents-i386";
+  SrcPackages "dists/@TARGETREPO@/non-free/source/Sources";
+};
+
+Tree "dists/@TARGETREPO@" {
+  Sections "non-free";
+  Architectures "i386 amd64";
+};
+

--- a/deploy/linux/deploy_scripts/conf/apt-release-config.in
+++ b/deploy/linux/deploy_scripts/conf/apt-release-config.in
@@ -1,0 +1,8 @@
+APT::FTPArchive::Release {
+  Origin "New Relic";
+  Label "New Relic";
+  Suite "@TARGETREPO@";
+  Architectures "i386 amd64";
+  Components "non-free";
+}
+

--- a/deploy/linux/deploy_scripts/conf/generate-testing.conf
+++ b/deploy/linux/deploy_scripts/conf/generate-testing.conf
@@ -1,0 +1,30 @@
+Dir {
+  ArchiveDir ".";
+  CacheDir ".";
+};
+
+Default::Packages {
+  Extensions ".deb";
+  Compress ". gzip bzip2";
+};
+
+Default::Sources::Compress "gzip bzip2";
+Default::Contents::Compress "gzip bzip2";
+
+BinDirectory "dists/newrelic-testing/non-free/binary-amd64" {
+  Packages "dists/newrelic-testing/non-free/binary-amd64/Packages";
+  Contents "dists/newrelic-testing/Contents-amd64";
+  SrcPackages "dists/newrelic-testing/non-free/source/Sources";
+};
+
+BinDirectory "dists/newrelic-testing/non-free/binary-i386" {
+  Packages "dists/newrelic-testing/non-free/binary-i386/Packages";
+  Contents "dists/newrelic-testing/Contents-i386";
+  SrcPackages "dists/newrelic-testing/non-free/source/Sources";
+};
+
+Tree "dists/newrelic-testing" {
+  Sections "non-free";
+  Architectures "i386 amd64";
+};
+

--- a/deploy/linux/deploy_scripts/conf/generate.conf
+++ b/deploy/linux/deploy_scripts/conf/generate.conf
@@ -1,0 +1,30 @@
+Dir {
+  ArchiveDir ".";
+  CacheDir ".";
+};
+
+Default::Packages {
+  Extensions ".deb";
+  Compress ". gzip bzip2";
+};
+
+Default::Sources::Compress "gzip bzip2";
+Default::Contents::Compress "gzip bzip2";
+
+BinDirectory "dists/newrelic/non-free/binary-amd64" {
+  Packages "dists/newrelic/non-free/binary-amd64/Packages";
+  Contents "dists/newrelic/Contents-amd64";
+  SrcPackages "dists/newrelic/non-free/source/Sources";
+};
+
+BinDirectory "dists/newrelic/non-free/binary-i386" {
+  Packages "dists/newrelic/non-free/binary-i386/Packages";
+  Contents "dists/newrelic/Contents-i386";
+  SrcPackages "dists/newrelic/non-free/source/Sources";
+};
+
+Tree "dists/newrelic" {
+  Sections "non-free";
+  Architectures "i386 amd64";
+};
+

--- a/deploy/linux/deploy_scripts/conf/release-testing.conf
+++ b/deploy/linux/deploy_scripts/conf/release-testing.conf
@@ -1,0 +1,7 @@
+APT::FTPArchive::Release {
+  Origin "New Relic";
+  Label "New Relic";
+  Suite "newrelic-testing";
+  Architectures "i386 amd64";
+  Components "non-free";
+}

--- a/deploy/linux/deploy_scripts/conf/release.conf
+++ b/deploy/linux/deploy_scripts/conf/release.conf
@@ -1,0 +1,7 @@
+APT::FTPArchive::Release {
+  Origin "New Relic";
+  Label "New Relic";
+  Suite "newrelic";
+  Architectures "i386 amd64";
+  Components "non-free";
+}

--- a/deploy/linux/deploy_scripts/deploy-packages.bash
+++ b/deploy/linux/deploy_scripts/deploy-packages.bash
@@ -1,0 +1,286 @@
+#!/bin/bash
+# deploy-packages.bash - deploy or rollback .NET Core agent Linux packages from APT and YUM repos
+
+### Usage: deploy-packages.bash --prefix=<dir> [--incoming-dir=<dir>]
+###                        <action> <s3-bucket> <version>
+###        deploy-packages.bash [--help]
+###
+### Arguments:
+###   <action>              action to perform, must be 'release' or 'rollback'
+###   <version>             agent version to relase or rollback
+###
+### Options:
+###   --prefix=<dir>        directory containing the working copy of the
+###                         download site
+###   --incoming-dir        directory containing build artifacts to deploy
+###   --help                print this message and exit
+###
+### Description:
+###
+###   Deploying or rolling back the .NET Core agent Linux packages proceeds 
+###   in three phases: pull, modify, push.
+###   The three phases are designed to ensure the deploy process is safe,
+###   reliable, and atomic. i.e. Changes should not be visible to customers
+###   unless they are both complete and correct. To achieve these goals, this
+###   script never makes direct changes to the public download website.
+###
+###   The first phase, the "pull" phase, ensures that a local copy of the
+###   download site is available and up-to-date. The download site is
+###   backed by Amazon S3, so this phase uses the AWS CLI[0] tools to
+###   synchronize the local copy with the current contents of the public
+###   download site. Warning: Synchronizing will remove any files present
+###   in the local copy, but not present on the download site.
+###   See libexec/s3-pull.bash for details.
+###
+###   The second phase, the "modify" phase, performs the real work of
+###   deploying or rolling back the agent. During this phase, each of the 
+###   files comprising an agent release is copied to the appropriate location 
+###   within the download site. Additionally, the Debian and Redhat package 
+###   repositories are re-indexed and digitally signed. See libexec/repoman-*.bash for
+###   details.
+###
+###   The third and final phase, the "push" phase, completes the deployment.
+###   This phase uploads the changes made during the "modify" phase to the
+###   download site. As in the "pull" phase, the AWS CLI[0] tools are used
+###   perform the synchronization. See libexec/s3-push.bash for details.
+###
+###   [0] https://aws.amazon.com/cli/
+###
+
+set -e
+
+# Determine our location in the filesystem.
+# See: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+pushd . > /dev/null
+  DEPLOY_HOME=${BASH_SOURCE[0]}
+
+  if [[ -h $DEPLOY_HOME ]]; then
+    while [[ -h $DEPLOY_HOME ]]; do
+      cd "$(dirname "$DEPLOY_HOME")"
+      DEPLOY_HOME=$(readlink "$DEPLOY_HOME")
+    done
+  fi
+
+  cd "$(dirname "$DEPLOY_HOME")" > /dev/null
+  DEPLOY_HOME=$(pwd)
+popd > /dev/null
+
+export DEPLOY_HOME
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+#
+# Print the path to a repository
+#
+repopath() {
+  "$DEPLOY_HOME/libexec/repoman-path.bash" --prefix="$PREFIX" "$@"
+}
+
+#
+# Given a stream of file paths, prints the unique filenames.
+#
+unique_files_by_basename() {
+  local REPLY
+
+  # Split into (dirname basename) pairs, sort by basename,
+  # uniqify by basename, then rejoin the pairs back into
+  # complete paths.
+  while read -r; do
+    printf '%q:%q\n' "${REPLY%/*}" "${REPLY##*/}"
+  done | sort -k 2 -t: -u | awk -F: '{print $1 "/" $2}'
+}
+
+PREFIX=
+PRODUCT='dotnet_agent'
+ACTION=
+VERSION=
+
+INCOMING_DIR=        # path of incoming package files (.deb and .rpm)
+TARGET=              # name of the target repo
+
+PRODUCT_REPO=        # path to the source product repo
+APT_REPO=            # path to the source APT repo
+YUM_REPO=            # path to the source YUM repo
+
+# Note: having separate source and dest buckets is a holdover from the PHP agent's more complex process.  The .NET Agent team's process (as of 2018-04-26) only ever pulls and pushes from/to the same bucket for a given operation
+SOURCE_BUCKET=       # s3:// URI for AWS S3 bucket to pull existing repo from
+DEST_BUCKET=         # s3:// URI for AWS S3 bucket to push new repo to
+
+while getopts ':i:p:a:s:v:' OPTNAME; do
+  case $OPTNAME in
+    i)
+      INCOMING_DIR=$OPTARG
+      ;;
+    p)
+      PREFIX=$OPTARG
+      ;;
+    a)
+      ACTION=$OPTARG
+      ;;
+    s)
+      S3_BUCKET=$OPTARG
+      ;;
+    v)
+      VERSION=$OPTARG
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+[[ -n $PREFIX && -d $PREFIX ]] || die 'must specify a working directory'
+[[ -n $ACTION  ]] || die 'must specify an action'
+[[ -n $S3_BUCKET ]] || die 'must specify an s3 bucket'
+[[ -n $VERSION ]] || die 'must specify a version'
+
+SOURCE_BUCKET="$S3_BUCKET"
+DEST_BUCKET="$S3_BUCKET"
+
+if [[ ! "$ACTION" =~ release|rollback ]]; then
+  echo "ACTION must be 'release' or 'rollback'.  You said '$ACTION'.  Exiting."
+  exit
+fi
+
+# Set the target (production vs. testing) based on the S3 bucket URI.  If the supplied bucket doesn't match one of the four we know about, bail out.
+if [ "$S3_BUCKET" == "$PROD_MAIN_S3" -o "$S3_BUCKET"  == "$PROD_TEST_S3" ]
+then
+  TARGET='production'
+elif [ "$S3_BUCKET" == "$TEST_PRIV_S3" -o "$S3_BUCKET"  == "$TEST_TEST_S3" ]
+then
+  TARGET='testing'
+else
+  echo "Specified S3 bucket uri '$S3_BUCKET' does not match any known buckets.  Exiting."
+  exit
+fi
+
+export TARGET
+
+# Make sure we have all the external tools we need
+for CMD in apt-ftparchive gpg createrepo curl rsync; do
+  if ! command -v $CMD > /dev/null; then
+    die 'command not found:' $CMD
+  fi
+done
+
+# Set a signal handler function to perform cleanup steps on exit
+on_exit() {
+  # This is leftover from the php agent team's version of this script; we don't need to do any cleanup at the moment
+  echo "Exiting."
+}
+trap 'on_exit $?' EXIT
+
+
+## BEGIN PULL PHASE ##
+# Pull the specified S3 bucket down to the local filesystem
+printf \\n
+"$DEPLOY_HOME/libexec/s3-pull.bash" --prefix="$PREFIX" "$SOURCE_BUCKET" "$TARGET"
+printf \\n
+## END PULL PHASE ##
+
+## BEGIN MODIFY PHASE ##
+
+PRODUCT_NAME='newrelic-netcore20-agent'
+
+if [[ "$ACTION" == 'release' ]]; then
+  # Find the local package files to be deployed
+  PRODUCT_REPO=$INCOMING_DIR
+  APT_REPO=$INCOMING_DIR
+  YUM_REPO=$INCOMING_DIR
+
+  [[ -d $PRODUCT_REPO ]] || die 'product repository not found:' "$PRODUCT_REPO"
+  [[ -d $APT_REPO     ]] || die 'APT repository not found:' "$APT_REPO"
+  [[ -d $YUM_REPO     ]] || die 'YUM repository not found:' "$YUM_REPO"
+
+  #
+  # Find the .NET agent packages for the given version.
+  #
+  findpkgs() {
+    {
+      find "$APT_REPO" -name "${PRODUCT_NAME}_${VERSION}_amd64.deb"
+      find "$YUM_REPO" -name "${PRODUCT_NAME}-${VERSION}-1.x86_64.rpm"
+    } | unique_files_by_basename
+  }
+
+  FILES=( $(findpkgs) )
+
+  if [[ ${#FILES[@]} -eq 0 ]]; then
+    die "no files found for $VERSION"
+  fi
+
+  printf '\n'
+  printf '>>> the following files will be added to %s\n' "$TARGET"
+  printf '\n'
+  printf '%s\n' "${FILES[@]}"
+
+  printf '\n'
+  printf '>>> promoting %s %s to %s...\n' "$PRODUCT" "$VERSION" "$TARGET"
+  printf '\n'
+
+  # The following commented-out call to repoman-demote is a carryover from the php agent team's version of this script.  In our usage since .NET Core was released, it never does anything useful.  Commenting out for now.
+  # "$DEPLOY_HOME/libexec/repoman-demote.bash" \
+  #     --prefix="$PREFIX" \
+  #     --product="$PRODUCT" \
+  #     --destination="$TARGET" \
+  #     --verbose \
+  #     --no-legend \
+  #     "$(repopath "$TARGET/$PRODUCT")"/*
+  # printf '\n'
+
+  "$DEPLOY_HOME/libexec/repoman-promote.bash" \
+      --prefix="$PREFIX" \
+      --product="$PRODUCT" \
+      --destination="$TARGET" \
+      --verbose \
+      "${FILES[@]}"
+
+elif [[ "$ACTION" == 'rollback' ]]; then
+
+  findpkgs() {
+    {
+      find "$PREFIX/$TARGET" -name "${PRODUCT_NAME}_${VERSION}_amd64.deb"
+      find "$PREFIX/$TARGET" -name "${PRODUCT_NAME}-${VERSION}-1.x86_64.rpm"
+    } | unique_files_by_basename
+  }
+
+  FILES=( $(findpkgs) )
+
+  if [[ ${#FILES[@]} -eq 0 ]]; then
+    die "no files found for $VERSION"
+  fi
+
+  printf '\n'
+  printf '>>> the following files will be removed from %s\n' "$TARGET"
+  printf '\n'
+  printf '%s\n' "${FILES[@]}"
+
+  printf '\n'
+  printf '>>> rolling back %s %s from %s...\n' "$PRODUCT" "$VERSION" "$TARGET"
+  printf '\n'
+
+  "$DEPLOY_HOME/libexec/repoman-demote.bash" \
+    --prefix="$PREFIX" \
+    --product="$PRODUCT" \
+    --destination="$TARGET" \
+    --verbose \
+    "${FILES[@]}"
+fi  
+
+## END MODIFY PHASE ##
+
+## BEGIN PUSH PHASE ##
+printf '\n'
+printf '>>> pushing changes to S3...\n'
+printf '\n'
+
+"$DEPLOY_HOME/libexec/s3-push.bash" \
+    --prefix="$PREFIX" \
+    --product="$PRODUCT" \
+    "$TARGET" "$DEST_BUCKET"
+
+printf '\n'
+printf '>>> %s %s %s to/from %s completed successfully.\n' \
+       "$ACTION" "$PRODUCT" "$VERSION" "$TARGET"
+### END PUSH PHASE ###
+
+exit

--- a/deploy/linux/deploy_scripts/lib/common.bash
+++ b/deploy/linux/deploy_scripts/lib/common.bash
@@ -1,0 +1,80 @@
+#!/bin/bash
+# common.bash - utility functions
+
+#
+# Print usage and exit.
+#
+#   $* - optional, an error message to print
+#
+usage() {
+  local exitstatus=0
+
+  if [[ $# -gt 0 ]]; then
+    printf '%s: %s\n\n' "$(basename "$0")" "$*" >&2
+    exitstatus=2
+  fi
+
+  grep '^###' "$0" | cut -c '5-' >&2
+  exit $exitstatus
+}
+
+#
+# Print a message and exit with an error.
+#
+die() {
+  if [[ $# -gt 0 ]]; then
+    printf '%s: %s\n' "$(basename "$0")" "$*" >&2
+  fi
+  exit 1
+}
+
+#
+# Wraps printf, but only prints if verbose output is enabled.
+#
+vprintf() {
+  if [[ $VERBOSE = yes ]]; then
+    printf -- "$@"
+  fi
+}
+
+#
+# Prompt the user with a yes/no question and return zero if the
+# user responds yes; otherwise, returns non-zero.
+#
+ask() {
+  local REPLY
+
+  printf \\n
+  read -e -r -p "$1 (y/N) " && [[ $REPLY = 'y' || $REPLY = 'Y' ]] || return 1
+}
+
+#
+# Set a variable to the value of a long option. This
+# depends on OPTARG and OPTIND being in scope and set as
+# part of a getopts loop.
+#
+#   $1 - name of the variable to set.
+#   $* - the program arguments
+#
+optparse() {
+  local var=$1; shift
+
+  if [[ $OPTARG = *=* ]]; then
+    eval $var='${OPTARG#*=}'
+  elif [[ $# -lt $OPTIND ]]; then
+    usage "option requires an argument -- $OPTARG"
+  else
+    eval $var='${!OPTIND}'
+    OPTIND=$((OPTIND + 1))
+  fi
+}
+
+#
+# Validate that the product is one of the expected values.
+#
+validate_product() {
+  case $1 in
+    php_agent|server_monitor|dotnet_agent) ;;
+    *) die 'product must be php_agent, dotnet_agent, or server_monitor' ;;
+  esac
+}

--- a/deploy/linux/deploy_scripts/libexec/colorize-changes.sed
+++ b/deploy/linux/deploy_scripts/libexec/colorize-changes.sed
@@ -1,0 +1,20 @@
+# colorize an itemized list of changes where the first column
+# indicates the type of change
+
+# add/create = yellow
+/^A\|C / {
+  s/^/\x1b[33m/
+  s/$/\x1b[m/
+}
+
+# delete = red
+/^D / {
+  s/^/\x1b[31m/
+  s/$/\x1b[m/
+}
+
+# modify = green
+/^M / {
+  s/^/\x1b[32m/
+  s/$/\x1b[m/
+}

--- a/deploy/linux/deploy_scripts/libexec/itemize-rsync.sed
+++ b/deploy/linux/deploy_scripts/libexec/itemize-rsync.sed
@@ -1,0 +1,59 @@
+# remove preamble
+/building\|receiving file list/ d
+
+# ignore files and directories with no changes
+/^\./ d
+
+# new file
+s/^[<>]f+++++++++\s*\(.*\)$/A \1/
+
+# new directory
+s/^cd+++++++++\s*\(.*\)$/C \1/
+
+# modified file, link or directory
+s/^[<>ch]..........\s*\(.*\)$/M \1/
+
+# deletion
+s/^\*deleting\s*\(.*\)/D \1/
+
+/^[ACDMS] debian/ {
+  # debian production repo
+  s!debian/dists/newrelic/.*$![production/debian]\x09&!
+
+  # debian other repo
+  s!debian/dists/newrelic-\([^/]*\)/.*$![\1/debian]\x09&!
+
+  b
+}
+
+/^[ACDMS] pub/ {
+  # redhat production repo
+  s!pub/newrelic/.*$![production/redhat]\x09&!
+
+  # redhat other repo
+  s!pub/newrelic-\([^/]*\)/.*$![\1/redhat]\x09&!
+
+  b
+}
+
+/^[ACDMS] php_agent/ {
+  tp
+  :p
+  
+  s!php_agent/release/.*$![production/php_agent]\x09&!
+  t
+
+  s!php_agent/\([^/]*\)/.*$![\1/php_agent]\x09&!
+  b
+}
+
+/^[ACDMS] server_monitor/ {
+  ts
+  :s
+
+  s!server_monitor/release/.*$![production/server_monitor]\x09&!
+  t
+
+  s!server_monitor/\([^/]*\)/.*$![\1/server_monitor]\x09&!
+  b
+}

--- a/deploy/linux/deploy_scripts/libexec/jenkins-build.bash
+++ b/deploy/linux/deploy_scripts/libexec/jenkins-build.bash
@@ -1,0 +1,87 @@
+#!/bin/bash
+# jenkins-build.bash - trigger a jenkins job
+
+### Usage: jenkins-build.bash [--host=<host>] [--user=<user>] [--token=<token>]
+###                           [-n | --dry-run] [-v | --verbose] [--] <job>...
+###        jenkins-build.bash [--help]
+###
+### Arguments:
+###    <job>...            jobs to trigger
+###
+### Options:
+###    --insecure          disable SSL certificate verification
+###    --host=<host>       hostname of the jenkins server
+###    --token=<token>     jenkins API token
+###    --user=<user>       user for the jenkins API token
+###    -n, --dry-run       don't actually execute the command, just show the
+###                        steps that would be performed
+###    -v, --verbose       cause jenkins-build.bash to be verbose
+###    --help              print this message and exit
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare DRYRUN=no VERBOSE=no VERIFYCERTS=yes
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    v) VERBOSE=yes ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	dry-run) DRYRUN=yes ;;
+	verbose) VERBOSE=yes ;;
+	insecure) VERIFYCERTS=no ;;
+	host|host=*) optparse JENKINS_HOST "$@" ;;
+	user|user=*) optparse JENKINS_USER "$@" ;;
+	token|token=*) optparse JENKINS_TOKEN "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+[[ -n $JENKINS_HOST   ]] || usage 'must specify a host'
+[[ -n $JENKINS_USER   ]] || usage 'must specify an auth user'
+[[ -n $JENKINS_TOKEN  ]] || usage 'must specify an auth token'
+
+#
+# Executes a curl command unless we're performing a dry-run, in which
+# case just print the command that would be executed.
+#
+perform_curl() {
+  local EXTRA
+
+  if [[ $VERIFYCERTS = no ]]; then
+    EXTRA='--insecure'
+  fi
+
+  if [[ $DRYRUN = no ]]; then
+    curl --silent --fail $EXTRA "$@"
+  else
+    echo curl --silent --fail $EXTRA "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  if [[ -n $1 ]]; then
+    vprintf "triggering build for '%s'...\n" "$1"
+    perform_curl -X POST --basic --user "$JENKINS_USER:$JENKINS_TOKEN" "https://$JENKINS_HOST/job/$1/build"
+  fi
+  shift
+done
+
+exit

--- a/deploy/linux/deploy_scripts/libexec/jenkins-download.bash
+++ b/deploy/linux/deploy_scripts/libexec/jenkins-download.bash
@@ -1,0 +1,134 @@
+#!/bin/bash
+# jenkins-download.bash -- download build artifacts from Jenkins
+
+### Usage: jenkins-download.bash --job=<name> [--build=<name-or-number>]
+###                              [--label=<label-or-node>]
+###                              [--directory-prefix=<prefix>]
+###                              [-n | --dry-run] [-v | --verbose]
+###        jenkins-download.bash [--help]
+###
+###    --job=<name>                  job name
+###    --build=<name-or-number>      build number or build name
+###                                  defaults to lastStableBuild
+###    --label=<label-or-node>       label/node containing the build artifacts
+###    --directory-prefix=<prefix>   directory where files will be saved
+###                                  defaults to the current directory
+###    --insecure                    disable SSL certificate verification
+###    -n, --dry-run                 don't actually execute the command, just
+###                                  show the steps that would be performed
+###    -v, --verbose                 cause jenkins-download to be verbose
+###    --help                        print this message and exit
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare DRYRUN=no VERBOSE=no VERIFYCERTS=yes
+declare JOB BUILD=lastSuccessfulBuild LABEL PREFIX=.
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    v) VERBOSE=yes ;;
+    -)
+      case $OPTARG in
+        'help') usage ;;
+	dry-run) DRYRUN=yes ;;
+	verbose) VERBOSE=yes ;;
+	insecure) VERIFYCERTS=no ;;
+	job|job=*) optparse JOB "$@" ;;
+	build|build=*) optparse BUILD "$@" ;;
+	label|label=*) optparse LABEL "$@" ;;
+	directory-prefix|directory-prefix=*) optparse PREFIX "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :) usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+[[ -n $JOB ]] || usage 'must specify a job'
+
+if [[ -n $LABEL ]]; then
+  [[ -n $BUILD ]] || usage 'must specify a build to use a label'
+elif [[ -z $BUILD ]]; then
+  usage 'must specify a build'
+fi
+
+: "${JENKINS_SCHEME:=https}"
+if [[ $JENKINS_SCHEME != http && $JENKINS_SCHEME != https ]]; then
+  usage 'scheme must be http or https'
+fi
+
+[[ -n $JENKINS_HOST ]] || usage 'must specify a host'
+
+#
+# Prints a list of artifact urls for a job, one per line.
+#
+#   $1 - base url of the build
+#
+artifacts() {
+  local SCRIPT BASEURL=$1
+
+  SCRIPT=$(cat <<EOF
+doc = REXML::Document.new \$stdin
+
+doc.elements.each("//artifact/relativePath") do |elt|
+  puts "${BASEURL}/artifact/#{elt.text}"
+end
+EOF
+)
+
+  curl --silent --fail "$BASEURL/api/xml?tree=artifacts\[relativePath\]" \
+    | ruby -r 'rexml/document' -e "$SCRIPT"
+
+  if [[ ${PIPESTATUS[0]} -ne 0 || ${PIPESTATUS[1]} -ne 0 ]]; then
+    printf >&2 \\n
+    printf >&2 "failed to retrieve the list of build artifacts\n"
+    printf >&2 "please verify the job, build and label are correct\n"
+    printf >&2 "url=%s\\n" "$BASEURL"
+    return 1
+  fi
+}
+
+#
+# Executes a curl command unless we're performing a dry-run, in which
+# case just print the command that would be executed.
+#
+perform_curl() {
+  local EXTRA
+
+  if [[ $VERIFYCERTS = no ]]; then
+    EXTRA='--insecure'
+  fi
+
+  if [[ $DRYRUN = no ]]; then
+    curl --fail $EXTRA "$@"
+  else
+    echo curl --fail $EXTRA "$@"
+  fi
+}
+
+vprintf 'fetching artifact list...'
+if [[ -z $LABEL ]]; then
+  ARTIFACTS=$(artifacts "$JENKINS_SCHEME://$JENKINS_HOST/job/$JOB/$BUILD")
+else
+  ARTIFACTS=$(artifacts "$JENKINS_SCHEME://$JENKINS_HOST/job/$JOB/$BUILD/label=$LABEL")
+fi
+vprintf 'done\n'
+
+for URL in $ARTIFACTS; do
+  ARTIFACT=$(basename "$URL")
+  vprintf 'downloading %s\n' "$ARTIFACT"
+  perform_curl --silent -o "$PREFIX/$ARTIFACT" "$URL"
+done

--- a/deploy/linux/deploy_scripts/libexec/repoman-archive.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-archive.bash
@@ -1,0 +1,174 @@
+#!/bin/bash
+# archive.sh - promote build artifacts into an archive directory
+
+### Usage: archive --product=<name> --version=<version> --prefix=<dir>
+###                [--skip-apt] [--skip-yum] [--skip-other] [--color]
+###                [--no-legend] [-n | --dry-run] [-v | --verbose] [--] <file>...
+###        archive [--help]
+###
+### Arguments:
+###   <files>...            files to archive
+###
+### Options:
+###   --product=<name>      product (php_agent or server_monitor)
+###   --version=<version>   version number
+###   --prefix=<dir>        path to the directory containing the archive
+###    --skip-apt           ignore DEB files
+###    --skip-yum           ignore RPM files
+###    --skip-other         ignore product files
+###    --color              colorize the output
+###    --no-legend          suppress output of legend
+###    -v, --verbose        cause promote to be verbose
+###    -n, --dry-run        don't actually archive the files, just show the
+###                         steps that would be performed
+###    --help               print this message and exit
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+#
+# Print the path to a repository
+#
+repopath() {
+  "$DEPLOY_HOME/libexec/repoman-path.bash" --prefix="$PREFIX" "$@"
+}
+
+declare DRYRUN=no VERBOSE=no COLORIZE=no LEGEND=yes
+declare PRODUCT VERSION PREFIX SKIP
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    v) VERBOSE=yes ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	color) COLORIZE=yes ;;
+	dry-run) DRYRUN=yes ;;
+	verbose) VERBOSE=yes ;;
+	no-legend) LEGEND=no ;;
+	skip-apt) SKIP="$SKIP apt" ;;
+	skip-yum) SKIP="$SKIP yum" ;;
+	skip-other) SKIP="$SKIP other" ;;
+	product|product=*) optparse PRODUCT "$@" ;;
+        version|version=*) optparse VERSION "$@" ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+validate_product "$PRODUCT"
+
+[[ -n $VERSION ]] || usage 'must specify a version'
+[[ -n $PREFIX  ]] || usage 'must specify a prefix'
+[[ -d $PREFIX  ]] || usage 'directory not found:' "$PREFIX"
+
+declare -r SPEC="archive/$PRODUCT"
+declare -r DEST=$(repopath -d "$VERSION" "archive/$PRODUCT")
+
+#
+# Wraps cp but adds support for dry-run.
+#
+#   $1 - source file to copy
+#
+copy_file() {
+  local STATUS NAME
+  
+  STATUS=A
+  NAME=$(basename "$1")
+
+  [[ -e "$DEST/$NAME" ]] && STATUS=M
+
+  vprintf '%s [%s] %s\n' $STATUS "$SPEC" "$NAME"
+
+  if [[ $DRYRUN = no ]]; then
+    cp "$1" "$DEST"
+  fi
+}
+
+#
+# Marks a file as skipped
+#
+#   $1 - name of skipped file
+#
+skip_file() {
+  local NAME
+
+  NAME=$(basename "$1")
+  vprintf 'S [%s] %s\n' "$SPEC" "$NAME"
+}
+
+process_files() {
+  {
+    if [[ ! -e "$DEST" ]]; then
+      vprintf 'C [%s] %s\n' "$SPEC" "$DEST/"
+      if [[ $DRYRUN = no ]]; then
+	mkdir -p "$DEST"
+      fi
+    fi
+
+    while [[ $# -gt 0 ]]; do
+      PKG=$1; shift
+
+      case $PKG in
+	*.deb)
+	  if [[ $SKIP != *apt* ]]; then
+	    copy_file "$PKG" "$DEST"
+	  else
+	    skip_file "$PKG" "$DEST"
+	  fi
+	  ;;
+	*.rpm)
+	  if [[ $SKIP != *yum* ]]; then
+	    copy_file "$PKG" "$DEST"
+	  else
+	    skip_file "$PKG" "$DEST"
+	  fi
+	  ;;
+	*)
+	  if [[ $SKIP != *other* ]]; then
+	    copy_file "$PKG" "$DEST"
+	  else
+	    skip_file "$PKG" "$DEST"
+	  fi
+	  ;;
+      esac
+    done
+  } | column -t
+}
+
+COLORIZE_CMD=(sed)
+
+# Prefer unbuffered output (-u) when available.
+if [[ "$(uname -s)" != Darwin ]]; then
+  COLORIZE_CMD+=(-u)
+fi
+
+COLORIZE_CMD+=(-f "$DEPLOY_HOME/libexec/colorize-changes.sed")
+
+if [[ $COLORIZE = yes ]]; then
+  process_files "$@" | "${COLORIZE_CMD[@]}"
+else
+  process_files "$@"
+fi
+
+if [[ $LEGEND = yes ]]; then
+  vprintf \\n
+  vprintf 'A = add, C = create, D = delete, M = modify, S = skip\n'
+fi
+
+exit

--- a/deploy/linux/deploy_scripts/libexec/repoman-demote.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-demote.bash
@@ -1,0 +1,220 @@
+#!/bin/bash
+# repoman-demote.bash - remove build artifacts from a repository
+
+### Usage: repoman-demote.bash --product=<name> --destination=<name>
+###                            --prefix=<dir> [--skip-apt] [--skip-yum]
+###                            [--skip-other] [--color] [--no-legend]
+###                            [-n | --dry-run] [-v | --verbose] [--]
+###                            <file>...
+###        repoman-demote.bash [--help]
+###
+### Arguments:
+###    <file>...              files to demote
+###
+### Options:
+###    --product=<product>    product (php_agent or server_monitor)
+###    --destination=<name>   where the files should be demoted
+###    --prefix=<dir>         path to the directory containing the repository
+###    --skip-apt             do not perform APT repository updates
+###    --skip-yum             do not perform YUM repository updates
+###    --skip-other           do not perform product repository updates
+###    --color                colorize the output
+###    --no-legend            suppress output of legend
+###    -v, --verbose          cause demote to be verbose
+###    -n, --dry-run          don't actually demote the files, just show the
+###                           steps that would be performed
+###    --help                 print this message and exit
+###
+
+set -e
+
+export ACTION
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare DRYRUN=no VERBOSE=no COLORIZE=no LEGEND=yes
+declare PRODUCT DESTINATION PREFIX SKIP REBUILD
+
+[[ $# -gt 0 ]] || usage
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    v) VERBOSE=yes ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	color) COLORIZE=yes ;;
+	dry-run) DRYRUN=yes ;;
+	verbose) VERBOSE=yes ;;
+	no-legend) LEGEND=no ;;
+	skip-apt) SKIP="$SKIP apt" ;;
+	skip-yum) SKIP="$SKIP yum" ;;
+	skip-other) SKIP="$SKIP other" ;;
+	product|product=*) optparse PRODUCT "$@" ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	destination|destination=*) optparse DESTINATION "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+validate_product "$PRODUCT"
+
+[[ -n $PREFIX      ]] || usage 'must specify a prefix'
+[[ -d $PREFIX      ]] || usage 'directory not found:' "$PREFIX"
+[[ -n $DESTINATION ]] || usage 'must specify a destination'
+
+#
+# Wraps rm but adds support for dry-run.
+#
+#   $1 - repository specification (e.g. production/debian)
+#   $2 - source file
+#
+remove_file() {
+  local NAME
+
+  NAME=$(basename "$2")
+  vprintf 'D [%s] %s\n' "$1" "$NAME"
+
+  if [[ $DRYRUN = no ]]; then
+    rm -f "$2"
+    if [[ -z $REBUILD ]]; then
+      REBUILD=$1
+    elif [[ $REBUILD != *"$1"* ]]; then
+      REBUILD=$REBUILD:$1
+    fi
+  fi
+}
+
+#
+# Marks a file as skipped
+#
+#   $1 - repository specification (e.g. production/debian)
+#   $2 - source file
+#
+skip_file() {
+  local NAME
+
+  NAME=$(basename "$2")
+  vprintf 'S [%s] %s\n' "$1" "$NAME"
+}
+
+#
+# Demote product files into the destination repository.
+#
+#   $* - package files
+#
+demote_file() {
+  local SPEC
+
+  SPEC="$DESTINATION/$PRODUCT"
+
+  while [[ $# -gt 0 ]]; do
+    if [[ $SKIP != *other* ]]; then
+      remove_file "$SPEC" "$1"
+    else
+      skip_file "$SPEC" "$1"
+    fi
+    shift
+  done
+}
+
+#
+# Demote DEB packages into the destination repository.
+#
+#   $* - package files
+#
+demote_deb() {
+  local SPEC PACKAGE
+
+  SPEC="$DESTINATION/debian"
+
+  while [[ $# -gt 0 ]]; do
+    PACKAGE=$1; shift
+
+    if [[ $SKIP != *apt* ]]; then
+      case $PACKAGE in
+	*.deb) remove_file "$SPEC" "$PACKAGE" ;;
+	*) skip_file "$SPEC" "$PACKAGE" ;;
+      esac
+    else
+      skip_file "$SPEC" "$PACKAGE"
+    fi
+  done
+}
+
+#
+# Demote RPM packages into the destination repository.
+#
+#   $1 - package to demote
+#
+demote_rpm() {
+  local SPEC PACKAGE
+
+  SPEC="$DESTINATION/redhat"
+
+  while [[ $# -gt 0 ]]; do
+    PACKAGE=$1; shift
+
+    if [[ $SKIP != *yum* ]]; then
+      case $PACKAGE in
+	*.rpm) remove_file "$SPEC" "$PACKAGE" ;;
+	*) skip_file "$SPEC" "$PACKAGE" ;;
+      esac
+    else
+      skip_file "$SPEC" "$PACKAGE"
+    fi
+  done
+}
+
+OUTFILE=$(mktemp -t demote.XXXXXX)
+trap 'rm -f $OUTFILE' EXIT
+
+while [[ $# -gt 0 ]]; do
+  PKG=$1; shift
+
+  case $PKG in
+    *.deb) demote_deb "$PKG" ;;
+    *.rpm) demote_rpm "$PKG" ;;
+    *) demote_file "$PKG" ;;
+  esac
+done > "$OUTFILE"
+
+COLORIZE_CMD=(sed)
+
+# Prefer unbuffered output (-u) when available.
+if [[ "$(uname -s)" != Darwin ]]; then
+  COLORIZE_CMD+=(-u)
+fi
+
+COLORIZE_CMD+=(-f "$DEPLOY_HOME/libexec/colorize-changes.sed")
+
+if [[ $COLORIZE = yes ]]; then
+  sort "$OUTFILE" -k 2 | column -t | "${COLORIZE_CMD[@]}"
+else
+  sort "$OUTFILE" -k 2 | column -t
+fi
+
+if [[ $LEGEND = yes ]]; then
+  vprintf \\n
+  vprintf 'A = add, C = create, D = delete, M = modify, S = skip\n'
+fi
+
+if [[ $DRYRUN = no ]]; then
+  IFS=: read -ra SPECS <<< "$REBUILD"
+  "$DEPLOY_HOME/libexec/repoman-rebuild.bash" --prefix="$PREFIX" "${SPECS[@]}"
+fi
+
+exit

--- a/deploy/linux/deploy_scripts/libexec/repoman-path.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-path.bash
@@ -1,0 +1,152 @@
+#!/bin/bash
+# repoman-path.bash - print the path to a repository
+
+### Usage: repoman-path.bash [--prefix=<dir>] [-d <name>] [-a <arch>] [--] <spec>
+###        repoman-path.bash [--help]
+###
+### Arguments:
+###   <spec>                     repository specification (e.g. production/debian)
+###
+### Options:
+###   -d <name>, --dist=<name>   repository distribution (e.g. non-free, el5)
+###   -a <arch>, --arch=<arch>   repository architecture (e.g. i386)
+###   --prefix=<dir>             path to the directory containing the repository
+###   --help                     print this message and exit
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare SPEC DIST ARCH PREFIX REPOPATH
+
+while getopts ':a:d:-:' OPTNAME; do
+  case $OPTNAME in
+    a) ARCH=$OPTARG ;;
+    d) DIST=$OPTARG ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	arch|arch=*) optparse ARCH "$@" ;;
+	dist|dist=*) optparse DIST "$@" ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+SPEC=$1
+
+[[ -n $SPEC ]] || usage 'must specify a repository'
+
+#
+# Construct the path to an APT repository.
+#
+apt_path() {
+  local APTPATH
+
+  case $SPEC in
+    production/*) APTPATH="$SPEC/dists/newrelic" ;;
+    */*) APTPATH="$SPEC/dists/newrelic-${SPEC%/*}" ;;
+  esac
+
+  if [[ -n $DIST ]]; then
+    APTPATH="$APTPATH/$DIST"
+  fi
+
+  if [[ -n $ARCH ]]; then
+    if [[ -z $DIST ]]; then
+      die 'a distribution is required to specify an architecture'
+    fi
+    APTPATH="$APTPATH/binary-$ARCH"
+  fi
+
+  echo "$APTPATH"
+}
+
+#
+# Construct the path to a YUM repository.
+#
+yum_path() {
+  local YUMPATH
+
+  case $SPEC in
+    production/*) YUMPATH="${SPEC%/*}/pub/newrelic" ;;
+    */*) YUMPATH="${SPEC%/*}/pub/newrelic-${SPEC%/*}" ;;
+  esac
+
+  if [[ -n $DIST ]]; then
+    YUMPATH="$YUMPATH/$DIST"
+  fi
+
+  if [[ -n $ARCH ]]; then
+    if [[ -z $DIST ]]; then
+      die 'a distribution is required to specify an architecture'
+    fi
+    YUMPATH="$YUMPATH/$ARCH"
+  fi
+
+  echo "$YUMPATH"
+}
+
+#
+# Construct the path to a product archive.
+#
+archive_path() {
+  local ARPATH="production/${SPEC#*/}/archive"
+
+  [[ -z $ARCH ]] || die 'architecture not supported for archives'
+
+  if [[ -n $DIST ]]; then
+    ARPATH="$ARPATH/$DIST"
+  fi
+
+  echo "$ARPATH"
+}
+
+#
+# Construct the path to a product file repository.
+#
+product_path() {
+  [[ -z $ARCH ]] || die 'architecture not supported for product repositories'
+  [[ -z $DIST ]] || die 'distribution not supported for product repositories'
+
+  case $SPEC in
+    production/*)
+      echo "$SPEC/release" ;;
+    */*)
+      echo "$SPEC/${SPEC%/*}" ;;
+  esac
+}
+
+# SPEC should have the form repository/type_or_product
+if [[ ${SPEC#*/} = */* ]]; then
+  die 'invalid repository specification:' "$SPEC"
+fi
+
+case $SPEC in
+  archive/*) REPOPATH="$(archive_path)" ;;
+  */debian) REPOPATH="$(apt_path)" ;;
+  */redhat) REPOPATH="$(yum_path)" ;;
+  */*) REPOPATH="$(product_path)" ;;
+  *) die 'invalid repository specification:' "$SPEC"
+esac
+
+if [[ -n $PREFIX ]]; then
+  echo "${PREFIX%%/}/$REPOPATH"
+else
+  echo "$REPOPATH"
+fi
+
+exit

--- a/deploy/linux/deploy_scripts/libexec/repoman-promote.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-promote.bash
@@ -1,0 +1,258 @@
+#!/bin/bash
+# repoman-promote.bash - promote build artifacts from one deployment stage to another
+
+### Usage: repoman-promote.bash --product=<product> --destination=<name>
+###                             --prefix=<dir> [--skip-apt] [--skip-yum]
+###                             [--skip-other] [--color] [--no-legend]
+###                             [-n | --dry-run] [-v | --verbose] [--]
+###                             <file>...
+###        repoman-promote.bash [--help]
+###
+### Arguments:
+###    <file>...              files to promote
+###
+### Options:
+###    --product=<product>    product (php_agent or server_monitor)
+###    --destination=<name>   where the files should be promoted
+###    --prefix=<dir>         path to the directory containing the repository
+###    --skip-apt             do not perform APT repository updates
+###    --skip-yum             do not perform YUM repository updates
+###    --skip-other           do not perform product repository updates
+###    --color                colorize the output
+###    --no-legend            suppress output of legend
+###    -v, --verbose          cause promote to be verbose
+###    -n, --dry-run          don't actually promote the build, just show the
+###                           steps that would be performed
+###    --help                 print this message and exit
+###
+
+set -e
+
+export ACTION
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+#
+# Print the path to a repository
+#
+repopath() {
+  "$DEPLOY_HOME/libexec/repoman-path.bash" --prefix="$PREFIX" "$@"
+}
+
+declare DRYRUN=no VERBOSE=no COLORIZE=no LEGEND=yes
+declare PRODUCT DESTINATION PREFIX SKIP REBUILD
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    v) VERBOSE=yes ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	color) COLORIZE=yes ;;
+	dry-run) DRYRUN=yes ;;
+	verbose) VERBOSE=yes ;;
+	no-legend) LEGEND=no ;;
+	skip-apt) SKIP="$SKIP apt" ;;
+	skip-yum) SKIP="$SKIP yum" ;;
+	skip-other) SKIP="$SKIP other" ;;
+	product|product=*) optparse PRODUCT "$@" ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	destination|destination=*) optparse DESTINATION "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+[[ -n $PREFIX      ]] || usage 'must specify a prefix'
+[[ -d $PREFIX      ]] || usage 'directory not found:' "$PREFIX"
+[[ -n $DESTINATION ]] || usage 'must specify a destination'
+
+validate_product "$PRODUCT"
+
+#
+# Wraps cp but adds support for dry-run.
+#
+#   $1 - repository specification (e.g. production/debian)
+#   $2 - source file
+#   $3 - destination
+#
+copy_file() {
+  local STATUS NAME
+
+  STATUS=A
+  NAME=$(basename "$2")
+
+  if [[ -d $3 ]]; then
+    [[ -e "$3/$NAME" ]] && STATUS=M
+  elif [[ -e $3 ]]; then
+    STATUS=M
+  fi
+
+  vprintf '%s [%s] %s\n' $STATUS "$1" "$NAME"
+
+  if [[ $DRYRUN = no ]]; then
+    mkdir -p "$3"
+    cp "$2" "$3"
+    if [[ -z $REBUILD ]]; then
+      REBUILD=$1
+    elif [[ $REBUILD != *"$1"* ]]; then
+      REBUILD=$REBUILD:$1
+    fi
+  fi
+}
+
+#
+# Marks a file as skipped
+#
+skip_file() {
+  local NAME
+
+  NAME=$(basename "$2")
+  vprintf 'S [%s] %s\n' "$1" "$NAME"
+}
+
+#
+# Promote product files into the destination repository.
+#
+#   $* - package files
+#
+promote_file() {
+  local SPEC
+
+  SPEC="$DESTINATION/$PRODUCT"
+
+  while [[ $# -gt 0 ]]; do
+    if [[ $SKIP != *other* ]]; then
+      copy_file "$SPEC" "$1" "$(repopath "$SPEC")"
+    else
+      skip_file "$SPEC" "$1"
+    fi
+    shift
+  done
+}
+
+#
+# Promote DEB packages into the destination repository.
+#
+#   $* - package files
+#
+promote_deb() {
+  local SPEC ARCH_amd64 ARCH_i386 PACKAGE
+
+  SPEC="$DESTINATION/debian"
+  ARCH_amd64=$(repopath -d non-free -a amd64 "$SPEC")
+  ARCH_i386=$(repopath -d non-free -a i386 "$SPEC")
+
+  while [[ $# -gt 0 ]]; do
+    PACKAGE=$1; shift
+
+    if [[ $SKIP != *apt* ]]; then
+      case $PACKAGE in
+	*_amd64.deb)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_amd64"
+          ;;
+	*_i386.deb)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_i386"
+          ;;
+	*_all.deb)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_amd64"
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_i386"
+          ;;
+	*)
+	  skip_file "$SPEC" "$PACKAGE"
+          ;;
+      esac
+    else
+      skip_file "$SPEC" "$PACKAGE"
+    fi
+  done
+}
+
+#
+# Promote RPM packages into the destination repository.
+#
+#   $1 - package to promote
+#
+promote_rpm() {
+  local SPEC ARCH_amd64 ARCH_i386 PACKAGE
+
+  SPEC="$DESTINATION/redhat"
+  ARCH_amd64=$(repopath -d el7 -a x86_64 "$SPEC")
+  ARCH_i386=$(repopath -d el7 -a i386 "$SPEC")
+
+  while [[ $# -gt 0 ]]; do
+    PACKAGE=$1; shift
+
+    if [[ $SKIP != *yum* ]]; then
+      case $PACKAGE in
+	*.x86_64.rpm)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_amd64"
+          ;;
+	*.i386.rpm)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_i386"
+          ;;
+	*.noarch.rpm)
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_amd64"
+          copy_file "$SPEC" "$PACKAGE" "$ARCH_i386"
+          ;;
+	*)
+          skip_file "$SPEC" "$PACKAGE"
+          ;;
+      esac
+    else
+      skip_file "$SPEC" "$PACKAGE"
+    fi
+  done
+}
+
+OUTFILE=$(mktemp -t promote.XXXXXX)
+trap 'rm -f $OUTFILE' EXIT
+
+while [[ $# -gt 0 ]]; do
+  PKG=$1; shift
+
+  case $PKG in
+    *.deb) promote_deb "$PKG" ;;
+    *.rpm) promote_rpm "$PKG" ;;
+    *) promote_file "$PKG" ;;
+  esac
+done > "$OUTFILE"
+
+COLORIZE_CMD=(sed)
+
+# Prefer unbuffered output (-u) when available.
+if [[ "$(uname -s)" != Darwin ]]; then
+  COLORIZE_CMD+=(-u)
+fi
+
+COLORIZE_CMD+=(-f "$DEPLOY_HOME/libexec/colorize-changes.sed")
+
+if [[ $COLORIZE = yes ]]; then
+  sort "$OUTFILE" -k 2 | column -t | "${COLORIZE_CMD[@]}"
+else
+  sort "$OUTFILE" -k 2 | column -t
+fi
+
+if [[ $LEGEND = yes ]]; then
+  vprintf \\n
+  vprintf 'A = add, C = create, D = delete, M = modify, S = skip\n'
+fi
+
+if [[ $DRYRUN = no ]]; then
+  IFS=: read -ra SPECS <<< "$REBUILD"
+  "$DEPLOY_HOME/libexec/repoman-rebuild.bash" --prefix="$PREFIX" "${SPECS[@]}"
+fi
+
+exit

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -1,0 +1,129 @@
+#!/bin/bash
+# repoman-rebuild.bash - scan a repository for changes
+
+### Usage: repoman-rebuild.bash --prefix=<dir> [--] <spec>...
+###        repoman-rebuild.bash [--help]
+###
+### Arguments:
+###   <spec>                     repository specification (e.g. production/debian)
+###
+### Options:
+###   -d <name>, --dist=<name>   repository distribution (e.g. non-free, el5)
+###   --prefix=<dir>             path to the directory containing the repository
+###   --help                     print this message and exit
+###
+
+set -e
+
+export TARGET
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+#
+# Print the path to a repository
+#
+repopath() {
+  "$DEPLOY_HOME/libexec/repoman-path.bash" --prefix="$PREFIX" "$@"
+}
+
+declare PREFIX SPEC
+
+while getopts ':-:' OPTNAME; do
+  case $OPTNAME in
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+[[ -n $PREFIX ]] || usage 'must specify a prefix'
+[[ -d $PREFIX ]] || usage 'directory not found:' "$PREFIX"
+
+#
+# Rescan an APT repository to pick-up any changes.
+#
+#   $1 - repository specification
+#
+rebuild_apt() (
+  printf \\n
+
+  REPO_DIR=$(repopath "$1")
+  REPO=$(basename "$REPO_DIR")
+
+  pushd "$REPO_DIR/../.." >/dev/null
+
+  config_files_root='/data/deploy_scripts/conf'
+  release_conf_file="${config_files_root}/release.conf"
+  generate_conf_file="${config_files_root}/generate.conf"
+  if [[ "$TARGET" == "testing" ]]
+  then
+    release_conf_file="${config_files_root}/release-testing.conf"
+    generate_conf_file="${config_files_root}/generate-testing.conf"
+  fi
+  apt-ftparchive generate -c "$release_conf_file" "$generate_conf_file"
+  apt-ftparchive release  -c "$release_conf_file" "dists/$REPO" > "dists/$REPO/Release"
+
+  tar -xjvf "$GPG_KEYS"
+
+  rm -f "dists/$REPO/Release.gpg"
+
+  gpg -abs --digest-algo SHA256 --keyring gpg-conf/pubring.gpg --secret-keyring gpg-conf/secring.gpg -o "dists/$REPO/Release.gpg" "dists/$REPO/Release"
+  chmod 644 dists/"$REPO"/Contents-*.{gz,bz2}
+
+  popd >/dev/null
+)
+
+#
+# Rescan a YUM repository to pick-up any changes.
+#
+#   $1 - repository specification
+#
+rebuild_yum() {
+   local ARCH REPO_DIR
+
+  for ARCH in x86_64; do
+    REPO_DIR=$(repopath -d el7 -a $ARCH "$1")
+
+    printf \\n
+    if [[ -d "$REPO_DIR" ]]; then
+      createrepo --update --checksum sha "$REPO_DIR"
+    fi
+  done
+}
+
+SED_ARGS=()
+
+# Prefer unbuffered output (-u) when available.
+if [[ "$(uname -s)" != Darwin ]]; then
+    SED_ARGS+=(-u)
+fi
+
+for SPEC; do
+  case $SPEC in
+    */debian)
+      rebuild_apt "$SPEC" 2>&1 | sed "${SED_ARGS[@]}" -e "/./ { s|^|[$SPEC] | }"
+      ;;
+    */redhat)
+      rebuild_yum "$SPEC" 2>&1 | sed "${SED_ARGS[@]}" -e "/./ { s|^|[$SPEC] | }"
+      ;;
+    *)
+      if [[ -n "$SPEC" ]]; then
+        printf \\n
+        printf '[%s]  nothing to do\n' "$SPEC"
+      fi
+      ;;
+  esac
+done

--- a/deploy/linux/deploy_scripts/libexec/s3-pull.bash
+++ b/deploy/linux/deploy_scripts/libexec/s3-pull.bash
@@ -1,0 +1,75 @@
+#!/bin/bash
+# s3-pull.bash - update local working copy by syncronizing with S3
+
+### Usage: s3-pull.bash [-n | --dry-run] --prefix=<dir> <bucket> <repo>
+###        s3-pull.bash --help
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare DRYRUN=no
+declare PREFIX
+declare SOURCE_BUCKET
+declare TARGET
+
+while getopts ':n-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	dry-run) DRYRUN=yes ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+SOURCE_BUCKET=$1
+TARGET=$2
+
+[[ $# -gt 2 ]] && usage 'wrong number of parameters'
+
+[[ -n $PREFIX ]] || usage 'must specify a prefix'
+[[ -n $SOURCE_BUCKET ]] || usage 'must specify a source bucket'
+[[ -n $TARGET ]] || usage 'must specify a repo'
+[[ -d $PREFIX ]] || usage 'directory not found:' "$PREFIX"
+
+SYNC_EXTRA_ARGS=()
+
+if [[ $DRYRUN = 'yes' ]]; then
+  SYNC_EXTRA_ARGS+=(--dryrun)
+fi
+
+# Be careful when making changes below. The aws tool is sensitive to the order
+# of the --include and --exclude options. In short, the last match wins.
+#
+# See: http://docs.aws.amazon.com/cli/latest/reference/s3/index.html#use-of-exclude-and-include-filters
+
+printf '>>> synchronizing local copy %s with latest changes from %s\n' "$PREFIX/$TARGET" "$SOURCE_BUCKET"
+printf '\n'
+
+  aws s3 sync \
+    "${SYNC_EXTRA_ARGS[@]}" \
+    --delete \
+    '--exclude=*' \
+    '--include=debian/dists/*' \
+    '--include=pub/*' \
+    '--exclude=*.DS_Store' \
+    "$SOURCE_BUCKET" \
+    "$PREFIX/$TARGET" 
+
+

--- a/deploy/linux/deploy_scripts/libexec/s3-push.bash
+++ b/deploy/linux/deploy_scripts/libexec/s3-push.bash
@@ -1,0 +1,149 @@
+#!/bin/bash
+# s3-push.bash - push contents of local working copy to S3
+
+### Usage: s3-push.bash --prefix=<dir> [-n | --dry-run] [--] <repo> <bucket>
+###        s3-push.bash [--help]
+###
+### Arguments:
+###    <repo>        repo to deploy (e.g. production, testing)
+###    <bucket>      name of s3 bucket to push to
+###
+### Options:
+###    --product       product to publish (php_agent or server_monitor)
+###    --prefix        directory prefix for the repository
+###                    to publish
+###    --help          show this message and exit
+###    -n, --dry-run   don't actually publish the content, just show the
+###                    steps that would be performed
+###
+
+set -e
+
+if [[ ! -d $DEPLOY_HOME ]]; then
+  printf '%s: DEPLOY_HOME is not defined\n' "$(basename "$0")" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+declare DRYRUN=no
+declare PREFIX TARGET SOURCE_DIR DEST_BUCKET
+
+[[ $# -eq 0 ]] && usage
+
+while getopts ':n-:' OPTNAME; do
+  case $OPTNAME in
+    n) DRYRUN=yes ;;
+    -)
+      case $OPTARG in
+	'help')	usage ;;
+	dry-run) DRYRUN=yes ;;
+	product|product=*) optparse PRODUCT "$@" ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+  *) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+TARGET=$1
+DEST_BUCKET=$2
+
+[[ $# -gt 2 ]] && usage 'wrong number of parameters'
+
+[[ -n $TARGET ]] || usage 'must specify a target'
+[[ -n $PREFIX ]] || usage 'must specify a prefix'
+[[ -n $DEST_BUCKET ]] || usage 'must specify a destination bucket'
+[[ -d $PREFIX ]] || die 'directory not found:' "$PREFIX"
+
+validate_product "$PRODUCT"
+
+case $TARGET in
+  production)
+    SOURCE_DIR="$PREFIX/$TARGET"
+    #DEST_BUCKET='PROD_TEST_S3'
+    ;;
+  testing)
+    SOURCE_DIR="$PREFIX/$TARGET"
+    #DEST_BUCKET='TEST_TEST_S3'
+    ;;
+  *)
+    die 'target must be production or testing'
+    ;;
+esac
+
+SYNC_EXTRA_ARGS=()
+
+if [[ $DRYRUN = 'yes' ]]; then
+  SYNC_EXTRA_ARGS+=(--dryrun)
+fi
+
+# Synchronizing local changes to S3 requires some subtlety. S3 does not
+# support transactional updates nor does it support atomic writes. This means
+# that clients can observe partially updated files! We attempt to workaround
+# these limitations as best we can by observing that once published, package
+# files should not be modified. Hence, the only modified files should be the
+# metadata files that describe the contents of the repository to tools like
+# APT and YUM. Files not described in those metadata files are invisible to
+# those tools. Therefore, we perform the synchronization in three phases:
+#
+#   1. Upload new package files.
+#   2. Upload modified package repository metadata files.
+#   3. Remove deleted package files.
+#
+# Currently, we do not workaround the problem of observed partial writes.
+# It is expected that the modified files are small enough and deploys rare
+# enough to reduce the time window during which a partial update can be
+# observed such that, in practice, no clients will be negatively affected.
+
+# Be careful when making changes below. The aws tool is sensitive to the order
+# of the --include and --exclude options. In short, the last match wins.
+#
+# See: http://docs.aws.amazon.com/cli/latest/reference/s3/index.html#use-of-exclude-and-include-filters
+
+printf 'publishing package files\n'
+printf '\n'
+
+aws s3 sync "${SYNC_EXTRA_ARGS[@]}" \
+    '--exclude=*' \
+    '--include=debian/dists/*' \
+    '--exclude=debian/dists/*/Contents*' \
+    '--exclude=debian/dists/*/Packages*' \
+    '--exclude=debian/dists/*/Release*' \
+    '--include=pub/*' \
+    '--exclude=pub/*/repodata/*' \
+    "--include=$PRODUCT/*" \
+    '--exclude=*.DS_Store' \
+    "$SOURCE_DIR" \
+    "$DEST_BUCKET"
+
+printf '\n'
+printf 'publishing package indexes\n'
+printf '\n'
+
+aws s3 sync "${SYNC_EXTRA_ARGS[@]}" \
+    '--exclude=*' \
+    '--include=debian/dists/*' \
+    '--include=pub/*' \
+    "--include=$PRODUCT/*" \
+    '--exclude=*.DS_Store' \
+    "$SOURCE_DIR" \
+    "$DEST_BUCKET"
+
+printf '\n'
+printf 'unpublishing unreferenced package files\n'
+printf '\n'
+
+aws s3 sync "${SYNC_EXTRA_ARGS[@]}" --delete \
+    '--exclude=*' \
+    '--include=debian/dists/*' \
+    '--include=pub/*' \
+    "--include=$PRODUCT/*" \
+    '--exclude=*.DS_Store' \
+    "$SOURCE_DIR" \
+    "$DEST_BUCKET"

--- a/deploy/linux/deploy_scripts/lint.bash
+++ b/deploy/linux/deploy_scripts/lint.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+: "${SHELLCHECK:=shellcheck}"
+
+if ! command -v "$SHELLCHECK" > /dev/null; then
+  printf 'shellcheck is required to run this script\n' >&2
+  printf 'see: https://github.com/koalaman/shellcheck\n' >&2
+
+  if [[ "$(uname -s)" = Darwin ]]; then
+    printf \\n >&2
+    printf 'shellcheck is available from Homebrew: brew install shellcheck\n' >&2
+  fi
+
+  exit 1
+fi
+
+"$SHELLCHECK" -s bash -x ./*.sh scripts/*.sh

--- a/deploy/linux/deploy_scripts/puppet/manifests/site.pp
+++ b/deploy/linux/deploy_scripts/puppet/manifests/site.pp
@@ -1,0 +1,34 @@
+#
+# Provisioning for PHP/LSM deploy VM
+#
+
+class { 'timezone':
+  timezone => 'America/Los_Angeles'
+}
+
+# APT repo mgmt
+package { "apt-utils":
+  ensure => installed
+}
+
+# YUM repo mgmt
+package { "createrepo":
+  ensure => installed
+}
+
+# Used by deploy scripts to gather build artifacts from Jenkins.
+file { ["/vagrant/builds"]:
+  ensure => "directory",
+  mode   => 0755,
+  owner  => vagrant,
+  group  => vagrant
+}
+
+# Contains the APT, YUM, and product file repositories that will be
+# published to CHI as the final deploy step.
+file { ["/vagrant/staging"]:
+  ensure => "directory",
+  mode   => 0755,
+  owner  => vagrant,
+  group  => vagrant
+}

--- a/deploy/linux/deploy_scripts/puppet/modules/timezone/manifests/init.pp
+++ b/deploy/linux/deploy_scripts/puppet/modules/timezone/manifests/init.pp
@@ -1,0 +1,82 @@
+# Class: timezone
+#
+# This module manages timezone settings
+#
+# Parameters:
+#   [*timezone*]
+#     The name of the timezone.
+#     Default: UTC
+#
+#   [*ensure*]
+#     Ensure if present or absent.
+#     Default: present
+#
+#   [*autoupgrade*]
+#     Upgrade package automatically, if there is a newer version.
+#     Default: false
+#
+#   [*package*]
+#     Name of the package.
+#     Only set this, if your platform is not supported or you know, what you're doing.
+#     Default: auto-set, platform specific
+#
+#   [*config_file*]
+#     Main configuration file.
+#     Only set this, if your platform is not supported or you know, what you're doing.
+#     Default: auto-set, platform specific
+#
+#   [*zoneinfo_dir*]
+#     Source directory of zoneinfo files.
+#     Only set this, if your platform is not supported or you know, what you're doing.
+#     Default: auto-set, platform specific
+#
+# Actions:
+#   Installs tzdata and configures timezone
+#
+# Requires:
+#   Nothing
+#
+# Sample Usage:
+#   class { 'timezone':
+#     timezone => 'Europe/Berlin',
+#   }
+#
+# [Remember: No empty lines between comments and class definition]
+class timezone (
+  $timezone = 'UTC',
+  $ensure = 'present',
+  $autoupgrade = false,
+  $package = $timezone::params::package,
+  $config_file = $timezone::params::config_file,
+  $zoneinfo_dir = $timezone::params::zoneinfo_dir
+) inherits timezone::params {
+
+  case $ensure {
+    /(present)/: {
+      if $autoupgrade == true {
+        $package_ensure = 'latest'
+      } else {
+        $package_ensure = 'present'
+      }
+      $config_ensure = 'link'
+    }
+    /(absent)/: {
+      # Leave package installed, as it is a system dependency
+      $package_ensure = 'present'
+      $config_ensure = 'absent'
+    }
+    default: {
+      fail('ensure parameter must be present or absent')
+    }
+  }
+
+  package { $package:
+    ensure => $package_ensure,
+  }
+
+  file { $config_file:
+    ensure  => $config_ensure,
+    target  => "${zoneinfo_dir}${timezone}",
+    require => Package[$package],
+  }
+}

--- a/deploy/linux/deploy_scripts/puppet/modules/timezone/manifests/params.pp
+++ b/deploy/linux/deploy_scripts/puppet/modules/timezone/manifests/params.pp
@@ -1,0 +1,12 @@
+class timezone::params {
+  case $::operatingsystem {
+    /(Ubuntu|Debian|Gentoo|CentOS|Amazon)/: {
+      $package = 'tzdata'
+      $zoneinfo_dir = '/usr/share/zoneinfo/'
+      $config_file = '/etc/localtime'
+    }
+    default: {
+      fail("Unsupported platform: ${::operatingsystem}")
+    }
+  }
+}

--- a/deploy/linux/deploy_scripts/rollback.bash
+++ b/deploy/linux/deploy_scripts/rollback.bash
@@ -1,0 +1,180 @@
+#!/bin/bash
+# rollback.bash - rollback a product release
+
+### Usage: rollback.bash --prefix=<dir> --product=<name> <target> <version>
+###        rollback.bash [--help]
+###
+### Arguments:
+###   <target>              target repository (production or testing)
+###   <version>             agent version to rollback
+###
+### Options:
+###   --prefix=<dir>        path to the directory containing the archive
+###   --product=<name>      product (php_agent or server_monitor)
+###   --help                print this message and exit
+###
+### Description:
+###
+###   Rolling back a release proceeds in three phases: pull, modify, push.
+###   The three phases are designed to ensure the rollback process is safe,
+###   reliable, and atomic. i.e. Changes should not be visible to customers
+###   unless they are both complete and correct. To achieve these goals, this
+###   script never makes direct changes to the public download website.
+###
+###   The first phase, the "pull" phase, ensures that a local copy of the
+###   download site is available and up-to-date. The download site is
+###   backed by Amazon S3, so this phase uses the AWS CLI[0] tools to
+###   synchronize the local copy with the current contents of the public
+###   download site. Warning: Synchronizing will remove any files present
+###   in the local copy, but not present on the download site.
+###   See libexec/s3-pull.bash for details.
+###
+###   The second phase, the "modify" phase, performs the real work of
+###   rolling back a release. During this phase, each of the files comprising
+###   an agent release is removed from the local copy. Additionally, the Debian
+###   and Redhat package repositories are re-indexed and digitally signed.
+###   See libexec/repoman-*.bash for details.
+###
+###   The third and final phase, the "push" phase, completes the rollback.
+###   This phase uploads the changes made during the "modify" phase to the
+###   download site. As in the "pull" phase, the AWS CLI[0] tools are used
+###   perform the synchronization. See libexec/s3-push.bash for details.
+###
+###   [0] https://aws.amazon.com/cli/
+###
+
+set -e
+
+# Determine our location in the filesystem.
+# See: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+pushd . > /dev/null
+  DEPLOY_HOME=${BASH_SOURCE[0]}
+
+  if [[ -h $DEPLOY_HOME ]]; then
+    while [[ -h $DEPLOY_HOME ]]; do
+      cd "$(dirname "$DEPLOY_HOME")"
+      DEPLOY_HOME=$(readlink "$DEPLOY_HOME")
+    done
+  fi
+
+  cd "$(dirname "$DEPLOY_HOME")" > /dev/null
+  DEPLOY_HOME=$(pwd)
+popd > /dev/null
+
+export DEPLOY_HOME
+
+# shellcheck source=lib/common.bash
+source "$DEPLOY_HOME/lib/common.bash"
+
+#
+# Print the path to a repository
+#
+repopath() {
+  "$DEPLOY_HOME/libexec/repoman-path.bash" --prefix="$PREFIX" "$@"
+}
+
+#
+# Print the files associated with the current product and version.
+#
+findpkgs() {
+  local PRODUCT_REPO APT_REPO YUM_REPO
+
+  PRODUCT_REPO=$(repopath "$TARGET/$PRODUCT")
+  APT_REPO=$(repopath "$TARGET/debian")
+  YUM_REPO=$(repopath --dist=el7 "$TARGET/redhat")
+
+  case $PRODUCT in
+    php_agent)
+      find "$PRODUCT_REPO" -name "newrelic-php5-${VERSION}-*.tar.gz"
+      find "$APT_REPO" -name "newrelic-daemon_${VERSION}_*.deb" \
+	   -or -name "newrelic-php5_${VERSION}_*.deb" \
+	   -or -name "newrelic-php5-common_${VERSION}_*.deb"
+      find "$YUM_REPO" -name "newrelic-daemon-${VERSION}-*.rpm" \
+	   -or -name "newrelic-php5-${VERSION}-*.rpm" \
+	   -or -name "newrelic-php5-common-${VERSION}-*.rpm"
+      ;;
+
+    server_monitor)
+      find "$PRODUCT_REPO" -name "newrelic-sysmond-${VERSION}-*.tar.gz"
+      find "$APT_REPO" -name "newrelic-sysmond_${VERSION}_*.deb"
+      find "$YUM_REPO" -name "newrelic-sysmond-${VERSION}-*.rpm"
+      ;;
+  esac
+}
+
+PREFIX=
+PRODUCT=
+TARGET=
+VERSION=
+
+while getopts ':nv-:' OPTNAME; do
+  case $OPTNAME in
+    -)
+      case $OPTARG in
+	'help') usage ;;
+	prefix|prefix=*) optparse PREFIX "$@" ;;
+	product|product=*) optparse PRODUCT "$@" ;;
+	*) usage "illegal option -- ${OPTARG%=*}" ;;
+      esac
+      ;;
+    :)  usage "option requires an argument -- $OPTARG" ;;
+    \?) usage "illegal option -- $OPTARG" ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+[[ $# -eq 2 ]] || usage
+
+TARGET=$1
+VERSION=$2
+
+[[ -n $PREFIX && -d $PREFIX ]] || die 'must specify a working directory'
+[[ -n $PRODUCT ]] || die 'must specify the product'
+[[ -n $VERSION ]] || die 'must specify the version'
+
+case $TARGET in
+  production|testing) ;;
+  *) die 'invalid target' "$TARGET" ;;
+esac
+
+printf '\n'
+
+"$DEPLOY_HOME/libexec/s3-pull.bash" --prefix="$PREFIX"
+
+printf '\n'
+printf '>>> rolling back %s %s from %s...\n' "$PRODUCT" "$VERSION" "$TARGET"
+
+FILES=( $(findpkgs) )
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  die "no files found for $PRODUCT $VERSION"
+fi
+
+printf '\n'
+printf 'the following files will be removed\n'
+printf '%s\n' "${FILES[@]}"
+
+printf '\n'
+
+"$DEPLOY_HOME/libexec/repoman-demote.bash" \
+    --prefix="$PREFIX" \
+    --product="$PRODUCT" \
+    --destination="$TARGET" \
+    --verbose \
+    "${FILES[@]}"
+
+printf '\n'
+printf '>>> pushing changes to S3...\n'
+printf '\n'
+
+"$DEPLOY_HOME/libexec/s3-push.bash" \
+    --prefix="$PREFIX" \
+    --product="$PRODUCT" \
+    "$TARGET"
+
+printf '\n'
+printf '>>> Rollback of %s %s from %s completed successfully.\n' \
+       "$PRODUCT" "$VERSION" "$TARGET"
+
+exit

--- a/deploy/linux/deploy_scripts/s3-index/.editorconfig
+++ b/deploy/linux/deploy_scripts/s3-index/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true

--- a/deploy/linux/deploy_scripts/s3-index/.gitignore
+++ b/deploy/linux/deploy_scripts/s3-index/.gitignore
@@ -1,0 +1,5 @@
+bin
+pkg
+*.sw?
+
+src/github.com

--- a/deploy/linux/deploy_scripts/s3-index/Makefile
+++ b/deploy/linux/deploy_scripts/s3-index/Makefile
@@ -1,0 +1,17 @@
+GO := go
+GOPATH := $(shell pwd)
+BINARIES := indexer
+
+export GOPATH
+
+all: deps
+	go install indexer
+
+clean:
+	rm -rf bin pkg
+
+deps:
+	go get github.com/aws/aws-sdk-go
+
+test: deps
+	go test indexer s3/indexer

--- a/deploy/linux/deploy_scripts/s3-index/README.md
+++ b/deploy/linux/deploy_scripts/s3-index/README.md
@@ -1,0 +1,49 @@
+# S3 Indexer
+
+Given a bucket and an optional prefix, this will write an `index.html` that
+contains a directory listing to every "directory" within that bucket.
+
+## Requirements
+
+This requires at least Go 1.5 with `GO15VENDOREXPERIMENT` enabled. In practice,
+I would strongly encourage Go 1.6 or later.
+
+## Building
+
+`make` should give you a `bin/indexer` that does useful things.
+
+## Not building
+
+You can also `go run` the tool provided you've already used `go get` to get the
+AWS SDK for Go. You can run `make deps` to handle this for you if you like.
+
+Once done, you can run the tool with:
+
+```sh
+GOPATH=$(pwd) go run src/indexer/main.go
+```
+
+## Configuration
+
+The AWS configuration in `~/.aws` will be used, or environment variables can be
+set. More details are at the
+[AWS Go documentation](http://docs.aws.amazon.com/sdk-for-go/api/).
+
+If you go the environment variable route, you'll need to set `AWS_REGION`
+(probably to `us-east-1`), `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+To set up an `~/.aws` directory for development and testing, the easiest method
+is to install the AWS CLI tool, and then run `aws configure`.
+
+## Cookbook
+
+To generate indexes for the `index` directory in the folder.
+bucket:
+
+```sh
+./bin/indexer -bucket <folder> -prefix index/
+```
+
+Behold! Indexes! (Or, at least, it'll tell you what it would do.)
+
+To *actually* upload the indexes, you have to pass the `-upload` flag.

--- a/deploy/linux/deploy_scripts/s3-index/src/indexer/main.go
+++ b/deploy/linux/deploy_scripts/s3-index/src/indexer/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"html/template"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
+	"s3/indexer"
+)
+
+var (
+	bucket string
+	prefix string
+	upload bool
+)
+
+const (
+	ContentType   = "text/html; charset=UTF-8"
+	IndexFileName = "index.html"
+)
+
+func indexDirectory(t *template.Template, mgr *s3manager.Uploader, dir *indexer.Directory) error {
+	content, err := dir.Index(t)
+	if err != nil {
+		return err
+	}
+
+	target := dir.Prefix + "/" + IndexFileName
+	log.Printf("Uploading index with %d dir(s) and %d file(s) for %s/ to %s\n", len(dir.Directories), len(dir.Files), dir.Prefix, target)
+
+	if upload {
+		contentType := ContentType
+		input := &s3manager.UploadInput{
+			Bucket:      &bucket,
+			Key:         &target,
+			Body:        bytes.NewReader(content),
+			ContentType: &contentType,
+		}
+		if _, err := mgr.Upload(input); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func handleDirectory(t *template.Template, mgr *s3manager.Uploader, dir *indexer.Directory) {
+	if dir.ShouldIndex(prefix) {
+		if err := indexDirectory(t, mgr, dir); err != nil {
+			log.Println("Error indexing directory %s: %v", dir.Prefix, err)
+		}
+	}
+
+	for _, d := range dir.Directories {
+		handleDirectory(t, mgr, d)
+	}
+}
+
+func main() {
+	flag.StringVar(&bucket, "bucket", "", "the S3 bucket")
+	flag.StringVar(&prefix, "prefix", "", "the prefix to enumerate")
+	flag.BoolVar(&upload, "upload", false, "true to actually upload the index files")
+	flag.Parse()
+
+	if !upload {
+		log.Println("-upload not given; just telling you what would happen instead of actually doing it")
+	}
+
+	t := template.New("index")
+	t, err := t.Parse(indexer.DefaultTemplate)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	svc := s3.New(sess)
+	mgr := s3manager.NewUploader(sess)
+
+	top := indexer.NewTopDirectory()
+	if err := top.Enumerate(svc, bucket, prefix); err != nil {
+		log.Fatalln(err)
+	}
+
+	handleDirectory(t, mgr, top)
+}

--- a/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/directory.go
+++ b/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/directory.go
@@ -1,0 +1,102 @@
+package indexer
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type Directory struct {
+	Parent       *Directory
+	Prefix       string
+	Name         string
+	LastModified time.Time
+	Directories  map[string]*Directory
+	Files        map[string]*File
+}
+
+func NewDirectory(prefix, name string, parent *Directory) *Directory {
+	return &Directory{
+		Parent:       parent,
+		Prefix:       prefix,
+		Name:         name,
+		LastModified: time.Unix(0, 0),
+		Directories:  make(map[string]*Directory),
+		Files:        make(map[string]*File),
+	}
+}
+
+func NewTopDirectory() *Directory {
+	return NewDirectory("", "", nil)
+}
+
+func (d *Directory) Enumerate(svc *s3.S3, bucket, prefix string) error {
+	params := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
+	}
+	if err := svc.ListObjectsV2Pages(params, func(resp *s3.ListObjectsV2Output, lastPage bool) bool {
+		for _, obj := range resp.Contents {
+			file := NewFile(obj)
+
+			// Special case: ignore index.html when generating directories.
+			if file.Name == "index.html" {
+				continue
+			}
+
+			// Split up the key and create the directory structure as required within
+			// the nested maps.
+			parts := strings.Split(*obj.Key, "/")
+			ctx := d
+			for i, part := range parts[:len(parts)-1] {
+				if ctx.LastModified.Before(*file.LastModified) {
+					ctx.LastModified = *file.LastModified
+				}
+
+				if child, ok := ctx.Directories[part]; ok {
+					ctx = child
+				} else {
+					ctx.Directories[part] = NewDirectory(strings.Join(parts[0:i+1], "/"), part, ctx)
+					ctx = ctx.Directories[part]
+				}
+			}
+
+			if ctx.LastModified.Before(*file.LastModified) {
+				ctx.LastModified = *file.LastModified
+			}
+
+			ctx.Files[file.Name] = file
+		}
+
+		return true
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Directory) Index(t *template.Template) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := t.Execute(buf, d); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (d *Directory) ShouldIndex(prefix string) bool {
+	if _, ok := d.Files[".noindex"]; ok {
+		return false
+	}
+
+	if strings.Index(strings.TrimRight(d.Prefix, "/"), strings.TrimRight(prefix, "/")) != 0 {
+		return false
+	}
+
+	return true
+}

--- a/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/file.go
+++ b/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/file.go
@@ -1,0 +1,19 @@
+package indexer
+
+import (
+	"path"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type File struct {
+	*s3.Object
+	Name string
+}
+
+func NewFile(obj *s3.Object) *File {
+	return &File{
+		Object: obj,
+		Name:   path.Base(*obj.Key),
+	}
+}

--- a/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/template.go
+++ b/deploy/linux/deploy_scripts/s3-index/src/s3/indexer/template.go
@@ -1,0 +1,67 @@
+package indexer
+
+const DefaultTemplate = `
+{{ define "Directory" }}
+	<tr>
+		<td><a href="/{{ .Prefix }}">{{ .Name }}/</a></td>
+		<td>{{ .LastModified.Format "02-Jan-2006 15:04" }}</td>
+		<td></td>
+	</tr>
+{{ end }}
+{{ define "ParentDirectory" }}
+	<tr>
+		<td><a href="/{{ .Prefix }}">../</a></td>
+		<td></td>
+		<td></td>
+	</tr>
+{{ end }}
+{{ define "File" }}
+	<tr>
+		<td><a href="/{{ .Key }}">{{ .Name }}</a></td>
+		<td>{{ .LastModified.Format "02-Jan-2006 15:04" }}</td>
+		<td>{{ .Size }}</td>
+	</tr>
+{{ end }}
+{{ define "Title" }}Index of /{{ .Prefix }}{{ end }}
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>{{ template "Title" . }}</title>
+		<style>
+			table {
+				font-family: monospace;
+			}
+			th:first-child, td:first-child {
+				min-width: 50vw;
+			}
+			td, th {
+				padding-right: 5em;
+				text-align: left;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>{{ template "Title" . }}</h1>
+		<table>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Time</th>
+					<th>Size</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{ if .Parent }}
+					{{ template "ParentDirectory" .Parent }}
+				{{ end }}
+				{{ range $dir := .Directories }}
+					{{ template "Directory" $dir }}
+				{{ end }}
+				{{ range $file := .Files }}
+					{{ template "File" $file }}
+				{{ end }}
+			</tbody>
+		</table>
+	</body>
+</html>`

--- a/deploy/linux/docker-compose.yml
+++ b/deploy/linux/docker-compose.yml
@@ -1,0 +1,14 @@
+deploy_packages: 
+    build: ./container
+# This was necessary to be able to debug using strace
+#    security_opt:
+#        - seccomp:unconfined
+    command: bash -c "/data/deploy.bash"
+    volumes: 
+        - .:/data
+        - ./packages:/packages
+        - ./deploy_scripts:/deployscripts
+    working_dir: /data
+    env_file:
+        - docker.env
+    

--- a/deploy/linux/docker-compose.yml
+++ b/deploy/linux/docker-compose.yml
@@ -1,14 +1,16 @@
-deploy_packages: 
-    build: ./container
-# This was necessary to be able to debug using strace
-#    security_opt:
-#        - seccomp:unconfined
-    command: bash -c "/data/deploy.bash"
-    volumes: 
-        - .:/data
-        - ./packages:/packages
-        - ./deploy_scripts:/deployscripts
-    working_dir: /data
-    env_file:
-        - docker.env
-    
+version: "3.8"
+services:
+    deploy_packages: 
+        build: ./container
+    # This was necessary to be able to debug using strace
+    #    security_opt:
+    #        - seccomp:unconfined
+        command: bash -c "/data/deploy.bash"
+        volumes: 
+            - .:/data
+            - ./packages:/packages
+            - ./deploy_scripts:/deployscripts
+        working_dir: /data
+        env_file:
+            - docker.env
+        

--- a/deploy/linux/packages/.gitignore
+++ b/deploy/linux/packages/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/deploy/linux/s3/production/.gitignore
+++ b/deploy/linux/s3/production/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/deploy/linux/s3/testing/.gitignore
+++ b/deploy/linux/s3/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Resolves #328 

### Description

Add the deployment portion of our CI to github actions.

Files and Directories
- Added a /deploy directory
- /deploy contains our formerly internal deploy scripting used to push out Linux packages for apt/yum.

all_solutions.yml
- Updated run-artifactbuilder to include /deploy directory in the deploy-artifacts
- Updates docker-compose build to only build the targets package type in the job.

deploy.yml
- New workflow
- Takes the following inputs
  - agent_version: Agent Version to deploy.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X
  - run_id: Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.
  - deploy: If "true", deploy the artifacts. If "false", do everything except deploy.
  - downloadsite: If "true", will run the deploy-downloadsite job. If "false", will not.
  - nuget: If "true", will run the deploy-nuget job. If "false", will not.
  - linux: If "true", will run the deploy-linux job. If "false", will not.
- This job can only be run manually.
- Job get-external-artifacts gets the artifacts from the all_solutions.yml run indicated by the run_id and splits it up into new local artifacts
- Job deploy-downloadsite configures AWS creds, sets up, and pushes the latest_release and previous_release to S3
- Job deploy-nuget configures nuget creds,, sets up the files, and pushes them to nuget (one step per package)
- Job deploy-linux sets up the files, builds a docker.env, and runs a very complex script to deploy the packages for apt/yum

### Testing

- The changes to all_solutions.yml can only be tested when a new release is created.  For this PR, it should not build at all.
- deploy.yml can only be fully  tested during an actual deploy.  Using the deploy setting, we can run it without pushing files and get most of the logic tested.
  - Here is a passing run, on a personal fork (slightly older version of logic), with deploy=false: https://github.com/jaffinito/newrelic-dotnet-agent/actions/runs/350591344
  - Here is a passing run, on a personal fork (slightly older version of logic), with deploy=false AND some jobs disabled: https://github.com/jaffinito/newrelic-dotnet-agent/actions/runs/350588321

We are intending to run a release as soon as possible after landing this PR to confirm that everything is in order.

### Changelog

n/a

