### PR TITLE
Add password setting env vars to dockerfile

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
@@ -1,6 +1,8 @@
 FROM microsoft/mssql-server-linux:2017-latest
 
 ENV ACCEPT_EULA=Y
+ENV MSSQL_SA_PASSWORD=password0TS
+ENV SQLCMDPASSWORD=password0TS
 ENV SA_PASSWORD=password0TS
 
 COPY setup.sh /var/


### PR DESCRIPTION
### Description

This resolves issues with unbounded integration tests on the `main` branch that require the MS SQL Server service.

It's not clear from git history, because things recently got moved around and deleted when we got rid of the Windows/Linux services split on the main branch, how these two env vars got removed from the Dockerfile for the mssql service.  However, the version on the `net35/main` branch was working, and these two vars were the only difference.  I think that, somehow, not having these vars set prevented the `NewRelic` database from being restored from the backup file.

### Testing

MS SQL unbounded integration tests now pass for me locally when running against the local docker `mssql` service.

### Changelog

N/A
