### PR TITLE
Separate MSI/Debian/RPM build artifacts

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -251,431 +251,431 @@ jobs:
           path: ${{ github.workspace }}\src\AwsLambda\AwsLambdaOpenTracer\bin\Release\netstandard2.0-ILRepacked
           if-no-files-found: error
 
-      - name: Unit Tests
-        run: |
-          # Write-Host ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
-          # ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
-          Write-Host "Creating TestResults directory to temporarily get around nunit limitation"
-          mkdir ${{ github.workspace }}\TestResults
+      # - name: Unit Tests
+      #   run: |
+      #     # Write-Host ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+      #     # ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+      #     Write-Host "Creating TestResults directory to temporarily get around nunit limitation"
+      #     mkdir ${{ github.workspace }}\TestResults
 
-          $testDllPatterns = @('*Tests.dll', '*Test.dll', '*Test.Legacy.dll')
+      #     $testDllPatterns = @('*Tests.dll', '*Test.dll', '*Test.Legacy.dll')
 
-          Write-Host "Finding files for Framework NUnit tests"
-          $frameworkTestPaths = @('Tests\Agent\UnitTests', 'Tests\NewRelic.Core.Tests')
-          $frameworkTestFileNames = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
-          $frameworkFiles = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
+      #     Write-Host "Finding files for Framework NUnit tests"
+      #     $frameworkTestPaths = @('Tests\Agent\UnitTests', 'Tests\NewRelic.Core.Tests')
+      #     $frameworkTestFileNames = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
+      #     $frameworkFiles = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
 
-          Write-Host "Building file list for Framework NUnit tests"
-          $frameworkUnitTestPaths = @()
-          for ($i = 0; $i -lt $frameworkTestFileNames.Length; $i++)
-          { $frameworkFiles | ForEach-Object { if ($_.Name -eq $frameworkTestFileNames[$i].Name) { $frameworkUnitTestPaths += $_.FullName; Continue } } }
+      #     Write-Host "Building file list for Framework NUnit tests"
+      #     $frameworkUnitTestPaths = @()
+      #     for ($i = 0; $i -lt $frameworkTestFileNames.Length; $i++)
+      #     { $frameworkFiles | ForEach-Object { if ($_.Name -eq $frameworkTestFileNames[$i].Name) { $frameworkUnitTestPaths += $_.FullName; Continue } } }
 
-          $frameworkUnitTestPaths | ForEach-Object { $_ }
-          Write-Host "Executing: vstest.console.exe " $frameworkUnitTestPaths " --parallel --logger:'html;LogFileName=agent-results.html'"
-          vstest.console.exe $frameworkUnitTestPaths --parallel --logger:"html;LogFileName=agent-results.html"
-          # & '.\Build\Tools\NUnit-Console\nunit3-console.exe ' $frameworkUnitTestPaths '--result=TestResults\NUnit2-results.xml;format=nunit2'
+      #     $frameworkUnitTestPaths | ForEach-Object { $_ }
+      #     Write-Host "Executing: vstest.console.exe " $frameworkUnitTestPaths " --parallel --logger:'html;LogFileName=agent-results.html'"
+      #     vstest.console.exe $frameworkUnitTestPaths --parallel --logger:"html;LogFileName=agent-results.html"
+      #     # & '.\Build\Tools\NUnit-Console\nunit3-console.exe ' $frameworkUnitTestPaths '--result=TestResults\NUnit2-results.xml;format=nunit2'
 
-          if ($LastExitCode -ne 0)
-          { exit $LastExitCode }
+      #     if ($LastExitCode -ne 0)
+      #     { exit $LastExitCode }
 
-          Write-Host "Finding files for .NET Core NUnit tests"
-          $netCoreTestFileNames = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
-          $netCoreFiles = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
+      #     Write-Host "Finding files for .NET Core NUnit tests"
+      #     $netCoreTestFileNames = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
+      #     $netCoreFiles = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
 
-          Write-Host "Building file list for .NET Core NUnit tests"
-          $netCoreUnitTestPaths = @()
+      #     Write-Host "Building file list for .NET Core NUnit tests"
+      #     $netCoreUnitTestPaths = @()
 
-          for ($i = 0; $i -lt $netCoreTestFileNames.Length; $i++)
-          { $netCoreFiles | ForEach-Object { if ($_.Name -eq $netCoreTestFileNames[$i].Name) { $netCoreUnitTestPaths += $_.FullName; Continue } } }
+      #     for ($i = 0; $i -lt $netCoreTestFileNames.Length; $i++)
+      #     { $netCoreFiles | ForEach-Object { if ($_.Name -eq $netCoreTestFileNames[$i].Name) { $netCoreUnitTestPaths += $_.FullName; Continue } } }
 
-          Write-Host "Executing .NET Core NUnit Tests:"
-          $netCoreUnitTestPaths | ForEach-Object { $_ }
+      #     Write-Host "Executing .NET Core NUnit Tests:"
+      #     $netCoreUnitTestPaths | ForEach-Object { $_ }
 
-          Write-Host "Executing: dotnet test " $netCoreUnitTestPaths " --parallel --logger:'html;LogFileName=lambda-results.html'"
-          dotnet test $netCoreUnitTestPaths --parallel --logger:"html;LogFileName=lambda-results.html"
+      #     Write-Host "Executing: dotnet test " $netCoreUnitTestPaths " --parallel --logger:'html;LogFileName=lambda-results.html'"
+      #     dotnet test $netCoreUnitTestPaths --parallel --logger:"html;LogFileName=lambda-results.html"
 
-          if ($LastExitCode -ne 0)
-          { exit $LastExitCode }
-        shell: powershell
+      #     if ($LastExitCode -ne 0)
+      #     { exit $LastExitCode }
+      #   shell: powershell
 
-      - name: Archive Test Results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results
-          path: ${{ github.workspace }}\TestResults
-          if-no-files-found: error
+      # - name: Archive Test Results
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: test-results
+      #     path: ${{ github.workspace }}\TestResults
+      #     if-no-files-found: error
 
-  build-publish-multiverse-testing:
-    needs: cancel-previous-workflow-runs
-    name: Build and Publish Multiverse Testing Suite
-    runs-on: windows-2019
+  # build-publish-multiverse-testing:
+  #   needs: cancel-previous-workflow-runs
+  #   name: Build and Publish Multiverse Testing Suite
+  #   runs-on: windows-2019
 
-    env:
-      multiverse_solution_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\MultiverseTesting.sln
-      multiverse_artifacts_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\ConsoleScanner\bin\Release\netcoreapp3.1
+  #   env:
+  #     multiverse_solution_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\MultiverseTesting.sln
+  #     multiverse_artifacts_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\ConsoleScanner\bin\Release\netcoreapp3.1
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+  #     - name: Add msbuild to PATH
+  #       uses: microsoft/setup-msbuild@v1
 
-      - name: Build MultiverseTesting.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}
-        shell: powershell
+  #     - name: Build MultiverseTesting.sln
+  #       run: |
+  #         Write-Host "List NuGet Sources"
+  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}"
+  #         MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}
+  #       shell: powershell
 
-      - name: Archive the artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: multiverse-testing
-          path: ${{ env.multiverse_artifacts_path }}
-          if-no-files-found: error
+  #     - name: Archive the artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: multiverse-testing
+  #         path: ${{ env.multiverse_artifacts_path }}
+  #         if-no-files-found: error
       
-      - name: Push artifacts to S3
-        run: |
-          $Env:AWS_ACCESS_KEY_ID="${{ secrets.TEAM_AWS_ACCESS_KEY_ID }}"
-          $Env:AWS_SECRET_ACCESS_KEY="${{ secrets.TEAM_AWS_SECRET_ACCESS_KEY }}"
-          $Env:AWS_DEFAULT_REGION="us-west-2"
-          Compress-Archive -Path "${{ env.multiverse_artifacts_path }}" -DestinationPath C:\MultiverseTesting.zip
-          aws s3 cp C:\MultiverseTesting.zip ${{ secrets.MULTIVERSE_BUCKET_NAME }} --acl public-read
-        shell: pwsh
+  #     - name: Push artifacts to S3
+  #       run: |
+  #         $Env:AWS_ACCESS_KEY_ID="${{ secrets.TEAM_AWS_ACCESS_KEY_ID }}"
+  #         $Env:AWS_SECRET_ACCESS_KEY="${{ secrets.TEAM_AWS_SECRET_ACCESS_KEY }}"
+  #         $Env:AWS_DEFAULT_REGION="us-west-2"
+  #         Compress-Archive -Path "${{ env.multiverse_artifacts_path }}" -DestinationPath C:\MultiverseTesting.zip
+  #         aws s3 cp C:\MultiverseTesting.zip ${{ secrets.MULTIVERSE_BUCKET_NAME }} --acl public-read
+  #       shell: pwsh
 
-  build-integration-tests:
-    needs: build-test-fullagent-msi
-    name: Build IntegrationTests
-    runs-on: windows-2019
+  # build-integration-tests:
+  #   needs: build-test-fullagent-msi
+  #   name: Build IntegrationTests
+  #   runs-on: windows-2019
 
-    env:
-      integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
+  #   env:
+  #     integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+  #     - name: Add msbuild to PATH
+  #       uses: microsoft/setup-msbuild@v1
 
-      - name: Build IntegrationTests.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
-        shell: powershell
+  #     - name: Build IntegrationTests.sln
+  #       run: |
+  #         Write-Host "List NuGet Sources"
+  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
+  #         MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
+  #       shell: powershell
 
-      - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: integrationtests
-          path: |
-            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-          if-no-files-found: error
+  #     - name: Archive Artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: integrationtests
+  #         path: |
+  #           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+  #           !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+  #         if-no-files-found: error
 
-  build-unbounded-tests:
-    needs: build-test-fullagent-msi
-    name: Build UnboundedIntegrationTests
-    runs-on: windows-2019
+  # build-unbounded-tests:
+  #   needs: build-test-fullagent-msi
+  #   name: Build UnboundedIntegrationTests
+  #   runs-on: windows-2019
 
-    env:
-      unbounded_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
+  #   env:
+  #     unbounded_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+  #     - name: Add msbuild to PATH
+  #       uses: microsoft/setup-msbuild@v1
 
-      - name: Build UnboundedIntegrationTests.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
-        shell: powershell
+  #     - name: Build UnboundedIntegrationTests.sln
+  #       run: |
+  #         Write-Host "List NuGet Sources"
+  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
+  #         MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
+  #       shell: powershell
 
-      - name: Archive Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: unboundedintegrationtests
-          path: |
-            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-          if-no-files-found: error
+  #     - name: Archive Artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: unboundedintegrationtests
+  #         path: |
+  #           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+  #           !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+  #         if-no-files-found: error
 
-  build-platform-tests: 
-    needs: build-test-fullagent-msi
-    name: Build PlatformTests
-    runs-on: windows-2019
+  # build-platform-tests: 
+  #   needs: build-test-fullagent-msi
+  #   name: Build PlatformTests
+  #   runs-on: windows-2019
 
-    env:
-      platform_solution_path: ${{ github.workspace }}\tests\Agent\PlatformTests\PlatformTests.sln
+  #   env:
+  #     platform_solution_path: ${{ github.workspace }}\tests\Agent\PlatformTests\PlatformTests.sln
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1
+  #     - name: Add msbuild to PATH
+  #       uses: microsoft/setup-msbuild@v1
 
-      - name: Build PlatformTests.sln
-        run: |
-          Write-Host "List NuGet Sources"
-          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
-          MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
-        shell: powershell
+  #     - name: Build PlatformTests.sln
+  #       run: |
+  #         Write-Host "List NuGet Sources"
+  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
+  #         MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
+  #       shell: powershell
 
-  run-integration-tests:
-    needs: [build-integration-tests]
-    name: Run IntegrationTests
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        namespace: [ AgentFeatures, AgentMetrics, Api, AspNetCore, BasicInstrumentation, CatInbound, CatOutbound, 
-          CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, 
-          HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Logging, Owin, ReJit.NetCore, 
-          ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
-          WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, 
-          RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35, RequestHandling]
-      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+  # run-integration-tests:
+  #   needs: [build-integration-tests]
+  #   name: Run IntegrationTests
+  #   runs-on: windows-2019
+  #   strategy:
+  #     matrix:
+  #       namespace: [ AgentFeatures, AgentMetrics, Api, AspNetCore, BasicInstrumentation, CatInbound, CatOutbound, 
+  #         CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, 
+  #         HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Logging, Owin, ReJit.NetCore, 
+  #         ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
+  #         WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, 
+  #         RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35, RequestHandling]
+  #     fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
-    env:
-      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
-      integration_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net461/NewRelic.Agent.IntegrationTests.dll
-      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-      enhanced_logging: false
-      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY : 1
+  #   env:
+  #     integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+  #     xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
+  #     integration_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net461/NewRelic.Agent.IntegrationTests.dll
+  #     # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+  #     enhanced_logging: false
+  #     NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY : 1
       
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Setup .NET Core 2.2.103
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '2.2.103'
+  #     - name: Setup .NET Core 2.2.103
+  #       uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: '2.2.103'
 
-      - name: Setup .NET Core 3.1.100
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.100'
+  #     - name: Setup .NET Core 3.1.100
+  #       uses: actions/setup-dotnet@v1
+  #       with:
+  #         dotnet-version: '3.1.100'
 
-      - name: Setup .NET 5.0
-        uses: actions/setup-dotnet@v1
-        with:
-            dotnet-version: '5.0.100'
+  #     - name: Setup .NET 5.0
+  #       uses: actions/setup-dotnet@v1
+  #       with:
+  #           dotnet-version: '5.0.100'
 
-      - name: Set up secrets
-        env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-        run: |
-          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+  #     - name: Set up secrets
+  #       env:
+  #         INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+  #       run: |
+  #         "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+  #       shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@v2
-        with:
-          name: homefolders
-          path: src/Agent
+  #     - name: Download Agent Home Folders
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: homefolders
+  #         path: src/Agent
 
-      - name: Download Integration Test Artifacts
-        uses: actions/download-artifact/@v2
-        with:
-          name: integrationtests
-          # Should not need a path because the integration test artifacts are archived with the full directory structure
+  #     - name: Download Integration Test Artifacts
+  #       uses: actions/download-artifact/@v2
+  #       with:
+  #         name: integrationtests
+  #         # Should not need a path because the integration test artifacts are archived with the full directory structure
 
-      - name: Install dependencies
-        run: |
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-          pip install aiohttp
-        shell: powershell
+  #     - name: Install dependencies
+  #       run: |
+  #         Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+  #         pip install aiohttp
+  #       shell: powershell
 
-      - name: Run Integration Tests
-        run: |
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "List ports in use"
-            netstat -no  
-          }
+  #     - name: Run Integration Tests
+  #       run: |
+  #         if ($Env:enhanced_logging -eq $True) {
+  #           Write-Host "List ports in use"
+  #           netstat -no  
+  #         }
 
-          Write-Host "Run tests"
-          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+  #         Write-Host "Run tests"
+  #         ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
           
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "Get HostableWebCore errors (if any)"
-            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+  #         if ($Env:enhanced_logging -eq $True) {
+  #           Write-Host "Get HostableWebCore errors (if any)"
+  #           Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
 
-            Write-Host "Get .NET Runtime errors (if any)"
-            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
-          }
-        shell: powershell
+  #           Write-Host "Get .NET Runtime errors (if any)"
+  #           Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+  #         }
+  #       shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: integration-test-artifacts
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
-          if-no-files-found: error
+  #     - name: Archive IntegrationTestWorkingDirectory on Failure
+  #       if: ${{ failure() }}
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: integration-test-artifacts
+  #         path: |
+  #           C:\IntegrationTestWorkingDirectory\**\*.log
+  #           C:\IntegrationTestWorkingDirectory\**\*.config
+  #         if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: integration-test-artifacts
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-          if-no-files-found: error
+  #     - name: Archive Test Artifacts
+  #       if: ${{ always() }}
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: integration-test-artifacts
+  #         path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+  #         if-no-files-found: error
 
-  run-unbounded-tests:
-    needs: [build-unbounded-tests]
-    name: Run Unbounded Tests
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
-      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+  # run-unbounded-tests:
+  #   needs: [build-unbounded-tests]
+  #   name: Run Unbounded Tests
+  #   runs-on: windows-2019
+  #   strategy:
+  #     matrix:
+  #       namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
+  #     fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
-    env:
-      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
-      unbounded_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net461/NewRelic.Agent.UnboundedIntegrationTests.dll
-      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
-      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-      enhanced_logging: false
+  #   env:
+  #     integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+  #     xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
+  #     unbounded_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net461/NewRelic.Agent.UnboundedIntegrationTests.dll
+  #     NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
+  #     # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+  #     enhanced_logging: false
 
-    steps:
-      - name: My IP
-        run: (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
-        shell: powershell
+  #   steps:
+  #     - name: My IP
+  #       run: (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
+  #       shell: powershell
         
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Download Agent Home Folders
-        uses: actions/download-artifact@v2
-        with:
-          name: homefolders
-          path: src/Agent
+  #     - name: Download Agent Home Folders
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: homefolders
+  #         path: src/Agent
 
-      - name: Download Unbounded Integration Test Artifacts
-        uses: actions/download-artifact/@v2
-        with:
-          name: unboundedintegrationtests
-          # Should not need a path because the integration test artifacts are archived with the full directory structure
+  #     - name: Download Unbounded Integration Test Artifacts
+  #       uses: actions/download-artifact/@v2
+  #       with:
+  #         name: unboundedintegrationtests
+  #         # Should not need a path because the integration test artifacts are archived with the full directory structure
       
-      - name: Setup TLS
-        run: |
-          $registryRootPath = "HKCU:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
-          $tls10 = "TLS 1.0"
-          $tls11 = "TLS 1.1"
-          $tls12 = "TLS 1.2"
-          $client = "Client"
-          $server = "Server"
-          $registryPaths = @(
-          "$registryRootPath\$tls10\$client",
-          "$registryRootPath\$tls10\$server",
-          "$registryRootPath\$tls11\$client",
-          "$registryRootPath\$tls11\$server",
-          "$registryRootPath\$tls12\$client",
-          "$registryRootPath\$tls12\$server"
-          )
-          $name = "Enabled"
-          $value = "1"
-          foreach ($registryPath in $registryPaths) {
-            if(!(Test-Path $registryPath)) {
-              New-Item -Path $registryPath -Force | Out-Null
-              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-            }
-            else {
-              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-            }
-          }  
-        shell: powershell
+  #     - name: Setup TLS
+  #       run: |
+  #         $registryRootPath = "HKCU:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
+  #         $tls10 = "TLS 1.0"
+  #         $tls11 = "TLS 1.1"
+  #         $tls12 = "TLS 1.2"
+  #         $client = "Client"
+  #         $server = "Server"
+  #         $registryPaths = @(
+  #         "$registryRootPath\$tls10\$client",
+  #         "$registryRootPath\$tls10\$server",
+  #         "$registryRootPath\$tls11\$client",
+  #         "$registryRootPath\$tls11\$server",
+  #         "$registryRootPath\$tls12\$client",
+  #         "$registryRootPath\$tls12\$server"
+  #         )
+  #         $name = "Enabled"
+  #         $value = "1"
+  #         foreach ($registryPath in $registryPaths) {
+  #           if(!(Test-Path $registryPath)) {
+  #             New-Item -Path $registryPath -Force | Out-Null
+  #             New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+  #           }
+  #           else {
+  #             New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+  #           }
+  #         }  
+  #       shell: powershell
 
-      - name: Install dependencies
-        run: |
-          Write-Host "Installing HostableWebCore Feature"
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-          Write-Host "Installing Msmq Features"
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
-          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
+  #     - name: Install dependencies
+  #       run: |
+  #         Write-Host "Installing HostableWebCore Feature"
+  #         Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+  #         Write-Host "Installing Msmq Features"
+  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
 
-          if ("${{ matrix.namespace }}" -eq "MsSql") {
-            Write-Host "Installing MSSQL CLI"
-            msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
-            Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
-          }
-        shell: powershell
+  #         if ("${{ matrix.namespace }}" -eq "MsSql") {
+  #           Write-Host "Installing MSSQL CLI"
+  #           msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
+  #           Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
+  #         }
+  #       shell: powershell
 
-      - name: Set up secrets
-        env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
-        run: |
-          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+  #     - name: Set up secrets
+  #       env:
+  #         INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
+  #       run: |
+  #         "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+  #       shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
-      - name: Run Unbounded Integration Tests
-        run: |
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "List ports in use"
-            netstat -no  
-          }
+  #     - name: Run Unbounded Integration Tests
+  #       run: |
+  #         if ($Env:enhanced_logging -eq $True) {
+  #           Write-Host "List ports in use"
+  #           netstat -no  
+  #         }
 
-          ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+  #         ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
 
-          if ($Env:enhanced_logging -eq $True) {
-            Write-Host "Get HostableWebCore errors (if any)"
-            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+  #         if ($Env:enhanced_logging -eq $True) {
+  #           Write-Host "Get HostableWebCore errors (if any)"
+  #           Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
 
-            Write-Host "Get .NET Runtime errors (if any)"
-            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
-          }
-        shell: powershell
+  #           Write-Host "Get .NET Runtime errors (if any)"
+  #           Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+  #         }
+  #       shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: integration-test-artifacts
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
-          if-no-files-found: error
+  #     - name: Archive IntegrationTestWorkingDirectory on Failure
+  #       if: ${{ failure() }}
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: integration-test-artifacts
+  #         path: |
+  #           C:\IntegrationTestWorkingDirectory\**\*.log
+  #           C:\IntegrationTestWorkingDirectory\**\*.config
+  #         if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: integration-test-artifacts
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-          if-no-files-found: error
+  #     - name: Archive Test Artifacts
+  #       if: ${{ always() }}
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: integration-test-artifacts
+  #         path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+  #         if-no-files-found: error
 
   create-package-rpm:
     needs: build-test-fullagent-msi

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -732,11 +732,11 @@ jobs:
           docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
         shell: bash
       
-      - name: Archive rpm Package Artifacts
+      - name: Archive RPM Package Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: rpm-build-folder-artifacts
-          path: ${{ github.workspace }}/src/_build
+          name: rpm-build-artifacts
+          path: ${{ github.workspace }}/src/_build/CoreArtifacts
           if-no-files-found: error
 
   create-package-deb:
@@ -769,7 +769,7 @@ jobs:
           name: agent-version
           path: ${{ github.workspace }}
 
-      - name: Build debian package
+      - name: Build Debian Package
         run: |
           sudo apt install dos2unix -y
           dos2unix ${{ github.workspace }}/agent_version.txt
@@ -780,11 +780,11 @@ jobs:
           docker-compose run -e AGENT_VERSION=$agentVersion build_deb
         shell: bash
         
-      - name: Archive deb Package Artifacts
+      - name: Archive Debian Package Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: deb-build-folder-artifacts
-          path: ${{ github.workspace }}/src/_build
+          name: debian-build-artifacts
+          path: ${{ github.workspace }}/src/_build/CoreArtifacts
           if-no-files-found: error
 
   run-artifactbuilder:
@@ -811,17 +811,17 @@ jobs:
           name: msi-build-folder-artifacts
           path: src/_build
 
-      - name: Download deb _build Artifacts
+      - name: Download Debian _build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: deb-build-folder-artifacts
-          path: src/_build
+          name: debian-build-artifacts
+          path: src/_build/CoreArtifacts
 
-      - name: Download rpm _build Artifacts
+      - name: Download RPM _build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: rpm-build-folder-artifacts
-          path: src/_build
+          name: rpm-build-artifacts
+          path: src/_build/CoreArtifacts
 
       - name: Download NewRelic.NuGetHelper
         uses: actions/download-artifact@v2

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -251,431 +251,431 @@ jobs:
           path: ${{ github.workspace }}\src\AwsLambda\AwsLambdaOpenTracer\bin\Release\netstandard2.0-ILRepacked
           if-no-files-found: error
 
-      # - name: Unit Tests
-      #   run: |
-      #     # Write-Host ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
-      #     # ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
-      #     Write-Host "Creating TestResults directory to temporarily get around nunit limitation"
-      #     mkdir ${{ github.workspace }}\TestResults
+      - name: Unit Tests
+        run: |
+          # Write-Host ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+          # ${{ env.scripts_path }}\DotNet-Agent-CI-UnitTests.ps1
+          Write-Host "Creating TestResults directory to temporarily get around nunit limitation"
+          mkdir ${{ github.workspace }}\TestResults
 
-      #     $testDllPatterns = @('*Tests.dll', '*Test.dll', '*Test.Legacy.dll')
+          $testDllPatterns = @('*Tests.dll', '*Test.dll', '*Test.Legacy.dll')
 
-      #     Write-Host "Finding files for Framework NUnit tests"
-      #     $frameworkTestPaths = @('Tests\Agent\UnitTests', 'Tests\NewRelic.Core.Tests')
-      #     $frameworkTestFileNames = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
-      #     $frameworkFiles = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
+          Write-Host "Finding files for Framework NUnit tests"
+          $frameworkTestPaths = @('Tests\Agent\UnitTests', 'Tests\NewRelic.Core.Tests')
+          $frameworkTestFileNames = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
+          $frameworkFiles = (Get-ChildItem -Recurse -Path $frameworkTestPaths -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
 
-      #     Write-Host "Building file list for Framework NUnit tests"
-      #     $frameworkUnitTestPaths = @()
-      #     for ($i = 0; $i -lt $frameworkTestFileNames.Length; $i++)
-      #     { $frameworkFiles | ForEach-Object { if ($_.Name -eq $frameworkTestFileNames[$i].Name) { $frameworkUnitTestPaths += $_.FullName; Continue } } }
+          Write-Host "Building file list for Framework NUnit tests"
+          $frameworkUnitTestPaths = @()
+          for ($i = 0; $i -lt $frameworkTestFileNames.Length; $i++)
+          { $frameworkFiles | ForEach-Object { if ($_.Name -eq $frameworkTestFileNames[$i].Name) { $frameworkUnitTestPaths += $_.FullName; Continue } } }
 
-      #     $frameworkUnitTestPaths | ForEach-Object { $_ }
-      #     Write-Host "Executing: vstest.console.exe " $frameworkUnitTestPaths " --parallel --logger:'html;LogFileName=agent-results.html'"
-      #     vstest.console.exe $frameworkUnitTestPaths --parallel --logger:"html;LogFileName=agent-results.html"
-      #     # & '.\Build\Tools\NUnit-Console\nunit3-console.exe ' $frameworkUnitTestPaths '--result=TestResults\NUnit2-results.xml;format=nunit2'
+          $frameworkUnitTestPaths | ForEach-Object { $_ }
+          Write-Host "Executing: vstest.console.exe " $frameworkUnitTestPaths " --parallel --logger:'html;LogFileName=agent-results.html'"
+          vstest.console.exe $frameworkUnitTestPaths --parallel --logger:"html;LogFileName=agent-results.html"
+          # & '.\Build\Tools\NUnit-Console\nunit3-console.exe ' $frameworkUnitTestPaths '--result=TestResults\NUnit2-results.xml;format=nunit2'
 
-      #     if ($LastExitCode -ne 0)
-      #     { exit $LastExitCode }
+          if ($LastExitCode -ne 0)
+          { exit $LastExitCode }
 
-      #     Write-Host "Finding files for .NET Core NUnit tests"
-      #     $netCoreTestFileNames = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
-      #     $netCoreFiles = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
+          Write-Host "Finding files for .NET Core NUnit tests"
+          $netCoreTestFileNames = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release') } | Select Name -Unique)
+          $netCoreFiles = (Get-ChildItem -Recurse -Path 'Tests\AwsLambda\UnitTests' -Include $testDllPatterns | Where-Object { !$_.FullName.Contains('obj\Release')  })
 
-      #     Write-Host "Building file list for .NET Core NUnit tests"
-      #     $netCoreUnitTestPaths = @()
+          Write-Host "Building file list for .NET Core NUnit tests"
+          $netCoreUnitTestPaths = @()
 
-      #     for ($i = 0; $i -lt $netCoreTestFileNames.Length; $i++)
-      #     { $netCoreFiles | ForEach-Object { if ($_.Name -eq $netCoreTestFileNames[$i].Name) { $netCoreUnitTestPaths += $_.FullName; Continue } } }
+          for ($i = 0; $i -lt $netCoreTestFileNames.Length; $i++)
+          { $netCoreFiles | ForEach-Object { if ($_.Name -eq $netCoreTestFileNames[$i].Name) { $netCoreUnitTestPaths += $_.FullName; Continue } } }
 
-      #     Write-Host "Executing .NET Core NUnit Tests:"
-      #     $netCoreUnitTestPaths | ForEach-Object { $_ }
+          Write-Host "Executing .NET Core NUnit Tests:"
+          $netCoreUnitTestPaths | ForEach-Object { $_ }
 
-      #     Write-Host "Executing: dotnet test " $netCoreUnitTestPaths " --parallel --logger:'html;LogFileName=lambda-results.html'"
-      #     dotnet test $netCoreUnitTestPaths --parallel --logger:"html;LogFileName=lambda-results.html"
+          Write-Host "Executing: dotnet test " $netCoreUnitTestPaths " --parallel --logger:'html;LogFileName=lambda-results.html'"
+          dotnet test $netCoreUnitTestPaths --parallel --logger:"html;LogFileName=lambda-results.html"
 
-      #     if ($LastExitCode -ne 0)
-      #     { exit $LastExitCode }
-      #   shell: powershell
+          if ($LastExitCode -ne 0)
+          { exit $LastExitCode }
+        shell: powershell
 
-      # - name: Archive Test Results
-      #   if: ${{ always() }}
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: test-results
-      #     path: ${{ github.workspace }}\TestResults
-      #     if-no-files-found: error
+      - name: Archive Test Results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: ${{ github.workspace }}\TestResults
+          if-no-files-found: error
 
-  # build-publish-multiverse-testing:
-  #   needs: cancel-previous-workflow-runs
-  #   name: Build and Publish Multiverse Testing Suite
-  #   runs-on: windows-2019
+  build-publish-multiverse-testing:
+    needs: cancel-previous-workflow-runs
+    name: Build and Publish Multiverse Testing Suite
+    runs-on: windows-2019
 
-  #   env:
-  #     multiverse_solution_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\MultiverseTesting.sln
-  #     multiverse_artifacts_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\ConsoleScanner\bin\Release\netcoreapp3.1
+    env:
+      multiverse_solution_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\MultiverseTesting.sln
+      multiverse_artifacts_path: ${{ github.workspace }}\tests\Agent\MultiverseTesting\ConsoleScanner\bin\Release\netcoreapp3.1
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Add msbuild to PATH
-  #       uses: microsoft/setup-msbuild@v1
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
 
-  #     - name: Build MultiverseTesting.sln
-  #       run: |
-  #         Write-Host "List NuGet Sources"
-  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}"
-  #         MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}
-  #       shell: powershell
+      - name: Build MultiverseTesting.sln
+        run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true ${{ env.multiverse_solution_path }}
+        shell: powershell
 
-  #     - name: Archive the artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: multiverse-testing
-  #         path: ${{ env.multiverse_artifacts_path }}
-  #         if-no-files-found: error
+      - name: Archive the artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: multiverse-testing
+          path: ${{ env.multiverse_artifacts_path }}
+          if-no-files-found: error
       
-  #     - name: Push artifacts to S3
-  #       run: |
-  #         $Env:AWS_ACCESS_KEY_ID="${{ secrets.TEAM_AWS_ACCESS_KEY_ID }}"
-  #         $Env:AWS_SECRET_ACCESS_KEY="${{ secrets.TEAM_AWS_SECRET_ACCESS_KEY }}"
-  #         $Env:AWS_DEFAULT_REGION="us-west-2"
-  #         Compress-Archive -Path "${{ env.multiverse_artifacts_path }}" -DestinationPath C:\MultiverseTesting.zip
-  #         aws s3 cp C:\MultiverseTesting.zip ${{ secrets.MULTIVERSE_BUCKET_NAME }} --acl public-read
-  #       shell: pwsh
+      - name: Push artifacts to S3
+        run: |
+          $Env:AWS_ACCESS_KEY_ID="${{ secrets.TEAM_AWS_ACCESS_KEY_ID }}"
+          $Env:AWS_SECRET_ACCESS_KEY="${{ secrets.TEAM_AWS_SECRET_ACCESS_KEY }}"
+          $Env:AWS_DEFAULT_REGION="us-west-2"
+          Compress-Archive -Path "${{ env.multiverse_artifacts_path }}" -DestinationPath C:\MultiverseTesting.zip
+          aws s3 cp C:\MultiverseTesting.zip ${{ secrets.MULTIVERSE_BUCKET_NAME }} --acl public-read
+        shell: pwsh
 
-  # build-integration-tests:
-  #   needs: build-test-fullagent-msi
-  #   name: Build IntegrationTests
-  #   runs-on: windows-2019
+  build-integration-tests:
+    needs: build-test-fullagent-msi
+    name: Build IntegrationTests
+    runs-on: windows-2019
 
-  #   env:
-  #     integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
+    env:
+      integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Add msbuild to PATH
-  #       uses: microsoft/setup-msbuild@v1
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
 
-  #     - name: Build IntegrationTests.sln
-  #       run: |
-  #         Write-Host "List NuGet Sources"
-  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
-  #         MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
-  #       shell: powershell
+      - name: Build IntegrationTests.sln
+        run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
+        shell: powershell
 
-  #     - name: Archive Artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: integrationtests
-  #         path: |
-  #           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-  #           !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-  #         if-no-files-found: error
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: integrationtests
+          path: |
+            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+          if-no-files-found: error
 
-  # build-unbounded-tests:
-  #   needs: build-test-fullagent-msi
-  #   name: Build UnboundedIntegrationTests
-  #   runs-on: windows-2019
+  build-unbounded-tests:
+    needs: build-test-fullagent-msi
+    name: Build UnboundedIntegrationTests
+    runs-on: windows-2019
 
-  #   env:
-  #     unbounded_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
+    env:
+      unbounded_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\UnboundedIntegrationTests.sln
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Add msbuild to PATH
-  #       uses: microsoft/setup-msbuild@v1
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
 
-  #     - name: Build UnboundedIntegrationTests.sln
-  #       run: |
-  #         Write-Host "List NuGet Sources"
-  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
-  #         MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
-  #       shell: powershell
+      - name: Build UnboundedIntegrationTests.sln
+        run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.unbounded_solution_path }}
+        shell: powershell
 
-  #     - name: Archive Artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: unboundedintegrationtests
-  #         path: |
-  #           ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
-  #           ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
-  #           !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
-  #         if-no-files-found: error
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: unboundedintegrationtests
+          path: |
+            ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
+            ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
+            !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*
+          if-no-files-found: error
 
-  # build-platform-tests: 
-  #   needs: build-test-fullagent-msi
-  #   name: Build PlatformTests
-  #   runs-on: windows-2019
+  build-platform-tests: 
+    needs: build-test-fullagent-msi
+    name: Build PlatformTests
+    runs-on: windows-2019
 
-  #   env:
-  #     platform_solution_path: ${{ github.workspace }}\tests\Agent\PlatformTests\PlatformTests.sln
+    env:
+      platform_solution_path: ${{ github.workspace }}\tests\Agent\PlatformTests\PlatformTests.sln
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Add msbuild to PATH
-  #       uses: microsoft/setup-msbuild@v1
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
 
-  #     - name: Build PlatformTests.sln
-  #       run: |
-  #         Write-Host "List NuGet Sources"
-  #         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-  #         Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
-  #         MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
-  #       shell: powershell
+      - name: Build PlatformTests.sln
+        run: |
+          Write-Host "List NuGet Sources"
+          dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+          Write-Host "MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}"
+          MSBuild.exe -restore -m -p:Configuration=Release ${{ env.platform_solution_path }}
+        shell: powershell
 
-  # run-integration-tests:
-  #   needs: [build-integration-tests]
-  #   name: Run IntegrationTests
-  #   runs-on: windows-2019
-  #   strategy:
-  #     matrix:
-  #       namespace: [ AgentFeatures, AgentMetrics, Api, AspNetCore, BasicInstrumentation, CatInbound, CatOutbound, 
-  #         CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, 
-  #         HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Logging, Owin, ReJit.NetCore, 
-  #         ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
-  #         WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, 
-  #         RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35, RequestHandling]
-  #     fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+  run-integration-tests:
+    needs: [build-integration-tests]
+    name: Run IntegrationTests
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        namespace: [ AgentFeatures, AgentMetrics, Api, AspNetCore, BasicInstrumentation, CatInbound, CatOutbound, 
+          CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, 
+          HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Logging, Owin, ReJit.NetCore, 
+          ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
+          WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, 
+          RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35, RequestHandling]
+      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
-  #   env:
-  #     integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-  #     xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
-  #     integration_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net461/NewRelic.Agent.IntegrationTests.dll
-  #     # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-  #     enhanced_logging: false
-  #     NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY : 1
+    env:
+      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
+      integration_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/bin/Release/net461/NewRelic.Agent.IntegrationTests.dll
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: false
+      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY : 1
       
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Setup .NET Core 2.2.103
-  #       uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: '2.2.103'
+      - name: Setup .NET Core 2.2.103
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '2.2.103'
 
-  #     - name: Setup .NET Core 3.1.100
-  #       uses: actions/setup-dotnet@v1
-  #       with:
-  #         dotnet-version: '3.1.100'
+      - name: Setup .NET Core 3.1.100
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.100'
 
-  #     - name: Setup .NET 5.0
-  #       uses: actions/setup-dotnet@v1
-  #       with:
-  #           dotnet-version: '5.0.100'
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '5.0.100'
 
-  #     - name: Set up secrets
-  #       env:
-  #         INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
-  #       run: |
-  #         "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-  #       shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+      - name: Set up secrets
+        env:
+          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+        run: |
+          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
-  #     - name: Download Agent Home Folders
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: homefolders
-  #         path: src/Agent
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@v2
+        with:
+          name: homefolders
+          path: src/Agent
 
-  #     - name: Download Integration Test Artifacts
-  #       uses: actions/download-artifact/@v2
-  #       with:
-  #         name: integrationtests
-  #         # Should not need a path because the integration test artifacts are archived with the full directory structure
+      - name: Download Integration Test Artifacts
+        uses: actions/download-artifact/@v2
+        with:
+          name: integrationtests
+          # Should not need a path because the integration test artifacts are archived with the full directory structure
 
-  #     - name: Install dependencies
-  #       run: |
-  #         Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-  #         pip install aiohttp
-  #       shell: powershell
+      - name: Install dependencies
+        run: |
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+          pip install aiohttp
+        shell: powershell
 
-  #     - name: Run Integration Tests
-  #       run: |
-  #         if ($Env:enhanced_logging -eq $True) {
-  #           Write-Host "List ports in use"
-  #           netstat -no  
-  #         }
+      - name: Run Integration Tests
+        run: |
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "List ports in use"
+            netstat -no  
+          }
 
-  #         Write-Host "Run tests"
-  #         ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+          Write-Host "Run tests"
+          ${{ env.xunit_console }} ${{ env.integration_tests_dll }} -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
           
-  #         if ($Env:enhanced_logging -eq $True) {
-  #           Write-Host "Get HostableWebCore errors (if any)"
-  #           Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "Get HostableWebCore errors (if any)"
+            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
 
-  #           Write-Host "Get .NET Runtime errors (if any)"
-  #           Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
-  #         }
-  #       shell: powershell
+            Write-Host "Get .NET Runtime errors (if any)"
+            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+          }
+        shell: powershell
 
-  #     - name: Archive IntegrationTestWorkingDirectory on Failure
-  #       if: ${{ failure() }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: integration-test-artifacts
-  #         path: |
-  #           C:\IntegrationTestWorkingDirectory\**\*.log
-  #           C:\IntegrationTestWorkingDirectory\**\*.config
-  #         if-no-files-found: error
+      - name: Archive IntegrationTestWorkingDirectory on Failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\**\*.config
+          if-no-files-found: error
 
-  #     - name: Archive Test Artifacts
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: integration-test-artifacts
-  #         path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-  #         if-no-files-found: error
+      - name: Archive Test Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+          if-no-files-found: error
 
-  # run-unbounded-tests:
-  #   needs: [build-unbounded-tests]
-  #   name: Run Unbounded Tests
-  #   runs-on: windows-2019
-  #   strategy:
-  #     matrix:
-  #       namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
-  #     fail-fast: false # we don't want one test failure in one namespace to kill the other runs
+  run-unbounded-tests:
+    needs: [build-unbounded-tests]
+    name: Run Unbounded Tests
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
+      fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
-  #   env:
-  #     integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-  #     xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
-  #     unbounded_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net461/NewRelic.Agent.UnboundedIntegrationTests.dll
-  #     NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
-  #     # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
-  #     enhanced_logging: false
+    env:
+      integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      xunit_console: ${{ github.workspace }}/build/Tools/XUnit-Console/xunit.console.exe
+      unbounded_tests_dll: ${{ github.workspace }}/tests/Agent/IntegrationTests/UnboundedIntegrationTests/bin/Release/net461/NewRelic.Agent.UnboundedIntegrationTests.dll
+      NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
+      # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
+      enhanced_logging: false
 
-  #   steps:
-  #     - name: My IP
-  #       run: (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
-  #       shell: powershell
+    steps:
+      - name: My IP
+        run: (Invoke-WebRequest -uri "http://ifconfig.me/ip").Content
+        shell: powershell
         
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - name: Download Agent Home Folders
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: homefolders
-  #         path: src/Agent
+      - name: Download Agent Home Folders
+        uses: actions/download-artifact@v2
+        with:
+          name: homefolders
+          path: src/Agent
 
-  #     - name: Download Unbounded Integration Test Artifacts
-  #       uses: actions/download-artifact/@v2
-  #       with:
-  #         name: unboundedintegrationtests
-  #         # Should not need a path because the integration test artifacts are archived with the full directory structure
+      - name: Download Unbounded Integration Test Artifacts
+        uses: actions/download-artifact/@v2
+        with:
+          name: unboundedintegrationtests
+          # Should not need a path because the integration test artifacts are archived with the full directory structure
       
-  #     - name: Setup TLS
-  #       run: |
-  #         $registryRootPath = "HKCU:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
-  #         $tls10 = "TLS 1.0"
-  #         $tls11 = "TLS 1.1"
-  #         $tls12 = "TLS 1.2"
-  #         $client = "Client"
-  #         $server = "Server"
-  #         $registryPaths = @(
-  #         "$registryRootPath\$tls10\$client",
-  #         "$registryRootPath\$tls10\$server",
-  #         "$registryRootPath\$tls11\$client",
-  #         "$registryRootPath\$tls11\$server",
-  #         "$registryRootPath\$tls12\$client",
-  #         "$registryRootPath\$tls12\$server"
-  #         )
-  #         $name = "Enabled"
-  #         $value = "1"
-  #         foreach ($registryPath in $registryPaths) {
-  #           if(!(Test-Path $registryPath)) {
-  #             New-Item -Path $registryPath -Force | Out-Null
-  #             New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-  #           }
-  #           else {
-  #             New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
-  #           }
-  #         }  
-  #       shell: powershell
+      - name: Setup TLS
+        run: |
+          $registryRootPath = "HKCU:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols"
+          $tls10 = "TLS 1.0"
+          $tls11 = "TLS 1.1"
+          $tls12 = "TLS 1.2"
+          $client = "Client"
+          $server = "Server"
+          $registryPaths = @(
+          "$registryRootPath\$tls10\$client",
+          "$registryRootPath\$tls10\$server",
+          "$registryRootPath\$tls11\$client",
+          "$registryRootPath\$tls11\$server",
+          "$registryRootPath\$tls12\$client",
+          "$registryRootPath\$tls12\$server"
+          )
+          $name = "Enabled"
+          $value = "1"
+          foreach ($registryPath in $registryPaths) {
+            if(!(Test-Path $registryPath)) {
+              New-Item -Path $registryPath -Force | Out-Null
+              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+            }
+            else {
+              New-ItemProperty -Path $registryPath -Name $name -Value $value -PropertyType DWORD -Force | Out-Null
+            }
+          }  
+        shell: powershell
 
-  #     - name: Install dependencies
-  #       run: |
-  #         Write-Host "Installing HostableWebCore Feature"
-  #         Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-  #         Write-Host "Installing Msmq Features"
-  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
-  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
-  #         Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
+      - name: Install dependencies
+        run: |
+          Write-Host "Installing HostableWebCore Feature"
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+          Write-Host "Installing Msmq Features"
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
 
-  #         if ("${{ matrix.namespace }}" -eq "MsSql") {
-  #           Write-Host "Installing MSSQL CLI"
-  #           msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
-  #           Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
-  #         }
-  #       shell: powershell
+          if ("${{ matrix.namespace }}" -eq "MsSql") {
+            Write-Host "Installing MSSQL CLI"
+            msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
+            Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
+          }
+        shell: powershell
 
-  #     - name: Set up secrets
-  #       env:
-  #         INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
-  #       run: |
-  #         "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
-  #       shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
+      - name: Set up secrets
+        env:
+          INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
+        run: |
+          "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
+        shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
-  #     - name: Run Unbounded Integration Tests
-  #       run: |
-  #         if ($Env:enhanced_logging -eq $True) {
-  #           Write-Host "List ports in use"
-  #           netstat -no  
-  #         }
+      - name: Run Unbounded Integration Tests
+        run: |
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "List ports in use"
+            netstat -no  
+          }
 
-  #         ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
+          ${{ env.xunit_console }} ${{ env.unbounded_tests_dll }} -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -parallel none -xml C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.xml
 
-  #         if ($Env:enhanced_logging -eq $True) {
-  #           Write-Host "Get HostableWebCore errors (if any)"
-  #           Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
+          if ($Env:enhanced_logging -eq $True) {
+            Write-Host "Get HostableWebCore errors (if any)"
+            Get-EventLog -LogName Application -Source HostableWebCore -ErrorAction:Ignore
 
-  #           Write-Host "Get .NET Runtime errors (if any)"
-  #           Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
-  #         }
-  #       shell: powershell
+            Write-Host "Get .NET Runtime errors (if any)"
+            Get-EventLog -LogName Application -Source ".NET Runtime" -EntryType "Error","Warning" -ErrorAction:Ignore  
+          }
+        shell: powershell
 
-  #     - name: Archive IntegrationTestWorkingDirectory on Failure
-  #       if: ${{ failure() }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: integration-test-artifacts
-  #         path: |
-  #           C:\IntegrationTestWorkingDirectory\**\*.log
-  #           C:\IntegrationTestWorkingDirectory\**\*.config
-  #         if-no-files-found: error
+      - name: Archive IntegrationTestWorkingDirectory on Failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\**\*.config
+          if-no-files-found: error
 
-  #     - name: Archive Test Artifacts
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: integration-test-artifacts
-  #         path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
-  #         if-no-files-found: error
+      - name: Archive Test Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.xml
+          if-no-files-found: error
 
   create-package-rpm:
     needs: build-test-fullagent-msi

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -237,10 +237,10 @@ jobs:
           MSBuild.exe -restore -m -p:Configuration=Release -p:AllowUnsafeBlocks=true -p:Platform=x64 ${{ env.msi_solution_path }}
         shell: powershell
 
-      - name: Archive _build Artifacts
+      - name: Archive msi _build Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: msi-build-folder-artifacts
           path: ${{ github.workspace }}\src\_build
           if-no-files-found: error
 
@@ -689,10 +689,10 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Download _build Artifacts
+      - name: Download msi _build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: msi-build-folder-artifacts
           path: src/_build
 
       - name: Download Agent Home Folders
@@ -732,10 +732,10 @@ jobs:
           docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
         shell: bash
       
-      - name: Archive Package Artifacts
+      - name: Archive rpm Package Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: rpm-build-folder-artifacts
           path: ${{ github.workspace }}/src/_build
           if-no-files-found: error
 
@@ -757,10 +757,10 @@ jobs:
           name: homefolders
           path: src/Agent
 
-      - name: Download _build Artifacts
+      - name: Download msi _build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: msi-build-folder-artifacts
           path: src/_build
 
       - name: Download agent_version.txt
@@ -780,10 +780,10 @@ jobs:
           docker-compose run -e AGENT_VERSION=$agentVersion build_deb
         shell: bash
         
-      - name: Archive Package Artifacts
+      - name: Archive deb Package Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: deb-build-folder-artifacts
           path: ${{ github.workspace }}/src/_build
           if-no-files-found: error
 
@@ -805,10 +805,22 @@ jobs:
           name: homefolders
           path: src/Agent 
       
-      - name: Download _build Artifacts
+      - name: Download msi _build Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: build-folder-artifacts
+          name: msi-build-folder-artifacts
+          path: src/_build
+
+      - name: Download deb _build Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: deb-build-folder-artifacts
+          path: src/_build
+
+      - name: Download rpm _build Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: rpm-build-folder-artifacts
           path: src/_build
 
       - name: Download NewRelic.NuGetHelper


### PR DESCRIPTION
### Description

A common failure in our GitHub Actions all solutions build is in the debian/rpm artifact upload steps. It is common to get 500 errors during artifact upload, and then 400 errors causing the deb or rpm artifacts to be missed. I believe this is due to the use/re-use of the 'build-folder-artifact' that is generated in the MSI build step. The deb/rpm builds were both downloading this artifact, adding 1-3 files to it, then simultaneously trying to upload the entire build folder again in to the same artifact name, including the already downloaded files from the MSI build step. This was causing simultaneous uploads of the same artifact name/file, which I believe is why we were encountering intermittent errors. GitHub warns against doing what we were doing here:
https://github.com/actions/upload-artifact#uploading-to-the-same-artifact

I made the debian/rpm builds upload only the new packages they generated as separate artifacts, and re-assembled everything in the ArtifactBuilder step to not require changes to expected paths. I can see a few ways to refactor this, but this should improve the reliability of our builds by avoiding trying to upload the same file(s) from concurrently running build steps.

### Testing

There is no code level change, I extensively tested the changes by manually kicking off the all solutions workflow in GHA.

I was hoping the RPM/Deb build steps would be INSANELY faster because they are only uploading about a 3rd of the data as artifacts, but the impact was pretty minimal.
