### PR TITLE
Fix path for signing keys

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -281,7 +281,7 @@ jobs:
             echo "AWS_ACCESS_KEY_ID=${{ secrets.TEST_BUCKET_AWS_ACCESS_KEY_ID }}" >> docker.env
             echo "AWS_SECRET_ACCESS_KEY=${{ secrets.TEST_BUCKET_AWS_SECRET_ACCESS_KEY }}" >> docker.env
           fi
-          echo "GPG_KEYS=/deployscripts/gpg.tar.bz2" >> docker.env
+          echo "GPG_KEYS=/data/deploy_scripts/gpg.tar.bz2" >> docker.env
         shell: bash
 
       - name: Build and Run Container


### PR DESCRIPTION
Need to fix a path in the agent deploy workflow based on the changes in this previous PR: https://github.com/newrelic/newrelic-dotnet-agent/pull/862/files

I tested this by running a test deploy and it succeeded: https://github.com/newrelic/newrelic-dotnet-agent/runs/4707961644?check_suite_focus=true