### PR TITLE
Reverts grpc packages update due to 8T breaking

### DIFF
--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -155,12 +155,11 @@ function Copy-AgentRoot {
 
     $grpcDir = Get-GrpcPackagePath $RootDirectory
     if ($Linux) {
-        Copy-Item -Path "$grpcDir\runtimes\linux-x64\native\libgrpc_csharp_ext.x64.so" -Destination "$Destination" -Force 
+        Copy-Item -Path "$grpcDir\runtimes\linux\native\libgrpc_csharp_ext.x64.so" -Destination "$Destination" -Force 
         Copy-Item -Path "$RootDirectory\src\Agent\_profilerBuild\linux-release\libNewRelicProfiler.so" -Destination "$Destination" -Force 
     }
     else {
-        Copy-Item -Path "$grpcDir\runtimes\win-x86\native\*.dll" -Destination "$Destination" -Force
-        Copy-Item -Path "$grpcDir\runtimes\win-x64\native\*.dll" -Destination "$Destination" -Force
+        Copy-Item -Path "$grpcDir\runtimes\win\native\*.dll" -Destination "$Destination" -Force 
 
         if ($Architecture -like "x64" ) {
             Copy-Item -Path "$RootDirectory\src\Agent\_profilerBuild\x64-Release\NewRelic.Profiler.dll" -Destination "$Destination" -Force 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 New Features Description
 
 ### Fixes
-* Fixes Issue [#394](https://github.com/newrelic/newrelic-dotnet-agent/issues/394): agent fails to enable infinite tracing in net5.0 docker images
+* **New Fixes Template** <br/>
+New Fixes Description
 
 ## [8.37] - 2021-01-04
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -24,10 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc" Version="2.34.0" />
-    <PackageReference Include="Grpc.Core" Version="2.34.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.34.0">
+    <PackageReference Include="Google.Protobuf" Version="3.11.4" />
+    <PackageReference Include="Grpc" Version="2.28.1" />
+    <PackageReference Include="Grpc.Core" Version="2.28.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.28.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Description
Updating gprc nuget packages to version 2.34.0 causes `System.TypeLoadException` when streaming span data. This PR reverts the change. 