### PR TITLE
Remove unneeded package references from WebApiAsync test app

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -66,33 +66,6 @@
   <ItemGroup>
     <PackageReference Include="Antlr">
       <Version>3.5.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="bootstrap">
-      <Version>3.3.7</Version>
-    </PackageReference>
-    <PackageReference Include="jQuery">
-      <Version>3.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept">
-      <Version>2.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel">
-      <Version>2.5.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.4</Version>


### PR DESCRIPTION
Cleaning up unnecessary package references from one of our test application projects.
