### PR TITLE
Restore using msbuild

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -51,22 +51,16 @@ jobs:
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-release" -Recurse -Force  -ErrorAction SilentlyContinue
         shell: powershell
 
-      - name: Install dependencies
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.profiler_solution_path }}"
-          MSBuild.exe /restore ${{ env.profiler_solution_path }}
-        shell: powershell
-
       - name: Build x64
         run: |
-          Write-Host "MSBuild.exe -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
-          MSBuild.exe -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
+          MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
         shell: powershell
         
       - name: Build x86
         run: |
-          Write-Host "MSBuild.exe -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}"
-          MSBuild.exe -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}"
+          MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
         shell: powershell
 
       - name: Archive Artifacts
@@ -155,23 +149,11 @@ jobs:
         with:
           name: profiler
           path: ${{ github.workspace }}/src/Agent/_profilerBuild/
-      
-      - name: Install dependencies for FullAgent.sln
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.fullagent_solution_path }}"
-          MSBuild.exe /restore ${{ env.fullagent_solution_path }}
-        shell: powershell
-
-      - name: Install dependencies for MsiInstaller.sln
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.msi_solution_path }}"
-          MSBuild.exe /restore ${{ env.msi_solution_path }}
-        shell: powershell
-      
+            
       - name: Build FullAgent.sln
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
         shell: powershell
 
       - name: Create agent_version.txt
@@ -240,14 +222,14 @@ jobs:
 
       - name: Build MsiInstaller.sln x86
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x86 ${{ env.msi_solution_path }}
         shell: powershell
 
       - name: Build MsiInstaller.sln x64
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}
         shell: powershell
 
       - name: Archive _build Artifacts
@@ -336,16 +318,10 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
 
-      - name: Install dependencies for IntegrationTests.sln
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.integration_solution_path }}"
-          MSBuild.exe /restore ${{ env.integration_solution_path }}
-        shell: powershell
-
       - name: Build IntegrationTests.sln
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
 
       - name: Archive Artifacts
@@ -376,16 +352,10 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
 
-      - name: Install dependencies for UnboundedIntegrationTests.sln
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.unbounded_solution_path }}"
-          MSBuild.exe /restore ${{ env.unbounded_solution_path }}
-        shell: powershell
-
       - name: Build UnboundedIntegrationTests.sln
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
         shell: powershell
 
       - name: Archive Artifacts
@@ -416,16 +386,10 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
 
-      - name: Install dependencies for PlatformTests.sln
-        run: |
-          Write-Host "MSBuild.exe /restore ${{ env.platform_solution_path }}"
-          MSBuild.exe /restore ${{ env.platform_solution_path }}
-        shell: powershell
-
       - name: Build PlatformTests.sln
         run: |
-          Write-Host "MSBuild.exe -m -p:Configuration=Release ${{ env.platform_solution_path }}"
-          MSBuild.exe -m -p:Configuration=Release ${{ env.platform_solution_path }}
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
         shell: powershell
 
   run-integration-tests:

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.profiler_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.profiler_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.profiler_solution_path }}"
+          MSBuild.exe /restore ${{ env.profiler_solution_path }}
         shell: powershell
 
       - name: Build x64
@@ -158,14 +158,14 @@ jobs:
       
       - name: Install dependencies for FullAgent.sln
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.fullagent_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.fullagent_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.fullagent_solution_path }}"
+          MSBuild.exe /restore ${{ env.fullagent_solution_path }}
         shell: powershell
 
       - name: Install dependencies for MsiInstaller.sln
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.msi_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.msi_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.msi_solution_path }}"
+          MSBuild.exe /restore ${{ env.msi_solution_path }}
         shell: powershell
       
       - name: Build FullAgent.sln
@@ -338,8 +338,8 @@ jobs:
 
       - name: Install dependencies for IntegrationTests.sln
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.integration_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.integration_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.integration_solution_path }}"
+          MSBuild.exe /restore ${{ env.integration_solution_path }}
         shell: powershell
 
       - name: Build IntegrationTests.sln
@@ -378,8 +378,8 @@ jobs:
 
       - name: Install dependencies for UnboundedIntegrationTests.sln
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.unbounded_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.unbounded_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.unbounded_solution_path }}"
+          MSBuild.exe /restore ${{ env.unbounded_solution_path }}
         shell: powershell
 
       - name: Build UnboundedIntegrationTests.sln
@@ -418,8 +418,8 @@ jobs:
 
       - name: Install dependencies for PlatformTests.sln
         run: |
-          Write-Host ${{ env.tools_path }}\nuget.exe restore ${{ env.platform_solution_path }} -NoCache -Source `"https://www.nuget.org/api/v2`"
-          ${{ env.tools_path }}\nuget.exe restore ${{ env.platform_solution_path }} -NoCache -Source "https://www.nuget.org/api/v2"
+          Write-Host "MSBuild.exe /restore ${{ env.platform_solution_path }}"
+          MSBuild.exe /restore ${{ env.platform_solution_path }}
         shell: powershell
 
       - name: Build PlatformTests.sln

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -214,7 +214,7 @@ jobs:
         shell: powershell
       
       - name: Create Self-signed code signing cert  
-        if: ${{ github.event.pull_request || github.event.workflow_dispatch }}
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -70,9 +70,9 @@ $solutions = [Ordered]@{
 
 Write-Host "Restoring NuGet packages"
 foreach ($sln in $solutions.Keys) {
-    & $nugetPath restore $sln -NoCache -Source "https://www.nuget.org/api/v2"
+    & $msBuildPath /restore $sln
     if ($LastExitCode -ne 0) {
-        Write-Host "Error during NuGet restore. Exiting with code: $LastExitCode.."
+        Write-Host "Error during MSBuild /restore. Exiting with code: $LastExitCode.."
         exit $LastExitCode
     }
 }

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -24,7 +24,6 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Performing validation"
 $rootDirectory = Resolve-Path "$(Split-Path -Parent $PSCommandPath)\.."
-$nugetPath = (Resolve-Path "$rootDirectory\build\Tools\nuget.exe").Path
 $vsWhere = (Resolve-Path "$rootDirectory\build\Tools\vswhere.exe").Path
 $msBuildPath = & "$vsWhere" -products 'Microsoft.VisualStudio.Product.BuildTools' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
 if (!$msBuildPath) {
@@ -64,19 +63,6 @@ $solutions = [Ordered]@{
     "$rootDirectory\tests\Agent\PlatformTests\PlatformTests.sln"                = @("Configuration=$Configuration");
 }
 
-#################
-# NuGet Restore #
-#################
-
-Write-Host "Restoring NuGet packages"
-foreach ($sln in $solutions.Keys) {
-    & $msBuildPath /restore $sln
-    if ($LastExitCode -ne 0) {
-        Write-Host "Error during MSBuild /restore. Exiting with code: $LastExitCode.."
-        exit $LastExitCode
-    }
-}
-
 #########
 # Build #
 #########
@@ -88,16 +74,18 @@ $env:SetSessionEnvironment = $SetSessionEnvironment
 Write-Host "Building solutions"
 foreach ($sln in $solutions.Keys) {
     foreach ($config in $solutions.Item($sln)) {
-        Write-Host "-- Building $sln : '. $msBuildPath -m -p:$($config) $sln'"
-        . $msBuildPath -nologo -m -p:$($config) $sln
+        Write-Host "-- Building $sln : '. $msBuildPath -r -m -p:$($config) $sln'"
+        . $msBuildPath -nologo -r -m -p:$($config) $sln
         Write-Host "MSBuild Exit code: $LastExitCode"
         if ($LastExitCode -ne 0) {
-            Write-Host "Error building solution $sln. Exiting with code: $LastExitCode.."
-            exit $LastExitCode
+           Write-Host "Error building solution $sln. Exiting with code: $LastExitCode.."
+           exit $LastExitCode
         }
     }
 }
 
+# temp for debugging
+exit 0
 $agentVersion = (Get-Item "$rootDirectory\src\_build\AnyCPU-$Configuration\NewRelic.Agent.Core\net45\NewRelic.Agent.Core.dll").VersionInfo.FileVersion
 
 ###################

--- a/src/Agent/NewRelic/Profiler/build/build.ps1
+++ b/src/Agent/NewRelic/Profiler/build/build.ps1
@@ -20,7 +20,6 @@ function ExitIfFailLastExitCode {
 }
 
 $rootDirectory = Resolve-Path "$(Split-Path -Parent $PSCommandPath)\..\..\..\..\.."
-$nugetPath = (Resolve-Path "$rootDirectory\build\Tools\nuget.exe").Path
 $vsWhere = (Resolve-Path "$rootDirectory\build\Tools\vswhere.exe").Path
 $msBuildPath = & "$vsWhere" -products 'Microsoft.VisualStudio.Product.BuildTools' -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
 if (!$msBuildPath) {
@@ -29,13 +28,11 @@ if (!$msBuildPath) {
 
 Write-Host "Building Platform=$Platform and Configuration=$Configuration"
 
-$nugetPath = "$rootDirectory\build\Tools\nuget.exe"
 $profilerRoot = "$rootDirectory\src\Agent\NewRelic\Profiler"
 $profilerSolutionPath = "$profilerRoot\NewRelic.Profiler.sln"
 $outputPath = "$rootDirectory\src\Agent\_profilerBuild"
 $linuxOutputPath = "$outputPath\linux-release"
 
-$restoreNuget = $Platform -eq "all" -or $Platform -eq "windows" -or $Platform -eq "x64" -or $Platform -eq "x86"
 $buildx64 = $Platform -eq "all" -or $Platform -eq "windows" -or $Platform -eq "x64"
 $buildx86 = $Platform -eq "all" -or $Platform -eq "windows" -or $Platform -eq "x86"
 $buildLinux = $Platform -eq "all" -or $Platform -eq "linux"
@@ -45,21 +42,15 @@ if ($Platform -eq "all") {
     if (Test-Path $outputPath) { Write-Error "Ouput path not cleared out: $outputPath"; exit 1; }
 }
 
-if ($restoreNuget) {
-    Write-Host "-- Profiler build: Restoring NuGet packages"
-    & $msBuildPath /restore $profilerSolutionPath
-    ExitIfFailLastExitCode
-}
-
 if ($buildx64) {
     Write-Host "-- Profiler build: x64-$Configuration"
-    & $msBuildPath /p:Platform=x64 /p:Configuration=$Configuration $profilerSolutionPath
+    & $msBuildPath /restore /p:Platform=x64 /p:Configuration=$Configuration $profilerSolutionPath
     ExitIfFailLastExitCode
 }
 
 if ($buildx86) {
     Write-Host "-- Profiler build: x86-$Configuration"
-    & "$msBuildPath" /p:Platform=Win32 /p:Configuration=$Configuration $profilerSolutionPath
+    & "$msBuildPath" /restore /p:Platform=Win32 /p:Configuration=$Configuration $profilerSolutionPath
     ExitIfFailLastExitCode
 }
 

--- a/src/Agent/NewRelic/Profiler/build/build.ps1
+++ b/src/Agent/NewRelic/Profiler/build/build.ps1
@@ -47,7 +47,7 @@ if ($Platform -eq "all") {
 
 if ($restoreNuget) {
     Write-Host "-- Profiler build: Restoring NuGet packages"
-    & $nugetPath restore $profilerSolutionPath -Source "https://www.nuget.org/api/v2"
+    & $msBuildPath /restore $profilerSolutionPath
     ExitIfFailLastExitCode
 }
 


### PR DESCRIPTION
### Description

This fixes a build problem that recently started happening due to a mismatch between MSBuild and NuGet versions on the GHA runners, described here: https://developercommunity.visualstudio.com/content/problem/1248649/error-netsdk1005-assets-file-projectassetsjson-doe.html

The fix is to use MSBuild for package restore instead of using NuGet directly.

This PR also fixes an issue with the workflow logic which was gating the creation of a self-signed certificate on manual (workflow_dispatch) runs.

### Testing

If the PR build works as expected (i.e. all build steps pass, but there will be some expected failures in integration tests) this should be good to go.

### Changelog

N/A
