### PR TITLE
Fixes datastore span naming.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -170,7 +170,7 @@ namespace NewRelic.Agent.Core.Segments
 
         public override string GetTransactionTraceName()
         {
-            var name = Model == null ? DatastoreVendorName.GetDatastoreOperation(Operation) : MetricNames.GetDatastoreStatement(DatastoreVendorName, Model, Operation);
+            var name = string.IsNullOrEmpty(Model) ? DatastoreVendorName.GetDatastoreOperation(Operation) : MetricNames.GetDatastoreStatement(DatastoreVendorName, Model, Operation);
             return name.ToString();
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/ExecuteItemQueryAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/ExecuteItemQueryAsyncWrapper.cs
@@ -46,8 +46,8 @@ namespace NewRelic.Providers.Wrapper.CosmosDb
             object querySpec = instrumentedMethodCall.MethodCall.MethodArguments[6];
 
             var splitAddressArray = resourceAddress.Split('/');
-            var databaseName = "Unknown";
-            var model = "Unknown";
+            var databaseName = string.Empty;
+            var model = string.Empty;
 
             if (splitAddressArray.Length > 1)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/RequestInvokerHandlerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/RequestInvokerHandlerWrapper.cs
@@ -41,8 +41,8 @@ namespace NewRelic.Providers.Wrapper.CosmosDb
             object operationType = instrumentedMethodCall.MethodCall.MethodArguments[2].ToString();
 
             var splittedAddressArray = resourceAddress.Split('/');
-            var databaseName = "Unknown";
-            var model = "Unknown";
+            var databaseName = string.Empty;
+            var model = string.Empty;
 
             if (splittedAddressArray.Length > 1)
             {


### PR DESCRIPTION
## Description
Fixes a bug where, in the event when `table` (the agent refers as `model`) can't be captured, the name of a datastore span event should be `Datastore/operation/datastore/operation_name` instead of `Datastore/statement/datastore/table/operation_name`. It is worth noting that this bug only affects span events, other metrics were  reported correctly.  

refs:
   https://source.datanerd.us/agents/agent-specs/blob/master/Datastore-Metrics-PORTED.md#datastore-metric-namespace (See `Operation` and `Statement` in the matrix).
   https://source.datanerd.us/agents/agent-specs/blob/master/Span-Events.md#name

This makes DT UI correctly displays datastore span that doesn't have table info captured:

Before:
<img width="1509" alt="Screen Shot 2021-10-28 at 2 02 06 PM" src="https://user-images.githubusercontent.com/56414817/139335327-850d9ca5-6cc7-4e8b-9b42-8b2a25c48cc5.png">

After
<img width="1527" alt="Screen Shot 2021-10-28 at 2 03 06 PM" src="https://user-images.githubusercontent.com/56414817/139335308-27c339e2-636b-4b2f-8025-9a27022a2eff.png">
:
