### PR TITLE
Improve sqlparsing tostring in FixParameterizedSql

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixes issue [#266](https://github.com/newrelic/newrelic-dotnet-agent/issues/266): Agent fails to initialize and provides no logs when configured with capitalized booleans. ([#617](https://github.com/newrelic/newrelic-dotnet-agent/pull/617))
 * Explain plans will be created if [transactionTracer.explainEnabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-explainEnabled) is true and one or both [transactionTracer.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#tracer-enabled) or [slowSql.enabled](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/#slow_sql) are true.  If transactionTracer.explainEnabled is false or both transactionTracer.enabled and slowSql.enabled are false, no Explain Plans will be created.
 * Fixes issue [#476](https://github.com/newrelic/newrelic-dotnet-agent/issues/476): When generating and explain plan MS SQL parsing is matching parts of words instead of whole words
+* Fixes issue [#477](https://github.com/newrelic/newrelic-dotnet-agent/issues/476): SQL Explain plans MS SQL parser needs to be able to ToString an object to work with parameterized queries
+  * Improves handling serializable types like DateTimeOffset
+  * The presence DbTypes Binary and Object will prevent an Explain Plan from being executed.  In order to execute an explain plan, the agent must replace any parameters in a query with the real values.  Binary and Object are too complex to properly serialize without introducing errors.
 
 ## [8.40.0] - 2021-06-08
 ### New Features

--- a/src/Agent/NewRelic/Agent/Parsing/MySqlExplainPlanActions.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/MySqlExplainPlanActions.cs
@@ -39,15 +39,14 @@ namespace NewRelic.Parsing
         public static ExplainPlan GenerateExplainPlan(object resources)
         {
             if (!(resources is IDbCommand))
+            {
                 return null;
-
-            var dbCommand = (IDbCommand)resources;
-            if (dbCommand.Connection.State != ConnectionState.Open)
-                dbCommand.Connection.Open();
+            }
 
             ExplainPlan explainPlan = null;
 
             //KILL THE CONNECTION NO MATTER WHAT HAPPENS DURING EXECUTION TO AVOID CONNECTION LEAKING
+            var dbCommand = (IDbCommand)resources;
             using (dbCommand)
             using (dbCommand.Connection)
             {
@@ -55,6 +54,11 @@ namespace NewRelic.Parsing
                 if (!shouldGeneratePlan)
                 {
                     return explainPlan;
+                }
+
+                if (dbCommand.Connection.State != ConnectionState.Open)
+                {
+                    dbCommand.Connection.Open();
                 }
 
                 dbCommand.Transaction = null;
@@ -77,9 +81,7 @@ namespace NewRelic.Parsing
                     }
 
                     explainPlan.ExplainPlanDatas = explainPlanDatas;
-
                 }
-
             }
 
             return explainPlan;

--- a/src/Agent/NewRelic/Agent/Parsing/MySqlExplainPlanActions.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/MySqlExplainPlanActions.cs
@@ -51,9 +51,13 @@ namespace NewRelic.Parsing
             using (dbCommand)
             using (dbCommand.Connection)
             {
+                var shouldGeneratePlan = SqlParser.FixParameterizedSql(dbCommand);
+                if (!shouldGeneratePlan)
+                {
+                    return explainPlan;
+                }
 
                 dbCommand.Transaction = null;
-                SqlParser.FixParameterizedSql(dbCommand);
                 dbCommand.CommandText = "EXPLAIN " + dbCommand.CommandText;
 
 

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -379,9 +379,14 @@ namespace NewRelic.Parsing
                 // Object: Object could be almost anything so there is no easy way ToString it that just works without trying to detect all the differnt objects
                 // It is safer, less error prone, and more efficient to short-circuit on these types than to try and parse them out.
                 var type = dbParam.DbType;
-                if (type == DbType.Binary || type == DbType.Object)
+                if (type == DbType.Binary)
                 {
-                    Log.DebugFormat("Not executing explain plan since DbType is either Binary or Object."); // not getting the enum string to save resources
+                    Log.DebugFormat("Not executing explain plan since DbType is Binary.");
+                    return false;
+                }
+                else if (type == DbType.Object)
+                {
+                    Log.DebugFormat("Not executing explain plan since DbType is Object.");
                     return false;
                 }
                 

--- a/src/Agent/NewRelic/Agent/Parsing/SqlServerExplainPlanActions.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlServerExplainPlanActions.cs
@@ -26,9 +26,13 @@ namespace NewRelic.Parsing
             using (dbCommand)
             using (dbCommand.Connection)
             {
-                SetShowPlan(dbCommand.Connection, true);
+                var shouldGeneratePlan = SqlParser.FixParameterizedSql(dbCommand);
+                if (!shouldGeneratePlan)
+                {
+                    return explainPlan;
+                }
 
-                SqlParser.FixParameterizedSql(dbCommand);
+                SetShowPlan(dbCommand.Connection, true);
 
                 using (IDataReader reader = dbCommand.ExecuteReader())
                 {

--- a/src/Agent/NewRelic/Agent/Parsing/SqlServerExplainPlanActions.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlServerExplainPlanActions.cs
@@ -14,15 +14,14 @@ namespace NewRelic.Parsing
         public static ExplainPlan GenerateExplainPlan(object resources)
         {
             if (!(resources is IDbCommand))
+            {
                 return null;
-
-            var dbCommand = (IDbCommand)resources;
-            if (dbCommand.Connection.State != ConnectionState.Open)
-                dbCommand.Connection.Open();
+            }
 
             ExplainPlan explainPlan = null;
 
             //KILL THE CONNECTION NO MATTER WHAT HAPPENS DURING EXECUTION TO AVOID CONNECTION LEAKING
+            var dbCommand = (IDbCommand)resources;
             using (dbCommand)
             using (dbCommand.Connection)
             {
@@ -30,6 +29,11 @@ namespace NewRelic.Parsing
                 if (!shouldGeneratePlan)
                 {
                     return explainPlan;
+                }
+
+                if (dbCommand.Connection.State != ConnectionState.Open)
+                {
+                    dbCommand.Connection.Open();
                 }
 
                 SetShowPlan(dbCommand.Connection, true);
@@ -52,6 +56,7 @@ namespace NewRelic.Parsing
                     explainPlan.ExplainPlanDatas = explainPlanDatas;
 
                 }
+
                 SetShowPlan(dbCommand.Connection, false);
             }
 


### PR DESCRIPTION
Resolves #477

### Description

Big change tl;dr: If DbType.Binary and DbType.Object are detected while parsing, we will exit and not collect an explain plan.  There is a debug message indicating as such.  This prevent any errors with custom objects or objects that are not easily serialized.

Prevents explain plans from being created when Binary or Object parameters are detected
- SqlParser.FixParameterizedSqlnow returns a bool to indicate if we should try to run the plan
- MySqlExplainPlanActions and SqlServerExplainPlanActions hasve been update to honor this boolean
- Without a large amount of overhead, we are not able to determine how to write the underlying objects as strings.  With the SqlParser we want to keep it very lightweight since it is already a large performance hit.  This should mean less errors for the customer while not reducing the amount of plans we can create since we would error out before
- Logs a Debug message when we block explain plans for Binary or Object
- Uses DbType enum for detecting Boolean
- Reorganizes SqlParser.FixParameterizedSql

### Testing

Expanded the SqlParser.FixParameterizedSql tests to cover more of the options include failures

### Changelog

Updated, but please check it for verbage!

