### PR TITLE
Use AppDomain.CurrentDomain.BaseDirectory to get path of appsettings*.json

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -12,8 +12,8 @@ New Feature Description
 ### Fixes
 Fixes Issue [#224](https://github.com/newrelic/newrelic-dotnet-agent/issues/224): leading "SET" commands will be ignored when parsing compound SQL statements. ([#370](https://github.com/newrelic/newrelic-dotnet-agent/pull/370))
 Fixes Issue [#226](https://github.com/newrelic/newrelic-dotnet-agent/issues/226): the profiler ignores drive letter in `HOME_EXPANDED` when detecting running in Azure Web Apps. ([#373](https://github.com/newrelic/newrelic-dotnet-agent/pull/373))
-
 Fixes Issue [#9](https://github.com/newrelic/newrelic-dotnet-agent/issues/9) where the agent failed to read settings from `appsettings.{environment}.json` files. ([#372](https://github.com/newrelic/newrelic-dotnet-agent/pull/372))
+Fixes Issue [#116](https://github.com/newrelic/newrelic-dotnet-agent/issues/116) where the agent failed to read settings from `appsettings.json` in certain hosting scenarios. ([#375](https://github.com/newrelic/newrelic-dotnet-agent/pull/375))
 
 ## [8.35] - 2020-11-09
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         private static IConfigurationRoot InitializeConfiguration()
         {
-            var env = new SystemInterfaces.Environment();
+            // Get application base directory, where appsettings*.json will be if they exist
             var applicationDirectory = string.Empty;
             try
             {
@@ -32,18 +32,21 @@ namespace NewRelic.Agent.Core.Configuration
             }
             catch (AppDomainUnloadedException)
             {
-                // Fall back to previous behavior
+                // Fall back to previous behavior of agents <=8.35.0
                 applicationDirectory = Directory.GetCurrentDirectory();
-            }
-            var environment = env.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            if (string.IsNullOrEmpty(environment))
-            {
-                environment = env.GetEnvironmentVariable("EnvironmentName");
             }
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(applicationDirectory)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+
+            // Determine if there might be an environment-specific appsettings file
+            var env = new SystemInterfaces.Environment();
+            var environment = env.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            if (string.IsNullOrEmpty(environment))
+            {
+                environment = env.GetEnvironmentVariable("EnvironmentName");
+            }
 
             if (!string.IsNullOrEmpty(environment))
             {


### PR DESCRIPTION
### Description

This fixes #116 by using `AppDomain.CurrentDomain.BaseDirectory` instead of `Directory.GetCurrentDirectory()` to get the path where an application's `appsettings.json` file(s) should be.

### Testing

Manually tested an ASP.NET Core 2.2 application hosted in a Windows service.  Prior to this fix, this app could not read its New Relic application name setting from `appsettings.json` even though it was there.  After the fix, the app is named correctly as expected.  I also tested some other cases (.NET 5.0 console application, ASP.NET Core 2.2 and 3.1 apps hosted in IIS in-process) and app naming via appsettings.json worked as expected.

### Changelog

Will update changelog once I have a PR # for this PR.