### PR TITLE
Adds RecordLogMessage and LogEvents to Transaction with tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transactions/IInternalTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/IInternalTransaction.cs
@@ -11,6 +11,7 @@ using NewRelic.Agent.Core.DistributedTracing;
 using NewRelic.Agent.Core.Segments;
 using NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders;
 using NewRelic.Agent.Extensions.Providers;
+using NewRelic.Agent.Core.WireModels;
 
 namespace NewRelic.Agent.Core.Transactions
 {
@@ -23,6 +24,7 @@ namespace NewRelic.Agent.Core.Transactions
         /// parent segment (unless it is a root segment).
         /// </summary>
         IList<Segment> Segments { get; }
+        IList<LogEventWireModel> LogEvents { get; }
         ICandidateTransactionName CandidateTransactionName { get; }
         void RollupTransactionNameByStatusCodeIfNeeded();
         ITransactionMetadata TransactionMetadata { get; }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -277,5 +277,10 @@ namespace NewRelic.Agent.Core.Transactions
         {
             return this;
         }
+
+        public void RecordLogMessage(DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId)
+        {
+
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -16,6 +16,7 @@ using NewRelic.Agent.Core.Segments;
 using NewRelic.Agent.Core.Timing;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders;
 using NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Data;
 using NewRelic.Agent.Extensions.Parsing;
@@ -866,6 +867,8 @@ namespace NewRelic.Agent.Core.Transactions
             return this;
         }
 
+        private readonly ConcurrentList<LogEventWireModel> _logEvents = new ConcurrentList<LogEventWireModel>();
+        public IList<LogEventWireModel> LogEvents { get => _logEvents; }
 
         private readonly ConcurrentList<Segment> _segments = new ConcurrentList<Segment>();
         public IList<Segment> Segments { get => _segments; }
@@ -944,6 +947,14 @@ namespace NewRelic.Agent.Core.Transactions
                 return _segments.AddAndReturnIndex(segment);
             }
             return -1;
+        }
+
+        public void RecordLogMessage(DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId)
+        {
+            if (!string.IsNullOrWhiteSpace(logLevel) && _configuration.LogEventCollectorEnabled)
+            {
+                _logEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, logLevel, spanId, traceId));
+            }
         }
 
         public ImmutableTransaction ConvertToImmutableTransaction()

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
@@ -39,5 +39,15 @@ namespace NewRelic.Agent.Api.Experimental
         /// <param name="method">The method of the request, such as an HTTP verb (e.g. GET or POST).</param>
         /// <returns>An object that can be used to manage all of the data we support for external requests.</returns>
         IExternalSegmentData CreateExternalSegmentData(Uri destinationUri, string method);
+
+        /// <summary>
+        /// Records the log message in the transaction to later be forwarded if log forwarding is enabled.
+        /// </summary>
+        /// <param name="timestamp">Timestamp from the log message.</param>
+        /// <param name="logLevel">Severity or level of the log message.</param>
+        /// <param name="logMessage">The log message.</param>
+        /// <param name="spanId">The span ID of the segment the log message occured within.</param>
+        /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
+        void RecordLogMessage(DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Instrumentation.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.Segments;
+using NewRelic.Agent.Core.Segments.Tests;
+using NewRelic.Agent.Core.Transformers.TransactionTransformer;
+using NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Data;
+using NewRelic.Core;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.Transactions
+{
+    [TestFixture]
+    public class TransactionTests
+    {
+        private static DateTime Timestamp = DateTime.Now;
+        private const string Level = "DEBUG";
+        private const string Message = "the message";
+        private const string SpanId = "span";
+        private const string TraceId = "trace";
+
+        private ITransactionSegmentState _transactionSegmentState;
+
+        private IConfigurationService _configurationService;
+
+        private IConfiguration _configuration;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _configuration = GetDefaultConfiguration();
+            _configurationService = Mock.Create<IConfigurationService>();
+            Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
+            _transactionSegmentState = TransactionSegmentStateHelpers.GetItransactionSegmentState();
+
+            Mock.Arrange(() => _transactionSegmentState.GetRelativeTime()).Returns(() => TimeSpan.Zero);
+        }
+
+        [Test]
+        public void RecordLogMessage_SuccessfullyAddsMessage()
+        {
+            var node1 = GetNodeBuilder("seg1");
+            var node2 = GetNodeBuilder("seg2");
+            node1.Children.Add(node2);
+            var node3 = GetNodeBuilder("seg3");
+            var transaction = TestTransactions.CreateDefaultTransaction(segments: new List<Segment>() { node1.Segment, node2.Segment, node3.Segment }, configurationService: _configurationService);
+            transaction.RecordLogMessage(Timestamp, Level, Message, SpanId, TraceId);
+
+            var logevent = transaction.LogEvents[0];
+            Assert.AreEqual(1, transaction.LogEvents.Count);
+            Assert.IsNotNull(logevent);
+            Assert.AreEqual(Timestamp.ToUnixTimeMilliseconds(), logevent.TimeStamp);
+            Assert.AreEqual(Level, logevent.Level);
+            Assert.AreEqual(Message, logevent.Message);
+            Assert.AreEqual(SpanId, logevent.SpanId);
+            Assert.AreEqual(TraceId, logevent.TraceId);
+        }
+
+        [Test]
+        public void RecordLogMessage_MissingLogLevel_DoesNotAdd()
+        {
+            var node1 = GetNodeBuilder("seg1");
+            var node2 = GetNodeBuilder("seg2");
+            node1.Children.Add(node2);
+            var node3 = GetNodeBuilder("seg3");
+            var transaction = TestTransactions.CreateDefaultTransaction(segments: new List<Segment>() { node1.Segment, node2.Segment, node3.Segment }, configurationService: _configurationService);
+            transaction.RecordLogMessage(Timestamp, null, Message, SpanId, TraceId);
+
+            Assert.AreEqual(0, transaction.LogEvents.Count);
+        }
+
+        [Test]
+        public void RecordLogMessage_Disabled_DoesNotAdd()
+        {
+            Mock.Arrange(() => _configuration.LogEventCollectorEnabled).Returns(false);
+
+            var node1 = GetNodeBuilder("seg1");
+            var node2 = GetNodeBuilder("seg2");
+            node1.Children.Add(node2);
+            var node3 = GetNodeBuilder("seg3");
+            var transaction = TestTransactions.CreateDefaultTransaction(segments: new List<Segment>() { node1.Segment, node2.Segment, node3.Segment }, configurationService: _configurationService);
+            transaction.RecordLogMessage(Timestamp, Level, Message, SpanId, TraceId);
+
+            Assert.AreEqual(0, transaction.LogEvents.Count);
+        }
+
+        private SegmentTreeNodeBuilder GetNodeBuilder(string name, TimeSpan startTime = new TimeSpan(), TimeSpan duration = new TimeSpan())
+        {
+            return new SegmentTreeNodeBuilder(
+                GetSegment(name, duration.TotalSeconds, startTime));
+        }
+
+        private Segment GetSegment(string name)
+        {
+            var builder = new Segment(_transactionSegmentState, new MethodCallData("foo", "bar", 1));
+            builder.SetSegmentData(new SimpleSegmentData(name));
+            builder.End();
+            return builder;
+        }
+
+        public Segment GetSegment(string name, double duration, TimeSpan start = new TimeSpan())
+        {
+            return new Segment(start, TimeSpan.FromSeconds(duration), GetSegment(name), null);
+        }
+
+        public static IConfiguration GetDefaultConfiguration()
+        {
+            return TestTransactions.GetDefaultConfiguration();
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -40,6 +40,10 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             Mock.Arrange(() => configuration.ErrorCollectorCaptureEvents).Returns(true);
             Mock.Arrange(() => configuration.CaptureErrorCollectorAttributes).Returns(true);
             Mock.Arrange(() => configuration.TransactionTracerEnabled).Returns(true);
+            Mock.Arrange(() => configuration.LogMetricsCollectorEnabled).Returns(true);
+            Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
+            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(50000);
+            Mock.Arrange(() => configuration.LogEventsHarvestCycle).Returns(TimeSpan.FromSeconds(5));
             return configuration;
         }
 


### PR DESCRIPTION
## Description

* Adds RecordLogMessage to ITransactionExperimental.  This is mainly so that its possible to change without requiring deprecation or other warning.
* Adds RecordLogMessage to NewRelic.Agent.Core.Transactions.Transaction.
* Adds LogEvents ConcurrentList to NewRelic.Agent.Core.Transactions.Transaction and IInternalTransaction to store the LogEventWireModels before they are transformed.
* Includes Tests for RecordLogMessage that also checks the LogEvents collection.
* Updated TestTransaction fixture to include logging settings (metrics as well as forwarding to be thorough)

Also updates the logging intrumentation XML to make it UTF-8 no BOM (somehow it got setup with a BOM).  

Resolves #905 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
