### PR TITLE
Update debian container images to latest stable and fix bugs

### DIFF
--- a/build/Linux/build/deb/Dockerfile
+++ b/build/Linux/build/deb/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stable
 
 RUN apt-get update
-RUN apt-get install --assume-yes dos2unix
+RUN apt-get install --assume-yes dos2unix exiftool

--- a/build/Linux/build/deb/build.sh
+++ b/build/Linux/build/deb/build.sh
@@ -5,10 +5,12 @@ AGENT_HOMEDIR='newrelichome_x64_coreclr_linux'
 
 if [ -z "$AGENT_VERSION" ]; then
     # Get version from agent core dll
-    AGENT_VERSION=$(exiftool ./${AGENT_HOMEDIR}/NewRelic.Agent.Core.dll |grep "Product Version Number" |cut -d':' -f2 |tr -d ' ')
-    if [ -z "$AGENT_VERSION" ]; then
-        echo "AGENT_VERSION is not set"
-        exit -1
+    version_from_dll=$(exiftool ./${AGENT_HOMEDIR}/NewRelic.Agent.Core.dll |grep "Product Version Number" |cut -d':' -f2 |tr -d ' ')
+    if [[ "$version_from_dll" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        AGENT_VERSION="$version_from_dll"
+    else
+        echo "AGENT_VERSION is not set, exiting."
+        exit 1
     fi
 fi
 

--- a/build/Linux/build/deb/build.sh
+++ b/build/Linux/build/deb/build.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 PACKAGE_NAME='newrelic-netcore20-agent'
+AGENT_HOMEDIR='newrelichome_x64_coreclr_linux'
+
 if [ -z "$AGENT_VERSION" ]; then
-    # try to parse the version from the last built Windows core stuff
-    windows_core_zipfile=$(ls -1 /release/${PACKAGE_NAME}-win_*_x64.zip | tail -n 1)
-    if [[ "$windows_core_zipfile" =~ win_(.+?)_x64\.zip ]]; then
-        AGENT_VERSION=${BASH_REMATCH[1]}
-    else
+    # Get version from agent core dll
+    AGENT_VERSION=$(exiftool ./${AGENT_HOMEDIR}/NewRelic.Agent.Core.dll |grep "Product Version Number" |cut -d':' -f2 |tr -d ' ')
+    if [ -z "$AGENT_VERSION" ]; then
         echo "AGENT_VERSION is not set"
         exit -1
     fi
@@ -23,7 +23,7 @@ INSTALL_LOCATION=${INSTALL_ROOT}/usr/local/${PACKAGE_NAME}
 
 mkdir -p ${INSTALL_LOCATION}
 
-cp -R newrelichome_x64_coreclr_linux/* ${INSTALL_LOCATION}
+cp -R ${AGENT_HOMEDIR}/* ${INSTALL_LOCATION}
 
 pushd ${INSTALL_LOCATION}
 

--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -1,4 +1,12 @@
 FROM rpmbuild/centos7
 
 USER root
-RUN yum --assumeyes install dos2unix rpm-sign expect
+RUN yum --assumeyes install dos2unix rpm-sign expect perl-ExtUtils-MakeMaker
+
+# Install exiftool
+RUN curl -o exiftool.tgz https://exiftool.org/Image-ExifTool-12.25.tar.gz; \
+tar -zxvf exiftool.tgz; \
+cd Image-ExifTool-12.25; \
+perl Makefile.PL; \
+make; \
+make install

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -35,15 +35,16 @@ EXPECT
 }
 
 PACKAGE_NAME='newrelic-netcore20-agent'
+AGENT_HOMEDIR='newrelichome_x64_coreclr_linux'
+
 if [ -z "$AGENT_VERSION" ]; then
-    # try to parse the version from the last built Windows core stuff
-    windows_core_zipfile=$(ls -1 /release/${PACKAGE_NAME}-win_*_x64.zip | tail -n 1)
-    if [[ "$windows_core_zipfile" =~ win_(.+?)_x64\.zip ]]; then
-        # the "export" is necessary because the rpm .spec file gets the version from the environment
-        export AGENT_VERSION=${BASH_REMATCH[1]}
+    # Get the agent version from the core .dll
+    version_from_dll=$(exiftool ./${AGENT_HOMEDIR}/NewRelic.Agent.Core.dll |grep "Product Version Number" |cut -d':' -f2 |tr -d ' ')
+    if [[ "$version_from_dll" =~ [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        export AGENT_VERSION="$version_from_dll"
     else
-        echo "AGENT_VERSION is not set"
-        exit -1
+        echo "AGENT_VERSION is not set, exiting."
+        exit 1
     fi
 fi
 echo "AGENT_VERSION=|$AGENT_VERSION|"
@@ -66,7 +67,7 @@ mkdir "${TARBALL_ROOT}"
 TARBALL_CONTENT_PATH="${TARBALL_ROOT}${TARGET_SYSTEM_INSTALL_PATH}"
 mkdir -p "${TARBALL_CONTENT_PATH}"
 
-cp -R /data/newrelichome_x64_coreclr_linux/* "${TARBALL_CONTENT_PATH}"
+cp -R /data/${AGENT_HOMEDIR}/* "${TARBALL_CONTENT_PATH}"
 
 pushd ${TARBALL_CONTENT_PATH}
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -84,8 +84,6 @@ foreach ($sln in $solutions.Keys) {
     }
 }
 
-# temp for debugging
-exit 0
 $agentVersion = (Get-Item "$rootDirectory\src\_build\AnyCPU-$Configuration\NewRelic.Agent.Core\net45\NewRelic.Agent.Core.dll").VersionInfo.FileVersion
 
 ###################

--- a/deploy/linux/container/Dockerfile
+++ b/deploy/linux/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stable
 
 RUN apt-get update && apt-get install -y \
     apt-utils \


### PR DESCRIPTION
### Description

This PR:
1. Updates two `debian:jessie` container images to `debian:stable`.  These containers are used by the build and deploy processes for the agent's Linux packages (.deb and .rpm).
2. Removes a stray debugging early exit from `build.ps1` that got committed accidentally.
3. Fixes a bug in the `build.sh` scripts for both the .deb and .rpm builds, introduced when we restructured the codebase.  What broke was the scripts' ability to automatically determine the agent version.  (FYI, when these scripts are used in our actual CI build process, the agent version is explicitly passed in to the container, so this feature is just for developers' convenience when doing local package builds.)

### Testing

I tested building the containers and running them to build the .rpm and .deb packages after my changes and it worked as expected.

Note: the container image for the rpm/deb deploy process was also updated from `jessie` to `stable`.  I tested building the container and it built as expected.  Since we have no "dry run" option for the deploy process inside the container, I can't test this change all the way to the end.

### Changelog
N/A
