### PR TITLE
Automatically detect CLR type.

### DIFF
--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -325,7 +325,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
         void SetLogLevel(rapidxml::xml_node<xchar_t>* configurationNode)
         {
             if (_systemCalls) {
-                auto envLevel = _systemCalls->GetNewRelicLogLevelEnvironment();
+                auto envLevel = _systemCalls->GetNewRelicLogLevel();
                 if (envLevel) {
                     _logLevel = TryParseLogLevel(*envLevel);
                     return;

--- a/src/Agent/NewRelic/Profiler/Logging/DefaultFileLogLocation.h
+++ b/src/Agent/NewRelic/Profiler/Logging/DefaultFileLogLocation.h
@@ -21,10 +21,11 @@ namespace NewRelic { namespace Profiler { namespace Logger
         virtual void DirectoryCreate(const xstring_t& logFilePath) = 0;
         // can throw on failure
         virtual xstring_t GetCommonAppDataFolderPath() = 0;
-        virtual xstring_t GetNewRelicHomePathEnvVar() = 0;
-        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() = 0;
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectoryEnvironment() = 0;
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevelEnvironment() = 0;
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicHomePath() = 0;
+        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectory() = 0;
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectory() = 0;
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevel() = 0;
     };
     typedef std::shared_ptr<IFileDestinationSystemCalls> IFileDestinationSystemCallsPtr;
 
@@ -53,14 +54,14 @@ namespace NewRelic { namespace Profiler { namespace Logger
         xstring_t GetLogFilePath()
         {
             // use the profiler environment variable if it is set
-            auto logDirectory = _system->GetNewRelicProfilerLogDirectoryEnvironment();
+            auto logDirectory = _system->GetNewRelicProfilerLogDirectory();
             if (logDirectory)
             {
                 return *logDirectory;
             }
 
             // use the general environment variable if it is set
-            logDirectory = _system->GetNewRelicLogDirectoryEnvironment();
+            logDirectory = _system->GetNewRelicLogDirectory();
             if (logDirectory)
             {
                 return *logDirectory;
@@ -73,7 +74,7 @@ namespace NewRelic { namespace Profiler { namespace Logger
             }
 
             // if there is a NEWRELIC_HOME environment variable log relative to it
-            logDirectory = _system->TryGetEnvironmentVariable(_system->GetNewRelicHomePathEnvVar());
+            logDirectory = _system->GetNewRelicHomePath();
             if (logDirectory)
             {
                 return *logDirectory + 

--- a/src/Agent/NewRelic/Profiler/Logging/DefaultFileLogLocation.h
+++ b/src/Agent/NewRelic/Profiler/Logging/DefaultFileLogLocation.h
@@ -21,7 +21,7 @@ namespace NewRelic { namespace Profiler { namespace Logger
         virtual void DirectoryCreate(const xstring_t& logFilePath) = 0;
         // can throw on failure
         virtual xstring_t GetCommonAppDataFolderPath() = 0;
-        virtual xstring_t GetNewRelicHomePath() = 0;
+        virtual xstring_t GetNewRelicHomePathEnvVar() = 0;
         virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() = 0;
         virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectoryEnvironment() = 0;
         virtual std::unique_ptr<xstring_t> GetNewRelicLogLevelEnvironment() = 0;
@@ -73,7 +73,7 @@ namespace NewRelic { namespace Profiler { namespace Logger
             }
 
             // if there is a NEWRELIC_HOME environment variable log relative to it
-            logDirectory = _system->TryGetEnvironmentVariable(_system->GetNewRelicHomePath());
+            logDirectory = _system->TryGetEnvironmentVariable(_system->GetNewRelicHomePathEnvVar());
             if (logDirectory)
             {
                 return *logDirectory + 

--- a/src/Agent/NewRelic/Profiler/LoggingTest/DefaultFileLogLocationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/LoggingTest/DefaultFileLogLocationTest.cpp
@@ -76,7 +76,7 @@ namespace NewRelic { namespace Profiler { namespace Logger { namespace Test
             else return L"C:\\Common\\AppData\\FolderPath";
         }
 
-        virtual std::wstring GetNewRelicHomePath() override
+        virtual std::wstring GetNewRelicHomePathEnvVar() override
         {
             return L"NEWRELIC_HOME";
         }

--- a/src/Agent/NewRelic/Profiler/LoggingTest/DefaultFileLogLocationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/LoggingTest/DefaultFileLogLocationTest.cpp
@@ -76,22 +76,22 @@ namespace NewRelic { namespace Profiler { namespace Logger { namespace Test
             else return L"C:\\Common\\AppData\\FolderPath";
         }
 
-        virtual std::wstring GetNewRelicHomePathEnvVar() override
+        virtual std::unique_ptr<xstring_t> GetNewRelicHomePath() override
         {
-            return L"NEWRELIC_HOME";
+            return TryGetEnvironmentVariable(L"NEWRELIC_HOME");
         }
 
-        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() override
+        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectory() override
         {
             return TryGetEnvironmentVariable(L"NEWRELIC_PROFILER_LOG_DIRECTORY");
         }
 
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectoryEnvironment() override
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectory() override
         {
             return TryGetEnvironmentVariable(L"NEWRELIC_LOG_DIRECTORY");
         }
 
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevelEnvironment() override
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevel() override
         {
             return TryGetEnvironmentVariable(L"NEWRELIC_LOG_LEVEL");
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
@@ -12,8 +12,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
     struct ISystemCalls
     {
         virtual std::unique_ptr<xstring_t> TryGetEnvironmentVariable(const xstring_t& variableName) = 0;
-        virtual xstring_t GetNewRelicHomePath() = 0;
-        virtual xstring_t GetNewRelicInstallPath() = 0;
+        virtual xstring_t GetNewRelicHomePathEnvVar() = 0;
+        virtual xstring_t GetNewRelicInstallPathEnvVar() = 0;
         virtual bool FileExists(const xstring_t& filePath) = 0;
     };
     typedef std::shared_ptr<ISystemCalls> ISystemCallsPtr;

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
@@ -12,6 +12,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
     struct ISystemCalls
     {
         virtual std::unique_ptr<xstring_t> TryGetEnvironmentVariable(const xstring_t& variableName) = 0;
+        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) = 0;
         virtual xstring_t GetNewRelicHomePathEnvVar() = 0;
         virtual xstring_t GetNewRelicInstallPathEnvVar() = 0;
         virtual bool FileExists(const xstring_t& filePath) = 0;

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
@@ -7,15 +7,73 @@
 #include <string>
 #include <set>
 #include "../Common/xplat.h"
+#include "../Logging/DefaultFileLogLocation.h"
 
 namespace NewRelic { namespace Profiler { namespace MethodRewriter {
-    struct ISystemCalls
+    struct ISystemCalls : Logger::IFileDestinationSystemCalls
     {
         virtual std::unique_ptr<xstring_t> TryGetEnvironmentVariable(const xstring_t& variableName) = 0;
-        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) = 0;
-        virtual xstring_t GetNewRelicHomePathEnvVar() = 0;
-        virtual xstring_t GetNewRelicInstallPathEnvVar() = 0;
         virtual bool FileExists(const xstring_t& filePath) = 0;
+
+        virtual void SetCoreAgent(bool IsCore = false)
+        {
+            _isCoreClr = IsCore;
+        }
+
+        virtual xstring_t GetNewRelicHomePathVariable()
+        {
+            return _isCoreClr
+                ? _X("CORECLR_NEWRELIC_HOME")
+                : _X("NEWRELIC_HOME");
+        }
+
+        virtual xstring_t GetNewRelicInstallPathVariable()
+        {
+            return _X("NEWRELIC_INSTALL_PATH");
+        }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicHomePath()
+        {
+            return TryGetEnvironmentVariable(GetNewRelicHomePathVariable());
+        }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicInstallPath()
+        {
+            return TryGetEnvironmentVariable(GetNewRelicInstallPathVariable());
+        }
+
+        virtual bool GetForceProfiling()
+        {
+            return TryGetEnvironmentVariable(_X("NEWRELIC_FORCE_PROFILING")) != nullptr;
+        }
+
+        virtual std::unique_ptr<xstring_t> GetProfilerDelay()
+        {
+            return TryGetEnvironmentVariable(_X("NEWRELIC_PROFILER_DELAY_IN_SEC"));
+        }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectory()
+        {
+            return TryGetEnvironmentVariable(_X("NEWRELIC_PROFILER_LOG_DIRECTORY"));
+        }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectory()
+        {
+            return TryGetEnvironmentVariable(_X("NEWRELIC_LOG_DIRECTORY"));
+        }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevel()
+        {
+            return TryGetEnvironmentVariable(_X("NEWRELIC_LOG_LEVEL"));
+        }
+
+        virtual std::unique_ptr<xstring_t> GetAppPoolId()
+        {
+            return TryGetEnvironmentVariable(_X("APP_POOL_ID"));
+        }
+
+    private:
+        bool _isCoreClr = false;
     };
     typedef std::shared_ptr<ISystemCalls> ISystemCallsPtr;
     typedef std::set<xstring_t> FilePaths;

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
@@ -25,12 +25,12 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return EnvironmentVariableResult(variableName);
         }
 
-        virtual std::wstring GetNewRelicHomePath() override
+        virtual std::wstring GetNewRelicHomePathEnvVar() override
         {
             return L"NEWRELIC_HOME_DIRECTORY";
         }
 
-        virtual std::wstring GetNewRelicInstallPath() override
+        virtual std::wstring GetNewRelicInstallPathEnvVar() override
         {
             return L"NEWRELIC_INSTALL_PATH";
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
@@ -25,16 +25,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             return EnvironmentVariableResult(variableName);
         }
 
-        virtual std::wstring GetNewRelicHomePathEnvVar() override
-        {
-            return L"NEWRELIC_HOME_DIRECTORY";
-        }
-
-        virtual std::wstring GetNewRelicInstallPathEnvVar() override
-        {
-            return L"NEWRELIC_INSTALL_PATH";
-        }
-
         virtual bool FileExists(const xstring_t&) override
         {
             return true;

--- a/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
@@ -20,13 +20,10 @@ namespace NewRelic { namespace Profiler {
             : ICorProfilerCallbackBase(
 #ifdef PAL_STDCPP_COMPAT
                   std::make_shared<SystemCalls>()
-#else
-                  std::make_shared<SystemCalls>(_X("CORECLR_NEWRELIC_HOME"), _X("NEWRELIC_INSTALL_PATH"))
 #endif
               )
         {
             GetSingletonish() = this;
-            _productName = _X("New Relic .NET CoreCLR Agent");
         }
 
         ~CoreCLRCorProfilerCallbackImpl()

--- a/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
@@ -17,11 +17,7 @@ namespace NewRelic { namespace Profiler {
 
     public:
         CoreCLRCorProfilerCallbackImpl()
-            : ICorProfilerCallbackBase(
-#ifdef PAL_STDCPP_COMPAT
-                  std::make_shared<SystemCalls>()
-#endif
-              )
+            : ICorProfilerCallbackBase()
         {
             GetSingletonish() = this;
         }

--- a/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CoreCLRCorProfilerCallbackImpl.h
@@ -53,11 +53,6 @@ namespace NewRelic { namespace Profiler {
             }
         }
 
-        virtual bool ShouldInstrument(std::shared_ptr<Configuration::Configuration> configuration, xstring_t processPath, xstring_t commandLine, xstring_t appPoolId) override
-        {
-            return configuration->ShouldInstrumentNetCore(processPath, appPoolId, commandLine);
-        }
-
         virtual xstring_t GetRuntimeExtensionsDirectoryName() override
         {
             return _X("netcore");

--- a/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
@@ -39,11 +39,6 @@ namespace NewRelic { namespace Profiler
         }
 #pragma warning (pop)
 
-        virtual bool ShouldInstrument(std::shared_ptr<Configuration::Configuration> configuration, xstring_t processPath, xstring_t /* commandLine */, xstring_t appPoolId) override
-        {
-            return configuration->ShouldInstrumentNetFramework(processPath, appPoolId);
-        }
-
         virtual xstring_t GetRuntimeExtensionsDirectoryName() override
         {
             return _X("netframework");

--- a/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
@@ -17,6 +17,7 @@ namespace NewRelic { namespace Profiler
 
     public:
         FrameworkCorProfilerCallbackImpl()
+            : ICorProfilerCallbackBase()
         {
             GetSingletonish() = this;
         }

--- a/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FrameworkCorProfilerCallbackImpl.h
@@ -17,10 +17,8 @@ namespace NewRelic { namespace Profiler
 
     public:
         FrameworkCorProfilerCallbackImpl()
-            : ICorProfilerCallbackBase(std::make_shared<SystemCalls>(_X("NEWRELIC_HOME"), _X("NEWRELIC_INSTALL_PATH")))
         {
             GetSingletonish() = this;
-            _productName = _X("New Relic .NET Agent");
         }
 
         ~FrameworkCorProfilerCallbackImpl()

--- a/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
@@ -836,7 +836,7 @@ namespace Profiler {
 
         static std::unique_ptr<xstring_t> TryGetNewRelicHomeFromEnvironment(std::shared_ptr<MethodRewriter::ISystemCalls> systemCalls)
         {
-            return systemCalls->TryGetEnvironmentVariable(systemCalls->GetNewRelicHomePath());
+            return systemCalls->TryGetEnvironmentVariable(systemCalls->GetNewRelicHomePathEnvVar());
         }
 
         static xstring_t GetNewRelicHomePath(std::shared_ptr<MethodRewriter::ISystemCalls> systemCalls)
@@ -981,8 +981,8 @@ namespace Profiler {
 
         std::unique_ptr<xstring_t> GetAgentCoreDllPath()
         {
-            auto nrInstallPathEnvVar = _systemCalls->GetNewRelicInstallPath();
-            auto nrHomeEnvVar = _systemCalls->GetNewRelicHomePath();
+            auto nrInstallPathEnvVar = _systemCalls->GetNewRelicInstallPathEnvVar();
+            auto nrHomeEnvVar = _systemCalls->GetNewRelicHomePathEnvVar();
             auto runtimeDirectoryName = GetRuntimeExtensionsDirectoryName();
 
             auto maybeCorePath = TryGetCorePathFromBasePath(_systemCalls->TryGetEnvironmentVariable(nrInstallPathEnvVar), runtimeDirectoryName);

--- a/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
@@ -74,6 +74,7 @@ namespace Profiler {
         ICorProfilerCallbackBase()
             : _referenceCount(0)
         {
+            _systemCalls = std::make_shared<SystemCalls>();
         }
 
         virtual ~ICorProfilerCallbackBase()
@@ -171,7 +172,6 @@ namespace Profiler {
         // Base profiler initialization method
         virtual HRESULT __stdcall Initialize(IUnknown* pICorProfilerInfoUnk) override
         {
-            _systemCalls = std::make_shared<SystemCalls>();
 #ifdef DEBUG
             DelayProfilerAttach();
 #endif
@@ -206,7 +206,7 @@ namespace Profiler {
                 }
 
                 // set systemCalls and productName
-                _systemCalls->SetNewRelicHomeAndInstallPathEnvVar(_isCoreClr);
+                _systemCalls->SetCoreAgent(_isCoreClr);
                 _productName = _isCoreClr ? _X("New Relic .NET CoreCLR Agent") : _X("New Relic .NET Agent");
 
                 HRESULT loggingInitResult = InitializeLogging();
@@ -236,7 +236,7 @@ namespace Profiler {
                 this->SetMethodRewriter(methodRewriter);
 
                 LogTrace("Checking to see if we should instrument this process.");
-                auto forceProfiling = _systemCalls->TryGetEnvironmentVariable(_X("NEWRELIC_FORCE_PROFILING")) != nullptr;
+                auto forceProfiling = _systemCalls->GetForceProfiling();
                 auto processPath = GetAndTransformProcessPath();
                 auto commandLine = _systemCalls->GetProgramCommandLine();
                 auto appPoolId = GetAppPoolId(_systemCalls);
@@ -780,7 +780,7 @@ namespace Profiler {
         {
             //This will pull the app pool name out of instances of IIS > 5.1
             //For more information see http://msdn.microsoft.com/en-us/library/ms524602(v=vs.90).aspx
-            auto appPoolId = systemCalls->TryGetEnvironmentVariable(_X("APP_POOL_ID"));
+            auto appPoolId = systemCalls->GetAppPoolId();
             if (appPoolId == nullptr) {
                 return _X("");
             } else {
@@ -864,7 +864,7 @@ namespace Profiler {
 
         static std::unique_ptr<xstring_t> TryGetNewRelicHomeFromEnvironment(std::shared_ptr<MethodRewriter::ISystemCalls> systemCalls)
         {
-            return systemCalls->TryGetEnvironmentVariable(systemCalls->GetNewRelicHomePathEnvVar());
+            return systemCalls->GetNewRelicHomePath();
         }
 
         static xstring_t GetNewRelicHomePath(std::shared_ptr<MethodRewriter::ISystemCalls> systemCalls)
@@ -1009,19 +1009,20 @@ namespace Profiler {
 
         std::unique_ptr<xstring_t> GetAgentCoreDllPath()
         {
-            auto nrInstallPathEnvVar = _systemCalls->GetNewRelicInstallPathEnvVar();
-            auto nrHomeEnvVar = _systemCalls->GetNewRelicHomePathEnvVar();
             auto runtimeDirectoryName = GetRuntimeExtensionsDirectoryName();
 
-            auto maybeCorePath = TryGetCorePathFromBasePath(_systemCalls->TryGetEnvironmentVariable(nrInstallPathEnvVar), runtimeDirectoryName);
+            auto maybeCorePath = TryGetCorePathFromBasePath(_systemCalls->GetNewRelicInstallPath(), runtimeDirectoryName);
             if (maybeCorePath != nullptr)
                 return maybeCorePath;
 
-            maybeCorePath = TryGetCorePathFromBasePath(_systemCalls->TryGetEnvironmentVariable(nrHomeEnvVar), runtimeDirectoryName);
+            maybeCorePath = TryGetCorePathFromBasePath(_systemCalls->GetNewRelicHomePath(), runtimeDirectoryName);
             if (maybeCorePath != nullptr)
                 return maybeCorePath;
 
-            LogError(L"Unable to find ", nrInstallPathEnvVar, L" or ", nrHomeEnvVar, L" environment variables.  Aborting instrumentation.");
+            auto homeEnvVar = _systemCalls->GetNewRelicHomePathVariable();
+            auto installEnvVar = _systemCalls->GetNewRelicInstallPathVariable();
+
+            LogError(L"Unable to find ", homeEnvVar, L" or ", installEnvVar, L" environment variables.  Aborting instrumentation.");
             return nullptr;
         }
 
@@ -1132,7 +1133,7 @@ namespace Profiler {
 
         void DelayProfilerAttach()
         {
-            auto profilerDelay = _systemCalls->TryGetEnvironmentVariable(_X("NEWRELIC_PROFILER_DELAY_IN_SEC"));
+            auto profilerDelay = _systemCalls->GetProfilerDelay();
             if (profilerDelay != nullptr) {
                 auto seconds = xstoi(*profilerDelay);
                 std::this_thread::sleep_for(std::chrono::seconds(seconds));

--- a/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
@@ -265,7 +265,10 @@ namespace Profiler {
             return eventMask;
         }
 
-        virtual bool ShouldInstrument(std::shared_ptr<Configuration::Configuration> configuration, xstring_t processPath, xstring_t commandLine, xstring_t appPoolId) = 0;
+        bool ShouldInstrument(std::shared_ptr<Configuration::Configuration> configuration, xstring_t processPath, xstring_t commandLine, xstring_t appPoolId)
+        {
+            return _isCoreClr ? configuration->ShouldInstrumentNetCore(processPath, appPoolId, commandLine) : configuration->ShouldInstrumentNetFramework(processPath, appPoolId);
+        }
 
         virtual void ConfigureEventMask(IUnknown*) = 0;
 

--- a/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/ICorProfilerCallbackBase.h
@@ -171,6 +171,7 @@ namespace Profiler {
         // Base profiler initialization method
         virtual HRESULT __stdcall Initialize(IUnknown* pICorProfilerInfoUnk) override
         {
+            _systemCalls = std::make_shared<SystemCalls>();
 #ifdef DEBUG
             DelayProfilerAttach();
 #endif
@@ -205,7 +206,7 @@ namespace Profiler {
                 }
 
                 // set systemCalls and productName
-                _systemCalls = std::make_shared<SystemCalls>(_isCoreClr);
+                _systemCalls->SetNewRelicHomeAndInstallPathEnvVar(_isCoreClr);
                 _productName = _isCoreClr ? _X("New Relic .NET CoreCLR Agent") : _X("New Relic .NET Agent");
 
                 HRESULT loggingInitResult = InitializeLogging();

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -19,54 +19,10 @@ namespace NewRelic { namespace Profiler
 {
     using NewRelic::Profiler::MethodRewriter::FilePaths;
 
-    struct SystemCalls : Logger::IFileDestinationSystemCalls, MethodRewriter::ISystemCalls
+    struct SystemCalls : MethodRewriter::ISystemCalls
     {
-        xstring_t _newRelicHomePathEnvVar;
-        xstring_t _newRelicInstallPathEnvVar;
-
         SystemCalls()
         {
-        }
-
-        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) override
-        {
-            if (isCoreClr)
-            {
-                _newRelicHomePathEnvVar = _X("CORECLR_NEWRELIC_HOME");
-                _newRelicInstallPathEnvVar = _X("NEWRELIC_INSTALL_PATH");
-            }
-            else
-            {
-                _newRelicHomePathEnvVar = _X("NEWRELIC_HOME");
-                _newRelicInstallPathEnvVar = _X("NEWRELIC_INSTALL_PATH");
-            }
-
-            return;
-        }
-
-        virtual xstring_t GetNewRelicHomePathEnvVar() override
-        {
-            return _newRelicHomePathEnvVar;
-        }
-
-        virtual xstring_t GetNewRelicInstallPathEnvVar() override
-        {
-            return _newRelicInstallPathEnvVar;
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() override
-        {
-            return TryGetEnvironmentVariable(L"NEWRELIC_PROFILER_LOG_DIRECTORY");
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectoryEnvironment() override
-        {
-            return TryGetEnvironmentVariable(L"NEWRELIC_LOG_DIRECTORY");
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevelEnvironment() override
-        {
-            return TryGetEnvironmentVariable(L"NEWRELIC_LOG_LEVEL");
         }
 
         virtual std::unique_ptr<xstring_t> TryGetEnvironmentVariable(const xstring_t& variableName) override

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -24,10 +24,18 @@ namespace NewRelic { namespace Profiler
         xstring_t _newRelicHomePathEnvVar;
         xstring_t _newRelicInstallPathEnvVar;
 
-        SystemCalls(xstring_t newRelicHomePathEnvVar, xstring_t newRelicInstallPathEnvVar)
+        SystemCalls(bool isCoreClr)
         {
-            _newRelicHomePathEnvVar = newRelicHomePathEnvVar;
-            _newRelicInstallPathEnvVar = newRelicInstallPathEnvVar;
+            if (isCoreClr)
+            {
+                _newRelicHomePathEnvVar = _X("CORECLR_NEWRELIC_HOME");
+                _newRelicHomePathEnvVar = _X("NEWRELIC_INSTALL_PATH");
+            }
+            else
+            {
+                _newRelicHomePathEnvVar = _X("NEWRELIC_HOME");
+                _newRelicHomePathEnvVar = _X("NEWRELIC_INSTALL_PATH");
+            }
         }
 
         virtual xstring_t GetNewRelicHomePathEnvVar() override

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -24,18 +24,24 @@ namespace NewRelic { namespace Profiler
         xstring_t _newRelicHomePathEnvVar;
         xstring_t _newRelicInstallPathEnvVar;
 
-        SystemCalls(bool isCoreClr)
+        SystemCalls()
+        {
+        }
+
+        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) override
         {
             if (isCoreClr)
             {
                 _newRelicHomePathEnvVar = _X("CORECLR_NEWRELIC_HOME");
-                _newRelicHomePathEnvVar = _X("NEWRELIC_INSTALL_PATH");
+                _newRelicInstallPathEnvVar = _X("NEWRELIC_INSTALL_PATH");
             }
             else
             {
                 _newRelicHomePathEnvVar = _X("NEWRELIC_HOME");
-                _newRelicHomePathEnvVar = _X("NEWRELIC_INSTALL_PATH");
+                _newRelicInstallPathEnvVar = _X("NEWRELIC_INSTALL_PATH");
             }
+
+            return;
         }
 
         virtual xstring_t GetNewRelicHomePathEnvVar() override

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -21,23 +21,23 @@ namespace NewRelic { namespace Profiler
 
     struct SystemCalls : Logger::IFileDestinationSystemCalls, MethodRewriter::ISystemCalls
     {
-        xstring_t _newRelicHomePath;
-        xstring_t _newRelicInstallPath;
+        xstring_t _newRelicHomePathEnvVar;
+        xstring_t _newRelicInstallPathEnvVar;
 
-        SystemCalls(xstring_t newRelicHomePath, xstring_t newRelicInstallPath)
+        SystemCalls(xstring_t newRelicHomePathEnvVar, xstring_t newRelicInstallPathEnvVar)
         {
-            _newRelicHomePath = newRelicHomePath;
-            _newRelicInstallPath = newRelicInstallPath;
+            _newRelicHomePathEnvVar = newRelicHomePathEnvVar;
+            _newRelicInstallPathEnvVar = newRelicInstallPathEnvVar;
         }
 
-        virtual xstring_t GetNewRelicHomePath() override
+        virtual xstring_t GetNewRelicHomePathEnvVar() override
         {
-            return _newRelicHomePath;
+            return _newRelicHomePathEnvVar;
         }
 
-        virtual xstring_t GetNewRelicInstallPath() override
+        virtual xstring_t GetNewRelicInstallPathEnvVar() override
         {
-            return _newRelicInstallPath;
+            return _newRelicInstallPathEnvVar;
         }
 
         virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() override

--- a/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
@@ -24,6 +24,14 @@ namespace NewRelic { namespace Profiler
 
     struct SystemCalls : Logger::IFileDestinationSystemCalls, MethodRewriter::ISystemCalls
     {
+        SystemCalls()
+        {
+        }
+
+        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) override
+        {
+            return;
+        }
 
         virtual xstring_t GetNewRelicHomePathEnvVar() override
         {

--- a/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
@@ -25,12 +25,12 @@ namespace NewRelic { namespace Profiler
     struct SystemCalls : Logger::IFileDestinationSystemCalls, MethodRewriter::ISystemCalls
     {
 
-        virtual xstring_t GetNewRelicHomePath() override
+        virtual xstring_t GetNewRelicHomePathEnvVar() override
         {
             return _X("CORECLR_NEWRELIC_HOME");
         }
 
-        virtual xstring_t GetNewRelicInstallPath() override
+        virtual xstring_t GetNewRelicInstallPathEnvVar() override
         {
             return _X("NEWRELIC_INSTALL_PATH");
         }

--- a/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
@@ -22,40 +22,10 @@ namespace NewRelic { namespace Profiler
 {
     using NewRelic::Profiler::MethodRewriter::FilePaths;
 
-    struct SystemCalls : Logger::IFileDestinationSystemCalls, MethodRewriter::ISystemCalls
+    struct SystemCalls : MethodRewriter::ISystemCalls
     {
         SystemCalls()
         {
-        }
-
-        virtual void SetNewRelicHomeAndInstallPathEnvVar(bool isCoreClr) override
-        {
-            return;
-        }
-
-        virtual xstring_t GetNewRelicHomePathEnvVar() override
-        {
-            return _X("CORECLR_NEWRELIC_HOME");
-        }
-
-        virtual xstring_t GetNewRelicInstallPathEnvVar() override
-        {
-            return _X("NEWRELIC_INSTALL_PATH");
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectoryEnvironment() override
-        {
-            return TryGetEnvironmentVariable(_X("NEWRELIC_PROFILER_LOG_DIRECTORY"));
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectoryEnvironment() override
-        {
-            return TryGetEnvironmentVariable(_X("NEWRELIC_LOG_DIRECTORY"));
-        }
-
-        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevelEnvironment() override
-        {
-            return TryGetEnvironmentVariable(_X("NEWRELIC_LOG_LEVEL"));
         }
 
         static std::string ToCharString(xstring_t str)


### PR DESCRIPTION
Before combining the `CoreCLRCorProfilerCallbackImpl.h` and `FrameworkCorProfilerCallbackImpl.h` into once, this PR lays some ground work. More specially, this PR adds the CLR type detection logic inside the `Initialize()` method which helps with the later combining work.

I manually tested the new profiler in both Core and Framework. It attached and the agent successfully started.