### PR TITLE
Add App Name and Source + NR and App configs to Environment

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### New Features
+* Feature [#580](https://github.com/newrelic/newrelic-dotnet-agent/issues/580): Send initial app name and source in environment data. ([#653](https://github.com/newrelic/newrelic-dotnet-agent/pull/653))
 ### Fixes
 * Fixes issue [#639](https://github.com/newrelic/newrelic-dotnet-agent/issues/639): RabbitMQ instrumentation can delete user headers from messages. Thank you @witoldsz for finding and reporting this bug. ([#648](https://github.com/newrelic/newrelic-dotnet-agent/pull/648))
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
+* Feature [#580](https://github.com/newrelic/newrelic-dotnet-agent/issues/580): Send initial app name and source in environment data. ([#653](https://github.com/newrelic/newrelic-dotnet-agent/pull/653))
 * Adds support for capturing stack traces for each instrumented method in a Transaction Trace.
   * This feature is disabled by default.
   * You can enable the capture of stack traces by setting either maxStackTrace to any value greater than 1.  This value will only be used to determine if stack traces are captured or not despite the name.

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### New Features
-* Feature [#580](https://github.com/newrelic/newrelic-dotnet-agent/issues/580): Send initial app name and source in environment data. ([#653](https://github.com/newrelic/newrelic-dotnet-agent/pull/653))
 ### Fixes
 * Fixes issue [#639](https://github.com/newrelic/newrelic-dotnet-agent/issues/639): RabbitMQ instrumentation can delete user headers from messages. Thank you @witoldsz for finding and reporting this bug. ([#648](https://github.com/newrelic/newrelic-dotnet-agent/pull/648))
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -22,6 +22,8 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
+        public static string AppSettingsFilePath => _appSettingsFilePaths;
+
         private static IConfigurationRoot InitializeConfiguration()
         {
             // Get application base directory, where appsettings*.json will be if they exist

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -216,12 +216,17 @@ namespace NewRelic.Agent.Core.Configuration
         private IEnumerable<string> _applicationNames;
         public virtual IEnumerable<string> ApplicationNames { get { return _applicationNames ?? (_applicationNames = GetApplicationNames()); } }
 
+        private string _applicationNamesSource;
+        public virtual string ApplicationNamesSource => _applicationNamesSource;
+
         private IEnumerable<string> GetApplicationNames()
         {
             var runtimeAppNames = _runTimeConfiguration.ApplicationNames.ToList();
             if (runtimeAppNames.Any())
             {
                 Log.Info("Application name from SetApplicationName API.");
+                _applicationNamesSource = "API";
+
                 return runtimeAppNames;
             }
 
@@ -229,6 +234,8 @@ namespace NewRelic.Agent.Core.Configuration
             if (appName != null)
             {
                 Log.Info("Application name from web.config or app.config.");
+                _applicationNamesSource = "Application Config";
+
                 return appName.Split(StringSeparators.Comma);
             }
 
@@ -236,6 +243,8 @@ namespace NewRelic.Agent.Core.Configuration
             if (appName != null)
             {
                 Log.Info("Application name from IISEXPRESS_SITENAME Environment Variable.");
+                _applicationNamesSource = "Environment Variable (IISEXPRESS_SITENAME)";
+
                 return appName.Split(StringSeparators.Comma);
             }
 
@@ -243,6 +252,8 @@ namespace NewRelic.Agent.Core.Configuration
             if (appName != null)
             {
                 Log.Info("Application name from NEW_RELIC_APP_NAME Environment Variable.");
+                _applicationNamesSource = "Environment Variable (NEW_RELIC_APP_NAME)";
+
                 return appName.Split(StringSeparators.Comma);
             }
 
@@ -250,12 +261,16 @@ namespace NewRelic.Agent.Core.Configuration
             if (appName != null)
             {
                 Log.Info("Application name from RoleName Environment Variable.");
+                _applicationNamesSource = "Environment Variable (RoleName)";
+
                 return appName.Split(StringSeparators.Comma);
             }
 
             if (_localConfiguration.application.name.Count > 0)
             {
                 Log.Info("Application name from newrelic.config.");
+                _applicationNamesSource = "NewRelic Config";
+
                 return _localConfiguration.application.name;
             }
 
@@ -263,12 +278,16 @@ namespace NewRelic.Agent.Core.Configuration
             if (!string.IsNullOrWhiteSpace(appName))
             {
                 Log.Info("Application name from Application Pool name.");
+                _applicationNamesSource = "Application Pool";
+
                 return appName.Split(StringSeparators.Comma);
             }
 
             if (_httpRuntimeStatic.AppDomainAppVirtualPath == null)
             {
                 Log.Info("Application name from process name.");
+                _applicationNamesSource = "Process Name";
+
                 return new List<string> { _processStatic.GetCurrentProcess().ProcessName };
             }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1797,7 +1797,8 @@ namespace NewRelic.Agent.Core.Configuration
 
         #endregion Metric naming
 
-        public string NewRelicConfigFilePath { get { return _localConfiguration.ConfigurationFileName; } }
+        public string NewRelicConfigFilePath => _localConfiguration.ConfigurationFileName;
+        public string AppSettingsConfigFilePath => _configurationManagerStatic.AppSettingsFilePath;
 
         #region Utilization
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/IConfigurationManagerStatic.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/IConfigurationManagerStatic.cs
@@ -13,6 +13,7 @@ namespace NewRelic.Agent.Core.Configuration
 {
     public interface IConfigurationManagerStatic
     {
+        string AppSettingsFilePath { get; }
         string GetAppSetting(string key);
     }
 
@@ -26,6 +27,8 @@ namespace NewRelic.Agent.Core.Configuration
             _getAppSetting = getAppSetting ?? (variable => null);
         }
 
+        public string AppSettingsFilePath => throw new NotImplementedException();
+
         public string GetAppSetting(string variable)
         {
             return _getAppSetting(variable);
@@ -37,6 +40,21 @@ namespace NewRelic.Agent.Core.Configuration
 	public class ConfigurationManagerStatic : IConfigurationManagerStatic
 	{
 		private bool localConfigChecksDisabled;
+
+        public string AppSettingsFilePath
+        {
+            get
+            {
+                try
+                {
+                    if (!localConfigChecksDisabled)
+                        return AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+                }
+                catch { }
+
+                return null;
+            }
+        }
 
 		public string GetAppSetting(string key)
 		{
@@ -58,6 +76,8 @@ namespace NewRelic.Agent.Core.Configuration
     public class ConfigurationManagerStatic : IConfigurationManagerStatic
     {
         private bool localConfigChecksDisabled;
+
+        public string AppSettingsFilePath => AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
 
         public string GetAppSetting(string key)
         {

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -61,6 +61,7 @@ namespace NewRelic.Agent.Core
                 AddVariable("GCSettings.IsServerGC", () => System.Runtime.GCSettings.IsServerGC);
                 AddVariable("AppDomain.FriendlyName", () => AppDomain.CurrentDomain.FriendlyName);
 
+                // If we have a name, report its source...
                 if (configurationService?.Configuration?.ApplicationNames?.Any() ?? false)
                     AddVariable("Application Name Source", () => configurationService.Configuration.ApplicationNamesSource);
 

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -16,6 +16,7 @@ using NewRelic.Agent.Core.Utilities;
 using NewRelic.Core.Logging;
 using NewRelic.SystemInterfaces;
 using Newtonsoft.Json;
+using NewRelic.Agent.Configuration;
 
 namespace NewRelic.Agent.Core
 {
@@ -29,7 +30,7 @@ namespace NewRelic.Agent.Core
         public ulong? TotalPhysicalMemory { get; }
         public string AppDomainAppPath { get; }
 
-        public Environment(ISystemInfo systemInfo, IProcessStatic processStatic)
+        public Environment(ISystemInfo systemInfo, IProcessStatic processStatic, IConfigurationService configurationService)
         {
             _processStatic = processStatic;
 
@@ -59,6 +60,9 @@ namespace NewRelic.Agent.Core
 
                 AddVariable("GCSettings.IsServerGC", () => System.Runtime.GCSettings.IsServerGC);
                 AddVariable("AppDomain.FriendlyName", () => AppDomain.CurrentDomain.FriendlyName);
+
+                if (configurationService?.Configuration?.ApplicationNames?.Any() ?? false)
+                    AddVariable("Application Name Source", () => configurationService.Configuration.ApplicationNamesSource);
 
 #if NET45
 				// This stuff is only available to web apps.

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -61,9 +61,12 @@ namespace NewRelic.Agent.Core
                 AddVariable("GCSettings.IsServerGC", () => System.Runtime.GCSettings.IsServerGC);
                 AddVariable("AppDomain.FriendlyName", () => AppDomain.CurrentDomain.FriendlyName);
 
-                // If we have a name, report its source...
+                // If we have a name, report it and its source...
                 if (configurationService?.Configuration?.ApplicationNames?.Any() ?? false)
-                    AddVariable("Application Name Source", () => configurationService.Configuration.ApplicationNamesSource);
+                {
+                    AddVariable("Application Names", () => String.Join(", ", configurationService.Configuration.ApplicationNames));
+                    AddVariable("Application Names Source", () => configurationService.Configuration.ApplicationNamesSource);
+                }
 
 #if NET45
 				// This stuff is only available to web apps.
@@ -82,7 +85,7 @@ namespace NewRelic.Agent.Core
 				}
 #endif
 
-                AddVariable("Plugin List", GetLoadedAssemblyNames);
+                    AddVariable("Plugin List", GetLoadedAssemblyNames);
 
 #if DEBUG
 				AddVariable("Debug Build", () => true.ToString());

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -45,9 +45,9 @@ namespace NewRelic.Agent.Core
 
                 AddVariable("OS", () => System.Environment.OSVersion?.VersionString);
 #if NETSTANDARD2_0
-				// This API is only supported on .net FX 4.7 + so limiting it
-				// to .net core since that is the one affected. 
-				AddVariable(".NET Version", () => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.ToString());
+                // This API is only supported on .net FX 4.7 + so limiting it
+                // to .net core since that is the one affected. 
+                AddVariable(".NET Version", () => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.ToString());
 #else
                 AddVariable(".NET Version", () => System.Environment.Version.ToString());
 #endif
@@ -75,20 +75,20 @@ namespace NewRelic.Agent.Core
                     AddVariable("Application Config", () => configurationService.Configuration.AppSettingsConfigFilePath);
 
 #if NET45
-				// This stuff is only available to web apps.
-				if (TryGetAppDomainAppId() != null)
-				{
-					AddVariable("AppDomainAppPath", () => AppDomainAppPath);
-					AddVariable("AppDomainAppId", () => HttpRuntime.AppDomainAppId);
-					AddVariable("AppDomainAppVirtualPath", () => HttpRuntime.AppDomainAppVirtualPath);
-					AppDomainAppPath = TryGetAppPath(() => HttpRuntime.AppDomainAppPath);
-					AddVariable("UsingIntegratedPipeline", () => HttpRuntime.UsingIntegratedPipeline.ToString());
+                // This stuff is only available to web apps.
+                if (TryGetAppDomainAppId() != null)
+                {
+                    AddVariable("AppDomainAppPath", () => AppDomainAppPath);
+                    AddVariable("AppDomainAppId", () => HttpRuntime.AppDomainAppId);
+                    AddVariable("AppDomainAppVirtualPath", () => HttpRuntime.AppDomainAppVirtualPath);
+                    AppDomainAppPath = TryGetAppPath(() => HttpRuntime.AppDomainAppPath);
+                    AddVariable("UsingIntegratedPipeline", () => HttpRuntime.UsingIntegratedPipeline.ToString());
 
-					var iisVersion = TryGetIisVersion();
-					if(iisVersion != null)
-						AddVariable("IIS Version", () => iisVersion.ToString());
+                    var iisVersion = TryGetIisVersion();
+                    if (iisVersion != null)
+                        AddVariable("IIS Version", () => iisVersion.ToString());
 
-				}
+                }
 #endif
 
                 AddVariable("Plugin List", GetLoadedAssemblyNames);
@@ -99,18 +99,18 @@ namespace NewRelic.Agent.Core
 
 #if NET45
                 var compilationSection = WebConfigurationManager.GetSection("system.web/compilation") as CompilationSection;
-				if (compilationSection?.DefaultLanguage != null)
-					AddVariable("system.web.compilation.defaultLanguage", () => compilationSection.DefaultLanguage);
+                if (compilationSection?.DefaultLanguage != null)
+                    AddVariable("system.web.compilation.defaultLanguage", () => compilationSection.DefaultLanguage);
 
-				var managementObjects = TryGetManagementObjects("Select * from Win32_ComputerSystem");
-				foreach (var managementObject in managementObjects)
-				{
-					if (managementObject == null)
-						continue;
+                var managementObjects = TryGetManagementObjects("Select * from Win32_ComputerSystem");
+                foreach (var managementObject in managementObjects)
+                {
+                    if (managementObject == null)
+                        continue;
 
-					AddVariable("Physical Processors", () => managementObject["NumberOfProcessors"]);
-					AddVariable("Logical Processors", () => managementObject["NumberOfLogicalProcessors"]);
-				}
+                    AddVariable("Physical Processors", () => managementObject["NumberOfProcessors"]);
+                    AddVariable("Logical Processors", () => managementObject["NumberOfLogicalProcessors"]);
+                }
 #endif
             }
             catch (Exception ex)
@@ -162,18 +162,18 @@ namespace NewRelic.Agent.Core
         }
 
 #if NET45
-		private static string TryGetAppDomainAppId()
-		{
-			try
-			{
-				return HttpRuntime.AppDomainAppId;
-			}
-			catch (Exception ex)
-			{
-				Log.Warn(ex);
-				return null;
-			}
-		}
+        private static string TryGetAppDomainAppId()
+        {
+            try
+            {
+                return HttpRuntime.AppDomainAppId;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex);
+                return null;
+            }
+        }
 #endif
 
         public static string TryGetAppPath(Func<string> pathGetter)
@@ -206,35 +206,35 @@ namespace NewRelic.Agent.Core
         }
 
 #if NET45
-		public Version TryGetIisVersion()
-		{
-			try
-			{
-				using (var componentsKey = Registry.LocalMachine?.OpenSubKey(@"Software\Microsoft\InetStp", false))
-				{
-					if (componentsKey == null)
-						return null;
+        public Version TryGetIisVersion()
+        {
+            try
+            {
+                using (var componentsKey = Registry.LocalMachine?.OpenSubKey(@"Software\Microsoft\InetStp", false))
+                {
+                    if (componentsKey == null)
+                        return null;
 
-					var majorVersionObject = componentsKey.GetValue("MajorVersion", -1);
-					var minorVersionObject = componentsKey.GetValue("MinorVersion", -1);
+                    var majorVersionObject = componentsKey.GetValue("MajorVersion", -1);
+                    var minorVersionObject = componentsKey.GetValue("MinorVersion", -1);
 
-					if (majorVersionObject == null || minorVersionObject == null)
-						return null;
+                    if (majorVersionObject == null || minorVersionObject == null)
+                        return null;
 
-					var majorVersion = (int)majorVersionObject;
-					var minorVersion = (int)minorVersionObject;
-					if (majorVersion == -1 || minorVersion == -1)
-						return null;
+                    var majorVersion = (int)majorVersionObject;
+                    var minorVersion = (int)minorVersionObject;
+                    if (majorVersion == -1 || minorVersion == -1)
+                        return null;
 
-					return new Version(majorVersion, minorVersion);
-				}
-			}
-			catch (Exception ex)
-			{
-				Log.Warn(ex);
-				return null;
-			}
-		}
+                    return new Version(majorVersion, minorVersion);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex);
+                return null;
+            }
+        }
 #endif
 
         private static IEnumerable<string> GetLoadedAssemblyNames()
@@ -244,28 +244,28 @@ namespace NewRelic.Agent.Core
                 .Where(assembly => assembly != null)
                 .Where(assembly => assembly.GetName().Version != versionZero)
 #if NET45
-				.Where(assembly => !(assembly is System.Reflection.Emit.AssemblyBuilder))
+                .Where(assembly => !(assembly is System.Reflection.Emit.AssemblyBuilder))
 #endif
                 .Select(assembly => assembly.FullName)
                 .ToList();
         }
 
 #if NET45
-		private static IEnumerable<ManagementBaseObject> TryGetManagementObjects(string query)
-		{
-			try
-			{
-				using (var managementObjectSearcher = new ManagementObjectSearcher(query))
-				{
-					return managementObjectSearcher.Get().Cast<ManagementBaseObject>();
-				}
-			}
-			catch (Exception ex)
-			{
-				Log.Warn($"Could not retrieve processor count information: {ex}");
-				return Enumerable.Empty<ManagementBaseObject>();
-			}
-		}
+        private static IEnumerable<ManagementBaseObject> TryGetManagementObjects(string query)
+        {
+            try
+            {
+                using (var managementObjectSearcher = new ManagementObjectSearcher(query))
+                {
+                    return managementObjectSearcher.Get().Cast<ManagementBaseObject>();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warn($"Could not retrieve processor count information: {ex}");
+                return Enumerable.Empty<ManagementBaseObject>();
+            }
+        }
 #endif
 
         public class EnvironmentConverter : JsonConverter

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -64,11 +64,11 @@ namespace NewRelic.Agent.Core
                 // If we have a name, report it and its source...
                 if (configurationService.Configuration.ApplicationNames.Any())
                 {
-                    AddVariable("Application Names", () => String.Join(", ", configurationService.Configuration.ApplicationNames));
-                    AddVariable("Application Names Source", () => configurationService.Configuration.ApplicationNamesSource);
+                    AddVariable("Initial Application Names", () => String.Join(", ", configurationService.Configuration.ApplicationNames));
+                    AddVariable("Initial Application Names Source", () => configurationService.Configuration.ApplicationNamesSource);
                 }
 
-                AddVariable("NewRelic Config", () => configurationService.Configuration.NewRelicConfigFilePath);
+                AddVariable("Initial NewRelic Config", () => configurationService.Configuration.NewRelicConfigFilePath);
 
                 // If we found an app config, report it...
                 if (!String.IsNullOrEmpty(configurationService.Configuration.AppSettingsConfigFilePath))

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -62,11 +62,17 @@ namespace NewRelic.Agent.Core
                 AddVariable("AppDomain.FriendlyName", () => AppDomain.CurrentDomain.FriendlyName);
 
                 // If we have a name, report it and its source...
-                if (configurationService?.Configuration?.ApplicationNames?.Any() ?? false)
+                if (configurationService.Configuration.ApplicationNames.Any())
                 {
                     AddVariable("Application Names", () => String.Join(", ", configurationService.Configuration.ApplicationNames));
                     AddVariable("Application Names Source", () => configurationService.Configuration.ApplicationNamesSource);
                 }
+
+                AddVariable("NewRelic Config", () => configurationService.Configuration.NewRelicConfigFilePath);
+
+                // If we found an app config, report it...
+                if (!String.IsNullOrEmpty(configurationService.Configuration.AppSettingsConfigFilePath))
+                    AddVariable("Application Config", () => configurationService.Configuration.AppSettingsConfigFilePath);
 
 #if NET45
 				// This stuff is only available to web apps.
@@ -85,14 +91,14 @@ namespace NewRelic.Agent.Core
 				}
 #endif
 
-                    AddVariable("Plugin List", GetLoadedAssemblyNames);
+                AddVariable("Plugin List", GetLoadedAssemblyNames);
 
 #if DEBUG
 				AddVariable("Debug Build", () => true.ToString());
 #endif
 
 #if NET45
-				var compilationSection = WebConfigurationManager.GetSection("system.web/compilation") as CompilationSection;
+                var compilationSection = WebConfigurationManager.GetSection("system.web/compilation") as CompilationSection;
 				if (compilationSection?.DefaultLanguage != null)
 					AddVariable("system.web.compilation.defaultLanguage", () => compilationSection.DefaultLanguage);
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -14,6 +14,7 @@ namespace NewRelic.Agent.Configuration
         bool AgentEnabled { get; }
         string AgentLicenseKey { get; }
         IEnumerable<string> ApplicationNames { get; }
+        string ApplicationNamesSource { get; }
         bool AutoStartAgent { get; }
         string BrowserMonitoringApplicationId { get; }
         bool BrowserMonitoringAutoInstrument { get; }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -113,6 +113,7 @@ namespace NewRelic.Agent.Configuration
         string Labels { get; }
         IEnumerable<RegexRule> MetricNameRegexRules { get; }
         string NewRelicConfigFilePath { get; }
+        string AppSettingsConfigFilePath { get; }
         string ProxyHost { get; }
         string ProxyUriPath { get; }
         int ProxyPort { get; }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/Environment.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/Environment.cs
@@ -11,10 +11,24 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 {
     public class Environment : List<object[]>
     {
+        public object[] GetProperty(string Name)
+        {
+            return this.FirstOrDefault(env => string.Equals(Name, env[0].ToString(), StringComparison.OrdinalIgnoreCase));
+        }
+
+        public string GetPropertyString(string Name)
+        {
+            var property = GetProperty(Name);
+
+            if (property == null || property.Length <= 1)
+                return null;
+
+            return property[1]?.ToString();
+        }
+
         public List<string> GetPluginList()
         {
-            var pluginListStructure = this
-                .FirstOrDefault(env => string.Equals("Plugin List", env[0].ToString(), StringComparison.InvariantCultureIgnoreCase));
+            var pluginListStructure = GetProperty("Plugin List");
 
             if (pluginListStructure == null)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -59,7 +59,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
         {
             _connectData = _connectData ?? _fixture.AgentLog.GetConnectData();
 
-            var nrConfig = _connectData?.Environment?.GetPropertyString("NewRelic Config");
+            var nrConfig = _connectData?.Environment?.GetPropertyString("Initial NewRelic Config");
             var appConfig = _connectData?.Environment?.GetPropertyString("Application Config");
 
             NrAssert.Multiple(

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -1,54 +1,98 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
-    [NetFrameworkTest]
-    public class EnvironmentTests : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public abstract class EnvironmentTests<T> : NewRelicIntegrationTest<T> where T : RemoteApplicationFixture
     {
+        protected readonly T _fixture;
+        protected ConnectData _connectData;
 
-        private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
-
-        public EnvironmentTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public EnvironmentTests(T fixture, ITestOutputHelper output)
             : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
             _fixture.Actions
             (
-                exerciseApplication: () =>
-                {
-                    _fixture.Get();
-                }
+                exerciseApplication: ExerciseApplication
             );
             _fixture.Initialize();
         }
 
-        [Fact]
-        public void Test()
-        {
-            var connectData = _fixture.AgentLog.GetConnectData();
+        protected abstract string ExpectedNrConfig { get; }
+        protected abstract string ExpectedAppConfig { get; }
 
-            var plugins = connectData?.Environment.GetPluginList();
+        protected abstract void ExerciseApplication();
+
+        [Fact]
+        public void TestPlugins()
+        {
+            _connectData = _connectData ?? _fixture.AgentLog.GetConnectData();
+
+            var plugins = _connectData?.Environment?.GetPluginList();
 
             Assert.NotEmpty(plugins);
 
             var hasSystem = plugins.Any(plugin => plugin.Contains("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken="));
+            var hasNetstandard = plugins.Any(plugin => plugin.Contains("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken="));
             var hasCore = plugins.Any(plugin => plugin.Contains("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken="));
             var hasNrAgentCore = plugins.Any(plugin => plugin.Contains("NewRelic.Agent.Core, Version="));
 
             NrAssert.Multiple(
-                () => Assert.True(hasSystem),
+                () => Assert.True(hasSystem || hasNetstandard),
                 () => Assert.True(hasCore),
                 () => Assert.True(hasNrAgentCore)
             );
         }
+
+        [Fact]
+        public void TestConfigPaths()
+        {
+            _connectData = _connectData ?? _fixture.AgentLog.GetConnectData();
+
+            var nrConfig = _connectData?.Environment?.GetPropertyString("NewRelic Config");
+            var appConfig = _connectData?.Environment?.GetPropertyString("Application Config");
+
+            NrAssert.Multiple(
+                () => Assert.NotNull(nrConfig),
+                () => Assert.EndsWith(ExpectedNrConfig, nrConfig),
+
+                () => Assert.NotNull(appConfig),
+                () => Assert.EndsWith(ExpectedAppConfig, appConfig)
+            );
+        }
+    }
+
+    [NetFrameworkTest]
+    public class EnvironmentFrameworkTests : EnvironmentTests<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    {
+        public EnvironmentFrameworkTests(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output) { }
+
+        protected override string ExpectedNrConfig => @"\newrelichome\newrelic.config";
+        protected override string ExpectedAppConfig => @"\BasicMvcApplication\web.config";
+
+        protected override void ExerciseApplication() => _fixture.Get();
+    }
+
+    [NetCoreTest]
+    public class EnvironmentCoreTests : EnvironmentTests<RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture>
+    {
+        public EnvironmentCoreTests(RemoteServiceFixtures.AspNetCoreMvcBasicRequestsFixture fixture, ITestOutputHelper output)
+            : base(fixture, output) { }
+
+        protected override string ExpectedNrConfig => @"\newrelichome\newrelic.config";
+        protected override string ExpectedAppConfig => @"\AspNetCoreMvcBasicRequestsApplication\appsettings.json";
+
+        protected override void ExerciseApplication() => _fixture.Get();
     }
 }

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
@@ -42,7 +42,8 @@ namespace CompositeTests.CrossAgentTests.SecurityPolicies
             _collectorWire = Mock.Create<ICollectorWire>();
             var systemInfo = Mock.Create<ISystemInfo>();
             var processStatic = Mock.Create<IProcessStatic>();
-            var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic);
+            var configurationService = Mock.Create<IConfigurationService>();
+            var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic, configurationService);
             var agentHealthReporter = Mock.Create<IAgentHealthReporter>();
 
             Mock.Arrange(() => collectorWireFactory.GetCollectorWire(null, Arg.IsAny<IAgentHealthReporter>())).IgnoreArguments().Returns(_collectorWire);

--- a/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
+using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.DataTransport;
@@ -31,7 +32,8 @@ namespace CompositeTests
             _collectorWire = Mock.Create<ICollectorWire>();
             var systemInfo = Mock.Create<ISystemInfo>();
             var processStatic = Mock.Create<IProcessStatic>();
-            var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic);
+            var configurationService = Mock.Create<IConfigurationService>();
+            var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic, configurationService);
 
             Mock.Arrange(() => collectorWireFactory.GetCollectorWire(null, Arg.IsAny<IAgentHealthReporter>())).IgnoreArguments().Returns(_collectorWire);
             Mock.Arrange(() => _collectorWire.SendData("preconnect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>()))

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1816,8 +1816,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("API", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1834,8 +1835,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(1, _defaultConfig.ApplicationNames.Count()),
-                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault())
-                );
+                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual("Application Config", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1853,8 +1855,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("Application Config", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1871,8 +1874,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(1, _defaultConfig.ApplicationNames.Count()),
-                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault())
-                );
+                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual("Environment Variable (IISEXPRESS_SITENAME)", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1890,8 +1894,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("Environment Variable (IISEXPRESS_SITENAME)", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1912,8 +1917,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(1, _defaultConfig.ApplicationNames.Count()),
-                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault())
-                );
+                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual("Environment Variable (RoleName)", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1935,8 +1941,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("Environment Variable (RoleName)", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1957,8 +1964,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("NewRelic Config", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -1978,8 +1986,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(1, _defaultConfig.ApplicationNames.Count()),
-                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault())
-                );
+                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual("Application Pool", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
         [Test]
@@ -2000,17 +2009,18 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.AreEqual(2, _defaultConfig.ApplicationNames.Count()),
                 () => Assert.AreEqual("MyAppName1", _defaultConfig.ApplicationNames.FirstOrDefault()),
-                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1))
-                );
+                () => Assert.AreEqual("MyAppName2", _defaultConfig.ApplicationNames.ElementAtOrDefault(1)),
+                () => Assert.AreEqual("Application Pool", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
-        [TestCase("AppPoolId", "w3wp.exe -ap AppPoolId")]
-        [TestCase("AppPoolId", "w3wp.exe -ap \"AppPoolId\"")]
-        [TestCase("W3WP", "w3wp.exe -app \"NotAnAppPool\"")]
-        [TestCase("W3WP", "w3wp.exe -ap")]
-        [TestCase("W3WP", "w3wp.exe -ap ")]
-        [TestCase("AppPoolId", "w3wp.exe -firstArg -ap \"AppPoolId\" -thirdArg")]
-        public void ApplicationNamesPullsSingleNameFromAppPoolIdFromCommandLine(string expected, string commandLine)
+        [TestCase("AppPoolId", "w3wp.exe -ap AppPoolId", "Application Pool")]
+        [TestCase("AppPoolId", "w3wp.exe -ap \"AppPoolId\"", "Application Pool")]
+        [TestCase("W3WP", "w3wp.exe -app \"NotAnAppPool\"", "Process Name")]
+        [TestCase("W3WP", "w3wp.exe -ap", "Process Name")]
+        [TestCase("W3WP", "w3wp.exe -ap ", "Process Name")]
+        [TestCase("AppPoolId", "w3wp.exe -firstArg -ap \"AppPoolId\" -thirdArg", "Application Pool")]
+        public void ApplicationNamesPullsSingleNameFromAppPoolIdFromCommandLine(string expected, string commandLine, string expectedSource)
         {
             _runTimeConfig.ApplicationNames = new List<string>();
 
@@ -2025,7 +2035,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("W3WP");
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(expected, _defaultConfig.ApplicationNames.FirstOrDefault())
+                () => Assert.AreEqual(expected, _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual(expectedSource, _defaultConfig.ApplicationNamesSource)
             );
         }
 
@@ -2046,8 +2057,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(1, _defaultConfig.ApplicationNames.Count()),
-                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault())
-                );
+                () => Assert.AreEqual("MyAppName", _defaultConfig.ApplicationNames.FirstOrDefault()),
+                () => Assert.AreEqual("Process Name", _defaultConfig.ApplicationNamesSource)
+            );
         }
 
 

--- a/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.FromLegacy/EnvironmentTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.FromLegacy/EnvironmentTest.cs
@@ -18,14 +18,14 @@ namespace NewRelic.Agent.Core
         [Test]
         public static void TestTotalMemory()
         {
-            var config = Mock.Create<IConfiguration>();
+            var configurationService = Mock.Create<IConfigurationService>();
             var systemInfo = Mock.Create<ISystemInfo>();
             var processStatic = Mock.Create<IProcessStatic>();
 
             Mock.Arrange(() => systemInfo.GetTotalPhysicalMemoryBytes()).Returns(16000);
-            using (new ConfigurationAutoResponder(config))
+            using (new ConfigurationAutoResponder(configurationService.Configuration))
             {
-                var env = new Environment(systemInfo, processStatic);
+                var env = new Environment(systemInfo, processStatic, configurationService);
                 Assert.Greater(env.TotalPhysicalMemory, 0);
             }
         }


### PR DESCRIPTION
### Description

Resolves #580 by adding `Application Names`, `Application Names Source`, `New Relic Conffig`, and `Application Config` to the `Environment` data sent up in the connect payload.

For .Net Core I leveraged the [existing code](https://github.com/newrelic/newrelic-dotnet-agent/blob/2379aace42dc1ddc7ce6bc6a1cd105b380c4f842/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs#L58..L59) in the Agent to try to grab the application config, however this approach is not ideal as it currently only supports default (`appsettings.json` and `appsettings.{environment}.json`) files. I tried finding a better way to do this, but I believe for a complete solution we would need to be instrumenting the `ConfigurationBuilder` so we can intercept all the files it's utilizing to build the application settings.

### Testing

Included some new unit tests to validate `Application Names Source`, and I broke out the `EnvironmentTests` into framework and core versions to validate the `New Relic Config` and `Application Config` file paths.