### PR TITLE
Mvs replace nuget

### DIFF
--- a/tests/Agent/MultiverseTesting/ConsoleScanner/ConsoleScanner.csproj
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/ConsoleScanner.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" Version="5.9.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/NugetClient.cs
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/NugetClient.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace NewRelic.Agent.ConsoleScanner
+{
+    public class NugetClient
+    {
+        private const string V3URL= "https://api.nuget.org/v3/index.json";
+
+        private ILogger _logger;
+        private CancellationToken _cancellationToken;
+        private SourceCacheContext _sourceCache;
+        private SourceRepository _sourceRepository;
+        private string _destinationPath;
+
+        public NugetClient(string destinationPath)
+        {
+            _logger = NullLogger.Instance;
+            _cancellationToken = CancellationToken.None;
+            _sourceCache = new SourceCacheContext();
+            _sourceRepository = Repository.Factory.GetCoreV3(V3URL);
+            _destinationPath = destinationPath;
+        }
+
+        public string GetLatestVersion(string packageName, bool includePrerelease = false)
+        {
+            var resource = _sourceRepository.GetResourceAsync<FindPackageByIdResource>().Result;
+            var versions = resource.GetAllVersionsAsync(
+                packageName,
+                _sourceCache,
+                _logger,
+                _cancellationToken).Result;
+
+            if (includePrerelease)
+            {
+                return versions.OrderBy(v => v).LastOrDefault().ToNormalizedString();
+            }
+
+            return versions.Where(v => !v.IsPrerelease).OrderBy(v => v).LastOrDefault().ToNormalizedString();
+        }
+        public string DownloadPackage(string packageName, string packageVersion)
+        {
+            var resource = _sourceRepository.GetResourceAsync<FindPackageByIdResource>().Result;
+            var packageId = packageName;
+            using (var packageStream = new MemoryStream())
+            {
+                _ = resource.CopyNupkgToStreamAsync(
+                    packageId,
+                    new NuGetVersion(packageVersion),
+                    packageStream,
+                    _sourceCache,
+                    _logger,
+                    _cancellationToken).Result;
+
+                using (var packageReader = new PackageArchiveReader(packageStream))
+                {
+                    var files = packageReader.GetFiles();
+                    foreach (var file in files)
+                    {
+                       _ =  packageReader.ExtractFile(file, $@"{_destinationPath}\{packageName.ToLower()}.{packageVersion}\{file}", _logger);
+                    }
+                }
+            }
+
+            return $@"{_destinationPath}\{packageName.ToLower()}.{packageVersion}";
+        }
+    }
+}

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/NugetSet.cs
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/NugetSet.cs
@@ -9,6 +9,7 @@ namespace NewRelic.Agent.ConsoleScanner
     public class NugetSet
     {
         public string PackageName { get; set; }
-        public string[] Versions { get; set; }
+
+        public List<string> Versions { get; set; }
     }
 }

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/Properties/launchSettings.json
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "commandLineArgs": "\".\\config.yml\"",
         "environmentVariables": {
-            "MVS_XML_PATH": "PATH_TO_THE_AGENT_WRAPPER_FOLDER"
+            "MVS_XML_PATH": "C:\\dev\\github\\newrelic-dotnet-agent\\src\\Agent\\NewRelic\\Agent\\Extensions\\Providers\\Wrapper"
         }
     }
   }

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/Properties/launchSettings.json
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "commandLineArgs": "\".\\config.yml\"",
         "environmentVariables": {
-            "MVS_XML_PATH": "C:\\dev\\github\\newrelic-dotnet-agent\\src\\Agent\\NewRelic\\Agent\\Extensions\\Providers\\Wrapper"
+            "MVS_XML_PATH": "PATH_TO_THE_AGENT_WRAPPER_FOLDER"
         }
     }
   }


### PR DESCRIPTION
Resolves: #516 

### Description
Uses NuGet.Protocol and NuGet.Packaging
Downloads packages in memory and extracts files, no zip
Finds latest non-prerelease version of package
Adds latests version to versions list for download and checking
Version in NugetSet change from sting[] to List<string> to make it easy to append to

### Testing

Should build fine, cannot test since it is not run.

### Changelog
N/A