### PR TITLE
Explain plan generation fixes

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Database/DatabaseService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Database/DatabaseService.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.Core.Database
 
         public DatabaseService(ICacheStatsReporter cacheStatsReporter)
         {
-            _sqlObfuscator = SqlObfuscator.GetSqlObfuscator(_configuration.TransactionTracerEnabled, _configuration.TransactionTracerRecordSql);
+            _sqlObfuscator = SqlObfuscator.GetSqlObfuscator(_configuration.TransactionTracerRecordSql);
             _cache = new CacheByDatastoreVendor<string, string>("SqlObfuscationCache", cacheStatsReporter);
         }
 
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.Core.Database
             // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
             // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
 
-            _sqlObfuscator = SqlObfuscator.GetSqlObfuscator(_configuration.TransactionTracerEnabled, _configuration.TransactionTracerRecordSql);
+            _sqlObfuscator = SqlObfuscator.GetSqlObfuscator(_configuration.TransactionTracerRecordSql);
             _cache.SetCapacity(_configuration.DatabaseStatementCacheCapcity);
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/Database/SqlObfuscator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Database/SqlObfuscator.cs
@@ -25,13 +25,8 @@ namespace NewRelic.Agent.Core.Database
             return ObfuscatingSqlObfuscatorInstanceUsingExplicit;
         }
 
-        public static SqlObfuscator GetSqlObfuscator(bool transactionTracerEnabled, string recordSqlValue)
+        public static SqlObfuscator GetSqlObfuscator(string recordSqlValue)
         {
-            if (!transactionTracerEnabled)
-            {
-                return new NoSqlObfuscator();
-            }
-
             if (string.IsNullOrEmpty(recordSqlValue))
             {
                 return GetObfuscatingSqlObfuscator();

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -406,7 +406,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                     short count = 0;
                     var sqlExplainPlansMax = _configurationService.Configuration.SqlExplainPlansMax;
                     var threshold = _configurationService.Configuration.SqlExplainPlanThreshold;
-                    var obfuscator = SqlObfuscator.GetSqlObfuscator(_configurationService.Configuration.TransactionTracerEnabled, _configurationService.Configuration.TransactionTracerRecordSql);
+                    var obfuscator = SqlObfuscator.GetSqlObfuscator(_configurationService.Configuration.TransactionTracerRecordSql);
                     foreach (var segment in segments.Where(s => s.Data is DatastoreSegmentData))
                     {
                         if (segment.Duration > threshold)

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -393,6 +393,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         private void TryGenerateExplainPlans(IEnumerable<Segment> segments)
         {
+            // First, check if explainPlans are disabled and return if they are
+            // If explainPlans are enabled, check if both TransactionTracer and SlowSql are disabled.  If they are, we don't need a plan, so return.
             if (!_configurationService.Configuration.SqlExplainPlansEnabled
                 || (!_configurationService.Configuration.TransactionTracerEnabled && !_configurationService.Configuration.SlowSqlEnabled))
             {

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTransformer.cs
@@ -393,10 +393,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         private void TryGenerateExplainPlans(IEnumerable<Segment> segments)
         {
-            if (!_configurationService.Configuration.SqlExplainPlansEnabled)
+            if (!_configurationService.Configuration.SqlExplainPlansEnabled
+                || (!_configurationService.Configuration.TransactionTracerEnabled && !_configurationService.Configuration.SlowSqlEnabled))
             {
                 return;
             }
+
             try
             {
                 using (new IgnoreWork())

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SqlObfuscation/SqlObfuscationCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SqlObfuscation/SqlObfuscationCrossAgentTests.cs
@@ -19,7 +19,7 @@ namespace CompositeTests.CrossAgentTests.SqlObfuscation
     {
         private static CompositeTestAgent _compositeTestAgent;
         private IAgent _agent;
-        private SqlObfuscator _obfuscator = SqlObfuscator.GetSqlObfuscator(true, "obfuscated");
+        private SqlObfuscator _obfuscator = SqlObfuscator.GetSqlObfuscator("obfuscated");
         private readonly List<string> validVendors = Enum.GetNames(typeof(DatastoreVendor)).Select(s => s.ToLower()).ToList();
 
         public static List<TestCaseData> SqlObfuscationTestDatas => GetSqlObfuscationTestDatas();

--- a/tests/Agent/UnitTests/Core.UnitTest/Database/SqlObfuscatorTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Database/SqlObfuscatorTest.cs
@@ -10,12 +10,12 @@ namespace NewRelic.Agent.Core.Database
     [TestFixture]
     public class SqlObfuscatorTest
     {
-        SqlObfuscator obfuscator = SqlObfuscator.GetSqlObfuscator(true, "obfuscated");
+        SqlObfuscator obfuscator = SqlObfuscator.GetSqlObfuscator("obfuscated");
 
         [Test]
         public static void verify_using_raw_obfuscator_that_GetObfuscatedSql_returns_sql_passed_in()
         {
-            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator(true, "raw");
+            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator("raw");
             string sql = "Select * from users where ssn = 433871122";
             Assert.AreEqual(sql, ob.GetObfuscatedSql(sql));
         }
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.Core.Database
         [Test]
         public static void verify_using_raw_obfuscator_and_quoted_string_in_sql_that_GetObfuscatedSql_returns_sql_passed_in()
         {
-            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator(true, "raw");
+            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator("raw");
             string sql = "Select * from users where name = 'dude'";
             Assert.AreEqual(sql, ob.GetObfuscatedSql(sql));
         }
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.Core.Database
         [Test]
         public static void verify_using_NoSql_objfuscator_that_GetObfuscatedSql_returns_null()
         {
-            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator(true, "off");
+            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator("off");
             string sql = "Select * from users where ssn = 433871122";
             Assert.IsNull(ob.GetObfuscatedSql(sql));
         }
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.Core.Database
         [Test]
         public static void verify_using_NoSql_objfuscator_and_quoted_string_in_sql_that_GetObfuscatedSql_returns_null()
         {
-            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator(true, "off");
+            SqlObfuscator ob = SqlObfuscator.GetSqlObfuscator("off");
             string sql = "Select * from users where name = 'dude'";
             Assert.IsNull(ob.GetObfuscatedSql(sql));
         }


### PR DESCRIPTION
Fixes #168 

### Description

Summary:
Explain plans are only capture if TransactionTracer.explainPlan is true and either TransactionTracer.enabled and/or slowSql.enabled  are true.  This prevents an explain plan from being capture when it is never going to be sent up.  It prevent a capture explain plan from being dropped (very expensive to capture) and replaced using a "null" SqlObfuscator if TransactionTracer.enabled is false, but slowSql.enabled  is true. 

Note: By default, the agent will not capture explain plans, but it will capture transaction traces and slow sql traces. This should not affect most customers.  Customers with the following configuration will start seeing explain plans and the performance hit to generate them:
- TransactionTracer.explainPlan is **true**
- TransactionTracer.enabled is **false**
- slowSql.enabled is **true**

Context:
- TransactionTracer determines if transaction traces are collected
- SlowSQL determines if SQL traces are collected
- Explain p-lans are optional for both trace types.
- Explain plans are generated in TransactionTransformer before either trace is created.
- Explain plans are only generated if TransactionTracer.explainPlan is true.
    (src\Agent\NewRelic\Agent\Core\Transformers\TransactionTransformer\TransactionTransformer.cs:396)
    (src\Agent\NewRelic\Agent\Core\Agent.cs#171)
- A "nulling" SqlObfuscator will be used if TransactionTracer.enabled is false despite a real explain plan being collected.
During *TraceMaker workflow, ExplainPlan types are serialized into ExplainPlanWireModels independently.

Fix 1
 Changes when explain plans run.  Now explain Plans now run only when:
- TransactionTracer.explainPlan is true AND one or more of the following is also true:
- TransactionTracer.enabled is true
- slowSql.enabled is true

Otherwise, no explain plans are run.

Fix 2
Changes required config for explain plans. 
- Removes the need for TransactionTracer.enabled to be true from SqlObfuscator since SlowSql also can use explain plans.
- SqlObfuscator now will return a proper obfuscator depending on TransactionTracer.recordSql which was always passed into the the getter,
- Updated dependent classes to not pass in TransactionTracer.enabled anymore and fixed up tests for the same

### Testing

Unit tests should mass as normal.

### Changelog

We will need to add a note to the change log for the above, depending if it is accepted.

