### PR TITLE
Always use thread id in agent logs

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixes issue [#551](https://github.com/newrelic/newrelic-dotnet-agent/issues/551): Missing external calls in WCF Service. ([#610](https://github.com/newrelic/newrelic-dotnet-agent/pull/610))
 * Fixes issue [#616](https://github.com/newrelic/newrelic-dotnet-agent/issues/616): Linux Kudu not accessible when .NET agent presents. ([#618](https://github.com/newrelic/newrelic-dotnet-agent/pull/618))
 * Explain plans will be created if [transactionTracer.explainEnabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-explainEnabled) is true and one or both [transactionTracer.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-enabled) or [slowSql.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#slow_sql) are true.  If transactionTracer.explainEnabled is false or both transactionTracer.enabled and slowSql.enabled are false, no Explain Plans will be created.
+* Fixes issue [#600](https://github.com/newrelic/newrelic-dotnet-agent/issues/600): Thread id will now be used in agent logging, even if a thread name has been set. ([#626](https://github.com/newrelic/newrelic-dotnet-agent/pull/626))
 
 ## [8.40.0] - 2021-06-08
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
@@ -13,10 +13,7 @@ namespace NewRelic.Agent.Core.Logging
 
         private void EnsureThreadIdPropertyExistsInContext()
         {
-            if(log4net.ThreadContext.Properties["threadid"] == null)
-            {
-                log4net.ThreadContext.Properties["threadid"] = Thread.CurrentThread.ManagedThreadId;
-            }
+            log4net.ThreadContext.Properties["threadid"] ??= Thread.CurrentThread.ManagedThreadId;
         }
 
         public bool IsEnabledFor(Level level)

--- a/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
@@ -3,12 +3,21 @@
 
 using NewRelic.Agent.Extensions.Logging;
 using System;
+using System.Threading;
 
 namespace NewRelic.Agent.Core.Logging
 {
     public class Logger : ILogger, global::NewRelic.Core.Logging.ILogger
     {
         private readonly log4net.ILog _logger = log4net.LogManager.GetLogger(typeof(Logger));
+
+        private void EnsureThreadIdPropertyExistsInContext()
+        {
+            if(log4net.ThreadContext.Properties["threadid"] == null)
+            {
+                log4net.ThreadContext.Properties["threadid"] = Thread.CurrentThread.ManagedThreadId;
+            }
+        }
 
         public bool IsEnabledFor(Level level)
         {
@@ -33,6 +42,8 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (!IsEnabledFor(level)) return;
             var messageString = message.ToString();
+
+            EnsureThreadIdPropertyExistsInContext();
 
             switch (level)
             {
@@ -68,6 +79,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Error(string message)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Error(message);
         }
 
@@ -76,6 +88,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Error(Exception exception)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Error(exception.ToString());
         }
 
@@ -86,6 +99,7 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (IsErrorEnabled)
             {
+                EnsureThreadIdPropertyExistsInContext();
                 _logger.Error(string.Format(format, args));
             }
         }
@@ -104,6 +118,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Warn(string message)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Warn(message);
         }
 
@@ -112,6 +127,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Warn(Exception exception)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Warn(exception.ToString());
         }
 
@@ -122,6 +138,7 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (IsWarnEnabled)
             {
+                EnsureThreadIdPropertyExistsInContext();
                 _logger.Warn(string.Format(format, args));
             }
         }
@@ -140,6 +157,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Info(string message)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Info(message);
         }
 
@@ -148,6 +166,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Info(Exception exception)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Info(exception.ToString());
         }
 
@@ -158,6 +177,7 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (IsInfoEnabled)
             {
+                EnsureThreadIdPropertyExistsInContext();
                 _logger.Info(string.Format(format, args));
             }
         }
@@ -176,6 +196,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Debug(string message)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Debug(message);
         }
 
@@ -184,6 +205,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Debug(Exception exception)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Debug(exception.ToString());
         }
 
@@ -194,6 +216,7 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (_logger.IsDebugEnabled)
             {
+                EnsureThreadIdPropertyExistsInContext();
                 _logger.Debug(string.Format(format, args));
             }
         }
@@ -212,6 +235,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Finest(string message)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Logger.Log(typeof(Logger), log4net.Core.Level.Finest, message, null);
         }
 
@@ -220,6 +244,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void Finest(Exception exception)
         {
+            EnsureThreadIdPropertyExistsInContext();
             _logger.Logger.Log(typeof(Logger), log4net.Core.Level.Finest, exception.ToString(), null);
         }
 
@@ -230,6 +255,7 @@ namespace NewRelic.Agent.Core.Logging
         {
             if (IsFinestEnabled)
             {
+                EnsureThreadIdPropertyExistsInContext();
                 var formattedMessage = string.Format(format, args);
                 _logger.Logger.Log(typeof(Logger), log4net.Core.Level.Finest, formattedMessage, null);
             }

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core
 
         // Watch out!  If you change the time format that the agent puts into its log files, other log parsers may fail.
         private static ILayout AuditLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %level: %message\r\n");
-        private static ILayout FileLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %6level: [pid: %property{pid}, tid: %thread] %message\r\n");
+        private static ILayout FileLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %6level: [pid: %property{pid}, tid: %property{threadid}] %message\r\n");
 
         private static ILayout eventLoggerLayout = new PatternLayout("%level: %message");
 

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
@@ -24,6 +24,8 @@ namespace AspNetCoreMvcAsyncApplication
 
         public static void Main(string[] args)
         {
+            Thread.CurrentThread.Name = "NewRelic Main Test Application Thread";
+
             var commandLine = string.Join(" ", args);
 
             _applicationName = Path.GetFileNameWithoutExtension(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath) + ".exe";

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcAsyncTests.cs
@@ -62,6 +62,15 @@ namespace NewRelic.Agent.IntegrationTests.AspNetCore
         [Fact]
         public void Test()
         {
+            foreach (var line in _fixture.AgentLog.GetFileLines())
+            {
+                // This first check has virtually no chance of failing until we upgrade the test app to .net 6
+                Assert.DoesNotContain("tid: .NET ThreadPool Worker", line);
+
+                // The mvc async test application sets it's main thread to this name
+                Assert.DoesNotContain("tid: NewRelic Main Test Application Thread", line);
+            }
+
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             Assert.NotNull(metrics);

--- a/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.FromLegacy/AgentLoggerTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.FromLegacy/AgentLoggerTest.cs
@@ -1,8 +1,10 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Reflection;
 using System.Linq;
+using System.Threading;
 using NewRelic.Agent.Core.Config;
 using NewRelic.Core.Logging;
 using NUnit.Framework;
@@ -127,6 +129,245 @@ namespace NewRelic.Agent.Core
             Assert.IsFalse(config.Console);
         }
 
+        [Test]
+        public static void Logging_sets_threadid_property_for_Info()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Info("Please set my thread id.");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Info_Exception()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Info(new Exception("oh no!"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_InfoFormat()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.InfoFormat("My message {0}", "works");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Debug()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Debug("debug mah");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Debug_Exception()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Debug(new Exception("oh no!"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_DebugFormat()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.DebugFormat("My message {0}", "works");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_ErrorFormat()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.ErrorFormat("My message {0}", "works");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Error()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Error("debug mah");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Error_Exception()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Error(new Exception("oh no!"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_FinestFormat()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.FinestFormat("My message {0}", "works");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Finest()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Finest("debug mah");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Finest_Exception()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Finest(new Exception("oh no!"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_WarnFormat()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.WarnFormat("My message {0}", "works");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Warn()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Warn("warn mah");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_Warn_Exception()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.Warn(new Exception("oh no!"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_LogMessage()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.LogMessage(LogLevel.Info, "Test Message");
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+        [Test]
+        public static void Logging_sets_threadid_property_for_LogException()
+        {
+            log4net.ThreadContext.Properties["threadid"] = null;
+
+            ILogConfig config = GetLogConfig("all");
+            LoggerBootstrapper.Initialize();
+            LoggerBootstrapper.ConfigureLogger(config);
+
+            Log.LogException(LogLevel.Info, new Exception("Test exception"));
+
+            Assert.AreEqual(log4net.ThreadContext.Properties["threadid"], Thread.CurrentThread.ManagedThreadId);
+        }
+
+
 
         static private ILogConfig GetLogConfig(string logLevel)
         {
@@ -175,11 +416,11 @@ namespace NewRelic.Agent.Core
 
         private static log4net.Repository.Hierarchy.Logger GetLogger()
         {
-            var hierarchy = log4net.LogManager.GetRepository(Assembly.GetCallingAssembly()) as log4net.Repository.Hierarchy.Hierarchy;
+            var hierarchy =
+                log4net.LogManager.GetRepository(Assembly.GetCallingAssembly()) as
+                    log4net.Repository.Hierarchy.Hierarchy;
             var logger = hierarchy.Root;
             return logger;
         }
-
-
     }
 }


### PR DESCRIPTION
### Description

While testing out .NET 6, we noticed that thread names were being logged for .NET managed threads instead of the actually desired thread id in agent logfiles. This happened because Log4Net prefers to log a thread name versus a thread id, and Microsoft began setting thread names for their managed threads in .NET 6. The behavior is reproducible in previous versions of the product, but only if a user explicitly set the name of a thread.

The resolution is to check/set a thread id in the log4net thread context object, and update the logging layout to log this property. This is the same approach we use to log the process id, with the exception of only ever needing to set the process id once.

Resolves #600. 

### Testing

Unit tests were added to verify that the thread id property is set in log4net by every possible agent log binding. The .net core mvc async integration test application was updated to set a main thread name, and assertions were added in the text fixture to verify that this thread name, and the new .net background worker thread name does not show up in the log file instead of a thread id.

