### PR TITLE
High security mode will disable request header capturing

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -360,7 +360,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public virtual bool AllowAllHeaders => _localConfiguration.allowAllHeaders.enabled;
+        public bool CaptureAllRequestHeaders => HighSecurityModeOverrides(false, _localConfiguration.allowAllHeaders.enabled);
 
         #region Attributes
 
@@ -416,6 +416,11 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                if (CaptureAllRequestHeaders)
+                {
+                    _localConfiguration.attributes.include.Add("request.headers.*");
+                }
+
                 if (CanUseAttributesIncludes)
                 {
                     return Memoizer.Memoize(ref _captureAttributesIncludes, () => new HashSet<string>(_localConfiguration.attributes.include));

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.Configuration
         bool BrowserMonitoringUseSsl { get; }
         string SecurityPoliciesToken { get; }
         bool SecurityPoliciesTokenExists { get; }
-        bool AllowAllHeaders { get; }
+        bool CaptureAllRequestHeaders { get; }
         bool CaptureAttributes { get; }
         bool CanUseAttributesIncludes { get; }
         string CanUseAttributesIncludesSource { get; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2644,7 +2644,19 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 _localConfig.allowAllHeaders.enabled = enabled.Value;
             }
 
-            Assert.AreEqual(expectedResult, _defaultConfig.AllowAllHeaders);
+            Assert.AreEqual(expectedResult, _defaultConfig.CaptureAllRequestHeaders);
+            Assert.AreEqual(_localConfig.allowAllHeaders.enabled ? true : false, _defaultConfig.CaptureAttributesIncludes.Contains("request.headers.*"));
+        }
+
+        [TestCase(true, false)]
+        [TestCase(false, false)]
+        public void AllowAllHeaders_HighSecurityMode_Enabled_Tests(bool enabled, bool expectedResult)
+        {
+            _localConfig.allowAllHeaders.enabled = enabled;
+            _localConfig.highSecurity.enabled = true;
+        
+            Assert.AreEqual(expectedResult, _defaultConfig.CaptureAllRequestHeaders);
+            Assert.AreEqual(0, _defaultConfig.CaptureAttributesIncludes.Count());
         }
 
         [TestCase(true, true)]


### PR DESCRIPTION
### Description:
This PR updates the followings:
1. High security mode will disable request header capturing. This is for spec compliance.
2. When allowAllHeaders config is set to "true", automatically add "request.header.*" to the inclusion list even when users don't explicitly specify it in the attribute element. This is doing similar to the `captureParameters` configuration.

### Testing
Unit tests.