### PR TITLE
Fix NuGet restore issue in GHA builds

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
 
-      - name: Print NuGet config file
-        run: |
-          Get-Content "C:\Users\runneradmin\AppData\Roaming\NuGet\NuGet.Config"
-        shell: powershell
-
       - name: Clean out _profilerBuild directory
         run: |
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\*.*" -Force -ErrorAction SilentlyContinue
@@ -159,6 +154,8 @@ jobs:
             
       - name: Build FullAgent.sln
         run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
         shell: powershell
@@ -327,6 +324,8 @@ jobs:
 
       - name: Build IntegrationTests.sln
         run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
@@ -361,6 +360,8 @@ jobs:
 
       - name: Build UnboundedIntegrationTests.sln
         run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
         shell: powershell
@@ -395,6 +396,8 @@ jobs:
 
       - name: Build PlatformTests.sln
         run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
         shell: powershell

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Build x64
         run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source
           Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
           MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
         shell: powershell

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
 
+      - name: Print NuGet config file
+        run: |
+          Get-Content "C:\Users\runneradmin\AppData\Roaming\NuGet\NuGet.Config"
+        shell: powershell
+
       - name: Clean out _profilerBuild directory
         run: |
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\*.*" -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build x64
         run: |
           Write-Host "List NuGet Sources"
-          dotnet nuget list source
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
           MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
         shell: powershell
@@ -155,7 +155,7 @@ jobs:
       - name: Build FullAgent.sln
         run: |
           Write-Host "List NuGet Sources"
-          dotnet nuget list source
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
         shell: powershell
@@ -325,7 +325,7 @@ jobs:
       - name: Build IntegrationTests.sln
         run: |
           Write-Host "List NuGet Sources"
-          dotnet nuget list source
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
@@ -361,7 +361,7 @@ jobs:
       - name: Build UnboundedIntegrationTests.sln
         run: |
           Write-Host "List NuGet Sources"
-          dotnet nuget list source
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
         shell: powershell
@@ -397,7 +397,7 @@ jobs:
       - name: Build PlatformTests.sln
         run: |
           Write-Host "List NuGet Sources"
-          dotnet nuget list source
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
           MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
         shell: powershell


### PR DESCRIPTION
### Description

This repo's main CI build started failing in GHA last week, with a NuGet package restore issue being the point of failure.  This appears to be a failure introduced by some change behind the scenes in GHA; there were no code changes associated with this problem suddenly appearing.

To investigate the issue, I attempted to get more visibility into what the NuGet package source configuration was on the GHA runner for the build jobs.  Eventually, I got around to putting a `dotnet nuget list source` command before running builds that were failing - and this somehow caused the failures to stop! 😕 

Since we have other work in progress we want to get merged to `main`, I'm willing to go with this fix for the problem without us really understanding why it fixes things. 🤷‍♂️  

### Testing

CI builds were failing before this change, and now they are not.

### Changelog

N/A