### PR TITLE
SQL parsing: ignore leading SET statements

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 New Feature Description
 
 ### Fixes
-Fixes Issue [#224](https://github.com/newrelic/newrelic-dotnet-agent/issues/224): leading "SET" commands will be ignored when parsing compound SQL statements.
+Fixes Issue [#224](https://github.com/newrelic/newrelic-dotnet-agent/issues/224): leading "SET" commands will be ignored when parsing compound SQL statements.([#370](https://github.com/newrelic/newrelic-dotnet-agent/pull/370))
 
 
 ## [8.35] - 2020-11-09

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 * **New Feature Template** <br/>
 New Feature Description
-Fixes Issue [#XX](https://github.com/newrelic/newrelic-dotnet-agent/issues/XX)
+
+### Fixes
+Fixes Issue [#224](https://github.com/newrelic/newrelic-dotnet-agent/issues/224): leading "SET" commands will be ignored when parsing compound SQL statements.
+
 
 ## [8.35] - 2020-11-09
 

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Parsing
         private const string SqlParamPrefix = "@";
 
         // Regex Phrases
-        private const string SelectPhrase = @"(?=^\bset\b.*;\s*\bselect\b|^\bselect\b).*?\s+";
+        private const string SelectPhrase = @"^\bselect\b.*?\s+";
         private const string InsertPhrase = @"^insert\s+into\s+";
         private const string UpdatePhrase = @"^update\s+";
         private const string DeletePhrase = @"^delete\s+";
@@ -134,6 +134,9 @@ namespace NewRelic.Parsing
                 if (!IsSingleSqlStatement(statement))
                 {
                     // Remove leading SET commands
+
+                    // Trimming any trailing semicolons is necessary to avoid having the LeadingSetPattern
+                    // match a SQL statement that ONLY contains SET commands, which would leave us with nothing
                     statement = statement.TrimEnd(';');
                     statement = LeadingSetPattern.Replace(statement, string.Empty).TrimStart();
                 }

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -72,7 +72,7 @@ namespace NewRelic.Parsing
         private const string SingleSqlStatementPhrase = @"^[^;]*[\s;]*$";
 
         private const string CommentPhrase = @"/\*.*?\*/"; //The ? makes the searching lazy
-        private const string LeadingSetPhrase = @"^(?:\s*\bset\b.+?\;)+(?=.*\w+.*)";
+        private const string LeadingSetPhrase = @"^(?:\s*\bset\b.+?\;)+(?!(\s*\bset\b))";
         private const string StartObjectNameSeparator = @"[\s\(\[`\""]*";
         private const string EndObjectNameSeparator = @"[\s\)\]`\""]*";
         private const string ValidObjectName = @"([^,;\[\s\]\(\)`\""\.]*)";
@@ -134,6 +134,7 @@ namespace NewRelic.Parsing
                 if (!IsSingleSqlStatement(statement))
                 {
                     // Remove leading SET commands
+                    statement = statement.TrimEnd(';');
                     statement = LeadingSetPattern.Replace(statement, string.Empty).TrimStart();
                 }
 

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -37,6 +37,7 @@ namespace NewRelic.Parsing
         private static readonly ConcurrentDictionary<DatastoreVendor, ParsedSqlStatement> _nullParsedStatementStore = new ConcurrentDictionary<DatastoreVendor, ParsedSqlStatement>();
 
         private const string SqlParamPrefix = "@";
+        private const char SemiColon = ';';
 
         // Regex Phrases
         private const string SelectPhrase = @"^\bselect\b.*?\s+";
@@ -137,7 +138,7 @@ namespace NewRelic.Parsing
 
                     // Trimming any trailing semicolons is necessary to avoid having the LeadingSetPattern
                     // match a SQL statement that ONLY contains SET commands, which would leave us with nothing
-                    statement = statement.TrimEnd(';');
+                    statement = statement.TrimEnd(SemiColon);
                     statement = LeadingSetPattern.Replace(statement, string.Empty).TrimStart();
                 }
 

--- a/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
+++ b/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
@@ -137,7 +137,7 @@ namespace ParsingTests
         {
             var parsedDatabaseStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, CommandType.Text, "set @FOO=17; set @BAR=18;");
             Assert.IsNotNull(parsedDatabaseStatement);
-            Assert.AreEqual("foo", parsedDatabaseStatement.Model);
+            Assert.AreEqual("bar", parsedDatabaseStatement.Model);
             Assert.AreEqual("set", parsedDatabaseStatement.Operation);
         }
 
@@ -471,6 +471,17 @@ namespace ParsingTests
             Assert.IsNotNull(parsedDatabaseStatement);
             Assert.AreEqual("(subquery)", parsedDatabaseStatement.Model, string.Format($"Expected model (subquery) but was {parsedDatabaseStatement.Model}", "(subquery)", parsedDatabaseStatement.Model));
             Assert.AreEqual("select", parsedDatabaseStatement.Operation, string.Format($"Expected operation select but was {parsedDatabaseStatement.Operation}", "select", parsedDatabaseStatement.Operation));
+        }
+
+        [Test]
+        public void SqlParserTest_IgnoreSetStatements()
+        {
+            // We want to prioritize the "EXEC" over the leading SET statements
+            const string test = "SET CONTEXT_INFO = @0; SET NOCOUNT ON; EXEC dbo.spSomeProconOurSystem";
+
+            var parsedDatabaseStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, CommandType.Text, test);
+            Assert.IsNotNull(parsedDatabaseStatement);
+            Assert.AreEqual("ExecuteProcedure", parsedDatabaseStatement.Operation, string.Format($"Expected operation select but was {parsedDatabaseStatement.Operation}", "ExecuteProcedure", parsedDatabaseStatement.Operation));
         }
 
         /// <summary>

--- a/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
+++ b/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
@@ -137,7 +137,7 @@ namespace ParsingTests
         {
             var parsedDatabaseStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, CommandType.Text, "set @FOO=17; set @BAR=18;");
             Assert.IsNotNull(parsedDatabaseStatement);
-            Assert.AreEqual("bar", parsedDatabaseStatement.Model);
+            Assert.AreEqual("foo", parsedDatabaseStatement.Model);
             Assert.AreEqual("set", parsedDatabaseStatement.Operation);
         }
 

--- a/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
+++ b/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
@@ -466,13 +466,16 @@ namespace ParsingTests
             // after the FROM contains a parentheses.  Here's an example that works, from Marina and now part of the test
             // DotNetTestApp/test.sqlserver.aspx
             const string test = "SELECT * FROM (SELECT * FROM [dbo].[Account] Where UserId like 'John') as test";
+            const string expectedModel = "(subquery)";
+            const string expectedOperation = "select";
 
             var parsedDatabaseStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, CommandType.Text, test);
             Assert.IsNotNull(parsedDatabaseStatement);
-            Assert.AreEqual("(subquery)", parsedDatabaseStatement.Model, string.Format($"Expected model (subquery) but was {parsedDatabaseStatement.Model}", "(subquery)", parsedDatabaseStatement.Model));
-            Assert.AreEqual("select", parsedDatabaseStatement.Operation, string.Format($"Expected operation select but was {parsedDatabaseStatement.Operation}", "select", parsedDatabaseStatement.Operation));
+            Assert.AreEqual(expectedModel, parsedDatabaseStatement.Model, $"Expected model {expectedModel} but was {parsedDatabaseStatement.Model}");
+            Assert.AreEqual(expectedOperation, parsedDatabaseStatement.Operation, $"Expected operation {expectedOperation} but was {parsedDatabaseStatement.Operation}");
         }
 
+        [Test]
         [TestCase("SELECT * FROM people", "select")]
         [TestCase("INSERT INTO people(firstname, lastname) values ('alice', 'smith');", "insert")]
         [TestCase("UPDATE dude SET man = 'yeah' WHERE id = 123", "update")]


### PR DESCRIPTION
### Description

Resolves #224:
For a compound SQL statement like `SET @foo = 1; EXEC dbo.someStoredProcedure`, the parsed DB operation will be the `EXEC`, not the `SET`.  (This case *was* previously handled for SELECT, but no other operations.) 

### Testing

Additional unit tests were added to `SqlParserTests.cs` to ensure coverage.

### Changelog

Changelog is updated.
