### PR TITLE
Fix async await in lambda tracer

### DIFF
--- a/src/AwsLambda/AwsLambdaWrapper/LambdaWrapper.cs
+++ b/src/AwsLambda/AwsLambdaWrapper/LambdaWrapper.cs
@@ -83,6 +83,7 @@ namespace NewRelic.OpenTracing.AmazonLambda
             var scope = BeforeWrappedMethod(handler.Method.Name, context, distributedTraceContext, input);
             TOut output = default(TOut);
             object realOutput = null;
+
             try
             {
                 output = handler(input, context);
@@ -99,10 +100,11 @@ namespace NewRelic.OpenTracing.AmazonLambda
             return output;
         }
 
-        public async Task<TOut> LambdaWrapper<TInput, TOut>(Func<TInput, ILambdaContext, Task<TOut>> handler, TInput input, ILambdaContext context, ISpanContext? distributedTraceContext = null)
+        public async Task<TOut> LambdaWrapper<TInput, TOut>(Func<TInput, ILambdaContext, Task<TOut>> handler, TInput input, ILambdaContext context, ISpanContext distributedTraceContext = null)
         {
             var scope = BeforeWrappedMethod(handler.Method.Name, context, distributedTraceContext, input);
-            TOut? output;
+            TOut output = default(TOut);
+
             try
             {
                 output = await handler(input, context).ConfigureAwait(false);
@@ -140,10 +142,11 @@ namespace NewRelic.OpenTracing.AmazonLambda
             return output;
         }
 
-        public async Task<TOut> LambdaWrapper<TOut>(Func<ILambdaContext, Task<TOut>> handler, ILambdaContext context, ISpanContext? distributedTraceContext = null)
+        public async Task<TOut> LambdaWrapper<TOut>(Func<ILambdaContext, Task<TOut>> handler, ILambdaContext context, ISpanContext distributedTraceContext = null)
         {
             var scope = BeforeWrappedMethod(handler.Method.Name, context, distributedTraceContext);
-            TOut? output;
+            TOut output = default(TOut);
+
             try
             {
                 output = await handler(context).ConfigureAwait(false);
@@ -175,7 +178,7 @@ namespace NewRelic.OpenTracing.AmazonLambda
             AfterWrappedMethod(scope: scope);
         }
 
-        public async Task LambdaWrapper<TInput>(Func<TInput, ILambdaContext, Task> handler, TInput input, ILambdaContext context, ISpanContext? distributedTraceContext = null)
+        public async Task LambdaWrapper<TInput>(Func<TInput, ILambdaContext, Task> handler, TInput input, ILambdaContext context, ISpanContext distributedTraceContext = null)
         {
             var scope = BeforeWrappedMethod(handler.Method.Name, context, distributedTraceContext, input);
 
@@ -209,7 +212,7 @@ namespace NewRelic.OpenTracing.AmazonLambda
             AfterWrappedMethod(scope: scope);
         }
 
-        public async Task LambdaWrapper(Func<ILambdaContext, Task> handler, ILambdaContext context, ISpanContext? distributedTraceContext = null)
+        public async Task LambdaWrapper(Func<ILambdaContext, Task> handler, ILambdaContext context, ISpanContext distributedTraceContext = null)
         {
             var scope = BeforeWrappedMethod(handler.Method.Name, context, distributedTraceContext);
 

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
-* Fixes in `LambdaWrapper` when using Tasks and async methods (`.Result` is no longer called and tasks are awaited correctly).
+* Fixes `LambdaWrapper` when using Tasks and async methods (`.Result` is no longer called and tasks are awaited correctly). ([#625](https://github.com/newrelic/newrelic-dotnet-agent/pull/625))
+	* Thank you [@williamdenton](https://github.com/williamdenton) for submitting this fix!
 
 
 ## [1.2.1] - 2021-03-09

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
+* Fixes in `LambdaWrapper` when using Tasks and async methods (`.Result` is no longer called and tasks are awaited correctly).
 
 
 ## [1.2.1] - 2021-03-09


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

### Description

The Lambda Tracing Wrapper uses Async over Sync and Reflection to call `.Result` on the task returned from lambda execution. Calling `.Result` can result in deadlocks and is considered bad practise.

This PR adds overloads to `LambdaWrapper` that support tasks correctly

### Testing

What unit or integration tests were added or modified, or why no testing changes were required.

### Changelog

Please remember to update our [changelog](/newrelic/newrelic-dotnet-agent/src/Agent/CHANGELOG.md) if applicable (or [this changelog](/newrelic/newrelic-dotnet-agent/blob/main/src/AwsLambda/CHANGELOG.md) for Lambda agent changes),

