### PR TITLE
Fixes allowAllHeaders setting logic

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -360,7 +360,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public bool CaptureAllRequestHeaders => HighSecurityModeOverrides(false, _localConfiguration.allowAllHeaders.enabled);
+        public bool AllowAllRequestHeaders => HighSecurityModeOverrides(false, _localConfiguration.allowAllHeaders.enabled);
 
         #region Attributes
 
@@ -416,11 +416,6 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                if (CaptureAllRequestHeaders)
-                {
-                    _localConfiguration.attributes.include.Add("request.headers.*");
-                }
-
                 if (CanUseAttributesIncludes)
                 {
                     return Memoizer.Memoize(ref _captureAttributesIncludes, () => new HashSet<string>(_localConfiguration.attributes.include));

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.Configuration
         bool BrowserMonitoringUseSsl { get; }
         string SecurityPoliciesToken { get; }
         bool SecurityPoliciesTokenExists { get; }
-        bool CaptureAllRequestHeaders { get; }
+        bool AllowAllRequestHeaders { get; }
         bool CaptureAttributes { get; }
         bool CanUseAttributesIncludes { get; }
         string CanUseAttributesIncludesSource { get; }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2645,7 +2645,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             }
 
             Assert.AreEqual(expectedResult, _defaultConfig.AllowAllRequestHeaders);
-            Assert.AreEqual(_localConfig.allowAllHeaders.enabled ? true : false, _defaultConfig.CaptureAttributesIncludes.Contains("request.headers.*"));
         }
 
         [TestCase(true, false)]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2644,7 +2644,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 _localConfig.allowAllHeaders.enabled = enabled.Value;
             }
 
-            Assert.AreEqual(expectedResult, _defaultConfig.CaptureAllRequestHeaders);
+            Assert.AreEqual(expectedResult, _defaultConfig.AllowAllRequestHeaders);
             Assert.AreEqual(_localConfig.allowAllHeaders.enabled ? true : false, _defaultConfig.CaptureAttributesIncludes.Contains("request.headers.*"));
         }
 
@@ -2655,7 +2655,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _localConfig.allowAllHeaders.enabled = enabled;
             _localConfig.highSecurity.enabled = true;
         
-            Assert.AreEqual(expectedResult, _defaultConfig.CaptureAllRequestHeaders);
+            Assert.AreEqual(expectedResult, _defaultConfig.AllowAllRequestHeaders);
             Assert.AreEqual(0, _defaultConfig.CaptureAttributesIncludes.Count());
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -84,7 +84,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             _serverConfig = new ServerConfiguration();
             _localConfig = new configuration();
 
-            _localConfig.attributes.include = new List<string>() { "request.parameters.*" };
+            _localConfig.attributes.include = new List<string>() { "request.parameters.*", "request.headers.*" };
 
             _localConfig.allowAllHeaders.enabled = true;
 


### PR DESCRIPTION
### Description

When `allowAllHeaders` set to `true`, don't implicitly add "request.header.*" to the global attribute inclusion list. This allows users to specifically tell the agent to include specific headers. 

### Testing
Unit tests modified/added.
