### PR TITLE
Fixes generateBuildProperties.ps1 to work with lightweighted tags

### DIFF
--- a/build/generateBuildProperties.ps1
+++ b/build/generateBuildProperties.ps1
@@ -11,7 +11,7 @@ Param(
 New-Item -ItemType Directory -Force -Path $outputPath
 
 function getVersionFromTag([string] $tagPrefix, [switch] $excludeCommitCount) {
-    $GitLatestTagVersion = git describe --match "$tagPrefix[0-9]*" --abbrev=0 HEAD
+    $GitLatestTagVersion = git describe --tags --match "$tagPrefix[0-9]*" --abbrev=0 HEAD
     $GitGitLatestTagVersionSanitized = $GitLatestTagVersion.Replace($tagPrefix,'')
     $GitCommitCount = git rev-list "$GitLatestTagVersion..$GitBranchName" --count HEAD
     $GitVersion = "$GitGitLatestTagVersionSanitized.$GitCommitCount"


### PR DESCRIPTION
### Description

There is problem with the generateBuildProperties.ps1 script to generate release versions for all of our packages. In that script, we use this command git describe --match "$tagPrefix[0-9]*" --abbrev=0 HEAD to pull up recently created tags that match whatever prefixes, however, that command only works with annotated tags. The tags created with Github releases are “lightweighted” tags. This PR fixes it.

