### PR TITLE
Update `errorCollector.ignoreErrors` to `errorCollector.ignoreClasses`

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
-* Feature [#671](https://github.com/newrelic/newrelic-dotnet-agent/issues/671): The maximum number of samples stored for Span Events can be configured via the `spanEvents.maximumSamplesStored` configuration in the `newrelic.config` or the `NEW_RELIC_SPAN_EVENTS_MAXIMUM_SAMPLES_STORED` Environemnt Variable.([#701](https://github.com/newrelic/newrelic-dotnet-agent/pull/701))
+* Feature [#671](https://github.com/newrelic/newrelic-dotnet-agent/issues/671): The maximum number of samples stored for Span Events can be configured via the `spanEvents.maximumSamplesStored` configuration in the `newrelic.config` or the `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED` Environemnt Variable.([#701](https://github.com/newrelic/newrelic-dotnet-agent/pull/701))
 
 ### Fixes
 

--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -24,10 +24,10 @@
 		explainThreshold="500" />
 	<distributedTracing enabled="true" />
 	<errorCollector enabled="true">
-		<ignoreErrors>
-			<exception>System.IO.FileNotFoundException</exception>
-			<exception>System.Threading.ThreadAbortException</exception>
-		</ignoreErrors>
+		<ignoreClasses>
+			<errorClass>System.IO.FileNotFoundException</errorClass>
+			<errorClass>System.Threading.ThreadAbortException</errorClass>
+		</ignoreClasses>
 		<ignoreStatusCodes>
 			<code>401</code>
 			<code>404</code>

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1281,11 +1281,11 @@
 
             <xs:sequence>
 
-              <xs:element name="ignoreErrors">
+              <xs:element name="ignoreErrors" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                   <xs:annotation>
                     <xs:documentation>
-                      To stop specific exceptions from reporting to New Relic, list them here.
+                      Disabled: To stop specific exceptions from reporting to New Relic, list them here.
                       Use the full name of the exception, such as "System.IO.FileNotFoundException".
                     </xs:documentation>
                   </xs:annotation>
@@ -1294,7 +1294,7 @@
                     <xs:element name="exception" type="xs:string">
                       <xs:annotation>
                         <xs:documentation>
-                          The full name of an exception to ignore, such as "System.IO.FileNotFoundException".
+                          Disabled: The full name of an exception to ignore, such as "System.IO.FileNotFoundException".
                         </xs:documentation>
                       </xs:annotation>
                     </xs:element>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1127,8 +1127,6 @@ namespace NewRelic.Agent.Core.Configuration
 
         public virtual uint ErrorsMaximumPerPeriod { get { return 20; } }
 
-        public virtual IEnumerable<string> IgnoreErrorsForAgentSettings { get; private set; }
-
         public IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration { get; private set; }
         public IEnumerable<string> IgnoreErrorClassesForAgentSettings { get; private set; }
         public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings { get; private set; }
@@ -2089,10 +2087,7 @@ namespace NewRelic.Agent.Core.Configuration
             //the ignoreErrorInfo dictionary gets mixed up between ignore messages and ignore classes configurations.
             var ignoreMessages = new Dictionary<string, IEnumerable<string>>(ignoreErrorInfo);
 
-            var ignoreClassesFromErrorCollectorIgnoreErrorsConfig = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorErrorsToIgnore, _localConfiguration.errorCollector.ignoreErrors.exception);
-
-            var ignoreClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorIgnoreClasses, _localConfiguration.errorCollector.ignoreClasses.errorClass)
-                .Concat(ignoreClassesFromErrorCollectorIgnoreErrorsConfig);
+            var ignoreClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorIgnoreClasses, _localConfiguration.errorCollector.ignoreClasses.errorClass);
 
             var count = ignoreErrorInfo.Count;
 
@@ -2130,7 +2125,6 @@ namespace NewRelic.Agent.Core.Configuration
                 }
             }
 
-            IgnoreErrorsForAgentSettings = ignoreClassesFromErrorCollectorIgnoreErrorsConfig;
             IgnoreErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreErrorInfo);
             IgnoreErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreMessages);
             IgnoreErrorClassesForAgentSettings = ignoreClasses;
@@ -2249,6 +2243,11 @@ namespace NewRelic.Agent.Core.Configuration
                 LogDisabledPropertyUse("browserMonitoring.captureAttributes", "browserMonitoring.attributes.enabled");
             }
 
+            //errorColelctor.ignoreErrors
+            if (_localConfiguration.errorCollector.ignoreErrors?.exception?.Any() ?? false)
+            {
+                LogDisabledPropertyUse("errorCollector.ignoreErrors", "errorCollector.ignoreClasses");
+            }
         }
 
         // This method is now unused as all previously deprecated config properties have been fully disabled.

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -47,9 +47,6 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("error_collector.ignore_status_codes")]
         public IEnumerable<string> ErrorCollectorIgnoreStatusCodes { get; set; }
 
-        [JsonProperty("error_collector.ignore_errors")]
-        public IEnumerable<string> ErrorCollectorIgnoreErrors { get; set; }
-
         [JsonProperty("error_collector.ignore_classes")]
         public IEnumerable<string> ErrorCollectorIgnoreClasses { get; set; }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
@@ -335,7 +335,6 @@ namespace NewRelic.Agent.Core.DataTransport
                 DistributedTracingEnabled = _configuration.DistributedTracingEnabled,
                 ErrorCollectorEnabled = _configuration.ErrorCollectorEnabled,
                 ErrorCollectorIgnoreStatusCodes = _configuration.HttpStatusCodesToIgnore.ToList(),
-                ErrorCollectorIgnoreErrors = _configuration.IgnoreErrorsForAgentSettings.ToList(),
                 ErrorCollectorIgnoreClasses = _configuration.IgnoreErrorClassesForAgentSettings,
                 ErrorCollectorIgnoreMessages = _configuration.IgnoreErrorMessagesForAgentSettings,
                 ErrorCollectorExpectedClasses = _configuration.ExpectedErrorClassesForAgentSettings,

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -96,7 +96,6 @@ namespace NewRelic.Agent.Configuration
         IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; }
         IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; }
-        IEnumerable<string> IgnoreErrorsForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration { get; }
         IEnumerable<string> IgnoreErrorClassesForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings { get; }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomAttributes/CustomAttributesIgnoredErrorAttributesNotInTransactionTrace.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests.CustomAttributes
                     configModifier.ForceTransactionTraces();
 
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "debug");
-                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(configPath, new[] { "configuration", "errorCollector", "ignoreErrors" }, "exception", "System.ArithmeticException");
+                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(configPath, new[] { "configuration", "errorCollector", "ignoreClasses" }, "errorClass", "System.ArithmeticException");
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
@@ -29,12 +29,10 @@ namespace NewRelic.Agent.IntegrationTests.Errors
 
                     var configModifier = new NewRelicConfigModifier(newRelicConfig);
 
-                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors");
+                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreClasses");
                     CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes");
 
-                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors", "");
                     CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes", "");
-
                 },
                 exerciseApplication: () =>
                 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
@@ -30,10 +30,9 @@ namespace NewRelic.Agent.IntegrationTests.Errors
 
                     var configModifier = new NewRelicConfigModifier(newRelicConfig);
 
-                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors");
+                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreClasses");
                     CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes");
 
-                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors", "");
                     CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes", "");
                 },
                 exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
@@ -32,10 +32,9 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                     var configModifier = new NewRelicConfigModifier(newRelicConfig);
                     configModifier.ForceTransactionTraces();
 
-                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors");
+                    CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreClasses");
                     CommonUtils.DeleteXmlNodeFromNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes");
 
-                    CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreErrors", "");
                     CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(newRelicConfig, new[] { "configuration", "errorCollector" }, "ignoreStatusCodes", "");
 
                 },

--- a/tests/Agent/UnitTests/CompositeTests/TransactionTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/TransactionTests.cs
@@ -242,9 +242,9 @@ namespace CompositeTests
         }
 
         [Test]
-        public void TransactionEventIgnoreErrors()
+        public void TransactionEventIgnoreErrorClasses()
         {
-            _compositeTestAgent.LocalConfiguration.errorCollector.ignoreErrors.exception =
+            _compositeTestAgent.LocalConfiguration.errorCollector.ignoreClasses.errorClass =
                 new List<string>() { "System.OperationCanceledException" };
             _compositeTestAgent.PushConfiguration();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -803,8 +803,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase(new[] { "local" }, null, ExpectedResult = "local")]
         public string ExceptionsToIgnoreSetFromLocalAndServerOverrides(string[] local, string[] server)
         {
-            _serverConfig.RpmConfig.ErrorCollectorErrorsToIgnore = server;
-            _localConfig.errorCollector.ignoreErrors.exception = new List<string>(local);
+            _serverConfig.RpmConfig.ErrorCollectorIgnoreClasses = server;
+            _localConfig.errorCollector.ignoreClasses.errorClass = new List<string>(local);
 
             CreateDefaultConfiguration();
 
@@ -908,19 +908,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             return _defaultConfig.ExpectedErrorsConfiguration.FirstOrDefault().Key + "," + _defaultConfig.IgnoreErrorsConfiguration.FirstOrDefault().Key;
         }
-
-        [TestCase(new[] { "Class1", "Class2" }, new[] { "Class1" }, ExpectedResult = "Class1,Class2")]
-        [TestCase(new[] { "Class1" }, new[] { "Class2" }, ExpectedResult = "Class1,Class2")]
-        public string IgnoreErrorsAndIgnoreClassesCombineTests(string[] ignoreClasses, string[] ignoreErrors)
-        {
-            _localConfig.errorCollector.ignoreClasses.errorClass = new List<string>(ignoreClasses);
-            _localConfig.errorCollector.ignoreErrors.exception = new List<string>(ignoreErrors);
-
-            CreateDefaultConfiguration();
-            return string.Join(",", _defaultConfig.IgnoreErrorsConfiguration.Keys);
-        }
-
-
 
         [TestCase("401", new[] { "405" }, ExpectedResult = new[] { "405" })]
         [TestCase("401", new string[0], ExpectedResult = new string[0])]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -909,6 +909,17 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.ExpectedErrorsConfiguration.FirstOrDefault().Key + "," + _defaultConfig.IgnoreErrorsConfiguration.FirstOrDefault().Key;
         }
 
+        [TestCase(new[] { "Class1", "Class2" }, new[] { "Class1" }, ExpectedResult = "Class1,Class2")]
+        [TestCase(new[] { "Class1" }, new[] { "Class2" }, ExpectedResult = "Class1")]
+        public string IgnoreErrorsAndIgnoreClassesCombineTests(string[] ignoreClasses, string[] ignoreErrors)
+        {
+            _localConfig.errorCollector.ignoreClasses.errorClass = new List<string>(ignoreClasses);
+            _localConfig.errorCollector.ignoreErrors.exception = new List<string>(ignoreErrors);
+
+            CreateDefaultConfiguration();
+            return string.Join(",", _defaultConfig.IgnoreErrorsConfiguration.Keys);
+        }
+
         [TestCase("401", new[] { "405" }, ExpectedResult = new[] { "405" })]
         [TestCase("401", new string[0], ExpectedResult = new string[0])]
         [TestCase("401", null, ExpectedResult = new[] { "401" })]

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -25,7 +25,6 @@ namespace NewRelic.Agent.Core.Configuration
         const bool DistributedTracingEnabled = true;
         const bool ErrorCollectorEnabled = true;
         List<string> ErrorCollectorIgnoreStatusCodes = new List<string> { "401", "404" };
-        List<string> ErrorCollectorIgnoreErrors = new List<string>();
         List<string> ErrorCollectorExpectedClasses = new List<string> { "ExceptionClass1" };
         IDictionary<string, IEnumerable<string>> ErrorCollectorExpectedMessages = new Dictionary<string, IEnumerable<string>>
             {
@@ -66,7 +65,6 @@ namespace NewRelic.Agent.Core.Configuration
             Mock.Arrange(() => configuration.ExpectedErrorMessagesForAgentSettings).Returns(ErrorCollectorExpectedMessages);
             Mock.Arrange(() => configuration.ExpectedErrorStatusCodesForAgentSettings).Returns(ErrorCollectorExpectedStatusCodes);
             Mock.Arrange(() => configuration.HttpStatusCodesToIgnore).Returns(ErrorCollectorIgnoreStatusCodes);
-            Mock.Arrange(() => configuration.IgnoreErrorsForAgentSettings).Returns(ErrorCollectorIgnoreStatusCodes);
             Mock.Arrange(() => configuration.IgnoreErrorClassesForAgentSettings).Returns(ErrorCollectorIgnoreClasses);
             Mock.Arrange(() => configuration.IgnoreErrorMessagesForAgentSettings).Returns(ErrorCollectorIgnoreMessages);
             Mock.Arrange(() => configuration.TransactionTracerStackThreshold).Returns(TransactionTracerStackThreshold);
@@ -93,7 +91,6 @@ namespace NewRelic.Agent.Core.Configuration
                 DistributedTracingEnabled = configuration.DistributedTracingEnabled,
                 ErrorCollectorEnabled = configuration.ErrorCollectorEnabled,
                 ErrorCollectorIgnoreStatusCodes = configuration.HttpStatusCodesToIgnore.ToList(),
-                ErrorCollectorIgnoreErrors = configuration.IgnoreErrorsForAgentSettings.ToList(),
                 ErrorCollectorIgnoreClasses = configuration.IgnoreErrorClassesForAgentSettings,
                 ErrorCollectorIgnoreMessages = configuration.IgnoreErrorMessagesForAgentSettings,
                 ErrorCollectorExpectedClasses = configuration.ExpectedErrorClassesForAgentSettings,
@@ -113,7 +110,7 @@ namespace NewRelic.Agent.Core.Configuration
 
             var json = JsonConvert.SerializeObject(agentSettings);
 
-            const string expectedJson = @"{""agent"":"".NET Agent"",""apdex_t"":10.0,""cross_process_id"":""acctId#appId"",""encoding_key"":""thisistheencodingkey"",""trusted_account_ids"":[123456,98765],""max_stack_trace_lines"":100,""using_server_side_config"":false,""thread_profiler.enabled"":false,""cross_application_tracer.enabled"":false,""distributed_tracing.enabled"":true,""error_collector.enabled"":true,""error_collector.ignore_status_codes"":[""401"",""404""],""error_collector.ignore_errors"":[""401"",""404""],""error_collector.ignore_classes"":[""ExceptionClass1""],""error_collector.ignore_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_classes"":[""ExceptionClass1""],""error_collector.expected_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_status_codes"":[""403"",""500""],""transaction_tracer.stack_trace_threshold"":11.0,""transaction_tracer.explain_enabled"":false,""transaction_tracer.max_sql_statements"":100,""transaction_tracer.max_explain_plans"":10,""transaction_tracer.explain_threshold"":12.0,""transaction_tracer.transaction_threshold"":13.0,""transaction_tracer.record_sql"":""obfuscate"",""slow_sql.enabled"":false,""browser_monitoring.auto_instrument"":true,""transaction_event.max_samples_stored"":10000}";
+            const string expectedJson = @"{""agent"":"".NET Agent"",""apdex_t"":10.0,""cross_process_id"":""acctId#appId"",""encoding_key"":""thisistheencodingkey"",""trusted_account_ids"":[123456,98765],""max_stack_trace_lines"":100,""using_server_side_config"":false,""thread_profiler.enabled"":false,""cross_application_tracer.enabled"":false,""distributed_tracing.enabled"":true,""error_collector.enabled"":true,""error_collector.ignore_status_codes"":[""401"",""404""],""error_collector.ignore_classes"":[""ExceptionClass1""],""error_collector.ignore_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_classes"":[""ExceptionClass1""],""error_collector.expected_messages"":{""ExceptionClass2"":[""exception message 1""]},""error_collector.expected_status_codes"":[""403"",""500""],""transaction_tracer.stack_trace_threshold"":11.0,""transaction_tracer.explain_enabled"":false,""transaction_tracer.max_sql_statements"":100,""transaction_tracer.max_explain_plans"":10,""transaction_tracer.explain_threshold"":12.0,""transaction_tracer.transaction_threshold"":13.0,""transaction_tracer.record_sql"":""obfuscate"",""slow_sql.enabled"":false,""browser_monitoring.auto_instrument"":true,""transaction_event.max_samples_stored"":10000}";
 
             Assert.AreEqual(expectedJson, json);
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
@@ -52,7 +52,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldCollectErrors_MatchesErrorCollectorEnabledConfig([Values(true, false)]bool errorCollectorEnabledSetting)
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: errorCollectorEnabledSetting);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: errorCollectorEnabledSetting);
 
             Assert.AreEqual(errorCollectorEnabledSetting, _errorService.ShouldCollectErrors);
         }
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsFalse_IfExceptionIsNotIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
 
             var exception = new Exception();
             Assert.IsFalse(_errorService.ShouldIgnoreException(exception));
@@ -69,7 +69,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
 
             var exception = new ArithmeticException();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfInnerExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, errorCollectorEnabled: true);
 
             var exception = new Exception("OuterException", new ArithmeticException("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -87,7 +87,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfOuterExceptionIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, true);
 
             var exception = new ArithmeticException("OuterException", new Exception("InnerException"));
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -96,7 +96,7 @@ namespace NewRelic.Agent.Core.Errors
         [Test]
         public void ShouldIgnoreException_ReturnsTrue_IfExceptionWithTypeParameterIsIgnored()
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, true);
 
             var exception = new ExceptionWithTypeParameter<string>();
             Assert.IsTrue(_errorService.ShouldIgnoreException(exception));
@@ -109,7 +109,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(500, null, ExpectedResult = false)]
         public bool ShouldIgnoreHttpStatusCode_ReturnsExpectedResult(int statusCode, int? subStatusCode)
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, false, null, null, null, true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, false, null, null, null, true);
 
             return _errorService.ShouldIgnoreHttpStatusCode(statusCode, subStatusCode);
         }
@@ -125,7 +125,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasIgnoreError)
             {
-                SetupConfiguration(null, ignoreClasses, null, null, false, null, null, null, true);
+                SetupConfiguration(ignoreClasses, null, null, false, null, null, null, true);
             }
 
             var ignoreExceptionRoot = new IOException("Root Exception", new DirectoryNotFoundException());
@@ -154,7 +154,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasIgnoreError)
             {
-                SetupConfiguration(null, null, ignoreErrorMessages, null, false, null, null, null, errorCollectorEnabled: true);
+                SetupConfiguration(null, ignoreErrorMessages, null, false, null, null, null, errorCollectorEnabled: true);
             }
 
             var ignoreException1 = new DirectoryNotFoundException("this is error message 1 ");
@@ -177,7 +177,7 @@ namespace NewRelic.Agent.Core.Errors
         [TestCase(false)]
         public void FromException_ReturnsExpectedErrorData(bool stripExceptionMessages)
         {
-            SetupConfiguration(_exceptionsToIgnore, null, null, _statusCodesToIgnore, stripExceptionMessages, null, null, null, true);
+            SetupConfiguration(_exceptionsToIgnore, null, _statusCodesToIgnore, stripExceptionMessages, null, null, null, true);
 
             var exception = new Exception();
             var errorData = _errorService.FromException(exception);
@@ -210,7 +210,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasExpectedError)
             {
-                SetupConfiguration(null, null, null, null, false, expectedClasses, null, null, true);
+                SetupConfiguration(null, null, null, false, expectedClasses, null, null, true);
             }
 
             var expectedExceptionRoot = new IOException("Root Exception", new DirectoryNotFoundException());
@@ -242,7 +242,7 @@ namespace NewRelic.Agent.Core.Errors
 
             if (hasExpectedError)
             {
-                SetupConfiguration(null, null, null, null, false, null, expectedMessages, null, errorCollectorEnabled: true);
+                SetupConfiguration(null, null, null, false, null, expectedMessages, null, errorCollectorEnabled: true);
             }
 
             var expectedException1 = new DirectoryNotFoundException("this is error message 1 ");
@@ -271,7 +271,7 @@ namespace NewRelic.Agent.Core.Errors
             if (hasExpectedError)
             {
                 var expectedStatusCodes = "400,401,404-415";
-                SetupConfiguration(null, null, null, null, false, null, null, expectedStatusCodes, errorCollectorEnabled: true);
+                SetupConfiguration(null, null, null, false, null, null, expectedStatusCodes, errorCollectorEnabled: true);
             }
 
             var errorData1 = _errorService.FromErrorHttpStatusCode(400, null, DateTime.Now);
@@ -308,7 +308,7 @@ namespace NewRelic.Agent.Core.Errors
                 "System.IO.DirectoryNotFoundException",
             };
 
-            SetupConfiguration(null, null, null, null, false, expectedClasses, expectedMessages, null, true);
+            SetupConfiguration(null, null, null, false, expectedClasses, expectedMessages, null, true);
             var expectedException = new DirectoryNotFoundException("any error messages");
 
             var errorData = _errorService.FromException(expectedException);
@@ -317,7 +317,7 @@ namespace NewRelic.Agent.Core.Errors
 
         }
 
-        private void SetupConfiguration(List<string> exceptionsToIgnore, List<string> classesToBeIgnored, IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeIgnored,
+        private void SetupConfiguration(List<string> classesToBeIgnored, IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeIgnored,
             List<float> statusCodesToIgnore, bool stripExceptionMessages, List<string> errorClassesToBeExpected,
             IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeExpected, string expectedStatusCodes, bool errorCollectorEnabled)
         {
@@ -325,11 +325,6 @@ namespace NewRelic.Agent.Core.Errors
 
             config.errorCollector.enabled = errorCollectorEnabled;
             config.stripExceptionMessages.enabled = stripExceptionMessages;
-
-            if (exceptionsToIgnore != null)
-            {
-                config.errorCollector.ignoreErrors.exception = exceptionsToIgnore;
-            }
 
             if (classesToBeIgnored != null)
             {


### PR DESCRIPTION
### Description

Resolves #668 with the updated config, some now unnecessary `errorCollector.ignoreErrors` code removed, and a warning logged when the old configuration is still being used.

### Testing

Unit and integration tests have been updated and passed, with one unneeded unit test being removed.
