### PR TITLE
Use registry query logic to send .NET Framework version in environment data

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 ### New Features
 * Adds additional logging to the Garbage Collection performance metrics to aid in troubleshooting performance counter issues. ([#792](https://github.com/newrelic/newrelic-dotnet-agent/pull/792))
+* Feature [#800](https://github.com/newrelic/newrelic-dotnet-agent/issues/800): for .NET Framework apps instrumented with the .NET Framework agent, the value of the ".NET Version" property in the Environment data page will more accurately reflect the version of .NET Framework in use. ([#801](https://github.com/newrelic/newrelic-dotnet-agent/pull/801))  
 ### Fixes
 
 ## [9.1.1] - 2021-11-02

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -17,6 +17,7 @@ using NewRelic.Core.Logging;
 using NewRelic.SystemInterfaces;
 using Newtonsoft.Json;
 using NewRelic.Agent.Configuration;
+using NewRelic.Core;
 
 namespace NewRelic.Agent.Core
 {
@@ -50,7 +51,7 @@ namespace NewRelic.Agent.Core
                 AddVariable(".NET Version", () => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.ToString());
                 AddVariable("Processor Architecture", () => System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString());
 #else
-                AddVariable(".NET Version", () => System.Environment.Version.ToString());
+                AddVariable(".NET Version", () => DotnetVersion.GetDotnetFrameworkVersion().ToString());
                 AddVariable("Processor Architecture", () => (IntPtr.Size == 8) ? "X64" : "X86");
 #endif
                 AddVariable("Total Physical System Memory", () => TotalPhysicalMemory);


### PR DESCRIPTION
## Description

Resolves #800.  To send the correct value for the .NET Framework version a profiled app is running on in the environment data, use the same logic that our supportability metrics do.

Since we're just ToString()ing the enum returned by `DotnetVersion.GetDotnetFrameworkVersion()`, the values reported will look like `net461` or `net48`.  If we want a different string format for this data we can implement some kind of mapping method.  For .NET Core apps, this data looks like `.NET 5.0.4` (for example).  I'm not sure how much we care about maintaining symmetry between the two.

# Author Checklist
- [X] Unit tests, ~Integration tests, and Unbounded tests~ completed
- [ ] Performance testing completed with satisfactory results (if required) - NA
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated - will update once we're sure we want to do this

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
