### PR TITLE
CosmosDB Intial Integration Test

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/CosmosDBConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/CosmosDBConfiguration.cs
@@ -1,0 +1,56 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+
+namespace NewRelic.Agent.IntegrationTests.Shared
+{
+    public class CosmosDBConfiguration
+    {
+        private static string _authKey;
+        private static string _cosmosDBServer;
+
+        public static string AuthKey
+        {
+            get
+            {
+                if (_authKey == null)
+                {
+                    try
+                    {
+                        var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("CosmosDBTests");
+                        _authKey = testConfiguration["AuthKey"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("CosmosDB authentication key configuration is invalid.", ex);
+                    }
+                }
+
+                return _authKey;
+            }
+        }
+
+        public static string CosmosDBServer
+        {
+            get
+            {
+                if (_cosmosDBServer == null)
+                {
+                    try
+                    {
+                        var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("CosmosDBTests");
+                        _cosmosDBServer = testConfiguration["Server"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("CosmosDB configuration is invalid.", ex);
+                    }
+                }
+
+                return _cosmosDBServer;
+            }
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -52,6 +52,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.22.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />
     <ProjectReference Include="..\..\..\Shared\Shared.csproj" />
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
@@ -18,6 +18,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB
     [Library]
     public class CosmosDBExerciser
     {
+        //This configuration is necessary to bypass the SSL connection error when testing with the CosmosDB server emulator without installing a cert.
         static readonly CosmosClientOptions _cosmosClientOptions = new CosmosClientOptions()
         {
             HttpClientFactory = () =>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
@@ -1,0 +1,104 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB
+{
+    [Library]
+    public class CosmosDBExerciser
+    {
+        static readonly CosmosClientOptions _cosmosClientOptions = new CosmosClientOptions()
+        {
+            HttpClientFactory = () =>
+            {
+                HttpMessageHandler httpMessageHandler = new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                };
+
+                return new HttpClient(httpMessageHandler);
+            },
+            ConnectionMode = ConnectionMode.Gateway
+        };
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task CreateReadAndDeleteDatabase(string databaseId)
+        {
+            try
+            {
+                var endpoint = CosmosDBConfiguration.CosmosDBServer;
+                var authKey = CosmosDBConfiguration.AuthKey;
+
+                using (CosmosClient client = new CosmosClient(endpoint, authKey, _cosmosClientOptions))
+                {
+                    var databaseResponse = await client.CreateDatabaseIfNotExistsAsync(databaseId);
+
+                    var database = databaseResponse.Database;
+
+                    // Read the database from Azure Cosmos
+                    var readResponse = await database.ReadAsync();
+
+                    // Create a container/collection
+                    await readResponse.Database.CreateContainerAsync("testContainer", "/pk");
+
+                    // Read database using GetDatabaseQueryIterator()
+                    using (FeedIterator<DatabaseProperties> iterator = client.GetDatabaseQueryIterator<DatabaseProperties>())
+                    {
+                        while (iterator.HasMoreResults)
+                        {
+                            foreach (DatabaseProperties db in await iterator.ReadNextAsync())
+                            {
+                                Console.WriteLine(db.Id);
+                            }
+                        }
+                    }
+
+                    // Read database using GetDatabaseStreamQueryIterator
+                    using (FeedIterator iterator = client.GetDatabaseQueryStreamIterator())
+                    {
+                        while (iterator.HasMoreResults)
+                        {
+                            using ResponseMessage response = await iterator.ReadNextAsync();
+                            using (StreamReader sr = new StreamReader(response.Content))
+                            {
+                                sr.ReadToEnd();
+                            }
+                        }
+                    }
+
+                    // Delete the database from Azure Cosmos.
+                    await database.DeleteAsync();
+                }
+            }
+            catch { }
+        }
+
+
+        [LibraryMethod]
+        public static void StartAgent()
+        {
+            NewRelic.Api.Agent.NewRelic.StartAgent();
+            //Get everything started up and time for initial Sample().
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+        }
+
+        [LibraryMethod]
+        public static void Wait()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(70));
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -1,0 +1,105 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Testing.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
+{
+    public abstract class CosmosDBTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly ConsoleDynamicMethodFixture _fixture;
+
+
+        protected CosmosDBTestsBase(TFixture fixture, ITestOutputHelper output)  : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
+            _fixture.AddCommand($"CosmosDBExerciser StartAgent");
+            _fixture.AddCommand($"CosmosDBExerciser CreateReadAndDeleteDatabase test_db_{Guid.NewGuid():x}");
+
+
+            _fixture.AddCommand($"CosmosDBExerciser Wait");
+
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.ForceTransactionTraces();
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = "Datastore/all", callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Datastore/CosmosDB/all", callCount = 7 },
+
+                new Assertions.ExpectedMetric { metricName = "Datastore/instance/CosmosDB/localhost/8081", callCount = 7 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadFeedDatabase", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase", callCount = 2 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase", callCount = 1 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase", callCount = 1 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase", callCount = 2 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase", callCount = 1 },
+
+            };
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/operation/CosmosDB"));
+
+
+            NrAssert.Multiple
+            (
+                () => Assertions.MetricsExist(expectedMetrics, metrics),
+                () => Assert.Equal(6, operationDatastoreSpans.Count())
+            );
+        }
+    }
+
+
+    [NetFrameworkTest]
+    public class CosmosDBTestsFW : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public CosmosDBTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+
+    [NetCoreTest]
+    public class CosmosDBTestsCore : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public CosmosDBTestsCore(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -77,7 +77,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
             NrAssert.Multiple
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Equal(6, operationDatastoreSpans.Count())
+                () => Assert.Equal(7, operationDatastoreSpans.Count())
             );
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
+++ b/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json
@@ -120,6 +120,12 @@
               "Password" : "YOUR_AZURE_PW_HERE",
               "TestUrl" : "YOUR_AZURE_TEST_URL_HERE"
           }
+        },
+        "CosmosDBTests": {
+          "CustomSettings": {
+            "AuthKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+            "Server": "https://localhost:8081"
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
This PR lays ground work for testing Cosmos DB instrumentation. More specific tests will be added in later PRs.

The integration test secret need to be updated with the new CosmosDB server secret

```
      "CosmosDBTests": {
        "CustomSettings": {
          "AuthKey": "your CosmosDB secret",
          "Server": "you CosmosDB endpoint"
        }
      }      
```
