### PR TITLE
Add Linux package deploy test mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -270,14 +270,18 @@ jobs:
           touch docker.env
           echo "AGENT_VERSION=$AGENT_VERSION" >> docker.env
           echo "ACTION=release" >> docker.env
-          echo "S3_BUCKET=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.LINUX_AWS_ACCESS_KEY_ID }}" >> docker.env
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.LINUX_AWS_SECRET_ACCESS_KEY }}" >> docker.env
+          if [ "${{ github.event.inputs.linux-deploy-to-production }}" == "true" ] ; then
+            # We're actually deploying to production (apt.newrelic.com and yum.newrelic.com)           
+            echo "S3_BUCKET=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
+            echo "AWS_ACCESS_KEY_ID=${{ secrets.LINUX_AWS_ACCESS_KEY_ID }}" >> docker.env
+            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.LINUX_AWS_SECRET_ACCESS_KEY }}" >> docker.env
+          else
+            # Deploy to the test bucket that mirrors apt/yum.newrelic.com
+            echo "S3_BUCKET=${{ secrets.TEST_S3_BUCKET }}" >> docker.env
+            echo "AWS_ACCESS_KEY_ID=${{ secrets.TEST_BUCKET_AWS_ACCESS_KEY_ID }}" >> docker.env
+            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.TEST_BUCKET_AWS_SECRET_ACCESS_KEY }}" >> docker.env
+          fi
           echo "GPG_KEYS=/deployscripts/gpg.tar.bz2" >> docker.env
-          echo "PROD_MAIN_S3=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
-          echo "PROD_TEST_S3=${{ secrets.PROD_TEST_S3 }}" >> docker.env
-          echo "TEST_TEST_S3=${{ secrets.TEST_TEST_S3 }}" >> docker.env
-          echo "TEST_PRIV_S3=${{ secrets.TEST_PRIV_S3 }}" >> docker.env
         shell: bash
 
       - name: Build and Run Container

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,10 @@ on:
         description: 'If "true", will run the deploy-linux job. If "false", will not.'
         required: true
         default: 'true'
+      linux-deploy-to-production:
+        description: 'If "true", will deploy Linux packages to the real apt/yum.newrelic.com. If "false", will deploy to a test repository.'
+        required: true
+        default: 'false'
 
 env:
   DOTNET_NOLOGO: true

--- a/deploy/linux/.gitignore
+++ b/deploy/linux/.gitignore
@@ -1,0 +1,1 @@
+docker.env

--- a/deploy/linux/.gitignore
+++ b/deploy/linux/.gitignore
@@ -1,1 +1,2 @@
 docker.env
+gpg.tar.bz2

--- a/deploy/linux/README.md
+++ b/deploy/linux/README.md
@@ -5,25 +5,44 @@ The assets in this path are used to deploy the Linux packages (.deb and .rpm) fo
 ## Requirements
 1. Docker, with the ability to run Linux containers
 2. AWS S3 access keys with read/write access to the bucket(s) you are updating
+3. A Linux-like command line environment, such as `git-bash` on Windows, or a real Linux system or VM (e.g. WSL2)
 
-To deploy the .rpm and .deb packages for a particular release version (e.g. 6.18.123.0), run the following commands from this directory (same directory as this README):
+To deploy the .rpm and .deb packages for a particular release version (e.g. 6.18.123.0): (note: all commands should be run from the same location as this README)
 
-1. `cp <packages_to_be_released> ./packages`
-2. `docker-compose build`
-3. The following environment variables MUST be set in the environment that `deploy.bash` executes in inside the container:
-    - `AGENT_VERSION` (e.g. 6.18.123.0)
-    - `AWS_ACCESS_KEY_ID`
-    - `AWS_SECRET_ACCESS_KEY`
-4. These environment variables can be passed to the container in a few ways:
-    - In a file, specified in the `docker-compose.yml` file (currently `docker.env`), one name/val pair per line with no quoting
-    - You can set them explicity in the `docker-compose run` command, like so:
-    `docker-compose run -e AGENT_VERSION=6.18.123.0 -e AWS_ACCESS_KEY_ID=AKAKAKAKAKAKAKA -e AWS_SECRET_ACCESS_KEY=6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ deploy_packages`
-5. The following environment variables MAY be passed to the container, but are not required:
+1. Add the packages to be released to the `packages` subfolder:
+    
+        cp <packages_to_be_released> ./packages
+
+2. Add the GPG signing keys to the `deploy_scripts` subfolder:
+
+        cp gpg.tar.bz2 ./deploy_scripts
+
+3. Create the `docker.env` [environment variable file](https://docs.docker.com/compose/env-file/) with required values (the values shown here are just examples, you will need to supply the correct ones):
+
+        echo "AGENT_VERSION=6.18.123.0" >docker.env
+        echo "S3_BUCKET=s3://your-s3-bucket" >>docker.env
+        echo "AWS_ACCESS_KEY_ID=AKAKAKAKAKAKAKA" >>docker.env
+        echo "AWS_SECRET_ACCESS_KEY=6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ" >>docker.env
+        echo "GPG_KEYS=/deployscripts/gpg.tar.bz2" >>docker.env
+
+4. Optionally, add additional non-required environment variables to the environment file:
     - `AWS_DEFAULT_REGION` (defaults to `us-west-2`)
     - `AWS_DEFAULT_OUTPUT` (defaults to `text`)
-    - `RELEASE_ACTION` (defaults to `release-2-fake-production`; set to `release-2-production` to REALLY release new agent packages for Linux)
-6. `docker-compose run deploy_packages`
+    - `ACTION` (value can be `deploy` (add new packages to the repos) or `rollback` (remove existing packages from the repos), defaults to `deploy`)
 
-Note that the scripts in ./deploy_scripts came from the PHP agent team and have a lot of logic in them to support their particular build/test/release processes, not all of which
-we are using.  However, since we are sharing the same public package sources with the PHP agent, anything this script does needs to be cautious to avoid breaking their repos.
-In particular, before we attempt to deploy a version of our agent to the main public repos, we should make sure the PHP agent team isn't also trying to deploy at the same time.
+5. Make sure all script files have the correct permissions and line endings for Linux:
+
+        find . -name "*.bash" |xargs chmod a+x
+        find . -type f |xargs dos2unix
+
+6. Build the Docker container:
+
+        docker-compose build
+
+7. Run the deploy (or rollback) process:
+
+        docker-compose run deploy_packages
+
+Note that the scripts in ./deploy_scripts came from the PHP agent team and have a lot of logic in them to support their particular build/test/release processes, 
+not all of which we are using.  However, since we are sharing the same public package sources with the PHP agent, anything this script does needs to be cautious 
+to avoid breaking their repos.  In particular, before we attempt to deploy a version of our agent to the main public repos, we should make sure the PHP agent team isn't also trying to deploy at the same time.

--- a/deploy/linux/deploy.bash
+++ b/deploy/linux/deploy.bash
@@ -1,8 +1,13 @@
 #!/bin/bash
-set -e # for initial debugging purposes, halt the build script on any error.  This should be removed before release, probably
+set -e # Exit script on any error
 
 if [ -z "$AGENT_VERSION" ]; then
     echo "AGENT_VERSION is not set"
+    exit -1
+fi
+
+if [ -z "$S3_BUCKET" ]; then
+    echo "S3_BUCKET is not set"
     exit -1
 fi
 

--- a/deploy/linux/deploy_scripts/deploy-packages.bash
+++ b/deploy/linux/deploy_scripts/deploy-packages.bash
@@ -17,7 +17,7 @@
 ###
 ### Description:
 ###
-###   Deploying or rolling back the .NET Core agent Linux packages proceeds 
+###   Deploying or rolling back the .NET Core agent Linux packages proceeds
 ###   in three phases: pull, modify, push.
 ###   The three phases are designed to ensure the deploy process is safe,
 ###   reliable, and atomic. i.e. Changes should not be visible to customers
@@ -33,9 +33,9 @@
 ###   See libexec/s3-pull.bash for details.
 ###
 ###   The second phase, the "modify" phase, performs the real work of
-###   deploying or rolling back the agent. During this phase, each of the 
-###   files comprising an agent release is copied to the appropriate location 
-###   within the download site. Additionally, the Debian and Redhat package 
+###   deploying or rolling back the agent. During this phase, each of the
+###   files comprising an agent release is copied to the appropriate location
+###   within the download site. Additionally, the Debian and Redhat package
 ###   repositories are re-indexed and digitally signed. See libexec/repoman-*.bash for
 ###   details.
 ###
@@ -142,19 +142,24 @@ if [[ ! "$ACTION" =~ release|rollback ]]; then
   exit
 fi
 
-# Set the target (production vs. testing) based on the S3 bucket URI.  If the supplied bucket doesn't match one of the four we know about, bail out.
-if [ "$S3_BUCKET" == "$PROD_MAIN_S3" -o "$S3_BUCKET"  == "$PROD_TEST_S3" ]
-then
-  TARGET='production'
-elif [ "$S3_BUCKET" == "$TEST_PRIV_S3" -o "$S3_BUCKET"  == "$TEST_TEST_S3" ]
-then
-  TARGET='testing'
-else
-  echo "Specified S3 bucket uri '$S3_BUCKET' does not match any known buckets.  Exiting."
-  exit
-fi
+# All of the following commented out code comes from the PHP agent team's more complex process.  The TARGET variable doesn't actually control what S3
+# bucket the packages are being deployed to or rolled back from, it's just used as a local path component by some sub-scripts (e.g. s3-pull/push)
 
-export TARGET
+# # Set the target (production vs. testing) based on the S3 bucket URI.  If the supplied bucket doesn't match one of the four we know about, bail out.
+# if [ "$S3_BUCKET" == "$PROD_MAIN_S3" -o "$S3_BUCKET"  == "$PROD_TEST_S3" ]
+# then
+#   TARGET='production'
+# elif [ "$S3_BUCKET" == "$TEST_PRIV_S3" -o "$S3_BUCKET"  == "$TEST_TEST_S3" ]
+# then
+#   TARGET='testing'
+# else
+#   echo "Specified S3 bucket uri '$S3_BUCKET' does not match any known buckets.  Exiting."
+#   exit
+# fi
+
+# export TARGET
+
+export TARGET='production' # this is just a string used in local paths for repository data pulled down from S3 and then pushed back up
 
 # Make sure we have all the external tools we need
 for CMD in apt-ftparchive gpg createrepo curl rsync; do
@@ -264,7 +269,7 @@ elif [[ "$ACTION" == 'rollback' ]]; then
     --destination="$TARGET" \
     --verbose \
     "${FILES[@]}"
-fi  
+fi
 
 ## END MODIFY PHASE ##
 

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -60,16 +60,12 @@ shift $((OPTIND - 1))
 rebuild_apt() (
   printf \\n
 
-  echo "got here 1"
-
   REPO_DIR=$(repopath "$1")
   REPO=$(basename "$REPO_DIR")
 
   echo "REPO_DIR=$REPO_DIR"
   pushd "$REPO_DIR/../.." >/dev/null
   
-  pwd
-
   config_files_root='/data/deploy_scripts/conf'
   release_conf_file="${config_files_root}/release.conf"
   generate_conf_file="${config_files_root}/generate.conf"


### PR DESCRIPTION
### Description

Resolves #606.

1. Modified `deploy.yml` to add a new input called `linux-deploy-to-production` with a default value of `false`.  The workflow adds values from the secrets store for a) the S3 bucket to operate on for the deployment and b) the AWS access keys to use to operate on that bucket.  When the new value is false, it will operate on an S3 bucket that the team owns and is set up to simulate the "real" S3 bucket that backs `apt.newrelic.com` and `yum.newrelic.com`.  When set to true (as in a real release deploy), it will operate on the "real" S3 bucket.
2. Updated the README.md file for the deploy system to be more understandable and fix some inaccuracies leftover from old versions.
3. Added some progress/troubleshooting output to the `repoman_rebuild.bash` script.

### Testing

I tested the changes to the deploy process script locally against the test S3 bucket.  I have not tested the `deploy.yml` functionality yet since it will need to work with a test "release" based on these code changes.

### Changelog

N/A since these changes are for an internal NR process and do not affect agent behavior.
