### PR TITLE
adds NEW_RELIC_LOG

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Not supported: Distributed Tracing is not supported with the RabbitMQ AMQP 1.0 plugin.
 
 * **Adds [configuration](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration) Environment Variables** <br/>
-  * Adds MAX_TRANSACTION_SAMPLES_STORED.
-  * Adds MAX_EVENT_SAMPLES_STORED. 
+  * Adds MAX_TRANSACTION_SAMPLES_STORE - the maximum number of samples stored for Transaction Events.
+  * Adds MAX_EVENT_SAMPLES_STORED - the maximum number of samples stored for Custom Events. 
+  * Adds NEW_RELIC_LOG - the unqualifed name for the Agent's log file.
 
 ### Fixes
 * **New Fixes Template** <br/>

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -484,7 +484,13 @@ namespace NewRelic.Agent.Core.Config
 
         private string GetLogFileName()
         {
-            string name = fileName;
+            string name = System.Environment.GetEnvironmentVariable("NEW_RELIC_LOG");
+            if (name != null)
+            {
+                return name;
+            }
+
+            name = fileName;
             if (name != null)
             {
                 return Strings.SafeFileName(name);

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -487,7 +487,7 @@ namespace NewRelic.Agent.Core.Config
             string name = System.Environment.GetEnvironmentVariable("NEW_RELIC_LOG");
             if (name != null)
             {
-                return name;
+                return Strings.SafeFileName(name);
             }
 
             name = fileName;

--- a/src/NewRelic.Core/Strings.cs
+++ b/src/NewRelic.Core/Strings.cs
@@ -18,14 +18,25 @@ namespace NewRelic.Core
         /// <returns>The sanitized file name.</returns>
         public static string SafeFileName(string name)
         {
-            foreach (var c in Path.GetInvalidPathChars())
+            var invalidPathChars = Path.GetInvalidPathChars();
+
+            if (name.IndexOfAny(invalidPathChars) != -1)
             {
-                name = name.Replace(c, '_');
+                foreach (var c in invalidPathChars)
+                {
+                    name = name.Replace(c, '_');
+                }
             }
-            foreach (var c in Path.GetInvalidFileNameChars())
+
+            var invalidFileNameChars = Path.GetInvalidFileNameChars();
+            if (name.IndexOfAny(invalidFileNameChars) != -1)
             {
-                name = name.Replace(c, '_');
+                foreach (var c in invalidFileNameChars)
+                {
+                    name = name.Replace(c, '_');
+                }
             }
+
             return name;
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ChangeLogDirectoryTests.cs
@@ -14,6 +14,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
+        private const string CustomLogFileNameFromConfigBase = "customLogFileName";
+        private const string CustomLogFileNameFromConfig = CustomLogFileNameFromConfigBase + ".log";
+        private const string CustomAuditLogFileNameFromConfig = CustomLogFileNameFromConfigBase + "_audit.log";
+
         public ChangeLogDirectoryTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
@@ -33,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
 
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "info");
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "directory", testLoggingDirectory);
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "fileName", "dotNetAgent.log");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "fileName", CustomLogFileNameFromConfig);
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "auditLog", "true");
                 },
                 exerciseApplication: () =>
@@ -47,8 +51,8 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         [Fact]
         public void Test()
         {
-            File.Exists(Path.Combine(_fixture.DestinationNewRelicLogFileDirectoryPath, "dotNetAgent.log"));
-            File.Exists(Path.Combine(_fixture.DestinationNewRelicLogFileDirectoryPath, "dotNetAgent_audit.log"));
+            Assert.True(File.Exists(Path.Combine(_fixture.DestinationNewRelicLogFileDirectoryPath, CustomLogFileNameFromConfig)));
+            Assert.True(File.Exists(Path.Combine(_fixture.DestinationNewRelicLogFileDirectoryPath, CustomAuditLogFileNameFromConfig)));
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
@@ -86,6 +86,15 @@ namespace NewRelic.Agent.Core.Utils
             Assert.AreEqual(content, result);
         }
 
+        [TestCase("commonName", ExpectedResult = "commonName")]
+        [TestCase("commonName.log", ExpectedResult = "commonName.log")]
+        [TestCase("name with spaces", ExpectedResult = "name with spaces")]
+        [TestCase("name\"with\\|invalidchars_", ExpectedResult = "name_with__invalidchars_")]
+        public string SafeFileName_Tests(string inputName)
+        {
+            return Strings.SafeFileName(inputName);
+        }
+
         private static IEnumerable<object[]> ConvertBytesToStringTestData()
         {
             var encodings = new Encoding[] { Encoding.Unicode, Encoding.UTF8, Encoding.ASCII };
@@ -118,6 +127,5 @@ namespace NewRelic.Agent.Core.Utils
                 yield return new object[] { encoding, "AB YZ 19 \uD800\udc05" }; // just to make sure
             }
         }
-
     }
 }


### PR DESCRIPTION
### Description
Resolves Issue #406.
Adds NEW_RELIC_LOG environment variable to specify the unqualified filename for the agent's log file.
This environment variable takes precedence over other log file name settings.
Fixes and optimizes SafeFileName method.

### Testing
Updates ChangeLogFilenameTests (Integration Tests) and adds SafeFileName tests (Unit tests).