### PR TITLE
Prevent inlining in integration test app methods

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/CustomMiddleware.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/CustomMiddleware.cs
@@ -19,6 +19,7 @@ namespace AspNetCoreMvcAsyncApplication
         }
 
         [Trace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task Invoke(HttpContext context)
         {
             await MiddlewareMethodAsync();

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/CustomMiddleware.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/CustomMiddleware.cs
@@ -19,6 +19,7 @@ namespace AspNetCoreMvcFrameworkAsyncApplication
         }
 
         [Trace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public async Task Invoke(HttpContext context)
         {
             await MiddlewareMethodAsync();

--- a/tests/Agent/IntegrationTests/Applications/ConsoleOtherTransactionWrapperApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleOtherTransactionWrapperApplication/Program.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,6 +31,7 @@ namespace ConsoleOtherTransactionWrapperApplication
         /// for recording the response time at its end.
         /// </summary>
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void OuterInstrumentedMethod()
         {
             Thread.Sleep(TimeSpan.FromSeconds(_delaySeconds));
@@ -41,6 +43,7 @@ namespace ConsoleOtherTransactionWrapperApplication
         /// the response time of the transaction because it was not the one that created the transaction.
         /// </summary>
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void InnerInstrumentedMethod()
         {
             Thread.Sleep(TimeSpan.FromSeconds(_delaySeconds));

--- a/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using CommandLine;
 using NewRelic.Api.Agent;
@@ -73,6 +74,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
         }
 
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static IDistributedTracePayload CallCreateDTPayload()
         {
             var currentTransaction = _agent.CurrentTransaction;
@@ -83,6 +85,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
         }
 
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CallAcceptDTPayload(IDistributedTracePayload payload)
         {
             var currentTransaction = _agent.CurrentTransaction;
@@ -93,6 +96,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
         }
 
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CallInsertDTHeaders()
         {
             var currentTransaction = _agent.CurrentTransaction;
@@ -100,6 +104,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
         }
 
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void CallAcceptDTHeaders()
         {
             var currentTransaction = _agent.CurrentTransaction;

--- a/tests/Agent/IntegrationTests/Applications/Owin2WebApi/CustomMiddleware.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin2WebApi/CustomMiddleware.cs
@@ -16,6 +16,7 @@ namespace Owin2WebApi
         }
 
         [Trace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public override async Task Invoke(IOwinContext context)
         {
             await MiddlewareMethodAsync();

--- a/tests/Agent/IntegrationTests/Applications/Owin3WebApi/CustomMiddleware.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin3WebApi/CustomMiddleware.cs
@@ -16,6 +16,7 @@ namespace Owin3WebApi
         }
 
         [Trace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public override async Task Invoke(IOwinContext context)
         {
             await MiddlewareMethodAsync();

--- a/tests/Agent/IntegrationTests/Applications/Owin4WebApi/CustomMiddleware.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin4WebApi/CustomMiddleware.cs
@@ -16,6 +16,7 @@ namespace Owin4WebApi
         }
 
         [Trace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public override async Task Invoke(IOwinContext context)
         {
             await MiddlewareMethodAsync();

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTSupportabilityMetricTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTSupportabilityMetricTests.cs
@@ -53,8 +53,8 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/Ignored/MajorVersion", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/Ignored/Null", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/ParseException", callCount = 1 },
-				// The methods for GenerateAcceptSuccessMetric and GenerateCreateSuccesMetric result in AcceptPayload/Success metrics so we should look for two.
-				new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/Success", callCount = 2 },
+                // The methods for GenerateAcceptSuccessMetric and GenerateCreateSuccessMetric result in AcceptPayload/Success metrics so we should look for two.
+                new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/Success", callCount = 2 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/AcceptPayload/Ignored/UntrustedAccount", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1 },
             };


### PR DESCRIPTION
### Description

This PR improves integration test reliability by adding the `MethodImplOptions.NoInlining` attribute to methods in test applications also decorated with `Transaction` or `Trace` attributes.

At least one integration test, `DistributedTracingApiTests_Legacy`, has been failing when the tests are built and run in `Release` mode (as they are when run in GHA as part of our CI) because some test methods in the underlying test application were being inlined by the compiler.  These methods were decorated with `[Transaction]` and were expected to create transactions in the agent to make the test work.  Preventing these methods from being inlined causes the test to pass reliably when built and run in `Release` mode.

I found other examples of transaction- or trace-decorated methods similarly unprotected from inlining, and added the MethodImpl attribute to those methods as well, just to be safe.

### Testing

The integration test all pass (with the exception of four tests known to have unrelated issues) for me on my system when built and run in release mode.

### Changelog

N/A
