### PR TITLE
Add dotnet version supportability metrics for net5

### DIFF
--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -26,6 +26,7 @@ namespace NewRelic.Core
     {
         LessThan30,
         netcoreapp30,
+        netcoreapp31,
         net5,
         Other,
     }
@@ -86,6 +87,11 @@ namespace NewRelic.Core
             if (envVer.Major == 3 && envVer.Minor == 0)
             {
                 return DotnetCoreVersion.netcoreapp30;
+            }
+
+            if (envVer.Major == 3 && envVer.Minor == 1)
+            {
+                return DotnetCoreVersion.netcoreapp31;
             }
 
             if (envVer.Major == 5)

--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -26,7 +26,8 @@ namespace NewRelic.Core
     {
         LessThan30,
         netcoreapp30,
-        GreaterThan30
+        net5,
+        Other,
     }
 
     public static class DotnetVersion
@@ -87,12 +88,17 @@ namespace NewRelic.Core
                 return DotnetCoreVersion.netcoreapp30;
             }
 
+            if (envVer.Major == 5)
+            {
+                return DotnetCoreVersion.net5;
+            }
+
             if (envVer.Major == 4)
             {
                 return DotnetCoreVersion.LessThan30;
             }
 
-            return DotnetCoreVersion.GreaterThan30;
+            return DotnetCoreVersion.Other;
         }
 #endif
     }


### PR DESCRIPTION
### Description

Add  `Supportability/Dotnet/NetCore/net5` for .Net 5.

### Testing

Manually tested. Steps I did for testing:
1. Created a vanilla .net core 3.0 app from Visual studio template.
2. Changed the target framework in the app project file to the following target framework and checked for the following supportability metrics.

   `netcoreapp20` expects `Supportability/Dotnet/NetCore/LessThan30`
   `netcoreapp21` expects `Supportability/Dotnet/NetCore/LessThan30`
   `netcoreapp22` expects `Supportability/Dotnet/NetCore/LessThan30`
   `netcoreapp30` expects `Supportability/Dotnet/NetCore/netcoreapp30`
   `netcoreapp31` expects `Supportability/Dotnet/NetCore/netcoreapp31`
   `net50` expects `Supportability/Dotnet/NetCore/net5`




