### PR TITLE
Changed GHA All Solutions Build to trigger on Release creation instead of publish

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [ published ]
+    types: [ created ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### Description

This is to support the new release process not having to immediately publish a release before all the necessary steps are actually completed. Publishing a release will be moved to the final step instead of first, so the workflow will need to trigger on creation.

### Testing

Testing will be completed/verified after this merge is completed.
