### PR TITLE
NSB: Fix issue with Handler transactions being ended by GC

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NServiceBus/LoadHandlersConnectorWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NServiceBus/LoadHandlersConnectorWrapper.cs
@@ -55,13 +55,22 @@ namespace NewRelic.Providers.Wrapper.NServiceBus
 
             void OnComplete(Task task)
             {
-                if (task?.Status == TaskStatus.RanToCompletion)
+                if (task == null)
                 {
-                    transaction.End();
+                    return;
                 }
-                else if (task?.Status == TaskStatus.Faulted)
+
+                if (task.Status == TaskStatus.Faulted)
                 {
                     transaction.NoticeError(task.Exception);
+                }
+
+                if (task.Status == TaskStatus.RanToCompletion
+                    || task.Status == TaskStatus.Canceled
+                    || task.Status == TaskStatus.Faulted)
+                {
+                    segment.End();
+                    transaction.End();
                 }
             }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -73,6 +73,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
             );
+
+            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
         }
     }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -73,6 +73,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
             );
+
+            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
         }
     }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -73,6 +73,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
             );
+
+            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
         }
     }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -73,6 +73,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
             );
+
+            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
         }
     }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -77,6 +77,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
             );
+
+            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
         }
     }
 


### PR DESCRIPTION
## Description

After reviewing some of the CI failures, the throwingHandler tests were relying on GC to close the transactions.

This updates the Handler wrapper to close the segment and transaction if the task is cancelled/failed/complete. I also added a check to all the handler tests to make sure we aren't relying on GC to close transactions.
