### PR TITLE
Fix correctly report whether SSC is enabled.

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 ### New Features
 * NServiceBus versions 6 and 7 are now supported in .NET Framework and .NET Core. ([#857](https://github.com/newrelic/newrelic-dotnet-agent/pull/857))
-* Add ability to disable agent support for Server-Configuration with `NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG` environment variable. ([#814](https://github.com/newrelic/newrelic-dotnet-agent/pull/814))
+* Add ability to disable agent support for Server-Configuration with `NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG` environment variable. The available value options are `true` and `false`. ([#814](https://github.com/newrelic/newrelic-dotnet-agent/pull/814))
 
 ### Fixes
 * Fixes issue [#36](https://github.com/newrelic/newrelic-dotnet-agent/issues/36): Total system memory will now be correctly reported on Linux. ([#855](https://github.com/newrelic/newrelic-dotnet-agent/pull/855))

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
@@ -310,10 +310,8 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 serverConfiguration.RpmConfig = new AgentConfig();
             }
-            else
-            {
-                serverConfiguration.ServerSideConfigurationEnabled = JsonContainsNonNullProperty(json, "agent_config");
-            }
+
+            serverConfiguration.ServerSideConfigurationEnabled = JsonContainsNonNullProperty(json, "agent_config");
 
             return serverConfiguration;
         }


### PR DESCRIPTION
Before the fix:
When the agent is set to ignore SSC, the agent didn't set the `serverConfiguration.ServerSideConfigurationEnabled` flag so that it would report the SSC Enabled/Disable correctly.

After the fix:
Regardless whether or not the agent is set to ignore SSC, `serverConfiguration.ServerSideConfigurationEnabled` flag will still reflect SSC Enable/Disable correctly.

This is manually tested.
