### PR TITLE
Adds condition to cancel-previous-workflow-runs for alternate releases

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -16,6 +16,7 @@ env:
 jobs:
 
   cancel-previous-workflow-runs:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') )
     name: Cancel Previous Runs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Resolves #468 

### Description

Adds conditional to cancel-previous-workflow-runs job to prevent the release build from running when a release for lambda is triggered.

Conditional: `github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') )`

### Testing

Workflow should just work as normal.

