### PR TITLE
HttpWebRequest async support

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/GetResponseBeginEndWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/GetResponseBeginEndWrapper.cs
@@ -1,0 +1,78 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Api.Experimental;
+using NewRelic.Agent.Extensions.Providers;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Providers.Storage.CallContext;
+
+namespace NewRelic.Providers.Wrapper.HttpWebRequest
+{
+    public class GetResponseBeginEndWrapper : IWrapper
+    {
+        private const string ContextSegmentKey = "NewRelic.HttpWebRequest.HttpContextSegmentKey";
+        private readonly IContextStorage<ISegment> _contextStorage = new CallContextStorage<ISegment>(ContextSegmentKey);
+
+        public bool IsTransactionRequired => true;
+
+        public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo) => new CanWrapResponse(nameof(GetResponseBeginEndWrapper).Equals(methodInfo.RequestedWrapperName));
+
+        public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            return instrumentedMethodCall.InstrumentedMethodInfo.Method.MethodName == "BeginGetResponse"
+                ? BeforeBeginGetResponse(instrumentedMethodCall, agent, transaction)
+                : BeforeEndGetResponse(instrumentedMethodCall, agent, transaction);
+        }
+
+        private AfterWrappedMethodDelegate BeforeBeginGetResponse(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            transaction.AttachToAsync();
+
+            var httpWebRequest = instrumentedMethodCall.MethodCall.InvocationTarget as System.Net.HttpWebRequest;
+            if (httpWebRequest == null)
+                throw new NullReferenceException(nameof(httpWebRequest));
+
+            var uri = httpWebRequest.RequestUri;
+            if (uri == null)
+                return Delegates.NoOp;
+
+            var method = httpWebRequest.Method ?? "<unknown>";
+            var transactionExperimental = transaction.GetExperimentalApi();
+            var externalSegmentData = transactionExperimental.CreateExternalSegmentData(uri, method);
+            var segment = transactionExperimental.StartSegment(instrumentedMethodCall.MethodCall);
+
+            segment.GetExperimentalApi().SetSegmentData(externalSegmentData);
+            segment.MakeCombinable();
+
+            _contextStorage.SetData(segment);
+
+            return Delegates.NoOp;
+        }
+
+        private AfterWrappedMethodDelegate BeforeEndGetResponse(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            return Delegates.GetDelegateFor<HttpWebResponse>
+            (
+                onSuccess: response =>
+                {
+                    var segment = _contextStorage.GetData();
+                    var externalSegmentData = segment.GetExperimentalApi().SegmentData as IExternalSegmentData;
+
+                    GetResponseWrapper.TryProcessResponse(response, transaction, segment, externalSegmentData);
+                    segment.End();
+                },
+                onFailure: exception =>
+                {
+                    var segment = _contextStorage.GetData();
+                    var externalSegmentData = segment.GetExperimentalApi().SegmentData as IExternalSegmentData;
+
+                    GetResponseWrapper.TryProcessResponse((exception as WebException)?.Response, transaction, segment, externalSegmentData);
+                    segment.End(exception);
+                }
+            );
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/GetResponseWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/GetResponseWrapper.cs
@@ -54,7 +54,7 @@ namespace NewRelic.Providers.Wrapper.HttpWebRequest
             );
         }
 
-        private static void TryProcessResponse(WebResponse response, ITransaction transaction, ISegment segment, IExternalSegmentData externalSegmentData)
+        internal static void TryProcessResponse(WebResponse response, ITransaction transaction, ISegment segment, IExternalSegmentData externalSegmentData)
         {
             if (segment == null)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/HttpWebRequest.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/HttpWebRequest.csproj
@@ -21,5 +21,6 @@
     <ItemGroup>
         <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />
         <ProjectReference Include="..\..\..\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
+        <ProjectReference Include="..\..\Storage\CallContext\CallContext.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/Instrumentation.xml
@@ -4,19 +4,26 @@ Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 <extension xmlns="urn:newrelic-extension">
-	<instrumentation>
-		
-		<tracerFactory>
-			<match assemblyName="System" className="System.Net.HttpWebRequest">
-				<exactMethodMatcher methodName="SerializeHeaders" />
-			</match>
-		</tracerFactory>
+  <instrumentation>
 
-		<tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.Net.HttpWebRequestTracerFactory">
-			<match assemblyName="System" className="System.Net.HttpWebRequest">
-				<exactMethodMatcher methodName="GetResponse" />
-			</match>
-		</tracerFactory>
+    <tracerFactory>
+      <match assemblyName="System" className="System.Net.HttpWebRequest">
+        <exactMethodMatcher methodName="SerializeHeaders" />
+      </match>
+    </tracerFactory>
 
-	</instrumentation>
+    <tracerFactory name="NewRelic.Agent.Core.Tracer.Factories.Net.HttpWebRequestTracerFactory">
+      <match assemblyName="System" className="System.Net.HttpWebRequest">
+        <exactMethodMatcher methodName="GetResponse" />
+      </match>
+    </tracerFactory>
+
+    <tracerFactory name="GetResponseBeginEndWrapper">
+      <match assemblyName="System" className="System.Net.HttpWebRequest">
+        <exactMethodMatcher methodName="BeginGetResponse" />
+        <exactMethodMatcher methodName="EndGetResponse" />
+      </match>
+    </tracerFactory>
+
+  </instrumentation>
 </extension>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/HttpWebRequestTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/HttpWebRequestTests.cs
@@ -1,0 +1,45 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
+{
+    [NetFrameworkTest]
+    public class HttpWebRequestTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        private readonly ConsoleDynamicMethodFixtureFWLatest _fixture;
+
+        public HttpWebRequestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    _fixture.AddCommand("HttpWebRequestLibrary GetAll http://newrelic.com");
+                }
+            );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var errorEvents = _fixture.AgentLog.GetErrorEvents();
+            var errorTraces = _fixture.AgentLog.GetErrorTraces();
+
+            Assert.Empty(errorEvents);
+            Assert.Empty(errorTraces);
+
+            var metric = _fixture.AgentLog.GetMetricByName("External/newrelic.com/Stream/GET");
+
+            Assert.Equal(3u, metric?.Values?.CallCount ?? 0);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/HttpWebRequestLibrary.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/HttpWebRequestLibrary.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries
+{
+    [Library]
+    class HttpWebRequestLibrary
+    {
+        [Transaction]
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void GetAll(string uri)
+        {
+            var tap = DoTAP(uri);
+            var beginEnd = DoBeginEnd(uri);
+
+            DoSync(uri);
+
+            Task.WaitAll(tap, beginEnd);
+        }
+
+        [Transaction]
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void GetSync(string uri)
+        {
+            DoSync(uri);
+        }
+
+        [Transaction]
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void GetAsync_TAP(string uri)
+        {
+            DoTAP(uri).Wait();
+        }
+
+        [Transaction]
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void GetAsync_BeginEnd(string uri)
+        {
+            DoBeginEnd(uri).Wait();
+        }
+
+        [Trace]
+        void DoSync(string uri)
+        {
+            var request = HttpWebRequest.CreateHttp(uri);
+
+            try
+            {
+                using (var response = request.GetResponse() as HttpWebResponse)
+                {
+
+                }
+            }
+            catch (WebException) { }
+        }
+
+        [Trace]
+        async Task DoTAP(string uri)
+        {
+            var request = HttpWebRequest.CreateHttp(uri);
+
+            try
+            {
+                using (var response = await request.GetResponseAsync() as HttpWebResponse)
+                {
+
+                }
+            }
+            catch (WebException) { }
+        }
+
+        [Trace]
+        async Task DoBeginEnd(string uri)
+        {
+            var request = HttpWebRequest.CreateHttp(uri);
+
+            try
+            {
+                using (var response = await Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null) as HttpWebResponse)
+                {
+
+                }
+            }
+            catch (WebException) { }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds async instrumentation support for `HttpWebRequest`, specifically the `BeginGetResponse` and `EndGetResponse` methods (which also covers `GetResponseAsync`).

Apart from the async plumbing the code mirrors the [existing synchronous implementation](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/GetResponseWrapper.cs#L24).

### Testing

Included is a new framework integration test that tests the three `GetResponse` methods and validates that they are all instrumented.

