### PR TITLE
Move to https and no caching for wget

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -157,8 +157,8 @@ jobs:
           install: |
             apt-get update -q -y
             apt-get install -q -y wget curl git dos2unix software-properties-common make binutils libc++-dev clang-3.9 lldb-3.9 build-essential
-            echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
-            wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+            echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
+            wget --no-cache --no-cookies -O - https://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
             mkdir /root/git
             cd /root/git
             git clone --branch release/3.0 https://github.com/dotnet/coreclr.git

--- a/src/Agent/NewRelic/Profiler/linux/Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y \
   dos2unix \
   software-properties-common
 
-RUN echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
-RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
+RUN wget --no-cache --no-cookies -O - https://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
 
 # The CoreCLR build notes say their repos should be pulled into a `git` directory.
 # That probably isn't necessary, but whatever.


### PR DESCRIPTION
Updates profiler depends to use https
Updates wget commands to not use caching

# Reviewer Checklist
- [x] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
