### PR TITLE
Update integration tests to use MySql.Data 8.0.25

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/MySqlConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/MySqlConfiguration.cs
@@ -14,7 +14,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         private static string _mySqlPort;
         private static string _mySqlDbName;
 
-        // example: "Network Address=1.2.3.4;Port=4444;Initial Catalog=CatalogName;Persist Security Info=no;User Name=root;Password=password"
+        // example: "Server=1.2.3.4;Port=4444;Initial Catalog=CatalogName;Persist Security Info=no;User Name=root;Password=password"
         public static string MySqlConnectionString
         {
             get
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                     try
                     {
                         var builder = new DbConnectionStringBuilder { ConnectionString = MySqlConnectionString };
-                        _mySqlServer = builder["Network Address"].ToString();
+                        _mySqlServer = builder["Server"].ToString();
                     }
                     catch (Exception ex)
                     {

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BasicMvcApplication</RootNamespace>
     <AssemblyName>BasicMvcApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
@@ -95,7 +95,7 @@
       <Version>1.0.0.0</Version>
     </PackageReference>
     <PackageReference Include="MySql.Data">
-      <Version>6.9.8</Version>
+      <Version>8.0.25</Version>
     </PackageReference>
     <PackageReference Include="MySqlConnector">
       <Version>1.0.1</Version>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Web.config
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Web.config
@@ -66,7 +66,7 @@
 <system.data>
     <DbProviderFactories>
       <remove invariant="MySql.Data.MySqlClient" />
-      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=8.0.25.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
       <remove invariant="Oracle.ManagedDataAccess.Client" />
       <add name="ODP.NET, Managed Driver" invariant="Oracle.ManagedDataAccess.Client" description="Oracle Data Provider for .NET, Managed Driver" type="Oracle.ManagedDataAccess.Client.OracleClientFactory, Oracle.ManagedDataAccess, Version=4.121.2.0, Culture=neutral, PublicKeyToken=89b483f429c47342" />
     </DbProviderFactories>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.3.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.3.1" />
-    <PackageReference Include="MySql.Data" Version="8.0.18" />
+    <PackageReference Include="MySql.Data" Version="8.0.25" />
     <PackageReference Include="MySqlConnector" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="CouchbaseNetClient" Version="2.3.8" />

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
@@ -151,15 +151,15 @@
   #       - { package-name: microsoft.netnetcore.app, versions: [2.1.25, 2.2.8] }
   #   local-assemblies:
 
-  # # TODO: add assembly for Oracle.DataAccess & Oracle.ManagedDataAccess & IBM.Data.DB2
-  # - name: sql
-  #   xml-file: C:\git\newrelic-dotnet-agent\src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\Sql\Instrumentation.xml
-  #   nuget-packages:
-  #       - { package-name: microsoft.netframework.referenceassemblies.net45, versions: [1.0.0] }
-  #       #- { package-name: microsoft.netnetcore.app, versions: [2.1.25, 2.2.8] }
-  #       - { package-name: System.Data.SqlClient, versions: [4.4.0, 4.5.3, 4.6.1, 4.7.0, 4.8.2] }
-  #       #- { package-name: Devart.Data.MySql, versions: [8.9.12, 8.19.1812] }
-  #       - { package-name: MySql.Data, versions: [6.9.12, 8.0.18, 8.0.23] }
-  #       - { package-name: MySqlConnector, versions: [0.69.10, 1.0.1, 1.2.1] }
-  #       - { package-name: Npgsql, versions: [4.0.5, 4.1.8, 5.0.3] }
-  #   local-assemblies:
+   # TODO: add assembly for Oracle.DataAccess & Oracle.ManagedDataAccess & IBM.Data.DB2
+  - name: sql
+    xml-file: ${{ MVS_XML_PATH }}\Sql\Instrumentation.xml
+    nuget-packages:
+        #- { package-name: microsoft.netframework.referenceassemblies.net45, versions: [1.0.0] }
+        #- { package-name: microsoft.netnetcore.app, versions: [2.1.25, 2.2.8] }
+        #- { package-name: System.Data.SqlClient, versions: [4.4.0, 4.5.3, 4.6.1, 4.7.0, 4.8.2] }
+        #- { package-name: Devart.Data.MySql, versions: [8.9.12, 8.19.1812] }
+        - { package-name: MySql.Data, versions: [6.9.12, 8.0.25] }
+        #- { package-name: MySqlConnector, versions: [0.69.10, 1.0.1, 1.2.1] }
+        #- { package-name: Npgsql, versions: [4.0.5, 4.1.8, 5.0.3] }
+    local-assemblies:


### PR DESCRIPTION
### Description

Addresses #545 by updating the unbounded integration tests to use the latest `MySql.Data` version of `8.0.25`, also added `MySql.Data` package to MVS.

Versions after `6.10.9` require .NET Framework 4.5.2 so I also had to bump up one of the projects to use it - this project does host a few things for other tests so we may want to break out the `MySqlController` into its own project, but so far I have not seen any issues with other tests because of this.

### Testing

With this version update `Network Address` is not supported in connection strings, so any existing secrets will need to be updated to use `Server` instead - GH secrets have been updated.
