### PR TITLE
Update StackTraces.ScrubAndTruncate to handle zero max depth

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 ### Fixes
 * Fixes issue [#500](https://github.com/newrelic/newrelic-dotnet-agent/issues/500): For transactions without errors, Agent should still create the `error` intrinsics attribute with its value set to `false`. ([#501](https://github.com/newrelic/newrelic-dotnet-agent/pull/501))
+* Fixes issue [#522](https://github.com/newrelic/newrelic-dotnet-agent/issues/522): When the `maxStackTraceLines` config value is set to 0, the agent should not send any stack trace data in the `error_data` payload. ([#523](https://github.com/newrelic/newrelic-dotnet-agent/pull/523))
 
 ## [8.39.1] - 2021-03-17
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Utils/StackTraces.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Utils/StackTraces.cs
@@ -77,11 +77,11 @@ namespace NewRelic.Agent.Core.Utils
             {
                 if (line != null && line.IndexOf("at NewRelic.Agent", 0, Math.Min(20, line.Length)) < 0)
                 {
-                    list.Add('\t' + line);
-                    if (list.Count == maxDepth)
+                    if (list.Count >= maxDepth)
                     {
                         return list;
                     }
+                    list.Add('\t' + line);
                 }
             }
 
@@ -104,11 +104,11 @@ namespace NewRelic.Agent.Core.Utils
             {
                 if (frame.GetMethod().DeclaringType != null && !frame.GetMethod().DeclaringType.FullName.StartsWith("NewRelic"))
                 {
-                    list.Add(frame);
-                    if (list.Count == maxDepth)
+                    if (list.Count >= maxDepth)
                     {
                         return list;
                     }
+                    list.Add(frame);
                 }
             }
             return list;

--- a/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.Utils.Fromlegacy/StackTracesTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.Utils.Fromlegacy/StackTracesTest.cs
@@ -120,6 +120,14 @@ namespace NewRelic.Agent.Core.Utils
         }
 
         [Test]
+        public static void TestTruncateWithZeroMax()
+        {
+            StackFrame[] stackTraces = GetStackTrace().GetFrames();
+            ICollection<StackFrame> frames = StackTraces.ScrubAndTruncate(stackTraces, 0);
+            Assert.AreEqual(0, frames.Count);
+        }
+
+        [Test]
         public static void TestToString()
         {
             StackFrame frame = new StackFrame("dude", 6, 6);


### PR DESCRIPTION
### Description

This fixes #522 by adjusting the logic of the `StackTraces.ScrubAndTruncate` method to return an empty list when the `maxDepth` parameter is set to 0.

### Testing

Added one unit test to cover this case.  I also manually tested a test app that threw an exception from a stack depth of 3 and verified that no stack trace lines are sent in the `error` data when `maxStackTraceLines` is set to 0 in the agent config file.

### Changelog

Changelog is updated.
