### PR TITLE
8t more failed precondition handling

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1051,6 +1051,15 @@ namespace NewRelic.Agent.Core.Configuration
                 _infiniteTracingObserverTestFlaky = TryGetAppSettingAsFloat("InfiniteTracingSpanEventsTestFlaky");
             }
 
+            if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY_CODE"), out var flakyCodeVal))
+            {
+                _infiniteTracingObserverTestFlakyCode = flakyCodeVal;
+            }
+            else
+            {
+                _infiniteTracingObserverTestFlakyCode = TryGetAppSettingAsInt("InfiniteTracingSpanEventsTestFlakyCode");
+            }
+
             if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_DELAY"), out var delayVal))
             {
                 _infiniteTracingObserverTestDelayMs = delayVal;
@@ -1074,6 +1083,20 @@ namespace NewRelic.Agent.Core.Configuration
                 }
 
                 return _infiniteTracingObserverTestFlaky;
+            }
+        }
+
+        private int? _infiniteTracingObserverTestFlakyCode;
+        public int? InfiniteTracingTraceObserverTestFlakyCode
+        {
+            get
+            {
+                if (!_infiniteTracingObtainedSettingsForTest)
+                {
+                    GetInfiniteTracingFlakyAndDelayTestSettings();
+                }
+
+                return _infiniteTracingObserverTestFlakyCode;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -919,7 +919,7 @@ namespace NewRelic.Agent.Core.DataTransport
             }
             catch (Exception ex)
             {
-                LogMessage(LogLevel.Debug, consumerId, $"Unknown execption attempting to send {items.Count} item(s)", ex);
+                LogMessage(LogLevel.Debug, consumerId, $"Unknown exception attempting to send {items.Count} item(s)", ex);
                 RecordResponseError();
             }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -49,7 +49,7 @@ namespace NewRelic.Agent.Core.DataTransport
             }
             catch (RpcException rpcEx)
             {
-                var logLevel = LogLevel.Debug;
+                var logLevel = LogLevel.Finest;
 
                 ResponseRpcException = rpcEx;
 
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.Core.DataTransport
             }
             catch (Exception ex)
             {
-                var logLevel = LogLevel.Finest;
+                var logLevel = LogLevel.Debug;
 
                 if (Log.IsEnabledFor(logLevel))
                 {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -671,14 +671,14 @@ namespace NewRelic.Agent.Core.DataTransport
 
                         if (grpcWrapperEx.Status == UnavailableStatus)
                         {
-                            LogMessage(LogLevel.Error, consumerId, $"The gRPC request stream could not be created because the gRPC endpoint defined at {EndpointHost}:{EndpointPort} is no longer available so we will restart this service.");
+                            LogMessage(LogLevel.Error, consumerId, $"The gRPC request stream could not be created because the gRPC endpoint defined at {EndpointHost}:{EndpointPort} is temporarily unavailable, so we will restart this service.");
                             Shutdown(true);
                             return false;
                         }
 
                         if (grpcWrapperEx.Status == FailedPreconditionStatus)
                         {
-                            LogMessage(LogLevel.Error, consumerId, $"The gRPC request stream could not be created because the gRPC endpoint defined at {EndpointHost}:{EndpointPort} has been moved to a different host so we will restart this service.");
+                            LogMessage(LogLevel.Error, consumerId, $"The gRPC request stream could not be created because the gRPC endpoint defined at {EndpointHost}:{EndpointPort} has been moved to a different host, so we will restart this service.");
                             Shutdown(true);
                             return false;
                         }
@@ -894,11 +894,11 @@ namespace NewRelic.Agent.Core.DataTransport
                 switch (grpcEx.Status)
                 {
                     case UnimplementedStatus:
-                        LogMessage(LogLevel.Info, consumerId, $"Attempting to send {items.Count} item(s) - Trace observer is no longer available, shutting down infinite tracing service.");
+                        LogMessage(LogLevel.Error, consumerId, $"Attempting to send {items.Count} item(s) - Trace observer is no longer available, shutting down infinite tracing service.");
                         Shutdown(false);
                         return TrySendStatus.Error;
                     case UnavailableStatus:
-                        LogMessage(LogLevel.Debug, consumerId, $"Attempting to send {items.Count} item(s) - Channel not available, requesting restart");
+                        LogMessage(LogLevel.Info, consumerId, $"Attempting to send {items.Count} item(s) - Channel not available, requesting restart");
                         Shutdown(true);
                         return TrySendStatus.Error;
                     case FailedPreconditionStatus:
@@ -919,7 +919,7 @@ namespace NewRelic.Agent.Core.DataTransport
             }
             catch (Exception ex)
             {
-                LogMessage(LogLevel.Finest, consumerId, $"Unknown execption attempting to send {items.Count} item(s)", ex);
+                LogMessage(LogLevel.Debug, consumerId, $"Unknown execption attempting to send {items.Count} item(s)", ex);
                 RecordResponseError();
             }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.Core.DataTransport
             LogMessage(LogLevel.Finest, consumerId, $"Received gRPC Server response: {responseModel.MessagesSeen}");
 
             RecordReceived(responseModel.MessagesSeen);
-                
+
         }
 
         private void RecordReceived(ulong countItems)

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
@@ -21,6 +21,7 @@ namespace NewRelic.Agent.Core.DataTransport
         protected override string EndpointPortConfigValue => _configuration?.InfiniteTracingTraceObserverPort;
         protected override string EndpointSslConfigValue => _configuration?.InfiniteTracingTraceObserverSsl;
         protected override float? EndpointTestFlakyConfigValue => _configuration?.InfiniteTracingTraceObserverTestFlaky;
+        protected override int? EndpointTestFlakyCodeConfigValue => _configuration?.InfiniteTracingTraceObserverTestFlakyCode;
         protected override int? EndpointTestDelayMsConfigValue => _configuration?.InfiniteTracingTraceObserverTestDelayMs;
         public override int BatchSizeConfigValue => (_configuration?.InfiniteTracingBatchSizeSpans).GetValueOrDefault(0);
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -71,6 +71,7 @@ namespace NewRelic.Agent.Configuration
         string InfiniteTracingTraceObserverPort { get; }
         string InfiniteTracingTraceObserverSsl { get; }
         float? InfiniteTracingTraceObserverTestFlaky { get; }
+        int? InfiniteTracingTraceObserverTestFlakyCode { get; }
         int? InfiniteTracingTraceObserverTestDelayMs { get; }
         int InfiniteTracingQueueSizeSpans { get; }
         int InfiniteTracingPartitionCountSpans { get; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanStreamingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanStreamingServiceTests.cs
@@ -1552,8 +1552,9 @@ namespace NewRelic.Agent.Core.Spans.Tests
             );
         }
 
-        [Test]
-        public void GrpcOkDuringTrySendDataCreatesNewStreamImmediately()
+        [TestCase(StatusCode.OK)]
+        [TestCase(StatusCode.Internal)]
+        public void GrpcOkOrInternalDuringTrySendDataCreatesNewStreamImmediately(StatusCode statusCode)
         {
             var actualCountGrpcErrors = 0;
             var actualCountGeneralErrors = 0;
@@ -1606,7 +1607,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
 
                 if (localInvocationId == 2)
                 {
-                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(StatusCode.OK, "Test gRPC Exception");
+                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(statusCode, "Test gRPC Exception");
                     return false;
                 }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanStreamingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanStreamingServiceTests.cs
@@ -1600,7 +1600,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
 
                 if (localInvocationId < 2 || localInvocationId == 3)
                 {
-                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(StatusCode.Internal, "Test gRPC Exception");
+                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(StatusCode.Unknown, "Test gRPC Exception");
                     return false;
                 }
 
@@ -1726,7 +1726,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
 
                 if (countCreateStreamsCalls < 4 || countCreateStreamsCalls == 5)
                 {
-                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(StatusCode.Internal, "Test gRPC Exception");
+                    MockGrpcWrapper<TRequest, TResponse>.ThrowGrpcWrapperException(StatusCode.Unknown, "Test gRPC Exception");
                     return null;
                 }
 


### PR DESCRIPTION
### Description

1. Updates the handling of GRPC responses to catch `FAILED_PRECONDITION` and restart the infinite tracing service per the spec.
2. Added support for an additional internal testing parameter which specifies which GRPC status code the backend should randomly throw (the `flaky_code`).
3. Improved handling of the `INTERNAL` GRPC response code, which indicates that the current stream has been reset due to inactivity, and which the agent handles by disposing of the current stream and then recreating it.
4. General tweaks to log message levels and wording.

### Testing

1. Added a unit test to cover handling of the `INTERNAL` status code response when sending spans.
2. Verified that the 8T integration tests pass.

### Changelog

N/A
