### PR TITLE
Remove log4net from unbounded integration tests project

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="MySqlConnector" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="CouchbaseNetClient" Version="2.3.8" />
-    <PackageReference Include="log4net" Version="1.2.10" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
     <PackageReference Include="xunit" version="2.4.0" />
     <PackageReference Include="xunit.assert" Version="2.4.0" />


### PR DESCRIPTION
I don't know why the unbounded integration tests project had a reference to log4net, but I removed it and the solution still builds.  I ran the MS SQL tests locally and they still run and pass as expected.  The server CI will run all of the tests and let us know for sure.