### PR TITLE
Removes nuget check from AWS Lambda

### DIFF
--- a/.github/workflows/deploy_awslambda.yml
+++ b/.github/workflows/deploy_awslambda.yml
@@ -39,7 +39,6 @@ jobs:
   
   deploy-nuget:
     needs: get-external-artifacts
-    if: ${{ github.event.inputs.nuget == 'true' }}
     name: Deploy to NuGet
     runs-on: windows-2019
 


### PR DESCRIPTION
Agent deploy has an extra conditional for deploying that lambda doesn't need.
