### PR TITLE
Report total physical system memory on Linux

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
+* Fixes issue [#36](https://github.com/newrelic/newrelic-dotnet-agent/issues/36): Total system memory will now be correctly reported on Linux. ([#855](https://github.com/newrelic/newrelic-dotnet-agent/pull/855))
 
 ## [9.2.0] - 2021-11-18
 ### .NET 6 Compatibility

--- a/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
@@ -8,6 +8,7 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace NewRelic.Agent.Core.Utilities
 {
@@ -27,20 +28,48 @@ namespace NewRelic.Agent.Core.Utilities
 
         public ulong? GetTotalPhysicalMemoryBytes()
         {
-            try
+            var isLinux = false;
+#if NETSTANDARD2_0
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+#endif
+            if (isLinux)
             {
-                MemoryStatus status = new MemoryStatus();
-                status.length = Marshal.SizeOf(status);
-                if (!GlobalMemoryStatusEx(ref status))
+                try
                 {
-                    int err = Marshal.GetLastWin32Error();
-                    throw new Win32Exception(err);
+                    var memInfo = File.ReadAllText("/proc/meminfo");
+                    var memTotalRegex = new Regex(@"MemTotal\:\s*(\d+)\ kB");
+                    var match = memTotalRegex.Match(memInfo);
+                    if (match.Success)
+                    {
+                        // Despite the text of meminfo showing everything as 'kB' which should be
+                        // 'kilobytes', i.e. 1000 bytes, in fact it is reporting 'kibibytes' (KiB, 1024 bytes)
+                        var memTotalKiB = ulong.Parse(match.Groups[1].Value);
+                        return memTotalKiB * 1024;
+                    }
+                    return null;
                 }
-                return status.totalPhys;
+                catch (Exception)
+                {
+                    return null;
+                }
             }
-            catch (Exception)
+            else
             {
-                return null;
+                try
+                {
+                    MemoryStatus status = new MemoryStatus();
+                    status.length = Marshal.SizeOf(status);
+                    if (!GlobalMemoryStatusEx(ref status))
+                    {
+                        int err = Marshal.GetLastWin32Error();
+                        throw new Win32Exception(err);
+                    }
+                    return status.totalPhys;
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.Core.Utilities
         {
             var isLinux = false;
 #if NETSTANDARD2_0
-            RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 #endif
             if (isLinux)
             {
@@ -48,8 +48,9 @@ namespace NewRelic.Agent.Core.Utilities
                     }
                     return null;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Log.Warn("GetTotalPhysicalMemoryBytes(): exception caught trying to read from /proc/meminfo: " + ex.Message);
                     return null;
                 }
             }


### PR DESCRIPTION
## Description

Resolves #36.

Total system memory will now be reported by .NET core agents running on Linux systems.  The agent reads `/proc/meminfo` and pulls out the `MemTotal` value.

Regarding testing: I considered adding a unit test for this, but the only real logic is the regex parsing of the `MemTotal: 12345 kB` line, and so a unit test using mock/fake `/proc/meminfo` data would just be testing that the regex works or doesn't.  I can still add a unit test like this if desired; some refactoring would be required to make the method in question testable.  We don't have any existing integration tests for this feature of the agent, and an integration test seems too heavyweight for this.

I did test this change manually on Ubuntu 20.04 and verified that the total physical memory was being sent in the utilization payload.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed - see above statement
- [X] Performance testing completed with satisfactory results (if required) - N/A
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
