### PR TITLE
Fix sqlparser word matching

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixes issue [#616](https://github.com/newrelic/newrelic-dotnet-agent/issues/616): Linux Kudu not accessible when .NET agent presents. ([#618](https://github.com/newrelic/newrelic-dotnet-agent/pull/618))
 * Fixes issue [#266](https://github.com/newrelic/newrelic-dotnet-agent/issues/266): Agent fails to initialize and provides no logs when configured with capitalized booleans. ([#617](https://github.com/newrelic/newrelic-dotnet-agent/pull/617))
 * Explain plans will be created if [transactionTracer.explainEnabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-explainEnabled) is true and one or both [transactionTracer.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-enabled) or [slowSql.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#slow_sql) are true.  If transactionTracer.explainEnabled is false or both transactionTracer.enabled and slowSql.enabled are false, no Explain Plans will be created.
+* Fixes issue [#476](https://github.com/newrelic/newrelic-dotnet-agent/issues/476): When generating and explain plan MS SQL parsing is matching parts of words instead of whole words
 
 ## [8.40.0] - 2021-06-08
 ### New Features


### PR DESCRIPTION
Resolves #476 

### Description
Replaces string.replace with regex.replace
Regex is: @\b{paramName}\b
This looks for a parameter with a word-boundary on either side with an @ before the first boundary
This is needed to handle the @ symbol not being a word character
Old method used the length of the string to get around not looking for whole words
This needed a sorted list, a custom comparer, and other code, all of this was removed
Added new SqlParser.FixParameterizedSql to cover different scenarios.
No integration tests since unit test are pretty thorough
Tested performance and there was not appreciable difference between the two

Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

### Testing

Added new SqlParser.FixParameterizedSql to cover different scenarios.
No integration tests since unit test are pretty thorough
Tested performance and there was not appreciable difference between the two

### Changelog

Updated.


