### PR TITLE
When high security mode is enabled, don't collect any request headers.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1197,6 +1197,11 @@ namespace NewRelic.Agent.Core.Transactions
                 throw new ArgumentNullException(nameof(getter));
             }
 
+            if (_configuration.HighSecurityModeEnabled)
+            {
+                return this;
+            }
+
             foreach (var key in keysToCapture)
             {
                 var value = getter(headers, key);


### PR DESCRIPTION
### Description
When high security mode is enabled, don't collect any request headers according to the agent specs.

### Testing
Unit test added.