### PR TITLE
Create AWS Lambda release build and test workflow

### DIFF
--- a/.github/workflows/awslambda_release.yml
+++ b/.github/workflows/awslambda_release.yml
@@ -1,0 +1,129 @@
+name: .NET New Relic Lambda Tracer Release Build
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+env:
+  scripts_path: ${{ github.workspace }}\build\scripts
+  tools_path: ${{ github.workspace }}\build\Tools
+  DOTNET_NOLOGO: true
+
+jobs:
+
+  cancel-previous-workflow-runs:
+    if:  github.event_name == 'workflow_dispatch' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/AwsLambdaOpenTracer_v') )
+    name: Cancel Previous Runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rokroskar/workflow-run-cleanup-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-test-lambda:
+    needs: [ cancel-previous-workflow-runs ]
+    name: Build and Test FullAgent and MSIInstaller
+    runs-on: windows-2019
+
+    env:
+      tracer_project_path: ${{ github.workspace }}\src\AwsLambda\AwsLambdaOpenTracer\Tracer.csproj
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Setup VSTest Path
+        uses: darenm/Setup-VSTest@v1
+      
+      - name: Build FullAgent.sln
+        run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.tracer_project_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.tracer_project_path }}
+        shell: powershell
+
+      - name: Archive NewRelic.OpenTracing.AmazonLambda.Tracer
+        uses: actions/upload-artifact@v2
+        with:
+          name: NewRelic.OpenTracing.AmazonLambda.Tracer
+          path: ${{ github.workspace }}\src\AwsLambda\AwsLambdaOpenTracer\bin\Release\netstandard2.0-ILRepacked
+          if-no-files-found: error
+
+      - name: Unit Tests
+        run: |
+          # Write-Host ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+          # ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+          Write-Host "Creating TestResults directory to temporarily get around nunit limitation"
+          mkdir ${{ github.workspace }}\TestResults
+
+          $testDllPatterns = @('*Tests.dll', '*Test.dll', '*Test.Legacy.dll')
+
+          Write-Host "Finding files for .NET Core NUnit tests"
+          $netCoreTestFileNames = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
+          $netCoreFiles = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
+
+          Write-Host "Building file list for .NET Core NUnit tests"
+          $netCoreUnitTestPaths = @()
+
+          for ($i = 0; $i -lt $netCoreTestFileNames.Length; $i++)
+          { $netCoreFiles | ForEach-Object { if ($_.Name -eq $netCoreTestFileNames[$i].Name) { $netCoreUnitTestPaths += $_.FullName; Continue } } }
+
+          Write-Host "Executing .NET Core NUnit Tests:"
+          $netCoreUnitTestPaths | ForEach-Object { $_ }
+
+          Write-Host "Executing: dotnet test " $netCoreUnitTestPaths " --parallel --logger:'html;LogFileName=lambda-results.html'"
+          dotnet test $netCoreUnitTestPaths --parallel --logger:"html;LogFileName=lambda-results.html"
+
+          if ($LastExitCode -ne 0)
+          { exit $LastExitCode }
+        shell: powershell
+        
+      - name: Archive Test Results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: ${{ github.workspace }}\TestResults
+          if-no-files-found: error
+
+  run-artifactbuilder:
+    needs: [ build-test-lambda ]
+    if: ${{ github.event.release }}
+    name: Run ArtifactBuilder
+    runs-on: windows-2019
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Download NewRelic.OpenTracing.AmazonLambda.Tracer
+        uses: actions/download-artifact@v2
+        with:
+          name: NewRelic.OpenTracing.AmazonLambda.Tracer
+          path: src/AwsLambda/AwsLambdaOpenTracer/bin/Release/netstandard2.0-ILRepacked
+
+      - name: Run ArtifactBuilder
+        run: |
+          $rootDirectory = Resolve-Path "$(Split-Path -Parent $PSCommandPath)\.."
+          $configuration = "Release"
+          $artifactBuilderCsproj = "$rootDirectory\build\ArtifactBuilder\ArtifactBuilder.csproj"
+          & "$rootDirectory\build\generateBuildProperties.ps1" -outputPath "$rootDirectory\build\BuildArtifacts\_buildProperties"
+          dotnet run --project "$artifactBuilderCsproj" NugetAwsLambdaOpenTracer $configuration
+        shell: powershell
+
+      - name: Archive Deploy Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: |
+            ${{ github.workspace }}\build\BuildArtifacts
+          if-no-files-found: error

--- a/.github/workflows/deploy_awslambda.yml
+++ b/.github/workflows/deploy_awslambda.yml
@@ -1,0 +1,72 @@
+name: Deploy the .NET New Relic Lambda Tracer
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
+        required: true
+      deploy:
+        description: 'If "true", deploy the artifacts. If "false", do everything except deploy.'
+        required: true
+        default: 'false'
+
+env:
+  DOTNET_NOLOGO: true
+
+jobs:
+
+  get-external-artifacts:
+    name: Get and Publish Deploy Artifacts Locally
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Deploy Artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: awslambda_release.yml
+          run_id: ${{ github.event.inputs.run_id }}
+          name: deploy-artifacts
+          path: ${{ github.workspace }}
+          repo: ${{ github.repository }}
+      
+      - name: Upload Deploy Artifacts Locally
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}/build/BuildArtifacts
+          if-no-files-found: error
+  
+  deploy-nuget:
+    needs: get-external-artifacts
+    if: ${{ github.event.inputs.nuget == 'true' }}
+    name: Deploy to NuGet
+    runs-on: windows-2019
+
+    env:
+      nuget_source: https://www.nuget.org
+
+    steps:
+      - name: Download Deploy Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}\working_dir
+
+      - name: Setup NuGet API Key
+        run: |
+          nuget.exe setApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }}
+        shell: pwsh
+
+      - name: Deploy .NET New Relic Lambda Tracer to Nuget
+        run: |
+          $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAwsLambdaOpenTracer\NewRelic.OpenTracing.AmazonLambda.Tracer.*.nupkg -Name
+          $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAwsLambdaOpenTracer\$packageName
+          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          }
+          else {
+            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
+          }
+        shell: powershell

--- a/.github/workflows/deploy_awslambda.yml
+++ b/.github/workflows/deploy_awslambda.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
+        description: 'Run ID of the Release Workflow (awslambda_release.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
       deploy:
         description: 'If "true", deploy the artifacts. If "false", do everything except deploy.'


### PR DESCRIPTION
Resolves #469 

### Description

Creates a new workflow for building and testing AWS Lambda releases
- Only runs on a release event with a tag that starts with `refs/tags/AwsLambdaOpenTracer_v` OR manually
- Only builds the Lambda Wrapper, Tracer, and NewRelic.Core
- Runs the Lambda Unit tests and save results
- Runs ArtifactBuilder for the Tracer only and saves results
- All steps are pulled from all_solutions,yml with limited changes to keep things simple

Creates new deploy workflow for AWS Lambda releases
- Use the same pattern as the agent deploy: copy artifacts>same them locally>deploy
- Deploys to nuget only
- Only inputs are run_id and deploy switch

### Testing

Create two fake releases, one with the proper tag and one without it.   It should only fully run the correct release. Note: do not use a tag that starts with `refs/tags/v` since that will start the agent release build.

Note: Cannot test deploy fully until we do a release for lambda.


