### PR TITLE
Fix issue with how stack trace depth is managed

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 ### Fixes
 * Fixes issue [#627](https://github.com/newrelic/newrelic-dotnet-agent/issues/627): Grpc channel shutdown can cause `license_key is required` error message. ([#663](https://github.com/newrelic/newrelic-dotnet-agent/pull/663))
+* Fixes issue [#683](https://github.com/newrelic/newrelic-dotnet-agent/issues/683): Requested stack trace depth is not always honored. ([#684](https://github.com/newrelic/newrelic-dotnet-agent/pull/684))
 
 ## [8.41.0] - 2021-07-21
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Utils/StackTraces.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Utils/StackTraces.cs
@@ -110,7 +110,7 @@ namespace NewRelic.Agent.Core.Utils
         {
             var maxFrames = Math.Min(frames.Length, maxDepth);
             var stackFrames = new List<StackFrame>(maxFrames);
-            for (var i = 0; i < maxFrames; i++)
+            for (var i = 0; i < frames.Length && stackFrames.Count < maxDepth; i++)
             {
                 if (frames[i].GetMethod().DeclaringType != null && !frames[i].GetMethod().DeclaringType.FullName.StartsWith("NewRelic"))
                 {

--- a/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.Utils.Fromlegacy/StackTracesTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/NewRelic.Agent.Core.Utils.Fromlegacy/StackTracesTest.cs
@@ -116,7 +116,7 @@ namespace NewRelic.Agent.Core.Utils
         {
             StackFrame[] stackTraces = GetStackTrace().GetFrames();
             ICollection<StackFrame> frames = StackTraces.ScrubAndTruncate(stackTraces, 3);
-            Assert.AreEqual(2, frames.Count);
+            Assert.AreEqual(3, frames.Count);
         }
 
         [Test]
@@ -125,6 +125,16 @@ namespace NewRelic.Agent.Core.Utils
             StackFrame[] stackTraces = GetStackTrace().GetFrames();
             ICollection<StackFrame> frames = StackTraces.ScrubAndTruncate(stackTraces, 0);
             Assert.AreEqual(0, frames.Count);
+        }
+
+        // The purpose of this test is to verify that we do something reasonable and don't throw an exception
+        // if a max depth greater than the available frames is supplied
+        [Test]
+        public static void TestTruncateWithMaxDepthGreaterThanInputList()
+        {
+            StackFrame[] stackTraces = GetStackTrace().GetFrames();
+            ICollection<StackFrame> frames = StackTraces.ScrubAndTruncate(stackTraces, stackTraces.Length + 666);
+            Assert.LessOrEqual(frames.Count, stackTraces.Length);
         }
 
         [Test]


### PR DESCRIPTION
Resolves: https://github.com/newrelic/newrelic-dotnet-agent/issues/683

Basically if any of the stack frames within the requested depth are from NewRelic, then we don't save the requested number of frames.

### Testing

Updated an existing unit test, and added one to capture an edge case where more stack frames are requested than available