### PR TITLE
use existing string instead of creating a new one

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -79,7 +79,7 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
             var segment = transaction.StartMessageBrokerSegment(instrumentedMethodCall.MethodCall, destType, MessageBrokerAction.Produce, VendorName, destName);
 
             //If the RabbitMQ version doesn't provide the BasicProperties parameter we just bail.
-            if (basicProperties.GetType().ToString() != BasicPropertiesType)
+            if (basicProperties.GetType().FullName != BasicPropertiesType)
             {
                 return segment;
             }
@@ -112,8 +112,9 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
             var segment = transaction.StartMessageBrokerSegment(instrumentedMethodCall.MethodCall, destType, MessageBrokerAction.Produce, VendorName, destName);
 
             //If the RabbitMQ version doesn't provide the BasicProperties parameter we just bail.
-            if (basicProperties.GetType().ToString() != BasicPropertiesType)
+            if (basicProperties.GetType().FullName != BasicPropertiesType)
             {
+                
                 return segment;
             }
 


### PR DESCRIPTION
### Description
GetType() returns a Type object that already has the string needed to compare. No need to create another one.

### Testing
RabbitMQ unbounded tests pass locally.

### Changelog
N/A
