### PR TITLE
A workflow to build linux arm64 profiler

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -53,6 +53,8 @@ jobs:
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\x64-Release" -Recurse -Force  -ErrorAction SilentlyContinue
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\x86-Release" -Recurse -Force  -ErrorAction SilentlyContinue
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-release" -Recurse -Force  -ErrorAction SilentlyContinue
+          Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-x64-release" -Recurse -Force  -ErrorAction SilentlyContinue
+          Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-arm64-release" -Recurse -Force  -ErrorAction SilentlyContinue
         shell: powershell
 
       - name: Build x64
@@ -76,9 +78,9 @@ jobs:
           path: ${{ github.workspace }}\src\Agent\_profilerBuild\**\*
           if-no-files-found: error
 
-  build-linux-profiler:
+  build-linux-x64-profiler:
     needs: cancel-previous-workflow-runs
-    name: Build Linux Profiler
+    name: Build Linux x64 Profiler
     runs-on: ubuntu-18.04
 
     env:
@@ -93,10 +95,12 @@ jobs:
 
       - name: Clean out _profilerBuild directory
         run: |
-          rm -f ${{ github.workspace }}/src/Agent/_profilerBuild/*.*
-          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-release
-          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x64-Release
-          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release
+          rm -f ${{ github.workspace }}/src/Agent/_profilerBuild/*.* || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-x64-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-arm64-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x64-Release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
         shell: bash
 
       - name: Build Linux Profler
@@ -119,9 +123,75 @@ jobs:
           path: ${{ github.workspace }}/src/Agent/_profilerBuild/
           if-no-files-found: error
 
+  build-linux-arm64-profiler:
+    needs: cancel-previous-workflow-runs
+    name: Build Linux ARM64 Profiler
+    runs-on: ubuntu-18.04
+    
+    env:
+      profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Clean out _profilerBuild directory
+        run: |
+          rm -f ${{ github.workspace }}/src/Agent/_profilerBuild/*.* || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-x64-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-arm64-release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x64-Release || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
+        shell: bash
+        
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Run commands
+        id: runcmd
+        with:
+          arch: aarch64
+          distro: ubuntu18.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y wget curl git dos2unix software-properties-common make binutils libc++-dev clang-3.9 lldb-3.9 build-essential
+            echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
+            wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+            mkdir /root/git
+            cd /root/git
+            git clone --branch release/3.0 https://github.com/dotnet/coreclr.git
+            curl -sSL https://virtuoso-testing.s3.us-west-2.amazonaws.com/cmake-3.9.0-rc3-aarch64.tar.gz | tar -xzC ~
+            chmod 777 ~/cmake-3.9.0-rc3-aarch64/bin/cmake
+            ln -s ~/cmake-3.9.0-rc3-aarch64/bin/cmake /usr/bin/cmake || true
+            rm /usr/bin/cc || true
+            ln -s /usr/bin/clang-3.9 /usr/bin/cc
+            rm /usr/bin/c++ || true
+            ln -s /usr/bin/clang++-3.9 /usr/bin/c++
+          dockerRunArgs: |
+            --volume "${{ env.profiler_path }}:/profiler"
+          run: |
+            cd /profiler
+            chmod 777 ./linux/build_profiler.sh
+            ./linux/build_profiler.sh
+            
+      - name: Move Profiler to staging folder
+        run: |
+          mkdir --parents ${{ github.workspace }}/src/Agent/_profilerBuild/linux-arm64-release/
+          mv -f ${{ env.profiler_path }}/libNewRelicProfiler.so  ${{ github.workspace }}/src/Agent/_profilerBuild/linux-arm64-release/libNewRelicProfiler.so
+        shell: bash
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: profiler
+          path: ${{ github.workspace }}/src/Agent/_profilerBuild/
+          if-no-files-found: error
+
   # This builds both FullAgent and MSIInstaller since MSIInstaller requires FullAgent artifacts.
   build-test-fullagent-msi:
-    needs: [ build-windows-profiler, build-linux-profiler ]
+    needs: [ build-windows-profiler, build-linux-x64-profiler, build-linux-arm64-profiler ]
     name: Build and Test FullAgent and MSIInstaller
     runs-on: windows-2019
 
@@ -147,6 +217,8 @@ jobs:
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\x64-Release" -Recurse -Force  -ErrorAction SilentlyContinue
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\x86-Release" -Recurse -Force  -ErrorAction SilentlyContinue
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-release" -Recurse -Force  -ErrorAction SilentlyContinue
+          Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-x64-release" -Recurse -Force  -ErrorAction SilentlyContinue
+          Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\linux-arm64-release" -Recurse -Force  -ErrorAction SilentlyContinue
         shell: powershell
 
       - name: Download Profiler Artifacts Before Agent Build

--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -156,7 +156,7 @@ function Copy-AgentRoot {
     $grpcDir = Get-GrpcPackagePath $RootDirectory
     if ($Linux) {
         Copy-Item -Path "$grpcDir\runtimes\linux-x64\native\libgrpc_csharp_ext.x64.so" -Destination "$Destination" -Force 
-        Copy-Item -Path "$RootDirectory\src\Agent\_profilerBuild\linux-release\libNewRelicProfiler.so" -Destination "$Destination" -Force 
+        Copy-Item -Path "$RootDirectory\src\Agent\_profilerBuild\linux-x64-release\libNewRelicProfiler.so" -Destination "$Destination" -Force 
     }
     else {
         Copy-Item -Path "$grpcDir\runtimes\win-x86\native\*.dll" -Destination "$Destination" -Force

--- a/src/Agent/NewRelic/Profiler/CMakeLists.txt
+++ b/src/Agent/NewRelic/Profiler/CMakeLists.txt
@@ -34,7 +34,7 @@ if(${WIN32})
 else()
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing -stdlib=libc++ -march=x86-64 -Wno-invalid-noreturn -Wno-ignored-attributes -Wno-macro-redefined -fms-extensions -fdeclspec -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing -stdlib=libc++ ${CMAKE_HOST_SYSTEM_PROCESSOR} -Wno-invalid-noreturn -Wno-ignored-attributes -Wno-macro-redefined -fms-extensions -fdeclspec -fPIC")
   set (CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++") 
 endif()
 


### PR DESCRIPTION
Adds new profiler build job for arm64
New job adds its profiler bits to _profilerBuild 
Updates existing linuc job name to callout out arch
Updates conditionals to match new job names
Updates _profilerBuild deletion list to include new paths
Updates build_functions.ps1 to support new folder names 

While the new profiler artifacts are saved, the main agent build does not create a home folder for the new arch.
This simply gets the arm64 profiler building in GH with some new folders.

Tested (mostly) in private repo: https://github.com/jaffinito/newrelic-dotnet-agent/actions/runs/1292485552
Manually tested GH built profiler in a graviton instance using a .NET 5 webapi app and it was fine (link posted in slack)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
