### PR TITLE
Do not cache property setter actions from VisibilityBypasser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If the issue has been confirmed as a bug or is a Feature request, please file a 
 **Support Channels**
 
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/net-agent): Comprehensive guidance for using our agent
-* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/.netagent): The best place to engage in troubleshooting questions
+* [New Relic Community](https://discuss.newrelic.com/tags/c/full-stack-observability/agents/466/dotnetagent): The best place to engage in troubleshooting questions
 * [New Relic Developer](https://developer.newrelic.com/): Resources for building a custom observability applications
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan). 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * Fixes issue [#169](https://github.com/newrelic/newrelic-dotnet-agent/issues/169): Profiler should be able to match method parameters from XML that contain a space.
+* Fixes issue [#464](https://github.com/newrelic/newrelic-dotnet-agent/issues/464): Distributed tracing over RabbitMQ does not work with `RabbitMQ.Client` versions 6.x+
 
 ## [8.39] - 2021-02-10
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
@@ -441,6 +441,7 @@ namespace NewRelic.Reflection
             return GenerateMethodCallerInternal(resultType, propertyGetter);
         }
 
+        // Do not cache the delegate returned by this method; it is only valid for the specific "owner" object instance
         public Action<TValue> GeneratePropertySetter<TValue>(object owner, string propertyName)
         {
             if (owner == null)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -26,11 +26,10 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
             return func(Properties) as Dictionary<string, object>;
         }
 
-        private static Action<Dictionary<string, object>> _setHeadersAction;
         public static void SetHeaders(object Properties, Dictionary<string, object> headers)
         {
-            var action = _setHeadersAction ??
-                (_setHeadersAction = VisibilityBypasser.Instance.GeneratePropertySetter<Dictionary<string, object>>(Properties, "Headers"));
+            // Unlike the GetHeaders function, we can't cache this action.  It is only valid for the specific Properties object instance provided.
+            var action = VisibilityBypasser.Instance.GeneratePropertySetter<Dictionary<string, object>>(Properties, "Headers");
 
             action(headers);
         }


### PR DESCRIPTION
### Description

Fixes #464 by no longer caching the Action returned from the `VisibilityBypasser` that allows the RabbitMQ `BasicProperties.Headers` dictionary to be set by our instrumentation wrapper. 

### Testing

RabbitMQ DT integration tests updated to make multiple pub/sub calls across the queue to verify it works the second time.

Added unit tests for the `VisibilityBypasser.Instance.GeneratePropertySetter` method.

### Changelog

Changelog updated.
