### PR TITLE
Fix bug when capturing explain plans for paramaterized SQL

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+* Fixes issue [#707](https://github.com/newrelic/newrelic-dotnet-agent/issues/707): In 8.40.1 SQL explain plans not being captured for parameterized SQL statements. ([#708](https://github.com/newrelic/newrelic-dotnet-agent/pull/708))
 
 ## [8.41.1] - 2021-08-25
 ### New Features

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -416,6 +416,7 @@ namespace NewRelic.Parsing
                 sql = Regex.Replace(sql, $@"@\b{paramName}\b", value.ToString());
             }
 
+            command.Parameters.Clear();
             command.CommandText = sql;
             return true;
         }


### PR DESCRIPTION
Resolves #707

Fixes bug was introduced in 8.40.1 that results in SQL explain plans not being captured for parameterized SQL statements.