### PR TITLE
Capture HTTP Request Method

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -83,6 +83,7 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<TimeSpan?, double> QueueDuration { get; }
         AttributeDefinition<TimeSpan?, string> QueueWaitTime { get; }
         AttributeDefinition<string, string> RequestReferrer { get; }
+        AttributeDefinition<string, string> RequestMethod { get; }
         AttributeDefinition<string, string> RequestUri { get; }
         AttributeDefinition<int?, string> ResponseStatus { get; }
         AttributeDefinition<bool, bool> Sampled { get; }
@@ -308,6 +309,16 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.TransactionTrace)
                 .AppliesTo(AttributeDestinations.ErrorEvent)
                 .AppliesTo(AttributeDestinations.JavaScriptAgent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<string, string> _requestMethod;
+        public AttributeDefinition<string, string> RequestMethod => _requestMethod ?? (_requestMethod =
+            AttributeDefinitionBuilder.CreateString("request.method", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.TransactionEvent)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .AppliesTo(AttributeDestinations.ErrorEvent)
+                .AppliesTo(AttributeDestinations.ErrorTrace)
+                .AppliesTo(AttributeDestinations.TransactionTrace)
                 .Build(_attribFilter));
 
         private AttributeDefinition<string, string> _requestUri;

--- a/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
@@ -19,6 +19,8 @@ namespace NewRelic.Agent.Core.Transactions
 
         IReadOnlyTransactionErrorState ReadOnlyTransactionErrorState { get; }
 
+        string RequestMethod { get; }
+
         string Uri { get; }
         string OriginalUri { get; }
         string ReferrerUri { get; }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -36,7 +36,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartCustomSegment(MethodCall methodCall, string segmentName)
         {
 #if DEBUG
-			Log.Finest("Skipping StartCustomSegment outside of a transaction");
+            Log.Finest("Skipping StartCustomSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartDatastoreSegment(MethodCall methodCall, ParsedSqlStatement parsedSqlStatement, ConnectionInfo connectionInfo, string commandText, IDictionary<string, IConvertible> queryParameters = null, bool isLeaf = false)
         {
 #if DEBUG
-			Log.Finest("Skipping StartDatastoreSegment outside of a transaction");
+            Log.Finest("Skipping StartDatastoreSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -52,7 +52,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartExternalRequestSegment(MethodCall methodCall, Uri destinationUri, string method, bool isLeaf = false)
         {
 #if DEBUG
-			Log.Finest("Skipping StartExternalRequestSegment outside of a transaction");
+            Log.Finest("Skipping StartExternalRequestSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartExternalRequestSegment(MethodCall methodCall, Uri destinationUri, string method, Action<IExternalSegmentData> segmentDataDelegate)
         {
 #if DEBUG
-			Log.Finest("Skipping StartExternalRequestSegment outside of a transaction");
+            Log.Finest("Skipping StartExternalRequestSegment outside of a transaction");
 #endif
             segmentDataDelegate?.Invoke(_noOpExternalSegmentData);
 
@@ -70,7 +70,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartMessageBrokerSegment(MethodCall methodCall, MessageBrokerDestinationType destinationType, MessageBrokerAction operation, string brokerVendorName, string destinationName)
         {
 #if DEBUG
-			Log.Finest("Skipping StartMessageBrokerSegment outside of a transaction");
+            Log.Finest("Skipping StartMessageBrokerSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartMethodSegment(MethodCall methodCall, string typeName, string methodName, bool isLeaf = false)
         {
 #if DEBUG
-			Log.Finest("Skipping StartMethodSegment outside of a transaction");
+            Log.Finest("Skipping StartMethodSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -86,7 +86,7 @@ namespace NewRelic.Agent.Core.Transactions
         public ISegment StartTransactionSegment(MethodCall methodCall, string segmentDisplayName)
         {
 #if DEBUG
-			Log.Finest("Skipping StartTransactionSegment outside of a transaction");
+            Log.Finest("Skipping StartTransactionSegment outside of a transaction");
 #endif
             return Segment.NoOpSegment;
         }
@@ -179,7 +179,10 @@ namespace NewRelic.Agent.Core.Transactions
 
         }
 
-        public void SetRequestMethod(string requestMethod) { }
+        public void SetRequestMethod(string requestMethod)
+        {
+
+        }
 
         public void SetUri(string uri)
         {

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -179,6 +179,8 @@ namespace NewRelic.Agent.Core.Transactions
 
         }
 
+        public void SetRequestMethod(string requestMethod) { }
+
         public void SetUri(string uri)
         {
 

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -778,7 +778,9 @@ namespace NewRelic.Agent.Core.Transactions
         public void SetRequestMethod(string requestMethod)
         {
             if (requestMethod == null)
+            {
                 throw new ArgumentNullException(nameof(requestMethod));
+            }
 
             TransactionMetadata.SetRequestMethod(requestMethod);
         }
@@ -1233,7 +1235,7 @@ namespace NewRelic.Agent.Core.Transactions
 
         private string RemoveQueryParameters(string url)
         {
-            if(string.IsNullOrEmpty(url) || url.Length < 2)
+            if (string.IsNullOrEmpty(url) || url.Length < 2)
             {
                 return url;
             }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -775,6 +775,14 @@ namespace NewRelic.Agent.Core.Transactions
             }
         }
 
+        public void SetRequestMethod(string requestMethod)
+        {
+            if (requestMethod == null)
+                throw new ArgumentNullException(nameof(requestMethod));
+
+            TransactionMetadata.SetRequestMethod(requestMethod);
+        }
+
         public void SetUri(string uri)
         {
             if (uri == null)

--- a/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
@@ -104,9 +104,9 @@ namespace NewRelic.Agent.Core.Transactions
         public bool IsSynthetics => !string.IsNullOrEmpty(_syntheticsResourceId) && !string.IsNullOrEmpty(_syntheticsJobId) &&
                                      !string.IsNullOrEmpty(_syntheticsMonitorId);
 
-        public void SetRequestMethod(string requestMehtod)
+        public void SetRequestMethod(string requestMethod)
         {
-            _requestMethod = requestMehtod;
+            _requestMethod = requestMethod;
         }
 
         public void SetUri(string uri)

--- a/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
@@ -18,6 +18,7 @@ namespace NewRelic.Agent.Core.Transactions
     {
         IImmutableTransactionMetadata ConvertToImmutableMetadata();
         string LatestCrossApplicationPathHash { get; }
+        void SetRequestMethod(string requestMethod);
         void SetUri(string uri);
         void SetOriginalUri(string uri);
         void SetReferrerUri(string uri);
@@ -83,6 +84,8 @@ namespace NewRelic.Agent.Core.Transactions
         private volatile int _httpResponseStatusCode = int.MinValue;
         private volatile int _httpResponseSubStatusCode = int.MinValue;
 
+        private volatile string _requestMethod;
+
         private volatile string _uri;
         private volatile string _originalUri;
         private volatile string _referrerUri;
@@ -100,6 +103,11 @@ namespace NewRelic.Agent.Core.Transactions
 
         public bool IsSynthetics => !string.IsNullOrEmpty(_syntheticsResourceId) && !string.IsNullOrEmpty(_syntheticsJobId) &&
                                      !string.IsNullOrEmpty(_syntheticsMonitorId);
+
+        public void SetRequestMethod(string requestMehtod)
+        {
+            _requestMethod = requestMehtod;
+        }
 
         public void SetUri(string uri)
         {
@@ -213,6 +221,8 @@ namespace NewRelic.Agent.Core.Transactions
         public float CrossApplicationResponseTimeInSeconds => _crossApplicationResponseTimeInSeconds;
 
         public bool HasOutgoingTraceHeaders { get; set; }
+
+        public string RequestMethod => _requestMethod;
 
         public string Uri => _uri;
         public string OriginalUri => _originalUri;

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -184,6 +184,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         public void SetUserAndAgentAttributes(IAttributeValueCollection attribValues, ITransactionAttributeMetadata metadata)
         {
+            _attribDefs.RequestMethod.TrySetValue(attribValues, metadata.RequestMethod);
             _attribDefs.RequestUri.TrySetValue(attribValues, metadata.Uri ?? "/Unknown");
 
             // original_url should only be generated if it is distinct from the current URI

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -217,6 +217,13 @@ namespace NewRelic.Agent.Api
         void SetCustomTransactionName(string name, TransactionNamePriority priority = TransactionNamePriority.Uri);
 
         /// <summary>
+        /// Set the Request Method for the current transaction (if there is one).
+        /// </summary>
+        /// <param name="requestMethod">The Request Method for this transaction. Must not be null.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        void SetRequestMethod(string requestMethod);
+
+        /// <summary>
         /// Set the URI for the current transaction (if there is one).
         /// </summary>
         /// <param name="uri">The URI for this transaction. Must not be null.</param>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Asp35/Shared/HttpContextActions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Asp35/Shared/HttpContextActions.cs
@@ -35,6 +35,7 @@ namespace NewRelic.Providers.Wrapper.Asp35.Shared
         {
             SetFilterHack(httpContext);
             StoreQueueTime(agent, httpContext);
+            StoreRequestMethod(agent, httpContext);
             StoreUrls(agent, httpContext);
             NameTransaction(agent, httpContext);
             ProcessHeaders(agent, httpContext);
@@ -79,6 +80,11 @@ namespace NewRelic.Providers.Wrapper.Asp35.Shared
             var workerRequestStartTime = GetStartTime(workerRequest);
             var inQueueTimeSpan = now - workerRequestStartTime;
             agent.CurrentTransaction.SetQueueTime(inQueueTimeSpan);
+        }
+
+        private static void StoreRequestMethod(IAgent agent, HttpContext httpContext)
+        {
+            agent.CurrentTransaction.SetRequestMethod(httpContext.Request.HttpMethod);
         }
 
         private static void StoreUrls(IAgent agent, HttpContext httpContext)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -165,6 +165,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
                 transactionDisplayName: path,
                 doNotTrackAsUnitOfWork: true);
 
+            transaction.SetRequestMethod(request.Method);
             transaction.SetUri(request.Path);
 
             if (request.QueryString.HasValue)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
@@ -82,6 +82,7 @@ namespace NewRelic.Providers.Wrapper.Owin
                 transactionDisplayName: path,
                 doNotTrackAsUnitOfWork: true);
 
+            transaction.SetRequestMethod(request.Method);
             transaction.SetUri(string.IsNullOrEmpty(request.Path.Value) ? "/Unknown" : request.Path.Value);
 
             if (request.QueryString.HasValue)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
@@ -168,6 +168,10 @@ namespace NewRelic.Providers.Wrapper.Wcf3
                 CaptureHttpRequestHeaders(agent, transaction);
             }
 
+            var requestMethod = System.ServiceModel.Web.WebOperationContext.Current?.IncomingRequest?.Method;
+            if (!string.IsNullOrEmpty(requestMethod))
+                transaction.SetRequestMethod(requestMethod);
+
             var requestPath = uri?.AbsolutePath;
             if (!string.IsNullOrEmpty(requestPath))
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/MethodInvokerWrapper.cs
@@ -334,7 +334,7 @@ namespace NewRelic.Providers.Wrapper.Wcf3
                 {
                     var headersToCapture = agent.Configuration.AllowAllRequestHeaders ? httpRequestMessage.Headers.AllKeys : Agent.Extensions.Providers.Wrapper.Statics.DefaultCaptureHeaders;
 
-                    transaction.SetRequestHeaders(httpRequestMessage.Headers, httpRequestMessage.Headers.AllKeys, GetHeaderValueFromWebHeaderCollection);
+                    transaction.SetRequestHeaders(httpRequestMessage.Headers, headersToCapture, GetHeaderValueFromWebHeaderCollection);
                 }
             }
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
@@ -72,7 +72,6 @@ namespace NewRelic.Agent.IntegrationTests.AspNetCore
 
             Assert.NotNull(transactionSample);
             Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample);
-            Assertions.TransactionTraceHasAttributes(new Dictionary<string, string>{ {"request.method", "GET" } }, TransactionTraceAttributeType.Agent, transactionSample);
 
             var getTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent("WebTransaction/MVC/Home/Index");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreMvcBasicRequestsTests.cs
@@ -72,6 +72,7 @@ namespace NewRelic.Agent.IntegrationTests.AspNetCore
 
             Assert.NotNull(transactionSample);
             Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample);
+            Assertions.TransactionTraceHasAttributes(new Dictionary<string, string>{ {"request.method", "GET" } }, TransactionTraceAttributeType.Agent, transactionSample);
 
             var getTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent("WebTransaction/MVC/Home/Index");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Asp35/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Asp35/AllowAllHeadersDisabledTests.cs
@@ -50,6 +50,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Asp35
             var expectedTransactionName = "WebTransaction/MVC/DefaultController/Index";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.headers.referer", "http://example.com/" },
                 { "request.headers.accept", "text/html" },
                 { "request.headers.content-length", "5" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Asp35/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Asp35/AllowAllHeadersEnabledTests.cs
@@ -56,6 +56,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Asp35
             var expectedTransactionName = "WebTransaction/MVC/DefaultController/Index";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.headers.referer", "http://example.com/" },
                 { "request.headers.accept", "text/html" },
                 { "request.headers.content-length", "5" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
@@ -49,6 +49,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
             var expectedTransactionName = "WebTransaction/MVC/Home/Index";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.headers.referer", "http://example.com" },
                 { "request.headers.accept", "text/html" },
                 { "request.headers.content-length", "5" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
@@ -47,6 +47,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
             var expectedTransactionName = "WebTransaction/MVC/Home/Index";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.headers.referer", "http://example.com" },
                 { "request.headers.accept", "text/html" },
                 { "request.headers.content-length", "5" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersDisabledTests.cs
@@ -51,6 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
             var expectedTransactionName = "WebTransaction/WebAPI/Values/Post";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.uri", "/api/Values/" },
 
                 // Captured headers

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersEnabledTestsBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersEnabledTestsBase.cs
@@ -51,6 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
             var expectedTransactionName = "WebTransaction/WebAPI/Values/Post";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.uri", "/api/Values/" },
 
                 // Captured headers

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersDisabledTests.cs
@@ -51,6 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
             var expectedTransactionName = "WebTransaction/WebAPI/AsyncAwait/SimplePostAsync";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.uri", "/AsyncAwait/SimplePostAsync" },
 
                 // Captured headers

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersEnabledTestsBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersEnabledTestsBase.cs
@@ -51,6 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
             var expectedTransactionName = "WebTransaction/WebAPI/AsyncAwait/SimplePostAsync";
             var expectedAttributes = new Dictionary<string, object>
             {
+                { "request.method", "POST" },
                 { "request.uri", "/AsyncAwait/SimplePostAsync" },
 
                 // Captured headers

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -28,6 +28,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
 
         protected virtual IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
         {
+            { "request.method", "POST" },
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -23,6 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
 
         protected override IDictionary<string, string> ExpectedHeaders => new Dictionary<string, string>
         {
+            { "request.method", "POST" },
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
@@ -16,6 +16,8 @@ namespace NewRelic.Agent.Core.Transactions
 {
     public class TestImmutableTransactionMetadata : IImmutableTransactionMetadata
     {
+        public string RequestMethod { get; }
+
         public string Uri { get; }
         public string OriginalUri { get; }
         public string ReferrerUri { get; }


### PR DESCRIPTION
### Description
  
Resolves #611 by adding a new `request.method` attribute to the Agent, and implementing its capture in the `AspNetCore`, `Asp35`, `Wcf3`, and `Owin` wrappers.

### Testing

Leveraged the new request capturing integration tests, adding a simple method assertion to each.

