### PR TITLE
Cosmosdb stored procedure tests

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -65,4 +65,10 @@
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="NetStandardLibraries\CosmosDB\StoredProcedures\HelloWorldStoredProc.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/CosmosDBExerciser.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
@@ -187,6 +188,49 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB
             {
                 await database.DeleteAsync();
             }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task CreateAndExecuteStoredProc(string databaseId, string containerId)
+        {
+            Console.WriteLine("Tests CosmosDB stored procedures");
+
+            var endpoint = CosmosDBConfiguration.CosmosDBServer;
+            var authKey = CosmosDBConfiguration.AuthKey;
+
+            using var client = new CosmosClient(endpoint, authKey, _cosmosClientOptions);
+            var databaseResponse = await client.CreateDatabaseIfNotExistsAsync(databaseId);
+            var database = databaseResponse.Database;
+
+            try
+            {
+                Container container = await database.CreateContainerIfNotExistsAsync(containerId, "/pk");
+
+                var cosmosScripts = container.Scripts;
+                var scriptId = "HelloWorldStoredProc";
+
+                Console.WriteLine("Creates HelloWorldStoredProc.js Stored procedure");
+
+                var sproc = await cosmosScripts.CreateStoredProcedureAsync(
+                    new StoredProcedureProperties(
+                        scriptId,
+                        File.ReadAllText("NetStandardLibraries/CosmosDB/StoredProcedures/HelloWorldStoredProc.js")));
+
+                Console.WriteLine("Executes HelloWorldStoredProc.js stored procedure");
+
+                var response = await container.Scripts.ExecuteStoredProcedureAsync<string>(
+                    scriptId, new PartitionKey(1), null);
+
+                Assert.True(String.Equals("Hello, World", response.Resource), "Failed to execute HelloWorldStoredProc.js stored procedure.");
+
+            }
+            finally
+            {
+                await database.DeleteAsync();
+            }
+
         }
 
         private static async Task QueryItems(Container container)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/StoredProcedures/HelloWorldStoredProc.js
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/CosmosDB/StoredProcedures/HelloWorldStoredProc.js
@@ -1,0 +1,6 @@
+﻿function hello () {
+    var context = getContext();
+    var response = context.getResponse();
+    response.setBody("Hello, World");
+}
+


### PR DESCRIPTION
Implemetation for https://github.com/newrelic/newrelic-dotnet-agent/issues/808

At level, this PR tests:
- Creates a simple stored procedure and stores it in the test cosmosdb database. CosmosDB stored procedures are basically javascript scripts that can be executed from the server side. The created test stored  procedure doesn’t do database related things much. All it does is returning “Hello, World” string to the client call.

- Executes the stored procedure.