### PR TITLE
Revert "Changed GHA All Solutions Build to trigger on Release creation instead of publish"

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
   release:
-    types: [ created ]
+    types: [ published ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Reverts newrelic/newrelic-dotnet-agent#535 as it proved unworkable due to GHA not being able to trigger on Release drafts.