### PR TITLE
Add exiftool tarball to repo and install it in container

### DIFF
--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -1,12 +1,11 @@
 FROM rpmbuild/centos7
 
 USER root
+ADD Image-ExifTool-12.28.tar.gz /exiftool
 RUN yum --assumeyes install dos2unix rpm-sign expect perl-ExtUtils-MakeMaker
 
 # Install exiftool
-RUN curl -o exiftool.tgz https://exiftool.org/Image-ExifTool-12.25.tar.gz; \
-tar -zxvf exiftool.tgz; \
-cd Image-ExifTool-12.25; \
+RUN cd /exiftool/Image-ExifTool-12.28; \
 perl Makefile.PL; \
 make; \
 make install


### PR DESCRIPTION
### Description

This PR adds a checked-in version of a tool ([exiftool](https://exiftool.org/index.html)) needed by the rpm package building process and modifies the Dockerfile to use the checked in version rather than pulling it from the web.  The reason for doing this is that we found out that the exiftool.org website regularly deletes older versions from their site and we don't want to have to update this Dockerfile every few months to bump to the latest version.

Note: Exiftool is free software per their [license](https://exiftool.org/index.html#license), so no issue adding this to our repo.

### Testing

Tested building the rpm_build container and then building the .rpm package on my local system.

### Changelog

N/A for an internal process.
