### PR TITLE
Adds allowAllHeaders config setting.

### DIFF
--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -7,6 +7,7 @@
 		<name>My Application</name>
 	</application>
 	<log level="info"/>
+	<allowAllHeaders enabled="true" />
 	<transactionTracer enabled="true"
 		transactionThreshold="apdex_f"
 		stackTraceThreshold="500"

--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -8,6 +8,15 @@
 	</application>
 	<log level="info"/>
 	<allowAllHeaders enabled="true" />
+	<attributes enabled="true">
+		<exclude>request.headers.cookie</exclude>
+		<exclude>request.headers.authorization</exclude>
+		<exclude>request.headers.proxyAuthorization</exclude>
+		<exclude>request.headers.x*</exclude>
+		<exclude>response.headers.setCookie*</exclude>
+
+		<include>request.headers.*</include>
+	</attributes>
 	<transactionTracer enabled="true"
 		transactionThreshold="apdex_f"
 		stackTraceThreshold="500"

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -39,6 +39,8 @@ namespace NewRelic.Agent.Core.Config
         
         private configurationInstrumentation instrumentationField;
         
+        private configurationAllowAllHeaders allowAllHeadersField;
+        
         private configurationAttributes attributesField;
         
         private configurationParameterGroups parameterGroupsField;
@@ -135,6 +137,7 @@ namespace NewRelic.Agent.Core.Config
             this.requestParametersField = new configurationRequestParameters();
             this.parameterGroupsField = new configurationParameterGroups();
             this.attributesField = new configurationAttributes();
+            this.allowAllHeadersField = new configurationAllowAllHeaders();
             this.instrumentationField = new configurationInstrumentation();
             this.logField = new configurationLog();
             this.applicationField = new configurationApplication();
@@ -218,6 +221,18 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.instrumentationField = value;
+            }
+        }
+        
+        public configurationAllowAllHeaders allowAllHeaders
+        {
+            get
+            {
+                return this.allowAllHeadersField;
+            }
+            set
+            {
+                this.allowAllHeadersField = value;
             }
         }
         
@@ -1397,7 +1412,7 @@ namespace NewRelic.Agent.Core.Config
         public configurationInstrumentation()
         {
             this.applicationsField = new List<configurationInstrumentationApplication>();
-            this.logField = false;
+            this.logField = true;
         }
         
         [System.Xml.Serialization.XmlArrayItemAttribute("application", IsNullable=false)]
@@ -1414,7 +1429,7 @@ namespace NewRelic.Agent.Core.Config
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(false)]
+        [System.ComponentModel.DefaultValueAttribute(true)]
         public bool log
         {
             get
@@ -1467,6 +1482,62 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationInstrumentationApplication Clone()
         {
             return ((configurationInstrumentationApplication)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationAllowAllHeaders
+    {
+        
+        private System.Nullable<bool> enabledField;
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public bool enabled
+        {
+            get
+            {
+                if (this.enabledField.HasValue)
+                {
+                    return this.enabledField.Value;
+                }
+                else
+                {
+                    return default(bool);
+                }
+            }
+            set
+            {
+                this.enabledField = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool enabledSpecified
+        {
+            get
+            {
+                return this.enabledField.HasValue;
+            }
+            set
+            {
+                if (value==false)
+                {
+                    this.enabledField = null;
+                }
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationAllowAllHeaders object
+        /// </summary>
+        public virtual configurationAllowAllHeaders Clone()
+        {
+            return ((configurationAllowAllHeaders)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -407,6 +407,23 @@
           </xs:complexType>
         </xs:element>
 
+        <xs:element name="allowAllHeaders" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+                <xs:annotation>
+                    <xs:documentation>
+                        Allow all request headers to be captured as attributes.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:attribute name="enabled" type="xs:boolean" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Turns on capturing. Enabled by default.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:complexType>
+        </xs:element>
+
         <xs:element name="attributes" minOccurs="0" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -360,6 +360,8 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
+        public virtual bool AllowAllHeaders => _localConfiguration.allowAllHeaders.enabled;
+
         #region Attributes
 
         public virtual bool CaptureAttributes => _localConfiguration.attributes.enabled;

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -26,6 +26,7 @@ namespace NewRelic.Agent.Configuration
         bool BrowserMonitoringUseSsl { get; }
         string SecurityPoliciesToken { get; }
         bool SecurityPoliciesTokenExists { get; }
+        bool AllowAllHeaders { get; }
         bool CaptureAttributes { get; }
         bool CanUseAttributesIncludes { get; }
         string CanUseAttributesIncludesSource { get; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2634,6 +2634,19 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
         #region Capture Attributes
 
+        [TestCase(null, false)]
+        [TestCase(true, true)]
+        [TestCase(false, false)]
+        public void AllowAllHeadersConfigTests(bool? enabled, bool expectedResult)
+        {
+            if (enabled.HasValue)
+            {
+                _localConfig.allowAllHeaders.enabled = enabled.Value;
+            }
+
+            Assert.AreEqual(expectedResult, _defaultConfig.AllowAllHeaders);
+        }
+
         [TestCase(true, true)]
         [TestCase(false, false)]
         public void CaptureAttributes(bool captureAttributes, bool expectedResult)


### PR DESCRIPTION
### Description

This PR does the followings:

1. allowAllHeaders is introduced at the root configuration level and enabled by default (the default newrelic.config will include this config). If this config isn't specified, it is set to `false`.

2. The excluded headers mentioned in this [specs](https://source.datanerd.us/agents/agent-specs/blob/master/Agent-Attributes-PORTED.md#request-headers) is explicitly listed in the global attribute exclusion list to satisfy the Security team.

Note: I attempted to add this new config setting to the Connect payload but our agent is currently not setup to do so. Deferring this work for later time.

### Testing
Unit tests added.

