### PR TITLE
Better unbounded service security

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/RabbitMqConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/RabbitMqConfiguration.cs
@@ -8,6 +8,8 @@ namespace NewRelic.Agent.IntegrationTests.Shared
     public class RabbitMqConfiguration
     {
         private static string _rabbitMqServerIp;
+        private static string _rabbitMqUsername;
+        private static string _rabbitMqPassword;
 
         public static string RabbitMqServerIp
         {
@@ -20,6 +22,32 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                 }
 
                 return _rabbitMqServerIp;
+            }
+        }
+        public static string RabbitMqUsername
+        {
+            get
+            {
+                if (_rabbitMqUsername == null)
+                {
+                    var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("RabbitMqTests");
+                    _rabbitMqUsername = testConfiguration["Username"];
+                }
+
+                return _rabbitMqUsername;
+            }
+        }
+        public static string RabbitMqPassword
+        {
+            get
+            {
+                if (_rabbitMqPassword == null)
+                {
+                    var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("RabbitMqTests");
+                    _rabbitMqPassword = testConfiguration["Password"];
+                }
+
+                return _rabbitMqPassword;
             }
         }
     }

--- a/tests/Agent/IntegrationTests/Shared/StackExchangeRedisConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/StackExchangeRedisConfiguration.cs
@@ -11,6 +11,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         private static string _stackExchangeRedisConnectionString;
         private static string _stackExchangeRedisServer;
         private static string _stackExchangeRedisPort;
+        private static string _stackExchangeRedisPassword;
 
         // example: "1.2.3.4:4444"
         public static string StackExchangeRedisConnectionString
@@ -73,6 +74,19 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                 }
 
                 return _stackExchangeRedisPort;
+            }
+        }
+        public static string StackExchangeRedisPassword
+        {
+            get
+            {
+                if (_stackExchangeRedisPassword == null)
+                {
+                    var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("StackExchangeRedisTests");
+                    _stackExchangeRedisPassword = testConfiguration["Password"];
+                }
+
+                return _stackExchangeRedisPassword;
             }
         }
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ.cs
@@ -12,7 +12,6 @@ using NewRelic.Api.Agent;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -26,7 +25,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
     [Library]
     class RabbitMQ
     {
-        private static readonly ConnectionFactory ChannelFactory = new ConnectionFactory() { HostName = RabbitMqConfiguration.RabbitMqServerIp };
+        private static readonly ConnectionFactory ChannelFactory = new ConnectionFactory()
+        { HostName = RabbitMqConfiguration.RabbitMqServerIp,
+          UserName = RabbitMqConfiguration.RabbitMqUsername,
+          Password = RabbitMqConfiguration.RabbitMqPassword };
         private static readonly IConnection Connection = ChannelFactory.CreateConnection();
         private static IModel Channel = Connection.CreateModel();
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - "27017:27017"
         environment: 
             - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
-            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPass}
+            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPassword}
         container_name: MongoDB32Server
 
     mongodb36: 
@@ -26,7 +26,7 @@ services:
             - "27018:27017"
         environment: 
             - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
-            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPass}
+            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPassword}
         container_name: MongoDB36Server
                     
     redis:
@@ -54,23 +54,27 @@ services:
         ports:
             - "5432:5432"
         environment:
-            # These credentials are only used to configure the Postgres container 
-            # for use by the integration tests. They must match the values from 
-            # the connection string used by those tests
+            # The username 'postgres' should not change since it needs to match
+            # the same value in the 'database.sql' backup/restore file.
+            # The password must match what is used in the connection string used by
+            # the tests.
             - POSTGRES_USER=postgres
-            - POSTGRES_PASSWORD=password
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-PostgresPassword}
         container_name: PostgresServer
 
     mssql:
-        build: ./mssql
+        build:
+            context: ./mssql
+            args:
+                SA_PASS: ${SA_PASSWORD:-MssqlPassw0rd}
         ports:
             - "1433:1433"
         environment:
             # The password set here must match the password set in the connection
-            # string being used by the MS SQL tests.  SQL server requires a more
-            # complex password than 'password' and that is why this service does
-            # not follow the same pattern as the others.
-            - SA_PASSWORD=password0TS
+            # string being used by the MS SQL tests, and also match what is set in the
+            # "SA_PASS" container build arg above.  If this password is changed, the container
+            # must be rebuilt.
+            - SA_PASSWORD=${SA_PASSWORD:-MssqlPassw0rd}
         container_name: MssqlServer
 
     oracle:
@@ -81,7 +85,7 @@ services:
         environment:
             # The password set here must match the password set in the connection 
             # string being used by the Oracle unbounded integration tests
-            - ORACLE_PWD=password
+            - ORACLE_PWD=${ORACLE_PWD:-OraclePassword}
         container_name: OracleServer
 
     db2:
@@ -89,16 +93,13 @@ services:
         privileged: true
         ports:
             - "50000:50000"
-            - "22"
-            - "55000"
-            - "60006-60007"
         environment:
             - LICENSE=accept
             # These credentials are only used to configure the Db2 container for 
             # use by the integration tests. They must match the values from the 
             # connection string used by those tests
             - DB2INSTANCE=newrelic
-            - DB2INST1_PASSWORD=password
+            - DB2INST1_PASSWORD=${DB2INST1_PASSWORD:-Db2Password}
             - SAMPLEDB=true
         container_name: Db2Server
 
@@ -112,6 +113,6 @@ services:
             # These credentials are only used to configure the MySql container 
             # for use by the integration tests. They must match the values from 
             # the connection string used by those tests
-            - MYSQL_ROOT_PASSWORD=password
+            - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-MysqlPassword}
         container_name: MySqlServer
         

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -25,6 +25,7 @@ services:
                     
     redis:
         build: ./redis
+        command: redis-server --requirepass ${REDIS_PASSWORD:-RedisPassword}
         ports:
             - "6379:6379"
         container_name: RedisServer

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -41,10 +41,6 @@ services:
         ports:
             - "8091-8094:8091-8094"
             - "11210:11210"
-            - "8095-8096"
-            - "11207"
-            - "11211"
-            - "18091-18096"
         environment:
             # These credentials are only used to configure the Couchbase container 
             # for use by the integration tests. You can change these to any value 

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -15,12 +15,18 @@ services:
         build: ./mongodb32 
         ports:
             - "27017:27017"
+        environment: 
+            - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
+            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPass}
         container_name: MongoDB32Server
 
     mongodb36: 
         build: ./mongodb36 
         ports:
             - "27018:27017"
+        environment: 
+            - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
+            - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPass}
         container_name: MongoDB36Server
                     
     redis:

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     rabbitmq: 
         build: ./rabbitmq 
         ports:
-            - "4369:4369"
             - "5671-5672:5671-5672"
-            - "25672:25672"
-            - "15691-15692"
         hostname: my-rabbit
+        environment:
+            - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER:-RabbitUser}
+            - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-RabbitPassword}
         container_name: RabbitmqServer
 
     mongodb32: 

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     couchbase: 
         build: ./couchbase
         ports:
-            - "8091-8094:8091-8094"
+            - "8092-8094:8092-8094"
             - "11210:11210"
         environment:
             # These credentials are only used to configure the Couchbase container 

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -45,8 +45,8 @@ services:
             # These credentials are only used to configure the Couchbase container 
             # for use by the integration tests. You can change these to any value 
             # you wish before running the container for the first time
-            - COUCHBASE_ADMINISTRATOR_USERNAME=Administrator
-            - COUCHBASE_ADMINISTRATOR_PASSWORD=password
+            - COUCHBASE_ADMINISTRATOR_USERNAME=${COUCHBASE_ADMINISTRATOR_USERNAME:-CouchbaseUser}
+            - COUCHBASE_ADMINISTRATOR_PASSWORD=${COUCHBASE_ADMINISTRATOR_PASSWORD:-CouchbasePassword}
         container_name: CouchbaseServer
                         
     postgres:

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -108,7 +108,6 @@ services:
         command: mysqld --default-authentication-plugin=mysql_native_password
         ports:
             - "3306:3306"
-            - "33060"
         environment:
             # These credentials are only used to configure the MySql container 
             # for use by the integration tests. They must match the values from 

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -69,7 +69,9 @@
         },
         "RabbitMqTests" : {
           "CustomSettings": {
-              "Server" : "127.0.0.1"
+              "Server" : "127.0.0.1",
+              "Username" : "RabbitUser",
+              "Passwordd" : "RabbitPassword"
           }
         },
         "CouchbaseTests" : {

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -60,12 +60,12 @@
         },
         "MongoDBTests" : {
           "CustomSettings": {
-              "ConnectionString" : "mongodb://127.0.0.1:27017"
+              "ConnectionString" : "mongodb://MongoUser:MongoPass@127.0.0.1:27017"
           }
         },
         "MongoDB26Tests" : {
           "CustomSettings": {
-              "ConnectionString" : "mongodb://127.0.0.1:27018"
+              "ConnectionString" : "mongodb://MongoUser:MongoPass@127.0.0.1:27018"
           }
         },
         "RabbitMqTests" : {

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -19,32 +19,32 @@
         },
         "PostgresTests" : {
           "CustomSettings": {
-              "ConnectionString" : "Server=127.0.0.1;Port=5432;User Id=postgres;Password=password;Database=postgres;"
+              "ConnectionString" : "Server=127.0.0.1;Port=5432;User Id=postgres;Password=PostgresPassword;Database=postgres;"
           }
         },
         "MSSQLTests" : {
           "CustomSettings": {
-              "ConnectionString" : "Server=127.0.0.1;Database=NewRelic;User ID=sa;Password=password0TS;Trusted_Connection=False;Encrypt=False;Connection Timeout=30;"
+              "ConnectionString" : "Server=127.0.0.1;Database=NewRelic;User ID=sa;Password=MssqlPassw0rd;Trusted_Connection=False;Encrypt=False;Connection Timeout=30;"
           }
         },
         "MSSQLOdbcTests" : {
           "CustomSettings": {
-              "ConnectionString" : "DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password0TS;Encrypt=no;"
+              "ConnectionString" : "DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=MssqlPassw0rd;Encrypt=no;"
           }
         },
         "MSSQLOleDbTests" : {
           "CustomSettings": {
-              "ConnectionString" : "PROVIDER=SQLNCLI11;Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password0TS;Encrypt=no;Timeout=30;"
+              "ConnectionString" : "PROVIDER=SQLNCLI11;Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=MssqlPassw0rd;Encrypt=no;Timeout=30;"
           }
         },
         "MySQLTests" : {
           "CustomSettings": {
-              "ConnectionString" : "Network Address=127.0.0.1;Port=3306;Initial Catalog=newrelic;Persist Security Info=no;User Name=root;Password=password;SslMode=None"
+              "ConnectionString" : "Server=127.0.0.1;Port=3306;Initial Catalog=newrelic;Persist Security Info=no;User Name=root;Password=MysqlPassword;SslMode=None"
           }
         },
         "OracleTests" : {
           "CustomSettings": {
-              "ConnectionString" : "Data Source=127.0.0.1:1521/XE;User Id=SYSTEM;Password=password;"
+              "ConnectionString" : "Data Source=127.0.0.1:1521/XE;User Id=SYSTEM;Password=OraclePassword;"
           }
         },
         "StackExchangeRedisTests" : {
@@ -55,24 +55,24 @@
         },
         "Db2Tests" : {
           "CustomSettings": {
-              "ConnectionString" : "Server=127.0.0.1;Database=SAMPLE;UserID=newrelic;Password=password"
+              "ConnectionString" : "Server=127.0.0.1;Database=SAMPLE;UserID=newrelic;Password=Db2Password"
           }
         },
         "MongoDBTests" : {
           "CustomSettings": {
-              "ConnectionString" : "mongodb://MongoUser:MongoPass@127.0.0.1:27017"
+              "ConnectionString" : "mongodb://MongoUser:MongoPassword@127.0.0.1:27017"
           }
         },
         "MongoDB26Tests" : {
           "CustomSettings": {
-              "ConnectionString" : "mongodb://MongoUser:MongoPass@127.0.0.1:27018"
+              "ConnectionString" : "mongodb://MongoUser:MongoPassword@127.0.0.1:27018"
           }
         },
         "RabbitMqTests" : {
           "CustomSettings": {
               "Server" : "127.0.0.1",
               "Username" : "RabbitUser",
-              "Passwordd" : "RabbitPassword"
+              "Password" : "RabbitPassword"
           }
         },
         "CouchbaseTests" : {

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -49,7 +49,8 @@
         },
         "StackExchangeRedisTests" : {
           "CustomSettings": {
-              "ConnectionString" : "127.0.0.1:6379"
+              "ConnectionString" : "127.0.0.1:6379",
+              "Password" : "RedisPassword"
           }
         },
         "Db2Tests" : {

--- a/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
@@ -1,9 +1,11 @@
 FROM mcr.microsoft.com/mssql/server:2017-latest
 
+ARG SA_PASS=MssqlPassw0rd
+
 ENV ACCEPT_EULA=Y
-ENV MSSQL_SA_PASSWORD=password0TS
-ENV SQLCMDPASSWORD=password0TS
-ENV SA_PASSWORD=password0TS
+ENV MSSQL_SA_PASSWORD=${SA_PASS}
+ENV SQLCMDPASSWORD=${SA_PASS}
+ENV SA_PASSWORD=${SA_PASS}
 
 COPY setup.sh /var/
 COPY entrypoint.sh /var/

--- a/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/rabbitmq/Dockerfile
@@ -1,1 +1,1 @@
-FROM rabbitmq:3.8
+FROM rabbitmq:3.9.5

--- a/tests/Agent/IntegrationTests/UnboundedServices/redis/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/redis/Dockerfile
@@ -1,1 +1,1 @@
-FROM redis:5
+FROM redis:6.2.5


### PR DESCRIPTION
### Description

The changes in this PR help enable better security for the Docker-hosted external services needed by the unbounded integration tests.  Summary of changes:
1. Enable the use of a username and password for some services that were previously set up to use no authentication at all (e.g. redis)
2. Allow (almost) all services to have credentials specified from the environment in `docker-compose.yml`, although default values are still specified to make it easy to use these containers for testing on a local machine.
3. Remove unnecessary port mappings from the `docker-compose.yml` file.
4. In some cases, the version of the container image for the service was updated to a more recent version.

### Testing

I've verified that all unbounded integration tests still pass for me locally using this version of the services setup and the `example-secrets.json` file with appropriate modifications (e.g. NR license key).

### Changelog

N/A
