### PR TITLE
Fix agent failed to read settings from appsettings.{environment}.json

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -12,6 +12,7 @@ New Feature Description
 ### Fixes
 Fixes Issue [#224](https://github.com/newrelic/newrelic-dotnet-agent/issues/224): leading "SET" commands will be ignored when parsing compound SQL statements.([#370](https://github.com/newrelic/newrelic-dotnet-agent/pull/370))
 
+Fixes Issue [#9](https://github.com/newrelic/newrelic-dotnet-agent/issues/9) where the agent failed to read settings from `appsettings.{environment}.json` files. ([#372](https://github.com/newrelic/newrelic-dotnet-agent/pull/372))
 
 ## [8.35] - 2020-11-09
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -25,9 +25,11 @@ namespace NewRelic.Agent.Core.Configuration
 		{
 			var env = new SystemInterfaces.Environment();
 			var currentDirectory = Directory.GetCurrentDirectory();
-			var environment = env.GetEnvironmentVariable("EnvironmentName");
+            var environment = env.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            if (string.IsNullOrEmpty(environment))
+                environment = env.GetEnvironmentVariable("EnvironmentName");
 
-			var builder = new ConfigurationBuilder()
+            var builder = new ConfigurationBuilder()
 				.SetBasePath(currentDirectory)
 				.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
 
@@ -51,8 +53,8 @@ namespace NewRelic.Agent.Core.Configuration
 
 			if (Log.IsDebugEnabled)
 			{
-				if (string.IsNullOrWhiteSpace(value)) Log.Debug($"Reading value from appsettings.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
-				else Log.Debug($"Reading value from appsettings.json: '{key}={value}'");
+				if (string.IsNullOrWhiteSpace(value)) Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
+				else Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={value}'");
 			}
 
 			return value;

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -8,57 +8,68 @@ using NewRelic.Core.Logging;
 
 namespace NewRelic.Agent.Core.Configuration
 {
-	public static class AppSettingsConfigResolveWhenUsed
-	{
-		private static IConfiguration _configuration;
-		private static string _appSettingsFilePaths;
+    public static class AppSettingsConfigResolveWhenUsed
+    {
+        private static IConfiguration _configuration;
+        private static string _appSettingsFilePaths;
 
-		private static IConfiguration Configuration
-		{
-			get
-			{
-				return _configuration ?? (_configuration = InitializeConfiguration());
-			}
-		}
+        private static IConfiguration Configuration
+        {
+            get
+            {
+                return _configuration ?? (_configuration = InitializeConfiguration());
+            }
+        }
 
-		private static IConfigurationRoot InitializeConfiguration()
-		{
-			var env = new SystemInterfaces.Environment();
-			var currentDirectory = Directory.GetCurrentDirectory();
+        private static IConfigurationRoot InitializeConfiguration()
+        {
+            var env = new SystemInterfaces.Environment();
+            var currentDirectory = Directory.GetCurrentDirectory();
             var environment = env.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             if (string.IsNullOrEmpty(environment))
+            {
                 environment = env.GetEnvironmentVariable("EnvironmentName");
+            }
 
             var builder = new ConfigurationBuilder()
-				.SetBasePath(currentDirectory)
-				.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+                .SetBasePath(currentDirectory)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
 
-			if (!string.IsNullOrEmpty(environment)) builder.AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false);
+            if (!string.IsNullOrEmpty(environment))
+            {
+                builder.AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false);
+            }
 
-			var appSettingsPath = Path.Combine(currentDirectory, "appsettings.json");
-			var appSettingsEnvPath = Path.Combine(currentDirectory, $"appsettings.{environment}.json");
-			_appSettingsFilePaths = !string.IsNullOrEmpty(environment) ? string.Join(", ", appSettingsPath, appSettingsEnvPath) : appSettingsPath;
+            var appSettingsPath = Path.Combine(currentDirectory, "appsettings.json");
+            var appSettingsEnvPath = Path.Combine(currentDirectory, $"appsettings.{environment}.json");
+            _appSettingsFilePaths = !string.IsNullOrEmpty(environment) ? string.Join(", ", appSettingsPath, appSettingsEnvPath) : appSettingsPath;
 
-			return builder.Build();
-		}
+            return builder.Build();
+        }
 
-		public static string GetAppSetting(string key)
-		{
-			if (key == null)
-			{
-				return null;
-			}
-			
-			var value = Configuration[key];
+        public static string GetAppSetting(string key)
+        {
+            if (key == null)
+            {
+                return null;
+            }
+            
+            var value = Configuration[key];
 
-			if (Log.IsDebugEnabled)
-			{
-				if (string.IsNullOrWhiteSpace(value)) Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
-				else Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={value}'");
-			}
+            if (Log.IsDebugEnabled)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
+                }
+                else
+                {
+                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={value}'");
+                }
+            }
 
-			return value;
-		}
-	}
+            return value;
+        }
+    }
 }
 #endif


### PR DESCRIPTION
### Description
Starting from .Net Core 2.1, for AspNetCore applications, the value from the `ASPNETCORE_ENVIRONMENT` environment variable will determine which  `appsettings.{environment}.json` files will be loaded. The agent currently does not use the `ASPNETCORE_ENVIRONMENT` environment variable for environment name; therefore, it ignores any New Relic specific settings in the `appsettings.{environment}.json`.

### Testing
Manually tested. Steps that I did for testing:
1. Create an AspNetCore application targets .Net Core 2.1 or greater.
2. Updates the value of the `ASPNETCORE_ENVIRONMENT` as `Staging` in the `launchSettings.json`
3. Creates an `appsettings.Staging.json` file with the following content:
```
{
  "Logging": {
    "LogLevel": {
      "Default": "Warning"
    }
  },
  "NewRelic.AppName": "Staging",
  "AllowedHosts": "*"
}
``` 
4. Runs the application with the new agent attached.
5. Checked the agent debug level logs to see whether the agent reports the test application name as "Staging".
 