### PR TITLE
Fix nservicebus test

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedApplications/NServiceBusBasicMvcApplication/Controllers/MessageQueueController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/NServiceBusBasicMvcApplication/Controllers/MessageQueueController.cs
@@ -9,6 +9,9 @@ namespace NServiceBusBasicMvcApplication.Controllers
 {
     public class MessageQueueController : Controller
     {
+
+        private const string DestinationReceiverHost = "NServiceBusReceiverHost";
+
         [HttpGet]
         public string NServiceBus_Send()
         {
@@ -16,7 +19,7 @@ namespace NServiceBusBasicMvcApplication.Controllers
             var message = new SampleNServiceBusMessage(new Random().Next(), "Foo bar");
 
             // Send the message. In this case we've hardcoded the recipient, but we could also use the web config to specify implicit recipients
-            MvcApplication.Bus.Send("NServiceBusReceiverHost", message);
+            MvcApplication.Bus.Send(DestinationReceiverHost, message);
 
             return string.Format("Message with ID={0} sent via NServiceBus", message.Id);
         }
@@ -28,7 +31,7 @@ namespace NServiceBusBasicMvcApplication.Controllers
             var message = new SampleNServiceBusMessage2(new Random().Next(), "Valid");
 
             // Send the message. In this case we've hardcoded the recipient, but we could also use the web config to specify implicit recipients
-            MvcApplication.Bus.Send("NServiceBusReceiverHost", message);
+            MvcApplication.Bus.Send(DestinationReceiverHost, message);
 
             return string.Format("Message with ID={0} sent via NServiceBus", message.Id);
         }
@@ -40,7 +43,7 @@ namespace NServiceBusBasicMvcApplication.Controllers
             var message = new SampleNServiceBusMessage2(new Random().Next(), "Invalid", false);
 
             // Send the message. In this case we've hardcoded the recipient, but we could also use the web config to specify implicit recipients
-            MvcApplication.Bus.Send("NServiceBusReceiverHost", message);
+            MvcApplication.Bus.Send(DestinationReceiverHost, message);
 
             return string.Format("Message with ID={0} sent via NServiceBus", message.Id);
         }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/NServiceBusBasicMvcApplication/Controllers/MessageQueueController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/NServiceBusBasicMvcApplication/Controllers/MessageQueueController.cs
@@ -16,7 +16,7 @@ namespace NServiceBusBasicMvcApplication.Controllers
             var message = new SampleNServiceBusMessage(new Random().Next(), "Foo bar");
 
             // Send the message. In this case we've hardcoded the recipient, but we could also use the web config to specify implicit recipients
-            MvcApplication.Bus.Send("NServiceBusReceiver", message);
+            MvcApplication.Bus.Send("NServiceBusReceiverHost", message);
 
             return string.Format("Message with ID={0} sent via NServiceBus", message.Id);
         }


### PR DESCRIPTION
### Description

Resolves #361.

The name of the destination handler specified in the test app controller method used by the failing test was incorrect.  This PR fixes that and also makes it a constant across all of the controller methods.

### Testing

Verified all NServiceBus int tests passed locally for me.

### Changelog

N/A
