### PR TITLE
Introduces SetRequestHeaders api method

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -116,6 +116,8 @@ namespace NewRelic.Agent.Core.Attributes
 
         AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName);
 
+        AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName);
+
         AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue destination);
     }
 
@@ -158,8 +160,8 @@ namespace NewRelic.Agent.Core.Attributes
         private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _spanCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
         private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _errorCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
         private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _customEventCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-
         private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestParameterAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
+        private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestHeadersAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
 
         private readonly ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>> _typeAttributes = new ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>>();
 
@@ -206,6 +208,20 @@ namespace NewRelic.Agent.Core.Attributes
                 .Build(_attribFilter);
         }
 
+        private AttributeDefinition<string, string> CreateRequestHeadersAttribute(string paramName)
+        {
+            var attribName = $"request.headers.{paramName}";
+
+            return AttributeDefinitionBuilder
+                .CreateString(attribName, AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
+                .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
+                .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
+                .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
+                .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
+                .Build(_attribFilter);
+        }
+
         public AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name)
         {
             return _trxCustomAttributes.GetOrAdd(name, CreateCustomAttributeForTransaction);
@@ -229,6 +245,11 @@ namespace NewRelic.Agent.Core.Attributes
         public AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName)
         {
             return _requestParameterAttributes.GetOrAdd(paramName, CreateRequestParameterAttribute);
+        }
+
+        public AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName)
+        {
+            return _requestHeadersAttributes.GetOrAdd(paramName, CreateRequestHeadersAttribute);
         }
 
         public AttributeDefinition<TypeAttributeValue, string> CreateTypeAttribute(TypeAttributeValue tm)

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -267,5 +267,10 @@ namespace NewRelic.Agent.Core.Transactions
         {
             return;
         }
+
+        public ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            return this;
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1179,5 +1179,24 @@ namespace NewRelic.Agent.Core.Transactions
                 }
             }
         }
+
+        public ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            foreach (var parameter in parameters)
+            {
+                if (parameter.Key != null && parameter.Value != null)
+                {
+                    var paramAttribute = _attribDefs.GetRequestHeadersAttribute(parameter.Key);
+                    TransactionMetadata.UserAndRequestAttributes.TrySetValue(paramAttribute, parameter.Value);
+                }
+            }
+
+            return this;
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -265,5 +265,7 @@ namespace NewRelic.Agent.Api
         void InsertDistributedTraceHeaders<T>(T carrier, Action<T, string, string> setter);
 
         void AcceptDistributedTraceHeaders<T>(T carrier, Func<T, string, IEnumerable<string>> getter, TransportType transportType);
+
+        ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters);
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
@@ -187,6 +187,44 @@ namespace NewRelic.Agent.Core.Attributes.Tests
             );
         }
 
+        [TestCase(null, null, false)]
+        [TestCase(true, null, true)]
+        [TestCase(false, null, false)]
+        [TestCase(true, "request.headers.foo", false)]
+        [TestCase(null, "request.headers.foo", false)]
+        [TestCase(true, "request.headers.*", false)]
+        public void RequestHeaderAttributeTests
+        (
+            bool? allowAllHeaders,
+            string attributesExclude,
+            bool expectCaptureRequestHeaders
+        )
+        {
+            //Arrange
+            if (allowAllHeaders.HasValue)
+            {
+                _localConfig.allowAllHeaders.enabled = allowAllHeaders.Value;
+            }
+
+            if (!string.IsNullOrWhiteSpace(attributesExclude))
+            {
+                _localConfig.attributes.exclude.Add(attributesExclude);
+            }
+
+            UpdateConfig();
+
+
+            var attrib = _attribDefs.GetRequestHeadersAttribute("foo");
+
+            NrAssert.Multiple
+            (
+                () => Assert.AreEqual(expectCaptureRequestHeaders, attrib.IsAvailableForAny(AttributeDestinations.TransactionEvent)),
+                () => Assert.AreEqual(expectCaptureRequestHeaders, attrib.IsAvailableForAny(AttributeDestinations.SpanEvent)),
+                () => Assert.AreEqual(expectCaptureRequestHeaders, attrib.IsAvailableForAny(AttributeDestinations.ErrorEvent)),
+                () => Assert.AreEqual(expectCaptureRequestHeaders, attrib.IsAvailableForAny(AttributeDestinations.ErrorTrace)),
+                () => Assert.AreEqual(expectCaptureRequestHeaders, attrib.IsAvailableForAny(AttributeDestinations.TransactionTrace))
+           );
+        }
 
         const string _lazyTest_AttribNameDtm = "dtmAttrib";
         private DateTime _lazyTest_AttribValDtm = DateTime.UtcNow;


### PR DESCRIPTION
### Description
This PR adds the `SetRequestHeaders` method in the `ITransaction` so that upstream code can use to add request headers data as user attributes. 
 
### Testing
Unit tests.
