### PR TITLE
Language independently convert float number value to string for tracestate Priority value

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
-* Fixes issue [#22](https://github.com/newrelic/newrelic-dotnet-agent/issues/22): Fixes Agent causes exception when distributed tracing is enabled in ASP.NET Core applications uses the RequestLocalization middleware in Linux environment. ([#493](https://github.com/newrelic/newrelic-dotnet-agent/pull/493))
+* Fixes issue [#22](https://github.com/newrelic/newrelic-dotnet-agent/issues/22): Agent causes exception when distributed tracing is enabled in ASP.NET Core applications that use the RequestLocalization middleware in a Linux environment. ([#493](https://github.com/newrelic/newrelic-dotnet-agent/pull/493))
 * Fixes issue [#399](https://github.com/newrelic/newrelic-dotnet-agent/issues/399): The New Relic Azure Site Extension leaves smaller footprint after install.
 * Fixes issue [#169](https://github.com/newrelic/newrelic-dotnet-agent/issues/169): Profiler should be able to match method parameters from XML that contain a space.
 * Fixes issue [#464](https://github.com/newrelic/newrelic-dotnet-agent/issues/464): Distributed tracing over RabbitMQ does not work with `RabbitMQ.Client` versions 6.x+

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
+* Fixes issue [#22](https://github.com/newrelic/newrelic-dotnet-agent/issues/22): Fixes Agent causes exception when distributed tracing is enabled in ASP.NET Core applications uses the RequestLocalization middleware in Linux environment. ([#493](https://github.com/newrelic/newrelic-dotnet-agent/pull/493))
 * Fixes issue [#399](https://github.com/newrelic/newrelic-dotnet-agent/issues/399): The New Relic Azure Site Extension leaves smaller footprint after install.
 * Fixes issue [#169](https://github.com/newrelic/newrelic-dotnet-agent/issues/169): Profiler should be able to match method parameters from XML that contain a space.
 * Fixes issue [#464](https://github.com/newrelic/newrelic-dotnet-agent/issues/464): Distributed tracing over RabbitMQ does not work with `RabbitMQ.Client` versions 6.x+

--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
@@ -158,7 +158,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
             var spanId = _configurationService.Configuration.SpanEventsEnabled ? transaction.CurrentSegment.SpanId : string.Empty;
             var transactionId = _configurationService.Configuration.TransactionEventsEnabled ? transaction.Guid : string.Empty;
             var sampled = transaction.Sampled.Value ? "1" : "0";
-            var priority = string.Format(PriorityFormat, transaction.Priority);
+            var priority = string.Format(System.Globalization.CultureInfo.InvariantCulture, PriorityFormat, transaction.Priority);
             var timestampInMillis = timestamp.ToUnixTimeMilliseconds();
 
             var newRelicTracestate = $"{accountKey}@nr={version}-{parentType}-{parentAccountId}-{appId}-{spanId}-{transactionId}-{sampled}-{priority}-{timestampInMillis}";

--- a/src/NewRelic.Core/DistributedTracing/W3CTracestate.cs
+++ b/src/NewRelic.Core/DistributedTracing/W3CTracestate.cs
@@ -69,7 +69,7 @@ namespace NewRelic.Core.DistributedTracing
             Error = error;
         }
 
-        public override string ToString() => $"{AccountId}@nr={Version}-{(int)ParentType}-{AccountId}-{AppId}-{SpanId}-{TransactionId}-{Sampled}-{Priority}-{Timestamp}";
+        public override string ToString() => $"{AccountId}@nr={Version}-{(int)ParentType}-{AccountId}-{AppId}-{SpanId}-{TransactionId}-{Sampled}-" + Priority?.ToString(System.Globalization.CultureInfo.InvariantCulture) + $"-{Timestamp}";
 
         public static W3CTracestate GetW3CTracestateFromHeaders(IEnumerable<string> tracestateCollection, string trustedAccountKey)
         {

--- a/src/NewRelic.Core/DistributedTracing/W3CTracestate.cs
+++ b/src/NewRelic.Core/DistributedTracing/W3CTracestate.cs
@@ -184,7 +184,7 @@ namespace NewRelic.Core.DistributedTracing
                 }
             }
 
-            if (float.TryParse(priorityString, out priority))
+            if (float.TryParse(priorityString, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out priority))
             {
                 return true;
             }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Controllers/HomeController.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Controllers/HomeController.cs
@@ -88,7 +88,7 @@ namespace AspNetCoreMvcBasicRequestsApplication.Controllers
         [HttpGet]
         public async Task<string> HttpClientFactory()
         {
-            await _httpClientFactory.CreateClient().GetStringAsync("https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/feed");
+            await _httpClientFactory.CreateClient().GetStringAsync("https://docs.newrelic.com/");
 
             return "Worked";
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/W3CTracestateTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/W3CTracestateTests.cs
@@ -125,8 +125,9 @@ namespace NewRelic.Agent.Core.DistributedTracing
         //Valid tracestate - Priority has only integer part
         [TestCase("33@nr=0-0-33-5043-27ddd2d8890283b4-5569065a5b1313bd-1-123-1518469636025,aa=1111,bb=222", "33", "aa=1111,bb=222", 1, 123f, IngestErrorType.None)]
 
-        //Invalid tracestate - Priority is in unaccepted format (Example: 1e-2) so will be null, but Invalid status is due to it parsing into 10 fields (not 9) which is not valid for the version (0)
+        //Invalid tracestate - Priority is in unaccepted format (Example: 1e-2, 1,234) so will be null, but Invalid status is due to it parsing into 10 fields (not 9) which is not valid for the version (0)
         [TestCase("33@nr=0-0-33-5043-27ddd2d8890283b4-5569065a5b1313bd-1-1e-2-1518469636025,aa=1111,bb=222", "33", "aa=1111,bb=222", null, null, IngestErrorType.TraceStateInvalidNrEntry)]
+        [TestCase("33@nr=0-0-33-5043-27ddd2d8890283b4-5569065a5b1313bd-1-1,234-1518469636025,aa=1111,bb=222", "33", "aa=1111,bb=222", null, null, IngestErrorType.TraceStateInvalidNrEntry)]
 
         //Invalid tracestate - Value has non ASCII characters
         [TestCase("33@nr=¢µÈÈÂÂÂÂÂ,aa=1111,bb=222", "33", "aa=1111,bb=222", null, null, IngestErrorType.TraceStateInvalidNrEntry)]

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/DistributedTracing/DistributedTracePayloadHandlerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/DistributedTracing/DistributedTracePayloadHandlerTests.cs
@@ -764,7 +764,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.DistributedTracing
             Mock.Assert(() => _agentHealthReporter.ReportSupportabilityTraceContextCreateSuccess(), Occurs.Once());
         }
 
-        //This test makes sure string presentation for Priority is culture independent.
+        //This test makes sure string presentation for Priority in a tracestate is culture independent.
         [TestCase(1.123000f, "1.123")]
         public void W3C_InsertDistributedTraceHeaders_CultureIndependent_PriorityInRightFormat(float testPriority, string expectedPriorityString)
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/DistributedTracing/DistributedTracePayloadHandlerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/DistributedTracing/DistributedTracePayloadHandlerTests.cs
@@ -766,9 +766,9 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.DistributedTracing
 
         //This test makes sure string presentation for Priority is culture independent.
         [TestCase(1.123000f, "1.123")]
-        public void W3C_InsertDistributedTraceHeaders_PriorityInRightFormat_CultureIndependent(float testPriority, string expectedPriorityString)
+        public void W3C_InsertDistributedTraceHeaders_CultureIndependent_PriorityInRightFormat(float testPriority, string expectedPriorityString)
         {
-            //Set up "eu-ES" culture for this test thread. In this culture, calling ToString() on a float of 1.123f will result a string of "1,123" instead of "1.123". 
+            //Set up "eu-ES" culture for this test thread. In this culture, calling ToString() on a float of 1.123f will result this string "1,123" instead of "1.123". 
             var ci = new CultureInfo("eu-ES");
             Thread.CurrentThread.CurrentCulture = ci;
             Thread.CurrentThread.CurrentUICulture = ci;


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

### Description
- This PR is a fix for the issue [#22](https://github.com/newrelic/newrelic-dotnet-agent/issues/22).
- The call `PriorityFormat, transaction.Priority` in the `BuildTracestate` function, under “Arabic” culture, yields two different string interpretations of the same float number in 2 different platforms (Window vs Unix). In windows, the decimal point is converted into an ascii character (.colon). In contrast, in Linux, the decimal point is converted into an unicode character (٫ Arabic decimal separator).
This difference is the real main cause of this exception `System.Net.Http.HttpRequestException: Request headers must contain only ASCII characters when DT was enabled`. The agent basically added a non ascii character in the outgoing payload when Arabic culture is set in Linux. 

### Testing
- Manually tested in Linux.
- Some unit tests are added, but they indirectly provide coverage for Linux. The issue only occurs in Linux and we currently don't have Linux test coverage. 

