### PR TITLE
Clamps negative count metrics to 0 to prevent GCSampler exceptions

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 * Fixes issue [#500](https://github.com/newrelic/newrelic-dotnet-agent/issues/500): For transactions without errors, Agent should still create the `error` intrinsics attribute with its value set to `false`. ([#501](https://github.com/newrelic/newrelic-dotnet-agent/pull/501))
 * Fixes issue [#522](https://github.com/newrelic/newrelic-dotnet-agent/issues/522): When the `maxStackTraceLines` config value is set to 0, the agent should not send any stack trace data in the `error_data` payload. ([#523](https://github.com/newrelic/newrelic-dotnet-agent/pull/523))
+* Fixes issue [#264](https://github.com/newrelic/newrelic-dotnet-agent/issues/264): Negative count metrics will now be clamped to 0, and a log message will be written to note the correction. This should resolve an issue where the GCSampler was encountering negative values and crashing.
 
 ## [8.39.1] - 2021-03-17
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricDataWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricDataWireModel.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Core.JsonConverters;
+using NewRelic.Core.Logging;
 using NewRelic.SystemExtensions;
 using Newtonsoft.Json;
 using System;
@@ -114,7 +115,8 @@ namespace NewRelic.Agent.Core.WireModels
         {
             if (callCount < 0)
             {
-                throw new ArgumentException(CannotBeNegative, nameof(callCount));
+                Log.Finest($"Encountered a negative call count: {callCount} for unknown metric");
+                callCount = 0;
             }
 
             return new MetricDataWireModel(callCount, 0, 0, 0, 0, 0);

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -963,7 +963,8 @@ namespace NewRelic.Agent.Core.WireModels
             public MetricWireModel TryBuildCacheSizeMetric(string name, int size)
             {
                 var proposedName = MetricNames.SupportabilityCachePrefix + name;
-                return BuildCountMetric(_metricNameService, proposedName, null, size);
+                var data = MetricDataWireModel.BuildAverageData(size);
+                return BuildMetric(_metricNameService, proposedName, null, data);
             }
 
             #endregion Span builders

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -82,7 +82,7 @@ namespace NewRelic.Agent.Core.WireModels
         }
 
         /// <summary>
-        /// Helper method to validate, log exceptional situations, and return a corrected count value Min(0)
+        /// Helper method to validate, log exceptional situations, and return a corrected count value as Max(0, inputValue)
         /// </summary>
         /// <returns>The input count corrected to a minimum of 0</returns>
         public static long ValidateCountMetric(string name, long count)

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricDataWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricDataWireModelTests.cs
@@ -1,0 +1,40 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Testing.Assertions;
+using NUnit.Framework;
+
+namespace NewRelic.Agent.Core.WireModels
+{
+    [TestFixture]
+    public class MetricDataWireModelTests
+    {
+
+        [Test]
+        public void BuildCountData_CorrectsNegativeValues()
+        {
+            var actualData = MetricDataWireModel.BuildCountData(-30);
+
+            Assert.AreEqual(MetricDataWireModel.BuildCountData(0), actualData);
+        }
+
+        [Test]
+        public void BuildCountData_IdentityTest()
+        {
+            var input = new Random().Next();
+
+            var actualData = MetricDataWireModel.BuildCountData(input);
+
+            NrAssert.Multiple(
+                () => Assert.AreEqual(actualData.Value0, input),
+                () => Assert.AreEqual(actualData.Value1, 0),
+                () => Assert.AreEqual(actualData.Value2, 0),
+                () => Assert.AreEqual(actualData.Value3, 0),
+                () => Assert.AreEqual(actualData.Value4, 0),
+                () => Assert.AreEqual(actualData.Value5, 0)
+            );
+        }
+
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
@@ -23,8 +23,62 @@ namespace NewRelic.Agent.Core.WireModels
         public void SetUp()
         {
             Mock.Arrange(() => _metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
-
         }
+
+        #region CountMetric NegativeValueCorrection
+
+        [Test]
+        public void ValidateCountMetric_IdentityTest()
+        {
+            var input = new Random().Next();
+            var actual = MetricWireModel.ValidateCountMetric("Don't taze me bro", input);
+            Assert.AreEqual(input, actual);
+        }
+
+        [Test]
+        public void ValidateCountMetric_ClampsNegativeValuesToZero()
+        {
+            var actual = MetricWireModel.ValidateCountMetric("pure evil", -666);
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        public void BuildCountMetric_IdentityTest()
+        {
+            var inputValue = new Random().Next();
+            var inputName = "Input name";
+            var inputScope = "Input scope";
+
+            var actual = MetricWireModel.BuildCountMetric(_metricNameService, inputName, inputScope, inputValue);
+
+            NrAssert.Multiple(
+                () => Assert.AreEqual(inputName, actual.MetricName.Name),
+                () => Assert.AreEqual(inputScope, actual.MetricName.Scope),
+                () => Assert.AreEqual(inputValue, actual.Data.Value0),
+                () => Assert.AreEqual(0, actual.Data.Value1),
+                () => Assert.AreEqual(0, actual.Data.Value2),
+                () => Assert.AreEqual(0, actual.Data.Value3),
+                () => Assert.AreEqual(0, actual.Data.Value4),
+                () => Assert.AreEqual(0, actual.Data.Value5)
+            );
+        }
+
+        [Test]
+        public void BuildCountMetric_ClampsNegativeValuesToZero()
+        {
+            var actual = MetricWireModel.BuildCountMetric(_metricNameService, "SOS", null, -505);
+
+            NrAssert.Multiple(
+                () => Assert.AreEqual(0, actual.Data.Value0),
+                () => Assert.AreEqual(0, actual.Data.Value1),
+                () => Assert.AreEqual(0, actual.Data.Value2),
+                () => Assert.AreEqual(0, actual.Data.Value3),
+                () => Assert.AreEqual(0, actual.Data.Value4),
+                () => Assert.AreEqual(0, actual.Data.Value5)
+            );
+        }
+
+        #endregion
 
         #region AddMetricsToEngine
 


### PR DESCRIPTION
### Description
Well hello!

I reviewed the bugs you had committed to in the next milestone and #264 seemed like one I could figure it out without much help. 

Essentially: Sometimes random negative counts come back from the GCSampler, and there is a desire to make this code more robust and correct any negative values to 0 so that the GCSampler isn't shut down for throwing too many exceptions.

The description of the ticket makes it sound like a 3 line change, but the requirement to log the name of the metric that is being corrected complicates things since the code that was throwing exceptions is not aware of the metric that it is validating. I tried to satisfy the requirement without too much copy/paste.

### Testing

I added unit tests for the core code that I modified which detects and corrects negative count metrics. I added identity tests to make sure positive values are not being transformed either.

There should probably be at-least one integration test that supplies a negative count value, but I have not cracked that code open and it's already late. If you can point me to a good spot to add this then I would totally add it :)

### Changelog

Updated with everything but this PR#

