### PR TITLE
Change SetRequestHeaders method signature.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -268,7 +268,7 @@ namespace NewRelic.Agent.Core.Transactions
             return;
         }
 
-        public ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters)
+        public ITransaction SetRequestHeaders<T>(T headers, IEnumerable<string> keysToCapture, Func<T, string, string> getter)
         {
             return this;
         }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1200,7 +1200,7 @@ namespace NewRelic.Agent.Core.Transactions
             foreach (var key in keysToCapture)
             {
                 var value = getter(headers, key);
-                if (!string.IsNullOrEmpty(value))
+                if (value != null)
                 {
                     var paramAttribute = _attribDefs.GetRequestHeadersAttribute(key);
                     TransactionMetadata.UserAndRequestAttributes.TrySetValue(paramAttribute, value);

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1180,19 +1180,30 @@ namespace NewRelic.Agent.Core.Transactions
             }
         }
 
-        public ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters)
+        public ITransaction SetRequestHeaders<T>(T headers, IEnumerable<string> keysToCapture, Func<T, string, string> getter)
         {
-            if (parameters == null)
+            if (headers == null)
             {
-                throw new ArgumentNullException(nameof(parameters));
+                throw new ArgumentNullException(nameof(headers));
             }
 
-            foreach (var parameter in parameters)
+            if (keysToCapture == null)
             {
-                if (parameter.Key != null && parameter.Value != null)
+                throw new ArgumentNullException(nameof(keysToCapture));
+            }
+
+            if (getter == null)
+            {
+                throw new ArgumentNullException(nameof(getter));
+            }
+
+            foreach (var key in keysToCapture)
+            {
+                var value = getter(headers, key);
+                if (!string.IsNullOrEmpty(value))
                 {
-                    var paramAttribute = _attribDefs.GetRequestHeadersAttribute(parameter.Key);
-                    TransactionMetadata.UserAndRequestAttributes.TrySetValue(paramAttribute, parameter.Value);
+                    var paramAttribute = _attribDefs.GetRequestHeadersAttribute(key);
+                    TransactionMetadata.UserAndRequestAttributes.TrySetValue(paramAttribute, value);
                 }
             }
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -266,6 +266,6 @@ namespace NewRelic.Agent.Api
 
         void AcceptDistributedTraceHeaders<T>(T carrier, Func<T, string, IEnumerable<string>> getter, TransportType transportType);
 
-        ITransaction SetRequestHeaders(IEnumerable<KeyValuePair<string, string>> parameters);
+        ITransaction SetRequestHeaders<T>(T headers, IEnumerable<string> keysToCapture, Func<T, string, string> getter);
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -344,6 +344,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             {
                 { "key1", "value1" },
                 { "key2", "value2" },
+                { "key3", ""}
             };
 
             string GetHeaderValue(Dictionary<string, string> headers, string key)
@@ -351,7 +352,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 return headers[key];
             }
 
-            transaction.SetRequestHeaders(headerCollection, new[] { "key1", "key2" }, GetHeaderValue);
+            transaction.SetRequestHeaders(headerCollection, new[] { "key1", "key2", "key3" }, GetHeaderValue);
             
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -379,7 +380,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.AreEqual(39, GetCount(transactionAttributes)),  // Assert that only these attributes are generated
+                () => Assert.AreEqual(40, GetCount(transactionAttributes)),  // Assert that only these attributes are generated
                 () => Assert.AreEqual("Transaction", GetAttributeValue(attributes, "type", AttributeDestinations.TransactionEvent)),
                 () => Assert.AreEqual("TransactionError", GetAttributeValue(attributes, "type", AttributeDestinations.ErrorEvent)),
                 () => Assert.AreEqual(expectedStartTime.ToUnixTimeMilliseconds(), GetAttributeValue(attributes, "timestamp", AttributeDestinations.TransactionEvent)),
@@ -418,7 +419,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.AreEqual(true, GetAttributeValue(transactionAttributes, "error")),
                 () => Assert.True(DoAttributesContain(transactionAttributes, "host.displayName")),
                 () => Assert.AreEqual("value1", GetAttributeValue(transactionAttributes, "request.headers.key1")),
-                () => Assert.AreEqual("value2", GetAttributeValue(transactionAttributes, "request.headers.key2"))
+                () => Assert.AreEqual("value2", GetAttributeValue(transactionAttributes, "request.headers.key2")),
+                () => Assert.AreEqual("", GetAttributeValue(transactionAttributes, "request.headers.key3"))
             );
         }
 


### PR DESCRIPTION
### Description

Changes `SetRequestHeaders` method signature to generically handle any header collection implementation.

### Testing
No tests as this is not being used anywhere yet.
