### PR TITLE
Fixes AddCustomAttribute throws Newtonsoft.Json.JsonWriterException: Unsupported type error when used to add header values

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/JsonSerializerHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/JsonSerializerHelpers.cs
@@ -27,9 +27,19 @@ namespace NewRelic.Agent.Core.JsonConverters
                     }
 
                     writer.WritePropertyName(attribVal.AttributeDefinition.Name);
-                    writer.WriteValue(outputValue);
+
+                    // Causes an exception since this type is unsupported by the JsonConverter
+                    if (outputValue.GetType().ToString() == "Microsoft.Extensions.Primitives.StringValues")
+                    {
+                        writer.WriteValue(outputValue.ToString());
+                    }
+                    else
+                    {
+                        writer.WriteValue(outputValue);
+                    }
                 }
             }
+
             writer.WriteEndObject();
         }
 

--- a/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Primitives;
 
 namespace CompositeTests
 {
@@ -2256,6 +2257,10 @@ namespace CompositeTests
             segment.AddCustomAttribute("key8", null);
             segment.AddCustomAttribute("", dtm2);
 
+            var singleStringValue = new StringValues("avalue");
+            var multiStringValue = new StringValues(new[] { "onevalue", "twovalue", "threevalue" });
+            segment.AddCustomAttribute("key9a", singleStringValue);
+            segment.AddCustomAttribute("key9b", multiStringValue);
 
             var expectedAttributes = new[]
             {
@@ -2265,7 +2270,9 @@ namespace CompositeTests
                 new ExpectedAttribute(){ Key = "key4", Value = 4.0d},
                 new ExpectedAttribute(){ Key = "key5", Value = true},
                 new ExpectedAttribute(){ Key = "key6", Value = dtm1.ToString("o")},
-                new ExpectedAttribute(){ Key = "key7", Value = dtm2.ToString("o")}
+                new ExpectedAttribute(){ Key = "key7", Value = dtm2.ToString("o")},
+                new ExpectedAttribute(){ Key = "key9a", Value = "avalue"},
+                new ExpectedAttribute(){ Key = "key9b", Value = "onevalue,twovalue,threevalue"}
             };
 
             var unexpectedAttributes = new[]

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Castle.Core" Version="3.3.0" />
     <PackageReference Include="Castle.Windsor" Version="3.3.0" />
     <PackageReference Include="JustMock" Version="2020.1.113.1" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
     <PackageReference Include="MoreLinq" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
Resolves #377 

### Description
Adds an if statement to JsonSerializerHelpers.cs to check if this the type is Microsoft.Extensions.Primitives.StringValues.
Went with strings since VS was not happy with using just the types as the conditional.

Added a small unit test to AgentApiTests.cs that checks StringValues.

### Testing

Tests should pass as normal.

### Changelog

Fixes a bug where using AddCustomAttribute throws Newtonsoft.Json.JsonWriterException: Unsupported type error when used to add header values.
