### PR TITLE
Reduce integration test solution build warnings

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/AspNetCore3BasicWebApiApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/AspNetCore3BasicWebApiApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/ConsoleAsyncApplication/AsyncFireAndForgetUseCases.cs
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleAsyncApplication/AsyncFireAndForgetUseCases.cs
@@ -35,7 +35,9 @@ namespace ConsoleAsyncApplication
             return "Worked";
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> Async_FireAndForget(EventWaitHandle waitHandle)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             var transactionName = UpdateTransactionName("AF");
 
@@ -58,7 +60,9 @@ namespace ConsoleAsyncApplication
             return "Worked";
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> Async_Sync()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             var transactionName = UpdateTransactionName("AS");
 
@@ -143,7 +147,9 @@ namespace ConsoleAsyncApplication
 
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         private static async Task AsyncMethod(int delayMs, string transactionName, EventWaitHandle handle = null)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             transactionName = UpdateTransactionName(transactionName, "AM");
 

--- a/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
@@ -20,9 +20,9 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
 
         private static IAgent _agent = null;
 
-        private static List<KeyValuePair<string, string>> _carrier = new List<KeyValuePair<string, string>>();
+        private static readonly List<KeyValuePair<string, string>> _carrier = new List<KeyValuePair<string, string>>();
 
-        private static Action<List<KeyValuePair<string, string>>, string, string> _setHeaders = new Action<List<KeyValuePair<string, string>>, string, string>((carrier, key, value) =>
+        private static readonly Action<List<KeyValuePair<string, string>>, string, string> _setHeaders = new Action<List<KeyValuePair<string, string>>, string, string>((carrier, key, value) =>
         {
             carrier.Add(new KeyValuePair<string, string>(key, value));
         });

--- a/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
@@ -76,14 +76,20 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
         private static IDistributedTracePayload CallCreateDTPayload()
         {
             var currentTransaction = _agent.CurrentTransaction;
+            // As long as this deprecated API is still shipping, we still need to test it
+#pragma warning disable CS0618 // Type or member is obsolete
             return currentTransaction.CreateDistributedTracePayload();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Transaction]
         private static void CallAcceptDTPayload(IDistributedTracePayload payload)
         {
             var currentTransaction = _agent.CurrentTransaction;
+            // As long as this deprecated API is still shipping, we still need to test it
+#pragma warning disable CS0618 // Type or member is obsolete
             currentTransaction.AcceptDistributedTracePayload(payload.HttpSafe());
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Transaction]

--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
@@ -79,7 +79,7 @@
       <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Seq.RequestLogsFeature">
-      <Version>5.0.2</Version>
+      <Version>5.1.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Server">
       <Version>5.5.0</Version>

--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -61,34 +61,33 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ServiceStack">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Client">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Common">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Interfaces">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.OrmLite">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Redis">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Seq.RequestLogsFeature">
       <Version>5.0.2</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Server">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Text">
-      <Version>5.0.2</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <None Include="Properties\PublishProfiles\LocalDeploy.pubxml" />
     <None Include="Web.Debug.config">

--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Controllers/AsyncFireAndForgetController.cs
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Controllers/AsyncFireAndForgetController.cs
@@ -42,7 +42,9 @@ namespace WebApiAsyncApplication.Controllers
 
         [HttpGet]
         [Route("AsyncFireAndForget/Async_FireAndForget")]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> Async_FireAndForget()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             var transactionName = UpdateTransactionName("AF");
 
@@ -66,7 +68,9 @@ namespace WebApiAsyncApplication.Controllers
 
         [HttpGet]
         [Route("AsyncFireAndForget/Async_Sync")]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task<string> Async_Sync()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             var transactionName = UpdateTransactionName("AS");
 
@@ -153,7 +157,9 @@ namespace WebApiAsyncApplication.Controllers
 
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         private static async Task AsyncMethod(int delayMs, string transactionName)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             transactionName = UpdateTransactionName(transactionName, "AM");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3BasicWebApiApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3BasicWebApiApplicationFixture.cs
@@ -12,7 +12,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
     {
         private const string ApplicationDirectoryName = @"AspNetCore3BasicWebApiApplication";
         private const string ExecutableName = @"AspNetCore3BasicWebApiApplication.exe";
-        private const string TargetFramework = "netcoreapp3.0";
+        private const string TargetFramework = "netcoreapp3.1";
 
         public AspNetCore3BasicWebApiApplicationFixture() : base(new RemoteService(ApplicationDirectoryName, ExecutableName, TargetFramework, ApplicationType.Bounded, true, true, true))
         {

--- a/tests/Agent/IntegrationTests/IntegrationTests/app.config
+++ b/tests/Agent/IntegrationTests/IntegrationTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net461;net471;net48</TargetFrameworks>
+    <!--We have some tests that specifically need to test .NET Core 2.2 behavior, so disabling the warning about 2.2 being EOL-->
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net461;net471;net48</TargetFrameworks>
@@ -9,15 +9,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.24.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.24.1">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Owin" Version="4.1.0">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="4.1.0">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Hosting" Version="4.1.0">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api" Version="8.36.0" />
-    <PackageReference Include="Owin" Version="1.0.0" />
+    <PackageReference Include="Owin" Version="1.0.0">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
+    <!--We have some tests that specifically need to test .NET Core 2.2 behavior, so disabling the warning about 2.2 being EOL-->
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/app.config
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <publisherPolicy apply="no" />


### PR DESCRIPTION
### Description

This PR reduces the number of build/restore warnings seen in the integration test and unbounded integration test solutions.  There were more than 70 warnings in the integration test solution before this work and the number is now down to 6 (all caused by the same issue which may be addressed in a separate PR, but I believe it will require a slightly more significant change).

Part of the motivation for doing this now is that as we begin to test .NET 6 preview versions, we want to make sure that any new warnings don't get lost in the noise.  However, this should help anybody either internally or externally to notice new warnings that may appear.

The following things were done to reduce the number of warnings:

* ServiceStackApplication was modified to reference 5.5.0 versions of ServiceStack nuget packages, since the version we were previously referencing (5.0.2) was no longer available.  This change is benign since the tests have been using 5.5.0 anyway.
* Suppressed warnings about out-of-date .NET Core target versions (netcoreapp2.2 specifically) - some of our tests need to specifically test these EOLed .NET Core versions
* In the Agent API tests, suppressed warnings about some of the APIs being deprecated - as long as we're still shipping these APIs we need to test them
* Suppressed warnings about `async` methods without `await` operators: we have tests that are testing this specific scenario on purpose.
* In MultiFunctionApplicationHelpers, ignore warnings about NuGet packages not being fully compatible with a given runtime version.  The way this project works, it is multi-targeted to several .NET Framework and .NET Core versions to allow testing multiple runtimes from the same test code.  However, not all targets are used in every test.  The warnings were for package references incompatible with `netcoreapp2.1`, but those packages are not used by any tests that run on `netcoreapp2.1`
* Updated binding redirects for `NewtonSoft.Json` to account for the many versions of this package used throughout the tests solutions.

### Testing

I made sure all of the integration tests and unbounded integration tests passed after making these changes.

### Changelog

N/A
