### PR TITLE
Update source of MS SQL Server docker image

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/mssql-server-linux:2017-latest
+FROM mcr.microsoft.com/mssql/server:2017-latest
 
 ENV ACCEPT_EULA=Y
 ENV MSSQL_SA_PASSWORD=password0TS


### PR DESCRIPTION
### Description

This fixes a problem which prevented the MS SQL Server service used for the unbounded integration tests from starting in Docker.

### Testing

Verified the SQL Server service would start (when running `docker-compose run --service-ports mssql`) and that the unbounded integration tests (for MS SQL) passed.

### Changelog

N/A
