### PR TITLE
Request Header capturing support for WCF

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -455,7 +455,7 @@ jobs:
           CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, 
           HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Logging, Owin, ReJit.NetCore, 
           ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
-          WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self ]
+          WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35]
       fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
     env:

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
+* **Adds support for capturing Request HTTP Headers.** Support is included in the following wrappers:
+  * AspNetCore ([#559](https://github.com/newrelic/newrelic-dotnet-agent/issues/559))
+  * Owin ([#560](https://github.com/newrelic/newrelic-dotnet-agent/issues/560))
+  * Asp35 ([#558](https://github.com/newrelic/newrelic-dotnet-agent/issues/558))
+  * WCF ([#593](https://github.com/newrelic/newrelic-dotnet-agent/pull/593)).
+
 ### Fixes
 * Fixes issue [#264](https://github.com/newrelic/newrelic-dotnet-agent/issues/264): Negative GC count metrics will now be clamped to 0, and a log message will be written to note the correction. This should resolve an issue where the GCSampler was encountering negative values and crashing. ([#550](https://github.com/newrelic/newrelic-dotnet-agent/pull/550))
 

--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -12,7 +12,7 @@
 		<exclude>request.headers.cookie</exclude>
 		<exclude>request.headers.authorization</exclude>
 		<exclude>request.headers.proxy-authorization</exclude>
-		<exclude>request.headers.x*</exclude>
+		<exclude>request.headers.x-*</exclude>
 
 		<include>request.headers.*</include>
 	</attributes>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Constants.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Constants.cs
@@ -20,6 +20,7 @@ namespace NewRelic.Agent.Extensions.Providers.Wrapper
         public const string TraceParentHeaderKey = "traceparent";
 
         public const string TraceStateHeaderKey = "tracestate";
+
     }
 
     public static class Statics

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Asp35/Shared/HttpContextActions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Asp35/Shared/HttpContextActions.cs
@@ -115,11 +115,9 @@ namespace NewRelic.Providers.Wrapper.Asp35.Shared
             }
         }
 
-        static readonly string[] DefaultCaptureHeaders = { "Referer", "Accept", "Content-Length", "Host", "User-Agent" };
-
         private static void StoreRequestHeaders(IAgent agent, HttpContext httpContext)
         {
-            var keysToCapture = agent.Configuration.AllowAllRequestHeaders ? httpContext.Request.Headers?.AllKeys : DefaultCaptureHeaders;
+            var keysToCapture = agent.Configuration.AllowAllRequestHeaders ? httpContext.Request.Headers?.AllKeys : Statics.DefaultCaptureHeaders;
 
             agent.CurrentTransaction.SetRequestHeaders(httpContext.Request.Headers, keysToCapture, (headers, key) => headers[key]);
         }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -22,7 +22,6 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
         private readonly RequestDelegate _next;
         private readonly IAgent _agent;
         private volatile bool _inspectingHttpContextForErrorsIsEnabled = true;
-        private readonly string[] _defaultCaptureHeaders = { "Referer", "Accept", "Content-Length", "Host", "User-Agent" };
 
         public WrapPipelineMiddleware(RequestDelegate next, IAgent agent)
         {
@@ -57,7 +56,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
                 }
                 else
                 {
-                    transaction.SetRequestHeaders(context.Request.Headers, _defaultCaptureHeaders, GetHeaderValue);
+                    transaction.SetRequestHeaders(context.Request.Headers, Constants.DefaultCaptureHeaders, GetHeaderValue);
                 }
 
                 ProcessHeaders(context);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -56,7 +56,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
                 }
                 else
                 {
-                    transaction.SetRequestHeaders(context.Request.Headers, Constants.DefaultCaptureHeaders, GetHeaderValue);
+                    transaction.SetRequestHeaders(context.Request.Headers, Agent.Extensions.Providers.Wrapper.Statics.DefaultCaptureHeaders, GetHeaderValue);
                 }
 
                 ProcessHeaders(context);

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -667,6 +667,33 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             Assert.True(succeeded, builder.ToString());
         }
 
+        public static void SpanEventHasAttributes(IEnumerable<KeyValuePair<string, string>> expectedAttributes, SpanEventAttributeType attributeType, SpanEvent spanEvent)
+        {
+            var succeeded = true;
+            var builder = new StringBuilder();
+            var actualAttributes = spanEvent.GetByType(attributeType);
+            foreach (var expectedAttribute in expectedAttributes)
+            {
+                if (!actualAttributes.ContainsKey(expectedAttribute.Key))
+                {
+                    builder.AppendFormat("Attribute named {0} was not found in the span event.", expectedAttribute);
+                    builder.AppendLine();
+                    succeeded = false;
+                }
+
+                var actualValue = actualAttributes[expectedAttribute.Key] as string;
+                if (actualValue != expectedAttribute.Value)
+                {
+                    builder.AppendFormat("Attribute named {0} in the span event had an unexpected value.  Expected: {1}, Actual: {2}", expectedAttribute.Key, expectedAttribute.Value, actualValue);
+                    builder.AppendLine();
+                    succeeded = false;
+                    continue;
+                }
+            }
+
+            Assert.True(succeeded, builder.ToString());
+        }
+
         public static void SpanEventHasAttributes(IEnumerable<KeyValuePair<string, object>> expectedAttributes, SpanEventAttributeType attributeType, SpanEvent spanEvent)
         {
             var succeeded = true;
@@ -681,7 +708,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                     succeeded = false;
                 }
 
-                if (!ValidateAttributeValues(expectedAttribute, actualAttributes[expectedAttribute.Key], builder, "span event"))
+                if (succeeded && !ValidateAttributeValues(expectedAttribute, actualAttributes[expectedAttribute.Key], builder, "span event"))
                 {
                     succeeded = false;
                 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                     var configModifier = new NewRelicConfigModifier(configPath);
 
                     configModifier.SetAllowAllHeaders(false)
-                    .EnableDistributedTrace();
+                    .EnableDistributedTrace().ForceTransactionTraces();
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
 
-                    configModifier.EnableDistributedTrace();
+                    configModifier.EnableDistributedTrace().ForceTransactionTraces();
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using NewRelic.Agent.IntegrationTests.WCF;
+using Xunit;
+using Xunit.Abstractions;
+using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
+
+namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
+{
+    public abstract class AllowAllHeadersDisabledTests : WCFEmptyTestBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output, HostingModel hostingModel, WCFBindingType bindingType)
+            : base(fixture, output, hostingModel, bindingType) { }
+
+        protected override NewRelicConfigModifier SetupConfiguration()
+        {
+            return base.SetupConfiguration().SetAllowAllHeaders(false);
+        }
+
+        protected override void AddFixtureCommands()
+        {
+            base.AddFixtureCommands();
+
+            _fixture.AddCommand($"WCFClient GetDataWithHeaders");
+        }
+
+        [Fact]
+        public override void TestHeadersCaptured()
+        {
+            base.TestHeadersCaptured();
+        }
+    }
+
+    #region IIS
+
+    [NetFrameworkTest]
+    public class IIS_Basic_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IIS_Basic_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class IIS_Web_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IIS_Web_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WebHttp) { }
+    }
+
+
+    [NetFrameworkTest]
+    public class IIS_WS_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IIS_WS_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion IIS
+
+    #region IISNoAsp
+
+    [NetFrameworkTest]
+    public class IISNoAsp_Basic_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IISNoAsp_Basic_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class IISNoAsp_Web_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IISNoAsp_Web_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.WebHttp) { }
+    }
+
+
+    [NetFrameworkTest]
+    public class IISNoAsp_WS_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public IISNoAsp_WS_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion IISNoAsp
+
+    #region Self
+
+    [NetFrameworkTest]
+    public class Self_Basic_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public Self_Basic_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class Self_Web_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public Self_Web_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.WebHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class Self_WS_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
+    {
+        public Self_WS_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion Self
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -48,6 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             {
                 case WCFBindingType.BasicHttp: return "168";
                 case WCFBindingType.WebHttp: return "75";
+                case WCFBindingType.WSHttpUnsecure: return "573";
                 case WCFBindingType.WSHttp: return _hostingModel == HostingModel.Self ? "6105" : "6119";
                 default: return null;
             }
@@ -112,7 +113,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
     public class IIS_WS_AllowAllHeadersDisabledTests : AllowAllHeadersDisabledTests
     {
         public IIS_WS_AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttp) { }
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttpUnsecure) { }
     }
 
     #endregion IIS

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
-using NewRelic.Agent.IntegrationTests.WCF;
 using Xunit;
 using Xunit.Abstractions;
 using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
@@ -21,6 +18,69 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
         public AllowAllHeadersDisabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output, HostingModel hostingModel, WCFBindingType bindingType)
             : base(fixture, output, hostingModel, bindingType) { }
 
+        protected virtual IEnumerable<string> UnallowedHeaders => new[]
+        {
+            "request.headers.cookie",
+            "request.headers.authorization",
+            "request.headers.proxy-authorization",
+            "request.headers.x-forwarded-for"
+        };
+
+        protected virtual IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
+        {
+            { "request.headers.referer", "http://example.com/" },
+            { "request.headers.accept", "text/html" },
+            { "request.headers.content-length", GetExpectedContentLength() },
+            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.user-agent", "FakeUserAgent" },
+        };
+
+        protected virtual IEnumerable<string> UnexpectedHeaders => new[]
+        {
+            "request.headers.foo",
+            "request.headers.dashes-are-valid",
+            "request.headers.dashesarevalid"
+        };
+
+        protected string GetExpectedContentLength()
+        {
+            switch (_binding)
+            {
+                case WCFBindingType.BasicHttp: return "166";
+                case WCFBindingType.WebHttp: return "73";
+                case WCFBindingType.WSHttp: return _hostingModel == HostingModel.Self ? "6105" : "6119";
+                default: return null;
+            }
+        }
+
+        [Fact]
+        public virtual void TestHeadersCaptured()
+        {
+            if (_hostingModel != HostingModel.Self)
+            {
+                var transactionSample = _logHelpers.TrxSamples_Service.FirstOrDefault(ts => ts.Uri?.Contains($"Test_{_binding}") ?? false);
+
+                Assert.NotNull(transactionSample);
+                Assertions.TransactionTraceDoesNotHaveAttributes(UnallowedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+                Assertions.TransactionTraceHasAttributes(ExpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+                Assertions.TransactionTraceDoesNotHaveAttributes(UnexpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+            }
+
+            var transactionEvent = _logHelpers.TrxEvents_Service.FirstOrDefault(te => te.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
+
+            Assert.NotNull(transactionEvent);
+            Assertions.TransactionEventDoesNotHaveAttributes(UnallowedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(ExpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventDoesNotHaveAttributes(UnexpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+
+            var spanEvent = _logHelpers.SpanEvents_Service.FirstOrDefault(se => se.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
+
+            Assert.NotNull(spanEvent);
+            Assertions.SpanEventDoesNotHaveAttributes(UnallowedHeaders, SpanEventAttributeType.Agent, spanEvent);
+            Assertions.SpanEventHasAttributes(ExpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
+            Assertions.SpanEventDoesNotHaveAttributes(UnexpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
+        }
+
         protected override NewRelicConfigModifier SetupConfiguration()
         {
             return base.SetupConfiguration().SetAllowAllHeaders(false);
@@ -31,12 +91,6 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             base.AddFixtureCommands();
 
             _fixture.AddCommand($"WCFClient GetDataWithHeaders");
-        }
-
-        [Fact]
-        public override void TestHeadersCaptured()
-        {
-            base.TestHeadersCaptured();
         }
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -56,15 +56,12 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
         [Fact]
         public virtual void TestHeadersCaptured()
         {
-            if (_hostingModel != HostingModel.Self)
-            {
-                var transactionSample = _logHelpers.TrxSamples_Service.FirstOrDefault(ts => ts.Uri?.Contains($"Test_{_binding}") ?? false);
+            var transactionSample = _logHelpers.TrxSamples_Service.FirstOrDefault(ts => ts.Uri?.Contains($"Test_{_binding}") ?? false);
 
-                Assert.NotNull(transactionSample);
-                Assertions.TransactionTraceDoesNotHaveAttributes(UnallowedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-                Assertions.TransactionTraceHasAttributes(ExpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-                Assertions.TransactionTraceDoesNotHaveAttributes(UnexpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-            }
+            Assert.NotNull(transactionSample);
+            Assertions.TransactionTraceDoesNotHaveAttributes(UnallowedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+            Assertions.TransactionTraceHasAttributes(ExpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+            Assertions.TransactionTraceDoesNotHaveAttributes(UnexpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
 
             var transactionEvent = _logHelpers.TrxEvents_Service.FirstOrDefault(te => te.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -46,8 +46,8 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
         {
             switch (_binding)
             {
-                case WCFBindingType.BasicHttp: return "166";
-                case WCFBindingType.WebHttp: return "73";
+                case WCFBindingType.BasicHttp: return "168";
+                case WCFBindingType.WebHttp: return "75";
                 case WCFBindingType.WSHttp: return _hostingModel == HostingModel.Self ? "6105" : "6119";
                 default: return null;
             }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -1,16 +1,10 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
-using NewRelic.Agent.IntegrationTests.WCF;
-using Xunit;
 using Xunit.Abstractions;
 using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using NewRelic.Agent.IntegrationTests.WCF;
+using Xunit;
+using Xunit.Abstractions;
+using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
+
+namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
+{
+    public abstract class AllowAllHeadersEnabledTests : AllowAllHeadersDisabledTests
+    {
+        public AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output, HostingModel hostingModel, WCFBindingType bindingType)
+            : base(fixture, output, hostingModel, bindingType) { }
+
+        protected override NewRelicConfigModifier SetupConfiguration()
+        {
+            return base.SetupConfiguration().SetAllowAllHeaders(true);
+        }
+
+        protected override IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
+        {
+            { "request.headers.referer", "http://example.com/" },
+            { "request.headers.accept", "text/html" },
+            { "request.headers.content-length", GetExpectedContentLength() },
+            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.user-agent", "FakeUserAgent" },
+            { "request.headers.foo", "bar" },
+            { "request.headers.dashes-are-valid", "true" },
+            { "request.headers.dashesarevalid", "definitely" }
+        };
+
+        protected override IEnumerable<string> UnexpectedHeaders => new[] { "request.headers.was-never-included" };
+    }
+
+    #region IIS
+
+    [NetFrameworkTest]
+    public class IIS_Basic_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IIS_Basic_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class IIS_Web_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IIS_Web_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WebHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class IIS_WS_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IIS_WS_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion IIS
+
+    #region IISNoAsp
+
+    [NetFrameworkTest]
+    public class IISNoAsp_Basic_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IISNoAsp_Basic_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class IISNoAsp_Web_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IISNoAsp_Web_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.WebHttp) { }
+    }
+
+
+    [NetFrameworkTest]
+    public class IISNoAsp_WS_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public IISNoAsp_WS_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.IISNoAsp, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion IISNoAsp
+
+    #region Self
+
+    [NetFrameworkTest]
+    public class Self_Basic_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public Self_Basic_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.BasicHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class Self_Web_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public Self_Web_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.WebHttp) { }
+    }
+
+    [NetFrameworkTest]
+    public class Self_WS_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
+    {
+        public Self_WS_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, HostingModel.Self, WCFBindingType.WSHttp) { }
+    }
+
+    #endregion Self
+
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -55,7 +55,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
     public class IIS_WS_AllowAllHeadersEnabledTests : AllowAllHeadersEnabledTests
     {
         public IIS_WS_AllowAllHeadersEnabledTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttp) { }
+            : base(fixture, output, HostingModel.IIS, WCFBindingType.WSHttpUnsecure) { }
     }
 
     #endregion IIS

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
@@ -1,86 +1,16 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Agent.IntegrationTests.WCF;
-using Xunit;
 using Xunit.Abstractions;
 using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
 
 namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
 {
-    public abstract partial class WCFEmptyTestBase<T> : NewRelicIntegrationTest<T> where T : ConsoleDynamicMethodFixture
-    {
-        protected virtual IEnumerable<string> UnallowedHeaders => new[]
-        {
-            "request.headers.cookie",
-            "request.headers.authorization",
-            "request.headers.proxy-authorization",
-            "request.headers.x-forwarded-for"
-        };
-
-        protected virtual IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
-        {
-            { "request.headers.referer", "http://example.com/" },
-            { "request.headers.accept", "text/html" },
-            { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
-            { "request.headers.user-agent", "FakeUserAgent" },
-        };
-
-        protected virtual IEnumerable<string> UnexpectedHeaders => new[]
-        {
-            "request.headers.foo",
-            "request.headers.dashes-are-valid",
-            "request.headers.dashesarevalid"
-        };
-
-        protected string GetExpectedContentLength()
-        {
-            switch (_binding)
-            {
-                case WCFBindingType.BasicHttp: return "166";
-                case WCFBindingType.WebHttp: return "73";
-                case WCFBindingType.WSHttp: return _hostingModel == HostingModel.Self ? "6105" : "6119";
-                default: return null;
-            }
-        }
-
-        public virtual void TestHeadersCaptured()
-        {
-            if (_hostingModel != HostingModel.Self)
-            {
-                var transactionSample = _logHelpers.TrxSamples_Service.FirstOrDefault(ts => ts.Uri?.Contains($"Test_{_binding}") ?? false);
-
-                Assert.NotNull(transactionSample);
-                Assertions.TransactionTraceDoesNotHaveAttributes(UnallowedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-                Assertions.TransactionTraceHasAttributes(ExpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-                Assertions.TransactionTraceDoesNotHaveAttributes(UnexpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
-            }
-
-            var transactionEvent = _logHelpers.TrxEvents_Service.FirstOrDefault(te => te.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
-
-            Assert.NotNull(transactionEvent);
-            Assertions.TransactionEventDoesNotHaveAttributes(UnallowedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
-            Assertions.TransactionEventHasAttributes(ExpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
-            Assertions.TransactionEventDoesNotHaveAttributes(UnexpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
-
-            var spanEvent = _logHelpers.SpanEvents_Service.FirstOrDefault(se => se.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
-
-            Assert.NotNull(spanEvent);
-            Assertions.SpanEventDoesNotHaveAttributes(UnallowedHeaders, SpanEventAttributeType.Agent, spanEvent);
-            Assertions.SpanEventHasAttributes(ExpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
-            Assertions.SpanEventDoesNotHaveAttributes(UnexpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
-        }
-    }
-
     public abstract partial class WCFEmptyTestBase<T> : NewRelicIntegrationTest<T> where T : ConsoleDynamicMethodFixture
     {
         protected readonly T _fixture;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
                     break;
                 case HostingModel.IIS:
                 case HostingModel.IISNoAsp:
-                    _fixture.AddCommand($"WCFServiceIISHosted StartService {Path.Combine(_fixture.IntegrationTestAppPath, "WcfAppIisHosted", "Deploy")} {_binding} {_fixture.RemoteApplication.Port} Test_{_binding} {_hostingModel == HostingModel.IISNoAsp}");
+                    _fixture.AddCommand($"WCFServiceIISHosted StartService {Path.Combine(_fixture.IntegrationTestAppPath, "WcfAppIisHosted", "Deploy")} {_binding} {_fixture.RemoteApplication.Port} Test_{_binding} {_hostingModel != HostingModel.IISNoAsp}");
                     _fixture.AddCommand($"WCFClient InitializeClient_IISHosted {_binding} {_fixture.RemoteApplication.Port} Test_{_binding}");
                     break;
             }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using NewRelic.Agent.IntegrationTests.WCF;
+using Xunit;
+using Xunit.Abstractions;
+using static NewRelic.Agent.IntegrationTests.WCF.WCFTestBase;
+
+namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
+{
+    public abstract partial class WCFEmptyTestBase<T> : NewRelicIntegrationTest<T> where T : ConsoleDynamicMethodFixture
+    {
+        protected virtual IEnumerable<string> UnallowedHeaders => new[]
+        {
+            "request.headers.cookie",
+            "request.headers.authorization",
+            "request.headers.proxy-authorization",
+            "request.headers.x-forwarded-for"
+        };
+
+        protected virtual IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
+        {
+            { "request.headers.referer", "http://example.com/" },
+            { "request.headers.accept", "text/html" },
+            { "request.headers.content-length", GetExpectedContentLength() },
+            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.user-agent", "FakeUserAgent" },
+        };
+
+        protected virtual IEnumerable<string> UnexpectedHeaders => new[]
+        {
+            "request.headers.foo",
+            "request.headers.dashes-are-valid",
+            "request.headers.dashesarevalid"
+        };
+
+        protected string GetExpectedContentLength()
+        {
+            switch (_binding)
+            {
+                case WCFBindingType.BasicHttp: return "166";
+                case WCFBindingType.WebHttp: return "73";
+                case WCFBindingType.WSHttp: return _hostingModel == HostingModel.Self ? "6105" : "6119";
+                default: return null;
+            }
+        }
+
+        public virtual void TestHeadersCaptured()
+        {
+            if (_hostingModel != HostingModel.Self)
+            {
+                var transactionSample = _logHelpers.TrxSamples_Service.FirstOrDefault(ts => ts.Uri?.Contains($"Test_{_binding}") ?? false);
+
+                Assert.NotNull(transactionSample);
+                Assertions.TransactionTraceDoesNotHaveAttributes(UnallowedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+                Assertions.TransactionTraceHasAttributes(ExpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+                Assertions.TransactionTraceDoesNotHaveAttributes(UnexpectedHeaders, TransactionTraceAttributeType.Agent, transactionSample);
+            }
+
+            var transactionEvent = _logHelpers.TrxEvents_Service.FirstOrDefault(te => te.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
+
+            Assert.NotNull(transactionEvent);
+            Assertions.TransactionEventDoesNotHaveAttributes(UnallowedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(ExpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventDoesNotHaveAttributes(UnexpectedHeaders, TransactionEventAttributeType.Agent, transactionEvent);
+
+            var spanEvent = _logHelpers.SpanEvents_Service.FirstOrDefault(se => se.AgentAttributes?["request.uri"]?.ToString()?.Contains($"Test_{_binding}") ?? false);
+
+            Assert.NotNull(spanEvent);
+            Assertions.SpanEventDoesNotHaveAttributes(UnallowedHeaders, SpanEventAttributeType.Agent, spanEvent);
+            Assertions.SpanEventHasAttributes(ExpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
+            Assertions.SpanEventDoesNotHaveAttributes(UnexpectedHeaders, SpanEventAttributeType.Agent, spanEvent);
+        }
+    }
+
+    public abstract partial class WCFEmptyTestBase<T> : NewRelicIntegrationTest<T> where T : ConsoleDynamicMethodFixture
+    {
+        protected readonly T _fixture;
+
+        protected readonly HostingModel _hostingModel;
+        protected readonly WCFBindingType _binding;
+        protected readonly IWCFLogHelpers _logHelpers;
+
+        public WCFEmptyTestBase(T fixture, ITestOutputHelper output, HostingModel hostingModelOption, WCFBindingType bindingToTest)
+            : base(fixture)
+        {
+            _hostingModel = hostingModelOption;
+            _binding = bindingToTest;
+
+            _logHelpers = hostingModelOption == HostingModel.Self ? (IWCFLogHelpers)new WCFLogHelpers_SelfHosted(fixture) : new WCFLogHelpers_IISHosted(fixture);
+
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    SetupConfiguration();
+                    AddFixtureCommands();
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        protected virtual NewRelicConfigModifier SetupConfiguration()
+        {
+            var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+
+            configModifier.ForceTransactionTraces()
+                .EnableSpanEvents(true);
+
+            return configModifier;
+        }
+
+        protected virtual void AddFixtureCommands()
+        {
+            switch (_hostingModel)
+            {
+                case HostingModel.Self:
+                    _fixture.AddCommand($"WCFServiceSelfHosted StartService {_binding} {_fixture.RemoteApplication.Port} Test_{_binding}");
+                    _fixture.AddCommand($"WCFClient InitializeClient_SelfHosted {_binding} {_fixture.RemoteApplication.Port} Test_{_binding}");
+                    break;
+                case HostingModel.IIS:
+                case HostingModel.IISNoAsp:
+                    _fixture.AddCommand($"WCFServiceIISHosted StartService {Path.Combine(_fixture.IntegrationTestAppPath, "WcfAppIisHosted", "Deploy")} {_binding} {_fixture.RemoteApplication.Port} Test_{_binding} {_hostingModel == HostingModel.IISNoAsp}");
+                    _fixture.AddCommand($"WCFClient InitializeClient_IISHosted {_binding} {_fixture.RemoteApplication.Port} Test_{_binding}");
+                    break;
+            }
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/BaseTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -37,6 +38,8 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
                     AddFixtureCommands();
                 }
             );
+
+            _fixture.SetTimeout(TimeSpan.FromMinutes(5));
 
             _fixture.Initialize();
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLogHelpers.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLogHelpers.cs
@@ -19,6 +19,9 @@ namespace NewRelic.Agent.IntegrationTests.WCF
     /// </summary>
     public interface IWCFLogHelpers
     {
+        TransactionSample[] TrxSamples_Client { get; }
+        TransactionSample[] TrxSamples_Service { get; }
+
         TransactionEvent[] TrxEvents { get; }
         TransactionEvent[] TrxEvents_Client { get; }
         TransactionEvent[] TrxEvents_Service { get; }
@@ -33,8 +36,10 @@ namespace NewRelic.Agent.IntegrationTests.WCF
         string[] TrxTripIDs_Client { get; }
 
         Metric[] MetricValues { get; }
+
         SpanEvent[] SpanEvents_Client { get; }
         SpanEvent[] SpanEvents_Service { get; }
+
         ConnectResponseData ConnectResponse_Client { get; }
         ConnectResponseData ConnectResponse_Service { get; }
 
@@ -44,10 +49,10 @@ namespace NewRelic.Agent.IntegrationTests.WCF
 
     public class WCFLogHelpers_IISHosted : IWCFLogHelpers
     {
-        private readonly ConsoleDynamicMethodFixtureFWLatest _fixture;
+        private readonly ConsoleDynamicMethodFixture _fixture;
 
         private AgentLogFile _agentLog_Client;
-        protected AgentLogFile AgentLog_Client
+        public AgentLogFile AgentLog_Client
         {
             get
             {
@@ -67,7 +72,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF
         }
 
         private AgentLogFile _agentLog_Service;
-        protected AgentLogFile AgentLog_Service
+        public AgentLogFile AgentLog_Service
         {
             get
             {
@@ -93,6 +98,10 @@ namespace NewRelic.Agent.IntegrationTests.WCF
                 .Union(logFunction.Invoke(AgentLog_Service));
         }
 
+        public TransactionSample[] TrxSamples_Client => throw new NotImplementedException();
+
+        private TransactionSample[] _trxSamples_Service;
+        public TransactionSample[] TrxSamples_Service => _trxSamples_Service ?? (_trxSamples_Service = AgentLog_Service.GetTransactionSamples().ToArray());
 
         private TransactionEvent[] _trxEvents;
         public TransactionEvent[] TrxEvents => _trxEvents ?? (_trxEvents = AgentLog_Client.GetTransactionEvents().Union(AgentLog_Service.GetTransactionEvents()).ToArray());
@@ -192,7 +201,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF
         public ConnectResponseData ConnectResponse_Service => _connectResponse_Service ?? (_connectResponse_Service = AgentLog_Service.GetConnectResponseData());
 
 
-        public WCFLogHelpers_IISHosted(ConsoleDynamicMethodFixtureFWLatest fixture)
+        public WCFLogHelpers_IISHosted(ConsoleDynamicMethodFixture fixture)
         {
             _fixture = fixture;
         }
@@ -201,17 +210,23 @@ namespace NewRelic.Agent.IntegrationTests.WCF
 
     public class WCFLogHelpers_SelfHosted : IWCFLogHelpers
     {
-        public WCFLogHelpers_SelfHosted(ConsoleDynamicMethodFixtureFWLatest fixture)
+        public WCFLogHelpers_SelfHosted(ConsoleDynamicMethodFixture fixture)
         {
             _fixture = fixture;
         }
 
-        private readonly ConsoleDynamicMethodFixtureFWLatest _fixture;
+        private readonly ConsoleDynamicMethodFixture _fixture;
 
         public IEnumerable<T> QueryLog<T>(Func<AgentLogFile, IEnumerable<T>> logFunction)
         {
             return logFunction.Invoke(_fixture.AgentLog);
         }
+
+        public TransactionSample[] TrxSamples_Client => throw new NotImplementedException();
+
+        private TransactionSample[] _trxSamples_Service;
+        public TransactionSample[] TrxSamples_Service => _trxSamples_Service ?? (_trxSamples_Service = _fixture.AgentLog.GetTransactionSamples().Where(ts => ts.Path.Contains("WcfService")).ToArray());
+
 
         private TransactionEvent[] _trxEvents;
         public TransactionEvent[] TrxEvents => _trxEvents ?? (_trxEvents = _fixture.AgentLog.GetTransactionEvents().ToArray());

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFTestBase.cs
@@ -28,7 +28,8 @@ namespace NewRelic.Agent.IntegrationTests.WCF
         public enum HostingModel
         {
             Self,
-            IIS
+            IIS,
+            IISNoAsp
         }
 
         public enum ASPCompatibilityMode
@@ -133,6 +134,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF
                     _fixture.RemoteApplication.NewRelicConfig.SetLogLevel("finest");
                     _fixture.RemoteApplication.NewRelicConfig.SetRequestTimeout(TimeSpan.FromSeconds(10));
                     _fixture.RemoteApplication.NewRelicConfig.ForceTransactionTraces();
+                    _fixture.RemoteApplication.NewRelicConfig.EnableSpanEvents(true);
                     _fixture.RemoteApplication.NewRelicConfig.SetOrDeleteDistributedTraceEnabled(_tracingTestOption == TracingTestOption.DT ? true : null as bool?);
                     _fixture.RemoteApplication.NewRelicConfig.SetCATEnabled(_tracingTestOption == TracingTestOption.CAT);
 

--- a/tests/Agent/IntegrationTests/Shared/WCF/WcfEnums.cs
+++ b/tests/Agent/IntegrationTests/Shared/WCF/WcfEnums.cs
@@ -8,6 +8,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared.Wcf
     {
         BasicHttp,
         WSHttp,
+        WSHttpUnsecure,
         WebHttp,
         NetTcp,
         Custom,

--- a/tests/Agent/IntegrationTests/Shared/WCF/WcfService.cs
+++ b/tests/Agent/IntegrationTests/Shared/WCF/WcfService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Net;
 using System.ServiceModel;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NewRelic.Agent.IntegrationTests.Shared.Wcf
@@ -21,6 +22,10 @@ namespace NewRelic.Agent.IntegrationTests.Shared.Wcf
         public string SyncGetData(int value)
         {
             if (_printOutput) Console.WriteLine("SyncGetData");
+
+            if (value == 2000)
+                Thread.Sleep(2000);
+
             return DoWork(value.ToString(), false, false).Result;
         }
 

--- a/tests/Agent/IntegrationTests/Shared/WCF/WcfService.cs
+++ b/tests/Agent/IntegrationTests/Shared/WCF/WcfService.cs
@@ -23,9 +23,6 @@ namespace NewRelic.Agent.IntegrationTests.Shared.Wcf
         {
             if (_printOutput) Console.WriteLine("SyncGetData");
 
-            if (value == 2000)
-                Thread.Sleep(2000);
-
             return DoWork(value.ToString(), false, false).Result;
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -35,8 +35,6 @@ namespace MultiFunctionApplicationHelpers
         private static readonly string ApplicationDirectoryName = @"ConsoleMultiFunctionApplicationFW";
         private static readonly string ExecutableName = $"{ApplicationDirectoryName}.exe";
 
-        public string IntegrationTestAppPath => RemoteApplication.SourceApplicationsDirectoryPath;
-
         /// <summary>
         /// Use this .ctor to specify a specific .NET framework version to target.
         /// </summary>
@@ -103,6 +101,8 @@ namespace MultiFunctionApplicationHelpers
         private List<string> _commands = new List<string>();
 
         protected RemoteConsoleApplication _remoteConsoleApplication => RemoteApplication as RemoteConsoleApplication;
+
+        public string IntegrationTestAppPath => RemoteApplication.SourceApplicationsDirectoryPath;
 
         public ConsoleDynamicMethodFixture SetTimeout(TimeSpan span)
         {

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -223,7 +223,6 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                     }
                 };
 
-                // 2000 creates a delay to trigger transaction traces
                 var result = _wcfClient.Sync_SyncGetData(2000);
 
                 Logger.Info($"Result: {result ?? "<NULL>"}");

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -201,21 +201,10 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         }
 
         [LibraryMethod]
-        [Transaction]
         public void GetDataWithHeaders()
         {
             using (var scope = new OperationContextScope((_wcfClient as WcfClient).InnerChannel))
             {
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Referer", "http://example.com/");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Accept", "text/html");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Host", "fakehost");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("User-Agent", "FakeUserAgent");
-
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("fOo", "bar");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("dashes-are-valid", "true");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("dashesarevalid", "definitely");
-                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Cookie", "itsasecret");
-
                 OperationContext.Current.OutgoingMessageProperties[HttpRequestMessageProperty.Name] = new HttpRequestMessageProperty()
                 {
                     Headers =
@@ -228,11 +217,11 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                         { "dashes-are-valid", "true" },
                         { "dashesarevalid", "definitely" },
                         { "Cookie", "itsasecret" }
-
                     }
                 };
 
-                var result = _wcfClient.Sync_SyncGetData(32);
+                // 2000 creates a delay to trigger transaction traces
+                var result = _wcfClient.Sync_SyncGetData(2000);
 
                 Logger.Info($"Result: {result ?? "<NULL>"}");
             }
@@ -430,6 +419,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         {
             var binding = new WSHttpBinding();
             var endpoint = new EndpointAddress(endpointAddress);
+
             return new WcfClient(binding, endpoint);
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -36,6 +36,9 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 case WCFBindingType.WSHttp:
                     _wcfClient = CreateClientWithWSHttpBinding(endpointAddress);
                     break;
+                case WCFBindingType.WSHttpUnsecure:
+                    _wcfClient = CreateClientWithWSHttpBinding(endpointAddress, SecurityMode.None);
+                    break;
                 case WCFBindingType.WebHttp:
                     _wcfClient = CreateClientWithWebHttpBinding(endpointAddress);
                     break;
@@ -415,9 +418,13 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
             return new WcfClient(binding, endpoint);
         }
 
-        private WcfClient CreateClientWithWSHttpBinding(Uri endpointAddress)
+        private WcfClient CreateClientWithWSHttpBinding(Uri endpointAddress, SecurityMode? securityMode = null)
         {
             var binding = new WSHttpBinding();
+
+            if (securityMode.HasValue)
+                binding.Security.Mode = securityMode.Value;
+
             var endpoint = new EndpointAddress(endpointAddress);
 
             return new WcfClient(binding, endpoint);

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -9,6 +9,7 @@ using NewRelic.Api.Agent;
 using System;
 using System.Reflection;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Web;
 using System.Threading;
@@ -197,6 +198,44 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
             }
 
             Logger.Info($"Result: {result ?? "<NULL>"}");
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        public void GetDataWithHeaders()
+        {
+            using (var scope = new OperationContextScope((_wcfClient as WcfClient).InnerChannel))
+            {
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Referer", "http://example.com/");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Accept", "text/html");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Host", "fakehost");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("User-Agent", "FakeUserAgent");
+
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("fOo", "bar");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("dashes-are-valid", "true");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("dashesarevalid", "definitely");
+                //WebOperationContext.Current.OutgoingRequest.Headers.Add("Cookie", "itsasecret");
+
+                OperationContext.Current.OutgoingMessageProperties[HttpRequestMessageProperty.Name] = new HttpRequestMessageProperty()
+                {
+                    Headers =
+                    {
+                        { "Referer", "http://example.com/" },
+                        { "Accept", "text/html" },
+                        { "Host", "fakehost" },
+                        { "User-Agent", "FakeUserAgent" },
+                        { "fOo", "bar" },
+                        { "dashes-are-valid", "true" },
+                        { "dashesarevalid", "definitely" },
+                        { "Cookie", "itsasecret" }
+
+                    }
+                };
+
+                var result = _wcfClient.Sync_SyncGetData(32);
+
+                Logger.Info($"Result: {result ?? "<NULL>"}");
+            }
         }
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
@@ -19,6 +19,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
             {
                 case WCFBindingType.BasicHttp:
                 case WCFBindingType.WSHttp:
+                case WCFBindingType.WSHttpUnsecure:
                 case WCFBindingType.WebHttp:
                 case WCFBindingType.Custom:
                 case WCFBindingType.CustomClass:

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceIISHosted.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceIISHosted.cs
@@ -20,6 +20,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         {
             { WCFBindingType.BasicHttp, "basicHttpBinding" },
             { WCFBindingType.WSHttp, "wsHttpBinding" },
+            { WCFBindingType.WSHttpUnsecure, "wsHttpBinding" },
             { WCFBindingType.WebHttp, "webHttpBinding" },
             { WCFBindingType.NetTcp, "netTcpBinding" },
             { WCFBindingType.Custom, "CustomHttpBinding" }
@@ -85,6 +86,13 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
             CommonUtils.ModifyOrCreateXmlAttribute(_hostedWebCore.WebConfigPath, "",
                 new[] { "configuration", "system.serviceModel", "services", "service", "endpoint" },
                 "binding", _bindingTypeNames[bindingType]);
+
+            if (bindingType == WCFBindingType.WSHttpUnsecure)
+            {
+                CommonUtils.ModifyOrCreateXmlAttribute(_hostedWebCore.WebConfigPath, "",
+                    new[] { "configuration", "system.serviceModel", "services", "service", "endpoint" },
+                    "bindingConfiguration", bindingType.ToString());
+            }
 
             if (bindingType == WCFBindingType.WebHttp)
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/WcfAppIisHosted/Web.config
+++ b/tests/Agent/IntegrationTests/SharedApplications/WcfAppIisHosted/Web.config
@@ -8,6 +8,13 @@
     <httpRuntime targetFramework="4.5.2" />
   </system.web>
   <system.serviceModel>
+    <bindings>
+      <wsHttpBinding>
+        <binding name="WSHttpUnsecure">
+          <security mode="None" />
+        </binding>
+      </wsHttpBinding>
+    </bindings>
     <behaviors>
       <serviceBehaviors>
         <behavior>


### PR DESCRIPTION
### Description

Fixes #561 by adding HTTP request header capturing support into the WCF wrapper.

### Testing

Includes some new WCF integration tests that should yield consistent results.

