### PR TITLE
Kwest/lambda 1097

### DIFF
--- a/src/AwsLambda/AwsLambdaOpenTracer/Util/FileSystemManager.cs
+++ b/src/AwsLambda/AwsLambdaOpenTracer/Util/FileSystemManager.cs
@@ -21,15 +21,14 @@ namespace NewRelic.OpenTracing.AmazonLambda
             return File.Exists(path);
         }
 
-        public async void WriteAllText(string path, string contents)
+        public void WriteAllText(string path, string contents)
         {
             try
             {
                 using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
-                var writer = new StreamWriter(stream);
-                await writer.WriteAsync(contents);
-                await writer.FlushAsync();
-                writer.Close();
+                using StreamWriter writer = new StreamWriter(stream);
+                writer.Write(contents);
+                writer.Flush();
             }
             catch (Exception e)
             {

--- a/src/AwsLambda/AwsLambdaOpenTracer/Util/FileSystemManager.cs
+++ b/src/AwsLambda/AwsLambdaOpenTracer/Util/FileSystemManager.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
+using NewRelic.Core.Logging;
 
 namespace NewRelic.OpenTracing.AmazonLambda
 {
@@ -19,9 +21,20 @@ namespace NewRelic.OpenTracing.AmazonLambda
             return File.Exists(path);
         }
 
-        public void WriteAllText(string path, string contents)
+        public async void WriteAllText(string path, string contents)
         {
-            File.WriteAllText(path, contents);
+            try
+            {
+                using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+                var writer = new StreamWriter(stream);
+                await writer.WriteAsync(contents);
+                await writer.FlushAsync();
+                writer.Close();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
         }
     }
 }

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Fix for lambdas using extension path that occasionally time out due to IOException: file is in use error. 
 
 ## [1.1.0] - 2020-09-15
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

### Description

The what, the why and the how of your PR.
Lambda team [Jira](https://newrelic.atlassian.net/browse/LAMBDA-1097) related to issue filed by sales team and customer.

Customers lambda was timing out randomly when using the extension path for sending telemetry data to NR. 
This appeared to be somehow related to an external package, `Serilog.Sinks.Elasticsearch`,  that they use for sending logs.
The code appeared to be hanging when trying to write to the named pipe because of a file lock.  

### Testing

Current testing for this path should be sufficient for validating correct behavior. 

### Changelog

Please remember to update our [changelog](/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),

Changelog updated. 

