### PR TITLE
Updated RabbitMq wrapper to work around read-only header dictionaries

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/RabbitMqHelper.cs
@@ -86,9 +86,15 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
             var setHeaders = new Action<dynamic, string, string>((carrier, key, value) =>
             {
                 var headers = carrier.Headers as IDictionary<string, object>;
+
                 if (headers == null)
                 {
                     headers = new Dictionary<string, object>();
+                    carrier.Headers = headers;
+                }
+                else if (headers is IReadOnlyDictionary<string, object>)
+                {
+                    headers = new Dictionary<string, object>(headers);
                     carrier.Headers = headers;
                 }
 
@@ -120,9 +126,15 @@ namespace NewRelic.Providers.Wrapper.RabbitMq
             var setHeaders = new Action<object, string, string>((carrier, key, value) =>
             {
                 var headers = GetHeaders(carrier);
+
                 if (headers == null)
                 {
                     headers = new Dictionary<string, object>();
+                    SetHeaders(carrier, headers);
+                }
+                else if (headers is IReadOnlyDictionary<string, object>)
+                {
+                    headers = new Dictionary<string, object>(headers);
                     SetHeaders(carrier, headers);
                 }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
@@ -14,6 +14,7 @@ using RabbitMQ.Client.Events;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -34,7 +35,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
         // A SortedDictionary is used to verify that the instrumentation interacts with the message
         // headers through the IDictionary interface.
         // See https://github.com/newrelic/newrelic-dotnet-agent/issues/639 for context
-        private static SortedDictionary<string,object> userHeaders = new SortedDictionary<string, object>() { { "aNumber", 123 }, { "aString", "foo" } };
+        private static IDictionary<string,object> userHeaders = new ReadOnlyDictionary<string, object>(new SortedDictionary<string, object>() { { "aNumber", 123 }, { "aString", "foo" } });
 
 
         [LibraryMethod]


### PR DESCRIPTION
### Description

Further resolves #639 by working around `IReadOnlyDictionary` header collections.

### Testing

RabbitMq integration tests were updated to use one, demonstrating that the Agent can successfully handle them.
