### PR TITLE
Add grpc unmanaged libraries to the .net core MSI installer

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 ### New Features
 ### Fixes
+* Fixes issue [#781](https://github.com/newrelic/newrelic-dotnet-agent/issues/781): Windows MSI installer was not deploying gRPC libraries for netcore applications. ([#788](https://github.com/newrelic/newrelic-dotnet-agent/pull/788))
 
 ## [9.1.0] - 2021-10-26
 ### New Features

--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -350,6 +350,14 @@ SPDX-License-Identifier: Apache-2.0
         <File Id="CoreNewRelic.Agent.Extensions.dll" Name="NewRelic.Agent.Extensions.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\NewRelic.Agent.Extensions.dll"/>
       </Component>
 
+      <!--Google gRPC CSharp Extensions-->
+      <Component Id="CoregRPCCSharpExtensionsLibx64" Guid="{3AC8931D-8D17-4834-A21F-783B61B1910C}">
+        <File Id="Coregrpc_csharp_ext.x64.dll" Name="grpc_csharp_ext.x64.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\grpc_csharp_ext.x64.dll"/>
+      </Component>
+      <Component Id="CoregRPCCSharpExtensionsLibx86" Guid="{7078C7BE-0216-4ECE-AC3F-6647D7C04DD3}">
+        <File Id="Coregrpc_csharp_ext.x86.dll" Name="grpc_csharp_ext.x86.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\grpc_csharp_ext.x86.dll"/>
+      </Component>
+
       <!-- Configuration -->
       <Component Id="CoreConfigurationShortcuts" Guid="{3F39FDDD-A607-4DA3-9B4D-3169D65BE49C}">
         <Shortcut Id="CoreExtensionsShortcut" Name="Extensions" Target="[CoreExtensionsFolder]" WorkingDirectory="CoreExtensionsFolder" Advertise="no"/>


### PR DESCRIPTION
## Description

Closes #781.

The windows MSI installer was not deploying gRPC libraries for netcore applications. This has been tested locally and it appears to deploy the missing unmanaged libraries.

# Author Checklist
- [x] Tested locally
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
