### PR TITLE
flipped finest boolean in WCF logging

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
@@ -218,7 +218,7 @@ namespace NewRelic.Providers.Wrapper.Wcf3
             Guid? wrapperExecutionID = null;
             void WriteLogMessage(string message)
             {
-                if (agent.Logger.IsEnabledFor(Agent.Extensions.Logging.Level.Finest))
+                if (!agent.Logger.IsEnabledFor(Agent.Extensions.Logging.Level.Finest))
                 {
                     return;
                 }


### PR DESCRIPTION
### Description
Intended `finest` logging is missing in some WCF instrumentation, hampering the ability to diagnose WCF issues.
Also a consequence, the extra logic intended only if logging is set to finest is always (unnecessarily) executed for the other log settings.

### Testing
Unit tests and IntegrationTests pass locally.

