### PR TITLE
Rabbitmq netstandard20

### DIFF
--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -35,6 +35,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MongoDb26.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Sql.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.RabbitMq.dll",
             };
 
             var wrapperXmls = new[]
@@ -45,6 +46,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MongoDb26.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.RabbitMq.Instrumentation.xml",
             };
 
             ExtensionXsd = $@"{SourceHomeBuilderPath}\extensions\extension.xsd";

--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -478,6 +478,9 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="CoreStackExchangeRedisWrapperComponent" Guid="{9278332C-3059-48F3-BD18-84C4323583DA}">
         <File Id="CoreStackExchangeRedisWrapperFile" Name="NewRelic.Providers.Wrapper.StackExchangeRedis.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.dll"/>
       </Component>
+      <Component Id="CoreRabbitMqWrapperComponent" Guid="{758394DD-AB71-4E58-8E18-BF1135F8B2C2}">
+        <File Id="CoreRabbitMqWrapperFile" Name="NewRelic.Providers.Wrapper.RabbitMq.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.RabbitMq.dll"/>
+      </Component>
 
       <!-- Reference libraries -->
       <Component Id="CoreNewRelicCoreReferenceComponent" Guid="{DD2BE979-7D4B-47EA-9FBE-F6B381D70E0B}">
@@ -585,6 +588,9 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreStackExchangeRedisInstrumentationComponent" Guid="{D7D3D2F7-1001-405A-9844-8640A39C5B9F}">
         <File Id="CoreStackExchangeRedisInstrumentationFile" Name="NewRelic.Providers.Wrapper.StackExchangeRedis.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.Instrumentation.xml"/>
+      </Component>
+      <Component Id="CoreRabbitMqInstrumentationComponent" Guid="{1CDC18CC-992A-4386-BC4D-DE87A85D9568}">
+        <File Id="CoreRabbitMqInstrumentationFile" Name="NewRelic.Providers.Wrapper.RabbitMq.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.RabbitMq.Instrumentation.xml"/>
       </Component>
     </ComponentGroup>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMq.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMq.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFramework>net45</TargetFramework>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
         <AssemblyName>NewRelic.Providers.Wrapper.RabbitMq</AssemblyName>
         <RootNamespace>NewRelic.Providers.Wrapper.RabbitMq</RootNamespace>
         <Description>RabbitMq Wrapper Provider for New Relic .NET Agent</Description>
@@ -11,7 +11,7 @@
         </Content>
     </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -15,7 +15,6 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
     {
         private const string TempQueuePrefix = "amq.";
         private const string BasicPropertiesType = "RabbitMQ.Client.Framing.BasicProperties";
-
         public const string VendorName = "RabbitMQ";
         public const string AssemblyName = "RabbitMQ.Client";
         public const string TypeName = "RabbitMQ.Client.Framing.Impl.Model";


### PR DESCRIPTION
Resolves #380 

### Description
- Multitargets the rabbitmq instrumentation project to support both net45 and netstandard2.0.
- Adds netstandard rabbitmq extensions files to:
  - ArtifactBuilder
  - MsiInstaller

### Testing

There are no unbounded tests for this yet, but the story is in progress.  The existing RabbitMq tests, net45 only, passed locally and should pass in GHA.

### Changelog

- Updates RabbitMQ instrumentation to support netstandard32.0

