### PR TITLE
- Add back self-signed cert step

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -229,8 +229,8 @@ jobs:
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
       
-      - name: Create Self-signed code signing cert
-        if: ${{ github.event.pull_request }}
+      - name: Create Self-signed code signing cert  
+        if: ${{ github.event.pull_request || github.event.workflow_dispatch }}
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -215,6 +215,7 @@ jobs:
           if-no-files-found: error
 
       - name: Get Code Signing Certificate
+        if: ${{ github.event.release }}
         id: write_cert
         uses: timheuer/base64-to-file@v1
         with:
@@ -222,8 +223,17 @@ jobs:
           encodedString: ${{ secrets.SIGNING_CERT }}
           
       - name: Install Code Signing Certificate
+        if: ${{ github.event.release }}
         run: |
+          Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
+        shell: powershell
+      
+      - name: Create Self-signed code signing cert
+        if: ${{ github.event.pull_request }}
+        run: |
+          Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
+          New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)
         shell: powershell
 
       - name: Build MsiInstaller.sln x86


### PR DESCRIPTION
### Description

In order to allow forks to build and test, we need to have add back the self-signing cert step.

- Add back self-signed cert step
- Self-signed step only runs on PR
- Update actual cert steps to only run on release

### Testing

Workflow should build using self-signed cert for PR since it is not a release build.

### Changelog

N/A
