### PR TITLE
Output checksum table in markdown for release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ Agent/NewRelic.Agent.IL/_NewRelic.Agent.IL.tlb
 newrelichome_*
 src/Agent/New Relic Home*
 
-
 # Ignore New Relic Home generated registry files
 src/Agent/New Relic Home x86.reg
 src/Agent/New Relic Home x64.reg
@@ -139,3 +138,6 @@ src/Agent/_profilerBuild/**/*.pdb
 
 # Ignore any locally built profiler Debug-mode binaries
 src/Agent/_profilerBuild/*Debug
+
+# Ignore any signing keys used in Linux packaging
+build/Linux/keys

--- a/build/ArtifactBuilder/Artifacts/DownloadSiteArtifact.cs
+++ b/build/ArtifactBuilder/Artifacts/DownloadSiteArtifact.cs
@@ -1,14 +1,14 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace ArtifactBuilder.Artifacts
 {
     public class DownloadSiteArtifact : Artifact
     {
-        private const string SourceShaFileName = "checksum.sha256";
+        private const string ShaFileExtension = ".sha256";
+        private const string SourceShaFileName = "checksum" + ShaFileExtension;
+        private const string ShaMarkdownTableFileName = "checksums.md";
 
         public string Version { get; }
         public string ShaDirectory { get; }
@@ -64,6 +64,9 @@ namespace ArtifactBuilder.Artifacts
 
             //Copying Readme.txt file
             FileHelpers.CopyFile($@"{PackageDirectory}\Readme.txt", $@"{OutputDirectory}");
+
+            //Create markdown file with table of SHA values for the release notes
+            CreateSHAValuesTableMarkdownFile(ShaDirectory, ShaMarkdownTableFileName);
         }
 
         private void CopyFileAndChecksum(string sourceDirectory, string sourceFileSearchPattern, string destinationDirectory, string destinationFileName = null)
@@ -77,7 +80,24 @@ namespace ArtifactBuilder.Artifacts
             }
 
             File.Copy(filePath, $@"{destinationDirectory}\{destinationFileName}");
-            File.Copy($@"{sourceDirectory}\{SourceShaFileName}", $@"{ShaDirectory}\{destinationFileName}.sha256");
+            File.Copy($@"{sourceDirectory}\{SourceShaFileName}", $@"{ShaDirectory}\{destinationFileName}{ShaFileExtension}");
+        }
+
+        private void CreateSHAValuesTableMarkdownFile(string shaDirectory, string outputFilename)
+        {
+            var outputLines = new List<string>() { { "### Checksums" }, { "| File | SHA - 256  Hash |" }, { "| ---| ---|" } };
+
+            // Add filename and sha value for each .sha256 file found
+            var shaFilenames = Directory.GetFiles(shaDirectory, $"*{ShaFileExtension}");
+            foreach (var shaFilename in shaFilenames)
+            {
+                var baseFilename = Path.GetFileNameWithoutExtension(shaFilename);
+                var contents = File.ReadAllText(shaFilename);
+                var shaValue = contents.Split(" ")[0]; // this handles the Linux files which have both the SHA value and the filename in them
+                outputLines.Add($"| {baseFilename} | {shaValue} |");
+            }
+
+            File.WriteAllLines(Path.Combine(shaDirectory, outputFilename), outputLines.ToArray());
         }
     }
 }


### PR DESCRIPTION
### Description

This will help reduce toil in the release process.  The `DownloadSite` target of the ArtifactBuilder now creates a `checksum.md` file in the `BuildArtifacts/DownloadSite/SHA256` folder, which has the table of filenames and SHA256 checksum values that we add to the release notes as part of the release process.  It should be as simple as copying and pasting the contents of this file into the appropriate portion of the release notes.

*Note*: this also adds `build/Linux/keys` to the `.gitignore` file.  Let's not accidentally check in a signing key!

### Testing

To test, run `build/package.ps1` with the `-IncludeDownloadSite` option.  This assumes you have built all the other things that the artifact builder expects to be there.

### Changelog

N/A

