### PR TITLE
Markdown dead link check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](/CODE_OF_CONDUCT.md).
+Thank you for submitting a pull request.  Please review our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).
 
 ### Description
 
@@ -10,5 +10,5 @@ What unit or integration tests were added or modified, or why no testing changes
 
 ### Changelog
 
-Please remember to update our [changelog](/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),
+Please remember to update our [changelog](src/Agent/CHANGELOG.md) if applicable (or [this changelog](src/AwsLambda/CHANGELOG.md) for Lambda agent changes),
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thank you for submitting a pull request.  Please review our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).
+Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).
 
 ### Description
 
@@ -10,5 +10,5 @@ What unit or integration tests were added or modified, or why no testing changes
 
 ### Changelog
 
-Please remember to update our [changelog](src/Agent/CHANGELOG.md) if applicable (or [this changelog](src/AwsLambda/CHANGELOG.md) for Lambda agent changes),
+Please remember to update our [changelog](/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),
 

--- a/.github/workflows/markdowncheck.config.json
+++ b/.github/workflows/markdowncheck.config.json
@@ -1,0 +1,18 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": "^http://example.net"
+      }
+    ],
+    "replacementPatterns": [
+      {
+        "pattern": "^/",
+        "replacement": "{{BASEURL}}/"
+      }
+    ],
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+  }

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -1,0 +1,15 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        #use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        #config-file: 'mlc_config.json'
+        #max-depth: 2

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -11,5 +11,5 @@ jobs:
       with:
         #use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
-        #config-file: 'mlc_config.json'
+        config-file: '.github/workflows/markdowncheck.config.json'
         #max-depth: 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing
 
 Contributions are always welcome. Before contributing please read the
-[code of conduct](https://opensource.newrelic.com/code-of-conduct/) and [search the issue tracker](../../issues); your issue may have already been discussed or fixed in `master`. To contribute,
+[code of conduct](https://opensource.newrelic.com/code-of-conduct/) and [search the issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues); your issue may have already been discussed or fixed in `master`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
 Note that our [code of conduct](https://opensource.newrelic.com/code-of-conduct/) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
 ## Feature Requests
 
-Feature requests should be submitted in the [Issue tracker](../../issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](../../issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
+Feature requests should be submitted in the [Issue tracker](https://github.com/newrelic/newrelic-dotnet-agent/issues), with a description of the expected behavior & use case, where they’ll remain closed until sufficient interest, [e.g. :+1: reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/), has been [shown by the community](https://github.com/newrelic/newrelic-dotnet-agent/issues?q=label%3A%22votes+needed%22+sort%3Areactions-%2B1-desc).
 Before submitting an Issue, please search for similar ones in the
-[closed issues](../../issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
+[closed issues](https://github.com/newrelic/newrelic-dotnet-agent/issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
 
 ## Pull Requests
 
@@ -63,13 +63,13 @@ Our repository includes an [.editorconfig](https://github.com/newrelic/newrelic-
 
 ### Testing Guidelines
 
-See our [development](/docs/development.md) and [integration testing](/docs/integration-tests.md) documentation to run tests, including required setup steps.
+See our [development](docs/development.md) and [integration testing](docs/integration-tests.md) documentation to run tests, including required setup steps.
 
 For most contributions it is strongly recommended to add additional tests which exercise your changes. This helps us efficiently incorporate your changes into our mainline codebase and provides a safeguard that your change won't be broken by future development. Because of this, we require that all changes come with tests. You are welcome to submit pull requests with untested changes, but they won't be merged until you or the development team have an opportunity to write tests for them.
 
 There are some rare cases where code changes do not result in changed functionality (e.g. a performance optimization) and new tests are not required. In general, including tests with your pull request dramatically increases the chances it will be accepted.
 
-Integration tests are used to test the functionality of [agent instrumentation](/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper).  PRs that add or modify instrumentation should include new or updated integration tests.
+Integration tests are used to test the functionality of [agent instrumentation](src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper).  PRs that add or modify instrumentation should include new or updated integration tests.
 
 ## Contributor License Agreement
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If the issue has been confirmed as a bug or is a Feature request, please file a 
 **Support Channels**
 
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/net-agent): Comprehensive guidance for using our agent
-* [New Relic Community](https://discuss.newrelic.com/c/support-products-agents/net-agent): The best place to engage in troubleshooting questions
+* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/.netagent): The best place to engage in troubleshooting questions
 * [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 
@@ -48,7 +48,7 @@ We define “Personal Data” as any information relating to an identified or id
 Please review [New Relic’s General Data Privacy Notice](https://newrelic.com/termsandconditions/privacy) for more information.
 
 ## Roadmap
-See our [roadmap](/ROADMAP.md), to learn more about our product vision, understand our plans, and provide us valuable feedback.
+See our [roadmap](ROADMAP.md), to learn more about our product vision, understand our plans, and provide us valuable feedback.
 
 ## Contributing
 We encourage your contributions to improve New Relic's .NET monitoring products! Keep in mind that when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
@@ -60,7 +60,7 @@ As noted in our [security policy](https://github.com/newrelic/newrelic-dotnet-ag
 
 If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
 
-If you would like to contribute to this project, please review [these guidelines](/CONTRIBUTING.md).
+If you would like to contribute to this project, please review [these guidelines](CONTRIBUTING.md).
 
 To [all contributors](https://github.com/newrelic/newrelic-dotnet-agent/graphs/contributors), we thank you!  Without your contribution, this project would not be what it is today.  We also host a community project page dedicated to
 the [New Relic .NET agent](https://opensource.newrelic.com/projects/newrelic/newrelic-dotnet-agent).

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ The Profiler.sln builds the native profiler component of the .NET agent. The pro
 
 As mentioned above, this solution does not need to be built if you will only be working with the agent's managed C# code. Pre-built versions of the profiler for both Windows (x86 and x64) and Linux (x64) are checked into the repository (src/Agent/_profilerBuild) and are used for creating the home directories built by the FullAgent.sln. These pre-built versions are for development purposes only, and should be updated if you do work on the profiler.
 
-You can use a Powershell [script](/src/Agent/NewRelic/Profiler/build/build.ps1) to build the profiler.
+You can use a Powershell [script](../src/Agent/NewRelic/Profiler/build/build.ps1) to build the profiler.
 
 The script uses the following syntax:
 ```
@@ -81,7 +81,7 @@ build.ps1
 ## Testing
 
 * Unit tests use the NUnit framework and are contained in the solutions. Run them using the Visual Studio Test Explorer.
-* There is a suite of [integration tests](./integration-tests.md). Refer to the separate documentation for setting up an environment to run the integration tests. Some integration tests require you to set up additional infrastructure (e.g., databases) and are therefore not easily run.
+* There is a suite of [integration tests](integration-tests.md). Refer to the separate documentation for setting up an environment to run the integration tests. Some integration tests require you to set up additional infrastructure (e.g., databases) and are therefore not easily run.
 
 ## Packaging
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -105,7 +105,7 @@ Fixes an issue where `newrelic.config` was being overwritten when upgrading the 
 ## [8.30] - 2020-07-15
 ### New Features
 * **The .NET Agent is now open source!** <br/>
-The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
+The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](LICENSE). See our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
 
 ### Fixes
 * **Memory Usage Reporting for Linux** <br/>

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -105,7 +105,7 @@ Fixes an issue where `newrelic.config` was being overwritten when upgrading the 
 ## [8.30] - 2020-07-15
 ### New Features
 * **The .NET Agent is now open source!** <br/>
-The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](LICENSE). See our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
+The New Relic .NET agent is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in this repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
 
 ### Fixes
 * **Memory Usage Reporting for Linux** <br/>

--- a/src/Agent/NewRelic/Profiler/README.md
+++ b/src/Agent/NewRelic/Profiler/README.md
@@ -2,7 +2,7 @@
 
 ## Building the Profiler
 
-Refer to our [development documentation](/docs/development.md#profilersln).
+Refer to our [development documentation](../../../../docs/development.md#profilersln).
 
 ## What the Project Does
 
@@ -48,7 +48,7 @@ We fetch the bytecode for methods by calling `ICorProfilerInfo4.GetILFunctionBod
 
 ### What we inject
 
-The exact ByteCode we inject can be found about [here](/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h).  Below I have written some pseudo-code that is more or less what we inject, though not exactly:
+The exact ByteCode we inject can be found about [here](MethodRewriter/FunctionManipulator.h).  Below I have written some pseudo-code that is more or less what we inject, though not exactly:
 ```cs
 	try
 	{
@@ -104,7 +104,7 @@ After the profiler attaches it uses custom environment variables to determine th
 
 ### What's a good starting point to check out in the code?
 
-The main entry point for the profiler is the `Initialize` method in [ICorProfilerCallbackBase.h](/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h).  If you want to see what we do when we modify methods check out [InstrumentFunctionManipulator.h](/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h).
+The main entry point for the profiler is the `Initialize` method in [ICorProfilerCallbackBase.h](Profiler/ICorProfilerCallbackBase.h).  If you want to see what we do when we modify methods check out [InstrumentFunctionManipulator.h](MethodRewriter/InstrumentFunctionManipulator.h).
 
 ### Why did the profiler detach without providing meaningful feedback?
 

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New SDK providing Open Tracing instrumentation for AWS Lambda. Refer to New Relic's AWS Lambda monitoring documentation to get started https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring.
 
 * **The New Relic AWS Lambda Agent for .NET is now Open Source** <br/>
-* The New Relic AWS Lambda Agent for .NET is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in the repository.  We are now using the [Apache 2 license](LICENSE). See our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
+* The New Relic AWS Lambda Agent for .NET is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in the repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
 
 [Unreleased]: https://github.com/newrelic/newrelic-dotnet-agent/compare/AwsLambdaOpenTracer_v1.1.0...HEAD
 [1.1.0]: https://github.com/newrelic/newrelic-dotnet-agent/compare/AwsLambdaOpenTracer_v1.0.0...AwsLambdaOpenTracer_v1.1.0

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New SDK providing Open Tracing instrumentation for AWS Lambda. Refer to New Relic's AWS Lambda monitoring documentation to get started https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring.
 
 * **The New Relic AWS Lambda Agent for .NET is now Open Source** <br/>
-* The New Relic AWS Lambda Agent for .NET is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in the repository.  We are now using the [Apache 2 license](/LICENSE). See our [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md) for details on contributing!
+* The New Relic AWS Lambda Agent for .NET is now open source! Now you can view the source code to help with troubleshooting, observe the project roadmap, and file issues directly in the repository.  We are now using the [Apache 2 license](LICENSE). See our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](https://opensource.newrelic.com/code-of-conduct/) for details on contributing!
 
 [Unreleased]: https://github.com/newrelic/newrelic-dotnet-agent/compare/AwsLambdaOpenTracer_v1.1.0...HEAD
 [1.1.0]: https://github.com/newrelic/newrelic-dotnet-agent/compare/AwsLambdaOpenTracer_v1.0.0...AwsLambdaOpenTracer_v1.1.0

--- a/tests/Agent/IntegrationTests/UnboundedServices/README.md
+++ b/tests/Agent/IntegrationTests/UnboundedServices/README.md
@@ -44,4 +44,4 @@ See the docker-compose.yml file for the names of the services provided.
 
 ## Configuring user secrets
 
-The integration tests, including the unbounded ones, use `dotnet user-secrets` to manage confuration data, including the connection strings needed to access these external services.  An [example-secrets.json](./example-secrets.json) file has been provided which contains connection strings for all of the containerized unbounded services.  See the [integration test documentation](/docs/integration-tests.md) for how to install the user secrets.
+The integration tests, including the unbounded ones, use `dotnet user-secrets` to manage confuration data, including the connection strings needed to access these external services.  An [example-secrets.json](example-secrets.json) file has been provided which contains connection strings for all of the containerized unbounded services.  See the [integration test documentation](../../../../docs/integration-tests.md) for how to install the user secrets.


### PR DESCRIPTION
### Description

This adds a workflow to check for broken links in all our markdown files.  It also fixes a bunch of links that have been broken for a while, which should explain why this is a good idea.

### Testing

Since this action is configured to run on push, I was able to see it run on this branch before PRing it.  The last run was successful.

### Changelog

N/A
