### PR TITLE
Enable httpclient 5 test

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -443,6 +443,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET Core 2.2.103
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '2.2.103'
+
+      - name: Setup .NET Core 3.1.100
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.100'
+
       - name: Setup .NET 5.0
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -321,6 +321,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '5.0.100'
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.1
 
@@ -360,6 +365,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '5.0.100'
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.1
@@ -442,6 +452,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '5.0.100'
 
       - name: Set up secrets
         env:
@@ -531,6 +546,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '5.0.100'
 
       - name: Download Agent Home Folders
         uses: actions/download-artifact@v2

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -41,7 +41,9 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: '[16.8,16.9)'
 
       - name: Clean out _profilerBuild directory
         run: |
@@ -137,7 +139,9 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: '[16.8,16.9)'
 
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1
@@ -327,7 +331,9 @@ jobs:
             dotnet-version: '5.0.100'
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: '[16.8,16.9)'
 
       - name: Install dependencies for IntegrationTests.sln
         run: |
@@ -372,7 +378,9 @@ jobs:
             dotnet-version: '5.0.100'
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: '[16.8,16.9)'
 
       - name: Install dependencies for UnboundedIntegrationTests.sln
         run: |
@@ -412,7 +420,9 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
+        with:
+          vs-version: '[16.8,16.9)'
 
       - name: Install dependencies for PlatformTests.sln
         run: |

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -41,9 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-        with:
-          vs-version: '[16.8,16.9)'
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Clean out _profilerBuild directory
         run: |
@@ -139,9 +137,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-        with:
-          vs-version: '[16.8,16.9)'
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Setup VSTest Path
         uses: darenm/Setup-VSTest@v1
@@ -325,15 +321,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-            dotnet-version: '5.0.100'
-
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-        with:
-          vs-version: '[16.8,16.9)'
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Install dependencies for IntegrationTests.sln
         run: |
@@ -372,15 +361,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-            dotnet-version: '5.0.100'
-
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-        with:
-          vs-version: '[16.8,16.9)'
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Install dependencies for UnboundedIntegrationTests.sln
         run: |
@@ -420,9 +402,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-        with:
-          vs-version: '[16.8,16.9)'
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Install dependencies for PlatformTests.sln
         run: |
@@ -556,11 +536,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-            dotnet-version: '5.0.100'
 
       - name: Download Agent Home Folders
         uses: actions/download-artifact@v2

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -12,6 +12,10 @@ Fixes Issue [#XX](https://github.com/newrelic/newrelic-dotnet-agent/issues/XX)
 
 ## [8.35] - 2020-11-09
 
+### New Features
+* **.NET 5 GA Support** <br/>
+We have validated that this version of the agent is compatible with .NET 5 GA. See the [compatibility and requirements for .NET Core](https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core) page for more details.
+
 ### Fixes
 Fixes Issue [#337](https://github.com/newrelic/newrelic-dotnet-agent/issues/337) by removing obsolete code which was causing memory growth associated with a large number of transaction names.
 PR [#348](https://github.com/newrelic/newrelic-dotnet-agent/pull/348): guards against potential exceptions being thrown from the agent API when the agent is not attached.  

--- a/tests/Agent/IntegrationTests/IntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/IntegrationTests.sln
@@ -18,6 +18,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests", "Integra
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Applications", "Applications", "{F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}"
+	ProjectSection(SolutionItems) = preProject
+		Applications\AspNet5BasicWebApiApplication\AspNet5BasicWebApiApplication.csproj = Applications\AspNet5BasicWebApiApplication\AspNet5BasicWebApiApplication.csproj
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomAttributesWebApi", "Applications\CustomAttributesWebApi\CustomAttributesWebApi.csproj", "{9E5D7614-414C-427E-83A9-2A723409F45D}"
 EndProject

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNet5.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/NetCore/HttpClientInstrumentationNet5.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.HttpClientInstrumentation.NetCore
             _fixture.Initialize();
         }
 
-        [Fact(Skip = "These tests will not be run until .NET 5 is officially released.")]
+        [Fact]
         public void Test()
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>


### PR DESCRIPTION
- Now .NET 5 is GA, the `HttpClientInstrumentationNet5`  can now be enabled to run as part of GHA.
- Updates the Changelog to announce .NET 5 GA support.