### PR TITLE
Update DbParameterData for Oracle

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/DbParameterData.cs
+++ b/tests/Agent/IntegrationTests/Shared/DbParameterData.cs
@@ -83,10 +83,11 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         public static DbParameter[] OracleParameters =
         {
             new DbParameter("number", "typeNumber", (byte) 123),
-            new DbParameter("binary_integer", "typeBinaryInteger", new byte[]{ 0, 1 }) { ExpectedValue = new byte[]{ 0, 1 }.ToString() },
+            new DbParameter("binary_integer", "typeBinaryInteger", (decimal) 123.4567),
+            new DbParameter("raw", "typeRaw", new byte[]{ 0, 1 }) { ExpectedValue = new byte[]{ 0, 1 }.ToString() },
             new DbParameter("date", "typeDate", new DateTime(1988, 3, 4)) { ExpectedValue = new DateTime(1988, 3, 4).ToString(CultureInfo.InvariantCulture) },
-            new DbParameter("double", "typeDecimal", (decimal) 123.4567),
-            new DbParameter("double", "typeDouble", (double) 123.4567),
+            new DbParameter("decimal", "typeDecimal", (decimal) 123.4567),
+            new DbParameter("double precision", "typeDouble", (double) 123.4567),
             new DbParameter("number", "typeSmallInt", (short) 123),
             new DbParameter("number", "typeInt", (int) 123),
             new DbParameter("long", "typeLong", (long) 123),


### PR DESCRIPTION
### Description

Fixes #359 by modifying the types of some of the parameters used in the `OracleParameterizedStoredProcedure` test.  The previous parameter types worked at some point in the past (before we open sourced the agent and migrated the CI from private Jenkins to public GHA), but they haven't worked for some time (most likely because the Oracle server version we're testing against changed in the shuffle).

I based the mapping of Oracle type names to .NET data types on this document: https://docs.oracle.com/database/121/ODPNT/featTypes.htm#ODPNT281 Note that the .NET data type for `binary_integer` should be `decimal`, and that the Oracle data type that corresponds to `System.Byte[]` is `raw`.

Changing "double" to "double precision" fixed a compilation error (on the Oracle server side) when creating the stored procedure.

### Testing

Verified that the Oracle tests all pass for me locally against a local Oracle server service running in Docker.  I'll monitor the GHA run for this PR to make sure it passes in the CI as well.

### Changelog

N/A

