### PR TITLE
Enable CosmosDB tests

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -717,7 +717,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        namespace: [ Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
+        namespace: [ CosmosDB, Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, Oracle, Postgres, RabbitMq, Redis ]
       fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
     env:


### PR DESCRIPTION
Enable running the CosmosDB integration tests in CI.  The CosmosDB service has been enabled on the server used by the CI.
