### PR TITLE
Add dotnet 6 supportability metric

### DIFF
--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -28,8 +28,8 @@ namespace NewRelic.Core
         netcoreapp30,
         netcoreapp31,
         net5,
-        Other,
-        net6
+        net6,
+        Other
     }
 
     public static class DotnetVersion

--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -29,6 +29,7 @@ namespace NewRelic.Core
         netcoreapp31,
         net5,
         Other,
+        net6
     }
 
     public static class DotnetVersion
@@ -92,6 +93,11 @@ namespace NewRelic.Core
             if (envVer.Major == 3 && envVer.Minor == 1)
             {
                 return DotnetCoreVersion.netcoreapp31;
+            }
+
+            if (envVer.Major == 6)
+            {
+                return DotnetCoreVersion.net6;
             }
 
             if (envVer.Major == 5)


### PR DESCRIPTION
### Description

We were not detecting .net core framework version 6. 

### Testing

@nr-ahemsath tested the changes locally. 