### PR TITLE
Improve integration test reliability

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -53,7 +53,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 // we got the port, so can return (implicitly closes listener using finally block)
                 return true;
             }
-            catch(Exception)
+            catch (Exception)
             {
                 // we were unable to get the port
                 return false;

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -46,19 +46,27 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         //but before the test app uses the assigned port.
         private static bool IsPortAvailable(int potentialPort)
         {
-
-            using (var tcpClient = new TcpClient())
+            var tcpListener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
+            try
+            {
+                tcpListener.Start();
+                // we got the port, so can return (implicitly closes listener using finally block)
+                return true;
+            }
+            catch(Exception)
+            {
+                // we were unable to get the port
+                return false;
+            }
+            finally
             {
                 try
                 {
-                    tcpClient.Connect("localhost", potentialPort);
-                    tcpClient.Close();
-                    return false;
+                    tcpListener.Stop();
                 }
                 catch (Exception)
                 {
-                    //There was nothing to connect to so the port is available.
-                    return true;
+                    // Ignore errors stopping the listener
                 }
             }
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests.cs
@@ -9,6 +9,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -361,7 +362,14 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Service
             var unexpectedMethodNames = new List<string>();
 
             var includeASPPipelineEvents = _hostingModelOption == HostingModel.IIS && _aspCompatibilityOption == ASPCompatibilityMode.Enabled;
-            const int COUNT_ASP_PIPELINE_EVENTS = 10;
+
+            // In debug we consistently get 10 extra ASP pipeline events, in Release we consistently get 9.
+            // We do not see spans for 'PreExecuteRequestHandler' in Release, but we do in Debug.
+            #if DEBUG
+                const int COUNT_ASP_PIPELINE_EVENTS = 10;
+            #else
+                const int COUNT_ASP_PIPELINE_EVENTS = 9;
+            #endif
 
             foreach (var svcTrxName in svcTrxNames)
             {
@@ -418,8 +426,17 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Service
                 }
             }
 
-            NrAssert.Multiple(
+            // Leaving this here commented out to help future code warriors who may want to dump and compare spans between runs
+            //using (var tempFileStream = new FileStream($"C:\\{Guid.NewGuid()}.spandump", FileMode.CreateNew))
+            //using (var sr = new StreamWriter(tempFileStream))
+            //{
+            //    foreach (var spanEvent in LogHelpers.SpanEvents_Service.OrderBy(x => x.IntrinsicAttributes["name"]))
+            //    {
+            //        sr.WriteLine($"Span event name: {spanEvent.IntrinsicAttributes["name"]}");
+            //    }
+            //}
 
+            NrAssert.Multiple(
                 () => Assert.True(countExpectedSpans == LogHelpers.SpanEvents_Service.Length, $"Incorrect Number of Spans, Expected {countExpectedSpans}, Actual {LogHelpers.SpanEvents_Service.Length}"),
                 () => Assert.True(!unexpectedMethodNames.Any(), $"The following methods were not Recognized {string.Join(", ", unexpectedMethodNames.ToArray())}")
             );


### PR DESCRIPTION
### Description

Issues have been identified with differences in ASP pipeline events generated between the release and debug runs of our WCF distributed tracing events. Additionally, issues have been identified where we think a port is available for use because no one is listening, but it is actually prevented from being used by the OS. 

The first issue was resolved by adjusting the static number of expected pipeline events between debug and release builds. I left some commented code in the PR which was useful in comparing the span contents of debug/release runs of the WCF DT tests.

The second issue was resolved by starting a TcpListener instead of using a TcpClient to test if a port is available. The TcpListener will get an error if the port is unavailable.

### Testing

I ran integration tests locally in debug and release and did not see any new failures
