### PR TITLE
Update maximum Span Event samples to 2000

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -3707,7 +3707,7 @@ namespace NewRelic.Agent.Core.Config
         {
             this.attributesField = new configurationSpanEventsAttributes();
             this.enabledField = true;
-            this.maximumSamplesStoredField = 1000;
+            this.maximumSamplesStoredField = 2000;
         }
         
         public configurationSpanEventsAttributes attributes
@@ -3737,7 +3737,7 @@ namespace NewRelic.Agent.Core.Config
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(1000)]
+        [System.ComponentModel.DefaultValueAttribute(2000)]
         public int maximumSamplesStored
         {
             get

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1187,10 +1187,10 @@
                 </xs:documentation>
               </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="maximumSamplesStored" type="xs:int" default="1000">
+            <xs:attribute name="maximumSamplesStored" type="xs:int" default="2000">
               <xs:annotation>
                 <xs:documentation>
-                  The maximum number of samples to store in memory at a time.	Default is 1000.
+                  The maximum number of samples to store in memory at a time. Default is 2000.
                 </xs:documentation>
               </xs:annotation>
             </xs:attribute>


### PR DESCRIPTION
### Description

Resolves #703 with the `spanEvent.maximumSamplesStored` default updated to 2000.