### PR TITLE
RabbitMQ: Use generic IDictionary interface when manipulating headers

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 ### Fixes
-* Fixes issue [#639](https://github.com/newrelic/newrelic-dotnet-agent/issues/639): RabbitMQ instrumentation can delete user headers from messages. ([#648](https://github.com/newrelic/newrelic-dotnet-agent/pull/648))
+* Fixes issue [#639](https://github.com/newrelic/newrelic-dotnet-agent/issues/639): RabbitMQ instrumentation can delete user headers from messages. Thank you @witoldsz for finding and reporting this bug. ([#648](https://github.com/newrelic/newrelic-dotnet-agent/pull/648))
 
 ## [8.40.1] - 2021-07-08
 ### Fixes

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 ### Fixes
+* Fixes issue [#639](https://github.com/newrelic/newrelic-dotnet-agent/issues/639): RabbitMQ instrumentation can delete user headers from messages. ([#648](https://github.com/newrelic/newrelic-dotnet-agent/pull/648))
+
+## [8.40.1] - 2021-07-08
+### Fixes
 * Fixes issue [#485](https://github.com/newrelic/newrelic-dotnet-agent/issues/485): `SendDataOnExit` configuration setting will prevent Infinite Traces data sending interuption on application exit. ([#550](https://github.com/newrelic/newrelic-dotnet-agent/pull/609))
 * Fixes issue [#155](https://github.com/newrelic/newrelic-dotnet-agent/issues/155): MVC invalid Action for valid Controller can cause MGI. ([#608](https://github.com/newrelic/newrelic-dotnet-agent/pull/608))
 * Fixes issue [#186](https://github.com/newrelic/newrelic-dotnet-agent/issues/186): Attribute based Routing (ex WebAPI) can cause transaction naming issues. ([#612](https://github.com/newrelic/newrelic-dotnet-agent/pull/612))
@@ -289,7 +293,8 @@ Fixes issue where updating custom instrumentation while application is running c
 ### Fixes
 * New Relic distributed tracing relies on propagating trace and span identifiers in the headers of external calls (e.g., an HTTP call). These identifiers now only contain lowercase alphanumeric characters. Previous versions of the .NET agent used uppercase alphanumeric characters. The usage of uppercase alphanumeric characters can break traces when calling downstream services also monitored by a New Relic agent that supports W3C trace context (New Relic's .NET agent does not currently support W3C trace context. Support for W3C trace context for .NET will be in an upcoming release). This is only a problem if a .NET application is the originator of the trace.
 
-[Unreleased]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.40.0...HEAD
+[Unreleased]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.40.1...HEAD
+[8.40.1]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.40.0...v8.40.1
 [8.40.0]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.39.2...v8.40.0
 [8.39.2]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.39.1...v8.39.2
 [8.39.1]: https://github.com/newrelic/newrelic-dotnet-agent/compare/v8.39.0...v8.39.1

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/HandleBasicDeliverWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/HandleBasicDeliverWrapper.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
                     transaction.End();
                 });
 
-            IEnumerable<string> GetHeaderValue(Dictionary<string, object> carrier, string key)
+            IEnumerable<string> GetHeaderValue(IDictionary<string, object> carrier, string key)
             {
                 if (headers != null)
                 {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -20,16 +20,16 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
         public const string TypeName = "RabbitMQ.Client.Framing.Impl.Model";
 
         private static Func<object, object> _getHeadersFunc;
-        public static IDictionary<string, object> GetHeaders(object Properties)
+        public static IDictionary<string, object> GetHeaders(object properties)
         {
-            var func = _getHeadersFunc ?? (_getHeadersFunc = VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(Properties.GetType(), "Headers"));
-            return func(Properties) as IDictionary<string, object>;
+            var func = _getHeadersFunc ?? (_getHeadersFunc = VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(properties.GetType(), "Headers"));
+            return func(properties) as IDictionary<string, object>;
         }
 
-        public static void SetHeaders(object Properties, IDictionary<string, object> headers)
+        public static void SetHeaders(object properties, IDictionary<string, object> headers)
         {
             // Unlike the GetHeaders function, we can't cache this action.  It is only valid for the specific Properties object instance provided.
-            var action = VisibilityBypasser.Instance.GeneratePropertySetter<IDictionary<string, object>>(Properties, "Headers");
+            var action = VisibilityBypasser.Instance.GeneratePropertySetter<IDictionary<string, object>>(properties, "Headers");
 
             action(headers);
         }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -20,16 +20,16 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
         public const string TypeName = "RabbitMQ.Client.Framing.Impl.Model";
 
         private static Func<object, object> _getHeadersFunc;
-        public static Dictionary<string, object> GetHeaders(object Properties)
+        public static IDictionary<string, object> GetHeaders(object Properties)
         {
             var func = _getHeadersFunc ?? (_getHeadersFunc = VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(Properties.GetType(), "Headers"));
-            return func(Properties) as Dictionary<string, object>;
+            return func(Properties) as IDictionary<string, object>;
         }
 
-        public static void SetHeaders(object Properties, Dictionary<string, object> headers)
+        public static void SetHeaders(object Properties, IDictionary<string, object> headers)
         {
             // Unlike the GetHeaders function, we can't cache this action.  It is only valid for the specific Properties object instance provided.
-            var action = VisibilityBypasser.Instance.GeneratePropertySetter<Dictionary<string, object>>(Properties, "Headers");
+            var action = VisibilityBypasser.Instance.GeneratePropertySetter<IDictionary<string, object>>(Properties, "Headers");
 
             action(headers);
         }
@@ -85,7 +85,7 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
 
             var setHeaders = new Action<dynamic, string, string>((carrier, key, value) =>
             {
-                Dictionary<string, object> headers = carrier.Headers as Dictionary<string, object>;
+                var headers = carrier.Headers as IDictionary<string, object>;
                 if (headers == null)
                 {
                     headers = new Dictionary<string, object>();

--- a/src/Agent/NewRelic/Profiler/README.md
+++ b/src/Agent/NewRelic/Profiler/README.md
@@ -120,6 +120,6 @@ The bytecode we inject into CoreCLR applications does not reference `System.Cann
 
 ### Links
 
-* ECMA-335, CIL specification: http://www.ecma-international.org/publications/standards/Ecma-335.htm
+* ECMA-335, CIL specification: https://www.ecma-international.org/publications-and-standards/standards/ecma-335/
 * CIL Instruction List: https://en.wikipedia.org/wiki/List_of_CIL_instructions
 * Broman post on ReJIT.  Note that the approach he suggests for implementing rejitting did not work well for us.  https://blogs.msdn.microsoft.com/davbr/2011/10/12/rejit-a-how-to-guide/

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
@@ -253,7 +253,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
                 }
                 else
                 {
-                    throw new Exception("Did not find expected user header value in recieved message.");
+                    throw new Exception("Did not find expected user header value in received message.");
                 }
             }
         }


### PR DESCRIPTION
### Description

Fixes #639 by modifying the RabbitMQ instrumentation to read and write RabbitMQ message headers via the generic `IDictionary<string,object>` interface rather than casting everything to a concrete Dictionary.  This will prevent the instrumentation from accidentally overwriting existing message headers if they were set using an IDictionary collection other than Dictionary. 

### Testing

Updated the test application used by the RabbitMQ integration tests to set some user headers in a `SortedDictionary` when sending messages and then verify they still exist and are correct when receiving messages.  Verified the tests pass locally.

### Changelog

Changelog updated.
