### PR TITLE
Make maximum Span Events configurable, and use new cycle and maximums sent from server

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
-* Feature [#671](https://github.com/newrelic/newrelic-dotnet-agent/issues/671): The maximum number of samples stored for Span Events can be configured via the `spanEvents.maximumSamplesStored` configuration in the `newrelic.config` or the `NEW_RELIC_SPAN_EVENTS_MAXIMUM_SAMPLES_STORED` Environemnt Variable.
+* Feature [#671](https://github.com/newrelic/newrelic-dotnet-agent/issues/671): The maximum number of samples stored for Span Events can be configured via the `spanEvents.maximumSamplesStored` configuration in the `newrelic.config` or the `NEW_RELIC_SPAN_EVENTS_MAXIMUM_SAMPLES_STORED` Environemnt Variable.([#701](https://github.com/newrelic/newrelic-dotnet-agent/pull/701))
 
 ### Fixes
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
+* Feature [#671](https://github.com/newrelic/newrelic-dotnet-agent/issues/671): The maximum number of samples stored for Span Events can be configured via the `spanEvents.maximumSamplesStored` configuration in the `newrelic.config` or the `NEW_RELIC_SPAN_EVENTS_MAXIMUM_SAMPLES_STORED` Environemnt Variable.
+
 ### Fixes
 
 ## [8.41.1] - 2021-08-25

--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -22,7 +22,7 @@
 		recordSql="obfuscated"
 		explainEnabled="false"
 		explainThreshold="500" />
-  <distributedTracing enabled="true" />
+	<distributedTracing enabled="true" />
 	<errorCollector enabled="true">
 		<ignoreErrors>
 			<exception>System.IO.FileNotFoundException</exception>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -28,6 +28,8 @@ namespace NewRelic.Agent.Core.Configuration
     {
         private const int DefaultSslPort = 443;
         private const int DefaultSqlStatementCacheCapacity = 1000;
+        private const int SPAN_EVENTS_MIN_SAMPLES_STORED = 1000;
+
 
         public static readonly string RawStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.raw);
         public static readonly string ObfuscatedStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.obfuscated);
@@ -882,8 +884,17 @@ namespace NewRelic.Agent.Core.Configuration
 
         public int? SamplingTarget => _serverConfiguration.SamplingTarget;
 
-        public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
-           EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
+        public int SpanEventsMaxSamplesStored
+        {
+            get
+            {
+                var local = EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault();
+
+                local = local > SPAN_EVENTS_MIN_SAMPLES_STORED ? local : SPAN_EVENTS_MIN_SAMPLES_STORED;
+
+                return ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit, local);
+            }
+        }
 
         public int? SamplingTargetPeriodInSeconds => _serverConfiguration.SamplingTargetPeriodInSeconds;
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -28,8 +28,6 @@ namespace NewRelic.Agent.Core.Configuration
     {
         private const int DefaultSslPort = 443;
         private const int DefaultSqlStatementCacheCapacity = 1000;
-        private const int SPAN_EVENTS_MIN_SAMPLES_STORED = 1000;
-
 
         public static readonly string RawStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.raw);
         public static readonly string ObfuscatedStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.obfuscated);
@@ -884,17 +882,8 @@ namespace NewRelic.Agent.Core.Configuration
 
         public int? SamplingTarget => _serverConfiguration.SamplingTarget;
 
-        public int SpanEventsMaxSamplesStored
-        {
-            get
-            {
-                var local = EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault();
-
-                local = local > SPAN_EVENTS_MIN_SAMPLES_STORED ? local : SPAN_EVENTS_MIN_SAMPLES_STORED;
-
-                return ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit, local);
-            }
-        }
+        public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
+           EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
 
         public int? SamplingTargetPeriodInSeconds => _serverConfiguration.SamplingTargetPeriodInSeconds;
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -828,13 +828,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public TimeSpan SpanEventsHarvestCycle
-        {
-            get
-            {
-                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.SpanEventHarvestCycle(), TimeSpan.FromMinutes(1));
-            }
-        }
+        public TimeSpan SpanEventsHarvestCycle => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestCycle, TimeSpan.FromMinutes(1));
 
         public bool SpanEventsAttributesEnabled => CaptureAttributes && _localConfiguration.spanEvents.attributes.enabled;
 
@@ -888,7 +882,10 @@ namespace NewRelic.Agent.Core.Configuration
 
         public int? SamplingTarget => _serverConfiguration.SamplingTarget;
 
-        public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.EventHarvestConfig?.SpanEventHarvestLimit(), EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault()); public int? SamplingTargetPeriodInSeconds => _serverConfiguration.SamplingTargetPeriodInSeconds;
+        public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
+           EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
+
+        public int? SamplingTargetPeriodInSeconds => _serverConfiguration.SamplingTargetPeriodInSeconds;
 
         public bool PayloadSuccessMetricsEnabled => _localConfiguration.distributedTracing.enableSuccessMetrics;
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
@@ -90,6 +90,9 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("event_harvest_config")]
         public EventHarvestConfig EventHarvestConfig { get; set; }
 
+        [JsonProperty("span_event_harvest_config")]
+        public SingleEventHarvestConfig SpanEventHarvestConfig { get; set; }
+
 
         // CAT
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
@@ -1,0 +1,20 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace NewRelic.Agent.Core.Configuration
+{
+    public class SingleEventHarvestConfig
+    {
+        [JsonProperty("report_period_ms")]
+        public int? ReportPeriodMs { get; set; }
+
+        [JsonProperty("harvest_limit")]
+        public int HarvestLimit { get; set; }
+
+        public TimeSpan? HarvestCycle => ReportPeriodMs.HasValue ? TimeSpan.FromMilliseconds(ReportPeriodMs.Value) : (TimeSpan?)null;
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
@@ -10,11 +10,11 @@ namespace NewRelic.Agent.Core.Configuration
     public class SingleEventHarvestConfig
     {
         [JsonProperty("report_period_ms")]
-        public int? ReportPeriodMs { get; set; }
+        public int ReportPeriodMs { get; set; }
 
         [JsonProperty("harvest_limit")]
         public int HarvestLimit { get; set; }
 
-        public TimeSpan? HarvestCycle => ReportPeriodMs.HasValue ? TimeSpan.FromMilliseconds(ReportPeriodMs.Value) : (TimeSpan?)null;
+        public TimeSpan? HarvestCycle => TimeSpan.FromMilliseconds(ReportPeriodMs);
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2054,9 +2054,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [Test]
         public void SpanEventsMaxSamplesStoredOverriddenBySpanEventHarvestConfig()
         {
-            _localConfig.spanEvents.maximumSamplesStored = 100;
+            _localConfig.spanEvents.maximumSamplesStored = 2000;
 
-            Assert.AreEqual(100, _defaultConfig.SpanEventsMaxSamplesStored);
+            Assert.AreEqual(2000, _defaultConfig.SpanEventsMaxSamplesStored);
 
             _serverConfig.SpanEventHarvestConfig = new SingleEventHarvestConfig
             {
@@ -2065,6 +2065,15 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             };
 
             Assert.AreEqual(10, _defaultConfig.SpanEventsMaxSamplesStored);
+        }
+
+        [Test]
+        public void SpanEventsMaxSamplesStoredCannotBeLessThan1000()
+        {
+            var expectedLimit = 1000;
+            _localConfig.spanEvents.maximumSamplesStored = 10;
+
+            Assert.AreEqual(expectedLimit, _defaultConfig.SpanEventsMaxSamplesStored);
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2052,27 +2052,32 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void SpanEventsMaxSamplesStoredOverriddenByEventHarvestConfig()
+        public void SpanEventsMaxSamplesStoredOverriddenBySpanEventHarvestConfig()
         {
-            _serverConfig.EventHarvestConfig = new EventHarvestConfig
+            _localConfig.spanEvents.maximumSamplesStored = 100;
+
+            Assert.AreEqual(100, _defaultConfig.SpanEventsMaxSamplesStored);
+
+            _serverConfig.SpanEventHarvestConfig = new SingleEventHarvestConfig
             {
                 ReportPeriodMs = 5000,
-                HarvestLimits = new Dictionary<string, int> { { EventHarvestConfig.SpanEventHarvestLimitKey, 10 } }
+                HarvestLimit = 10
             };
 
             Assert.AreEqual(10, _defaultConfig.SpanEventsMaxSamplesStored);
         }
 
         [Test]
-        public void SpanEventsHarvestCycleUsesDefaultOrEventHarvestConfig()
+        public void SpanEventsHarvestCycleUsesDefaultOrSpanEventHarvestConfig()
         {
             Assert.AreEqual(TimeSpan.FromMinutes(1), _defaultConfig.SpanEventsHarvestCycle);
 
-            _serverConfig.EventHarvestConfig = new EventHarvestConfig
+            _serverConfig.SpanEventHarvestConfig = new SingleEventHarvestConfig
             {
                 ReportPeriodMs = 5000,
-                HarvestLimits = new Dictionary<string, int> { { EventHarvestConfig.SpanEventHarvestLimitKey, 10 } }
+                HarvestLimit = 10
             };
+
             Assert.AreEqual(TimeSpan.FromSeconds(5), _defaultConfig.SpanEventsHarvestCycle);
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2054,9 +2054,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [Test]
         public void SpanEventsMaxSamplesStoredOverriddenBySpanEventHarvestConfig()
         {
-            _localConfig.spanEvents.maximumSamplesStored = 2000;
+            _localConfig.spanEvents.maximumSamplesStored = 100;
 
-            Assert.AreEqual(2000, _defaultConfig.SpanEventsMaxSamplesStored);
+            Assert.AreEqual(100, _defaultConfig.SpanEventsMaxSamplesStored);
 
             _serverConfig.SpanEventHarvestConfig = new SingleEventHarvestConfig
             {
@@ -2065,15 +2065,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             };
 
             Assert.AreEqual(10, _defaultConfig.SpanEventsMaxSamplesStored);
-        }
-
-        [Test]
-        public void SpanEventsMaxSamplesStoredCannotBeLessThan1000()
-        {
-            var expectedLimit = 1000;
-            _localConfig.spanEvents.maximumSamplesStored = 10;
-
-            Assert.AreEqual(expectedLimit, _defaultConfig.SpanEventsMaxSamplesStored);
         }
 
         [Test]


### PR DESCRIPTION
### Description

Resolves #671 by adding a new `spanEvents.maximumSamplesStored` local setting, and implementing the new `span_event_harvest_config` values sent down by the server.

Note - somehow the new setting already got pulled into this feature branch, so I removed them from this PR to not have any conflicts.

### Testing

Two related unit tests were updated to check these configurations and validate they are being set correctly.

