### PR TITLE
Clamp negative GC counts to 0

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+* Fixes issue [#264](https://github.com/newrelic/newrelic-dotnet-agent/issues/264): Negative GC count metrics will now be clamped to 0, and a log message will be written to note the correction. This should resolve an issue where the GCSampler was encountering negative values and crashing. ([#550](https://github.com/newrelic/newrelic-dotnet-agent/pull/550))
 
 ## [8.39.2] - 2021-04-14
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
@@ -75,7 +75,7 @@ namespace NewRelic.Agent.Core.Transformers
 
         private MetricWireModel CreateMetric_Count(GCSampleType sampleType, float sampleValue)
         {
-            if(sampleValue < 0)
+            if (sampleValue < 0)
             {
                 Log.Finest($"The GC Sampler encountered a negative value: {sampleValue}, for sample: {Enum.GetName(typeof(GCSampleType), sampleType)}");
                 sampleValue = 0;

--- a/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
@@ -78,8 +78,9 @@ namespace NewRelic.Agent.Core.Transformers
             if(sampleValue < 0)
             {
                 Log.Finest($"The GC Sampler encountered a negative value: {sampleValue}, for sample: {Enum.GetName(typeof(GCSampleType), sampleType)}");
+                sampleValue = 0;
             }
-            return _metricBuilder.TryBuildGCCountMetric(sampleType, Math.Max(0, (int)sampleValue));
+            return _metricBuilder.TryBuildGCCountMetric(sampleType, (int)sampleValue);
         }
 
         private MetricWireModel CreateMetric_ByteData(GCSampleType sampleType, float sampleValue)

--- a/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/GcSampleTransformer.cs
@@ -4,6 +4,7 @@
 using NewRelic.Agent.Core.Aggregators;
 using NewRelic.Agent.Core.Samplers;
 using NewRelic.Agent.Core.WireModels;
+using NewRelic.Core.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -74,7 +75,11 @@ namespace NewRelic.Agent.Core.Transformers
 
         private MetricWireModel CreateMetric_Count(GCSampleType sampleType, float sampleValue)
         {
-            return _metricBuilder.TryBuildGCCountMetric(sampleType, (int)sampleValue);
+            if(sampleValue < 0)
+            {
+                Log.Finest($"The GC Sampler encountered a negative value: {sampleValue}, for sample: {Enum.GetName(typeof(GCSampleType), sampleType)}");
+            }
+            return _metricBuilder.TryBuildGCCountMetric(sampleType, Math.Max(0, (int)sampleValue));
         }
 
         private MetricWireModel CreateMetric_ByteData(GCSampleType sampleType, float sampleValue)

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
@@ -139,39 +139,28 @@ namespace NewRelic.Agent.Core.Transformers
         [Test]
         public void TransformerClampsNegativeCountValuesToZero()
         {
-            var metricNameService = new MetricNameService();
-            var metricBuilder = Mock.Create<IMetricBuilder>();
-
-            var sampleTypes_CountMetrics = new List<GCSampleType>();
-
-            //This dictionary defines which GCSampleTypes SHOULD be found in which metric type list.
-            var expectationsDict = new Dictionary<GCSampleType, List<GCSampleType>>()
+            var countTypes = new List<GCSampleType>()
             {
-                { GCSampleType.InducedCount, sampleTypes_CountMetrics },
-                { GCSampleType.Gen0CollectionCount, sampleTypes_CountMetrics },
-                { GCSampleType.Gen1CollectionCount, sampleTypes_CountMetrics },
-                { GCSampleType.Gen2CollectionCount, sampleTypes_CountMetrics },
+                GCSampleType.InducedCount,
+                GCSampleType.Gen0CollectionCount,
+                GCSampleType.Gen1CollectionCount,
+                GCSampleType.Gen2CollectionCount
             };
 
-        
-            Mock.Arrange(() => metricBuilder.TryBuildGCCountMetric(Arg.IsAny<GCSampleType>(), Arg.IsAny<int>()))
-                .DoInstead<GCSampleType, int>((type, _) => { sampleTypes_CountMetrics.Add(type); });
+            foreach(var countMetric in countTypes)
+            {
+                _sampleData[countMetric] = -1;
+            }
 
-            var transformer = new GcSampleTransformer(metricBuilder, _metricAggregator);
+            //Collect metrics that are generated from sample data
+            var generatedMetrics = new Dictionary<string, MetricWireModel>();
+            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>()))
+                .DoInstead<MetricWireModel>((metric) => { generatedMetrics.Add(metric.MetricName.Name, metric); });
 
             //Act
-            transformer.Transform(_sampleData);
+            _transformer.Transform(_sampleData);
 
-            //Assert
-            //Ensure that all of the sample types have a corresponding expected metric shape
-            //A failure here indicates that new GCSampleTypes have been added, but the type of metric that it generates has not been identified.
-            Assert.AreEqual(_sampleTypesCount, expectationsDict.Count, "Not all GCSampleTypes have a metric shape associated with them.  expectationsDic is missing entries");
-
-            //Validate that each SampleType generated the expected MetricType
-            foreach (var q in expectationsDict)
-            {
-                Assert.Contains(q.Key, q.Value, $"GC Sample Type {q.Key} was not of the expected metric type.");
-            }
+            Assert.IsFalse(generatedMetrics.Any(x => x.Value.Data.Value0 < 0));
         }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes #264 . Essentially, we occasionally encounter negative GC counts which cause an exception to be thrown. This exception can cause the GC sampler to be shut down after multiple errors are encountered. In order to prevent this from happening, we want to clamp all negative count metrics coming from the GC.

The fix is implemented at the GC layer, and will work for both .NET framework, and .NET standard.

### Testing

A new unit test was added that verifies that negative GC counts are clamped to 0. As we do not have a repro path, an integration test was not written.