### PR TITLE
8T integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -51,11 +51,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string TransactionEndedByGCFinalizerLogLineRegEx = DebugLogLinePrefixRegex + @"Transaction was garbage collected without ever ending(.*)";
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 
-        public const string CountGroupName = "CountGroupName";
-        public string AttemptToSend = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Attempting to send (?'{CountGroupName}'.*) item\(s\)\.";
-        public string AttemptToSendSuccess = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Attempting to send (?'{CountGroupName}'.*) item\(s\) - Success";
-        public string GrpcServerResponseReceived = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Received gRPC Server response: (?'{CountGroupName}'.*)";
-
         public abstract IEnumerable<string> GetFileLines();
 
         public string GetAccountId(TimeSpan? timeoutOrZero = null)
@@ -395,49 +390,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         {
             var match = WaitForLogLine(InstrumentationRefreshFileWatcherStarted, TimeSpan.FromSeconds(timeOut));
             return match.Success;
-        }
-
-        #endregion
-
-        #region InfiniteTracing
-
-        public int GetInfiniteTracingAttemptToSendCount()
-        {
-            var count = 0;
-            var matches = TryGetLogLines(AttemptToSend);
-
-            foreach (var match in matches)
-            {
-                count += int.Parse(match.Groups[CountGroupName].Value);
-            }
-
-            return count;
-        }
-
-        public int GetInfiniteTracingAttemptToSendSuccessCount()
-        {
-            var count = 0;
-            var matches = TryGetLogLines(AttemptToSendSuccess);
-
-            foreach(var match in matches)
-            {
-                count += int.Parse(match.Groups[CountGroupName].Value);
-            }
-
-            return count;
-        }
-
-        public int GetInfiniteTracingGrpcServerReceivedCount()
-        {
-            var count = 0;
-            var matches = TryGetLogLines(GrpcServerResponseReceived);
-
-            foreach (var match in matches)
-            {
-                count += int.Parse(match.Groups[CountGroupName].Value);
-            }
-
-            return count;
         }
 
         #endregion

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -51,6 +51,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string TransactionEndedByGCFinalizerLogLineRegEx = DebugLogLinePrefixRegex + @"Transaction was garbage collected without ever ending(.*)";
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 
+        public const string CountGroupName = "CountGroupName";
+        public string AttemptToSend = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Attempting to send (?'{CountGroupName}'.*) item\(s\)\.";
+        public string AttemptToSendSuccess = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Attempting to send (?'{CountGroupName}'.*) item\(s\) - Success";
+        public string GrpcServerResponseReceived = FinestLogLinePrefixRegex + $@"SpanStreamingService: consumer (.*) - Received gRPC Server response: (?'{CountGroupName}'.*)";
+
         public abstract IEnumerable<string> GetFileLines();
 
         public string GetAccountId(TimeSpan? timeoutOrZero = null)
@@ -390,6 +395,49 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         {
             var match = WaitForLogLine(InstrumentationRefreshFileWatcherStarted, TimeSpan.FromSeconds(timeOut));
             return match.Success;
+        }
+
+        #endregion
+
+        #region InfiniteTracing
+
+        public int GetInfiniteTracingAttemptToSendCount()
+        {
+            var count = 0;
+            var matches = TryGetLogLines(AttemptToSend);
+
+            foreach (var match in matches)
+            {
+                count += int.Parse(match.Groups[CountGroupName].Value);
+            }
+
+            return count;
+        }
+
+        public int GetInfiniteTracingAttemptToSendSuccessCount()
+        {
+            var count = 0;
+            var matches = TryGetLogLines(AttemptToSendSuccess);
+
+            foreach(var match in matches)
+            {
+                count += int.Parse(match.Groups[CountGroupName].Value);
+            }
+
+            return count;
+        }
+
+        public int GetInfiniteTracingGrpcServerReceivedCount()
+        {
+            var count = 0;
+            var matches = TryGetLogLines(GrpcServerResponseReceived);
+
+            foreach (var match in matches)
+            {
+                count += int.Parse(match.Groups[CountGroupName].Value);
+            }
+
+            return count;
         }
 
         #endregion

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -104,6 +104,19 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return this;
         }
 
+        public NewRelicConfigModifier EnableDistributedTrace()
+        {
+            SetOrDeleteDistributedTraceEnabled(true);
+            return this;
+        }
+
+        public NewRelicConfigModifier EnableInfinteTracing(string traceObserverUrl)
+        {
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath,
+               new[] { "configuration", "infiniteTracing", "trace_observer" }, "host", traceObserverUrl);
+            return this;
+        }
+
         public void AutoInstrumentBrowserMonitoring(bool shouldAutoInstrument)
         {
             var stringValue = shouldAutoInstrument.ToString().ToLower(); //We don't seem to handle the uppercase parse

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
@@ -75,9 +75,9 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
     }
 
     [NetCoreTest]
-    public class DotNetPerfMetricsTestsCoreLatest : DotNetPerfMetricsTests<ConsoleDynamicMethodFixtureCoreLatest>
+    public class DotNetPerfMetricsTestsCoreLatest : DotNetPerfMetricsTests<ConsoleDynamicMethodFixtureCore31>
     {
-        public DotNetPerfMetricsTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public DotNetPerfMetricsTestsCoreLatest(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -21,9 +21,9 @@ namespace NewRelic.Agent.IntegrationTests.Api
     }
 
     [NetCoreTest]
-    public class ApiCallsTestsCore : ApiCallsTests<ConsoleDynamicMethodFixtureCoreLatest>
+    public class ApiCallsTestsCore : ApiCallsTests<ConsoleDynamicMethodFixtureCore31>
     {
-        public ApiCallsTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public ApiCallsTestsCore(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
@@ -22,9 +22,9 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
     }
 
     [NetCoreTest]
-    public class NetStandardLibraryInstrumentationNetCore : NetStandardLibraryInstrumentation<ConsoleDynamicMethodFixtureCoreLatest>
+    public class NetStandardLibraryInstrumentationNetCore : NetStandardLibraryInstrumentation<ConsoleDynamicMethodFixtureCore31>
     {
-        public NetStandardLibraryInstrumentationNetCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+        public NetStandardLibraryInstrumentationNetCore(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output) : base(fixture, output)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
@@ -20,9 +20,9 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
     }
 
     [NetCoreTest]
-    public class FasterEventHarvestNetCoreTests : FasterEventHarvestTests<ConsoleDynamicMethodFixtureCoreLatest>
+    public class FasterEventHarvestNetCoreTests : FasterEventHarvestTests<ConsoleDynamicMethodFixtureCore31>
     {
-        public FasterEventHarvestNetCoreTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+        public FasterEventHarvestNetCoreTests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output) : base(fixture, output)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -47,7 +47,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
             var sentCount = _fixture.AgentLog.GetInfiniteTracingAttemptToSendSuccessCount();
             var receivedCount = _fixture.AgentLog.GetInfiniteTracingGrpcServerReceivedCount();
 
-            var senderExpectedMetrics = new List<Assertions.ExpectedMetric>
+            var actualMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", callCount = sendCount },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", callCount = sentCount },
@@ -55,7 +55,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
             };
 
             var metrics = _fixture.AgentLog.GetMetrics();
-            Assertions.MetricsExist(senderExpectedMetrics, metrics);
+            Assertions.MetricsExist(actualMetrics, metrics);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
+{
+    public class InfiniteTracingTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        private readonly ConsoleDynamicMethodFixture _fixture;
+
+        public InfiniteTracingTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output):base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"InfiniteTracingTester StartAgent");
+            _fixture.AddCommand($"InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand($"InfiniteTracingTester Wait");
+
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier.ForceTransactionTraces()
+                    .EnableDistributedTrace()
+                    .EnableInfinteTracing(_fixture.TestConfiguration.TraceObserverUrl)
+                    .SetLogLevel("finest");
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var sendCount = _fixture.AgentLog.GetInfiniteTracingAttemptToSendCount();
+            var sentCount = _fixture.AgentLog.GetInfiniteTracingAttemptToSendSuccessCount();
+            var receivedCount = _fixture.AgentLog.GetInfiniteTracingGrpcServerReceivedCount();
+
+            var senderExpectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", callCount = sendCount },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", callCount = sentCount },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Received", callCount = receivedCount }
+            };
+
+            var metrics = _fixture.AgentLog.GetMetrics();
+            Assertions.MetricsExist(senderExpectedMetrics, metrics);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -44,6 +44,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
         [Fact]
         public void Test()
         {
+            //1 span count for the Make8TSpan method, another span count for the root span.
             var expectedSeenCount = 2;
             var expectedSentCount = 2;
             var expectedReceivedCount = 2;

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -9,11 +9,12 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
 {
-    public class InfiniteTracingTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureCoreLatest>
+    public abstract class InfiniteTracingTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        private readonly TFixture _fixture;
 
-        public InfiniteTracingTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output):base(fixture)
+        public InfiniteTracingTestsBase(TFixture fixture, ITestOutputHelper output):base(fixture)
         {
             _fixture = fixture;
             _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
@@ -56,6 +57,61 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
 
             var metrics = _fixture.AgentLog.GetMetrics();
             Assertions.MetricsExist(actualMetrics, metrics);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFWLatestTests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public InfiniteTracingFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFW471Tests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public InfiniteTracingFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFW461Tests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureFW461>
+    {
+        public InfiniteTracingFW461Tests(ConsoleDynamicMethodFixtureFW461 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingNetCoreLatestTests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public InfiniteTracingNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingNetCore31Tests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public InfiniteTracingNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingNetCore21Tests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureCore21>
+    {
+        public InfiniteTracingNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -44,15 +44,15 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
         [Fact]
         public void Test()
         {
-            var sendCount = _fixture.AgentLog.GetInfiniteTracingAttemptToSendCount();
-            var sentCount = _fixture.AgentLog.GetInfiniteTracingAttemptToSendSuccessCount();
-            var receivedCount = _fixture.AgentLog.GetInfiniteTracingGrpcServerReceivedCount();
+            var expectedSeenCount = 2;
+            var expectedSentCount = 2;
+            var expectedReceivedCount = 2;
 
             var actualMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", callCount = sendCount },
-                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", callCount = sentCount },
-                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Received", callCount = receivedCount }
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", callCount = expectedSeenCount },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", callCount = expectedSentCount },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Received", callCount = expectedReceivedCount }
             };
 
             var metrics = _fixture.AgentLog.GetMetrics();

--- a/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
@@ -41,6 +41,19 @@ namespace NewRelic.Agent.IntegrationTests.Shared
             }
         }
 
+        public string TraceObserverUrl
+        {
+            get
+            {
+                if (TestSettingOverrides.TryGetValue(_configurationCategory, out var item) && !string.IsNullOrEmpty(item.TraceObserverUrl))
+                {
+                    return item.TraceObserverUrl;
+                };
+
+                return DefaultSetting.TraceObserverUrl;
+            }
+        }
+
         private IntegrationTestConfiguration(string configurationCategory)
         {
             _configurationCategory = configurationCategory;
@@ -77,6 +90,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         public string AwsAccessKeyId { get; set; }
         public string AwsSecretAccessKey { get; set; }
         public string AwsAccountNumber { get; set; }
+        public string TraceObserverUrl { get; set; }
         public IDictionary<string, string> CustomSettings { get; set; }
     }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -60,6 +60,13 @@ namespace MultiFunctionApplicationHelpers
         }
     }
 
+    public class ConsoleDynamicMethodFixtureCore31 : ConsoleDynamicMethodFixtureCoreSpecificVersion
+    {
+        public ConsoleDynamicMethodFixtureCore31() : base("netcoreapp3.1")
+        {
+        }
+    }
+
     /// <summary>
     /// Use this fixture if you don't care about which .net core version the test application should use.
     /// If you need to test against a feature that belongs to a specific .net core version, then consider
@@ -68,7 +75,7 @@ namespace MultiFunctionApplicationHelpers
     /// </summary>
     public class ConsoleDynamicMethodFixtureCoreLatest : ConsoleDynamicMethodFixtureCoreSpecificVersion
     {
-        public ConsoleDynamicMethodFixtureCoreLatest() : base("netcoreapp3.1")
+        public ConsoleDynamicMethodFixtureCoreLatest() : base("net5.0")
         {
         }
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries
+{
+    [Library]
+    public class InfiniteTracingTester
+    {
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void Make8TSpan()
+        {
+            var rand = new Random(10);
+            rand.Next();
+            rand.Next();
+            rand.Next();
+            rand.Next();
+        }
+
+        /// <summary>
+        /// This is an instrumented method that doesn't actually do anything.  Its purpose
+        /// is to ensure that the agent starts up.  Without an instrumented method, the agent won't
+        /// start.
+        /// </summary>
+        [LibraryMethod]
+        [Transaction]
+        public static void StartAgent()
+        {
+            Logger.Info("Instrumented Method to start the Agent");
+
+            //Get everything started up and time for initial Sample().
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+        }
+
+        [LibraryMethod]
+        public static void Wait()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(70));
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
@@ -24,17 +24,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
             rand.Next();
         }
 
-        /// <summary>
-        /// This is an instrumented method that doesn't actually do anything.  Its purpose
-        /// is to ensure that the agent starts up.  Without an instrumented method, the agent won't
-        /// start.
-        /// </summary>
         [LibraryMethod]
-        [Transaction]
         public static void StartAgent()
         {
-            Logger.Info("Instrumented Method to start the Agent");
-
+            NewRelic.Api.Agent.NewRelic.StartAgent();
             //Get everything started up and time for initial Sample().
             Thread.Sleep(TimeSpan.FromSeconds(10));
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
@@ -89,9 +89,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
     }
 
     [NetCoreTest]
-    public class RabbitMqDistributedTracingNetCore621Tests : RabbitMqDistributedTracingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class RabbitMqDistributedTracingNetCore621Tests : RabbitMqDistributedTracingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public RabbitMqDistributedTracingNetCore621Tests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public RabbitMqDistributedTracingNetCore621Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
@@ -139,9 +139,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
     }
 
     [NetCoreTest]
-    public class RabbitMqNetCore621Tests : RabbitMqTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class RabbitMqNetCore621Tests : RabbitMqTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public RabbitMqNetCore621Tests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public RabbitMqNetCore621Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -7,7 +7,8 @@
         "AwsTestRoleArn" : "YOUR_AWS_TEST_ROLE_ARN_HERE",
         "AwsAccessKeyId" : "YOUR_AWS_ACCESS_KEY_ID_HERE",
         "AwsSecretAccessKey" : "YOUR_AWS_SECRET_ACCESS_KEY_HERE",
-        "AwsAccountNumber" : "YOUR_AWS_ACCOUNT_NUMBER_HERE"
+        "AwsAccountNumber" : "YOUR_AWS_ACCOUNT_NUMBER_HERE",
+        "TraceObserverUrl" : "YOUR_NR_EDGE_TRACE_OBSERVER_HERE"
       },
       "TestSettingOverrides": {
         "HSM": {


### PR DESCRIPTION
### Description

This PR adds initial integration tests for the Agent Infinite Tracing functionality. The scope of this PR is limited to Infinite Tracing smoke tests on different flavors of .NET Frameworks and Core. The set of tests doesn't test all infinite tracing case scenarios.

In order to run the tests, trace observer url need to be configured in the local secrets.json. Adds the line at the root node of your local secret file.
```
{
...
...
"TraceObserverUrl" : "_REPLACE_WITH_A_TRACE_OBSERVER_URL_"
}
```
