### PR TITLE
Updated TransactionAttributeMaker to always include an error attribute

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+* Fixes issue [#500](https://github.com/newrelic/newrelic-dotnet-agent/issues/500): Agent should always create the "error" intrinsics attribute. ([#501](https://github.com/newrelic/newrelic-dotnet-agent/pull/501))
 
 ## [8.39.1] - 2021-03-17
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -85,23 +85,30 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 _attribDefs.DatabaseCallCount.TrySetValue(attribValues, databaseData.Value0);
             }
 
-            if (_configurationService.Configuration.ErrorCollectorEnabled && immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
+            if (_configurationService.Configuration.ErrorCollectorEnabled)
             {
-                var errorData = immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData;
-
-                _attribDefs.GetTypeAttribute(TypeAttributeValue.TransactionError).TrySetDefault(attribValues);
-
-                _attribDefs.TimestampForError.TrySetValue(attribValues, errorData.NoticedAt);
-                _attribDefs.ErrorClass.TrySetValue(attribValues, errorData.ErrorTypeName);
-                _attribDefs.ErrorType.TrySetValue(attribValues, errorData.ErrorTypeName);
-                _attribDefs.ErrorMessage.TrySetValue(attribValues, errorData.ErrorMessage);
-                _attribDefs.ErrorDotMessage.TrySetValue(attribValues, errorData.ErrorMessage);
-                _attribDefs.IsError.TrySetValue(attribValues, true);
-                _attribDefs.ErrorEventSpanId.TrySetValue(attribValues, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorDataSpanId);
-
-                if (errorData.IsExpected)
+                if (immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.HasError)
                 {
-                    _attribDefs.IsErrorExpected.TrySetValue(attribValues, true);
+                    var errorData = immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData;
+
+                    _attribDefs.GetTypeAttribute(TypeAttributeValue.TransactionError).TrySetDefault(attribValues);
+
+                    _attribDefs.TimestampForError.TrySetValue(attribValues, errorData.NoticedAt);
+                    _attribDefs.ErrorClass.TrySetValue(attribValues, errorData.ErrorTypeName);
+                    _attribDefs.ErrorType.TrySetValue(attribValues, errorData.ErrorTypeName);
+                    _attribDefs.ErrorMessage.TrySetValue(attribValues, errorData.ErrorMessage);
+                    _attribDefs.ErrorDotMessage.TrySetValue(attribValues, errorData.ErrorMessage);
+                    _attribDefs.IsError.TrySetValue(attribValues, true);
+                    _attribDefs.ErrorEventSpanId.TrySetValue(attribValues, immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorDataSpanId);
+
+                    if (errorData.IsExpected)
+                    {
+                        _attribDefs.IsErrorExpected.TrySetValue(attribValues, true);
+                    }
+                }
+                else
+                {
+                    _attribDefs.IsError.TrySetValue(attribValues, false);
                 }
             }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
@@ -73,6 +73,11 @@ namespace NewRelic.Agent.IntegrationTests.AspNetCore
             Assert.NotNull(transactionSample);
             Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample);
 
+            var getTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent("WebTransaction/MVC/Home/Index");
+
+            // Ensure false error attribute was included even with no errors
+            Assert.True(getTransactionEvent.IntrinsicAttributes.ContainsKey("error"));
+            Assert.Equal(false, getTransactionEvent.IntrinsicAttributes["error"]);
 
             var expectedErrorEventAttributes = new Dictionary<string, string>
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -130,7 +130,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(10, transactionAttributes.Count()),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(11, transactionAttributes.Count()),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", transactionAttributes["type"]),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), transactionAttributes["timestamp"]),
                 () => Assert.AreEqual("WebTransaction/TransactionName", transactionAttributes["name"]),
@@ -169,7 +169,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(12, transactionAttributes.Count()),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(13, transactionAttributes.Count()),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", transactionAttributes["type"]),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), transactionAttributes["timestamp"]),
                 () => Assert.AreEqual("WebTransaction/TransactionName", transactionAttributes["name"]),
@@ -214,7 +214,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(12, transactionAttributes.Count),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(13, transactionAttributes.Count),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", transactionAttributes["type"]),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), transactionAttributes["timestamp"]),
                 () => Assert.AreEqual("WebTransaction/TransactionName", transactionAttributes["name"]),
@@ -256,7 +256,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(12, transactionAttributes.Count),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(13, transactionAttributes.Count),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", transactionAttributes["type"]),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), transactionAttributes["timestamp"]),
                 () => Assert.AreEqual("WebTransaction/TransactionName", transactionAttributes["name"]),
@@ -301,7 +301,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(12, transactionAttributes.Count),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(13, transactionAttributes.Count),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", transactionAttributes["type"]),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), transactionAttributes["timestamp"]),
                 () => Assert.AreEqual("WebTransaction/TransactionName", transactionAttributes["name"]),
@@ -444,7 +444,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var tripId = immutableTransaction.Guid;
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(26, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(27, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", GetAttributeValue(transactionAttributes, "type", AttributeDestinations.TransactionEvent)),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), GetAttributeValue(transactionAttributes, "timestamp", AttributeDestinations.TransactionEvent)),
                 () => Assert.AreEqual("WebTransaction/TransactionName", GetAttributeValue(transactionAttributes, "name")),
@@ -622,7 +622,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             // ASSERT
             NrAssert.Multiple
             (
-                () => Assert.AreEqual(30, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(31, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => CollectionAssert.Contains(transactionAttributes, "type"),
                 () => CollectionAssert.Contains(transactionAttributes, "timestamp"),
                 () => CollectionAssert.Contains(transactionAttributes, "name"),
@@ -701,7 +701,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(32, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(33, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes, "type", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.SpanEvent, AttributeDestinations.CustomEvent),
                 () => CollectionAssert.Contains(intrinsicAttributes, "name"),
@@ -928,7 +928,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(26, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(27, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", intrinsicAttribValues["type"]),
                 () => Assert.True(intrinsicAttribValues.ContainsKey("timestamp")),
                 () => Assert.AreEqual("WebTransaction/TransactionName", intrinsicAttribValues["name"]),
@@ -1046,7 +1046,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(26, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(27, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes,"type", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes,"timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.SpanEvent, AttributeDestinations.CustomEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes,"name", AttributeDestinations.TransactionEvent),
@@ -1092,7 +1092,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(26, GetCount(attributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(27, GetCount(attributes)),  // Assert that only these attributes are generated
                 () => CollectionAssert.Contains(intrinsicAttributes, "type"),
                 () => CollectionAssert.Contains(intrinsicAttributes, "timestamp"),
                 () => CollectionAssert.Contains(intrinsicAttributes, "name"),

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
@@ -172,8 +172,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                //Test Change:  Moved from 19->18, missing attribute is transactionName which belongs to error events.
-                () => Assert.AreEqual(18, intrinsicAttributes.Count, "intrinsicAttributes.Count"),
+                () => Assert.AreEqual(19, intrinsicAttributes.Count, "intrinsicAttributes.Count"),
                 () => Assert.Contains("guid", intrinsicAttributes.Keys.ToArray(), "IntrinsicAttributes.Keys.Contains('guid')"),
                 () => Assert.AreEqual(immutableTransaction.TracingState.Type.ToString(), intrinsicAttributes["parent.type"], "parent.type"),
                 () => Assert.AreEqual(immutableTransaction.TracingState.AppId, intrinsicAttributes["parent.app"], "parent.app"),


### PR DESCRIPTION
### Description

* Fixes #500
* As per Agent specs, the error attribute is still omitted when the Error Collector is disabled.

### Testing

Both a new unit test was added and an integration test was updated to validate this.

