### PR TITLE
Fixes for net35/main deploy issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,20 +111,6 @@ jobs:
           nuget.exe setApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }}
         shell: pwsh
 
-      - name: Deploy Agent to Nuget
-        run: |
-          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgent\NewRelic.Agent.*.nupkg -Name
-          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgent\$packageName
-          $version = $packageName.TrimStart('NewRelic.Agent').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
-            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
-          }
-          else {
-            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
-            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
-          }
-        shell: powershell
-
       - name: Deploy Agent API to Nuget
         run: |
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgentApi\NewRelic.Agent.Api.*.nupkg -Name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,6 @@ jobs:
           path: ${{ github.workspace }}/build/BuildArtifacts
           if-no-files-found: error
 
-      - name: Upload Deploy Tooling Locally
-        uses: actions/upload-artifact@v2
-        with:
-          name: deploy-tooling
-          path: ${{ github.workspace }}/deploy/
-          if-no-files-found: error
-
   deploy-downloadsite:
     needs: get-external-artifacts
     if: ${{ github.event.inputs.downloadsite == 'true' }}


### PR DESCRIPTION
### Description

This PR fixes a few issues with the `deploy.yml` workflow on the `net35/main` branch (for deploying 6.x agent versions).

1. The `deploy` tools folder doesn't exist in 6.x, because those tools are for pushing the .NET Core Linux packages to APT and YUM repos.  We don't build any .NET Core assets for 6.x because customers wanting to monitor .NET Core apps can use the latest agent versions.
2. The `NugetAgent` nuget package doesn't exist in 6.x, so it doesn't need to be deployed.

### Testing

I did a test deploy run on the latest version of this branch and it succeeded: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/518358727

### Changelog

N/A
