### PR TITLE
Adds LogEventAggregator with supportability metrics and tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -554,6 +554,12 @@ namespace NewRelic.Agent.Core.AgentHealth
             _logLinesCountByLevel[normalizedLevel].Increment();
         }
 
+        public void ReportLoggingEventCollected() => TrySend(_metricBuilder.TryBuildSupportabilitLoggingEventsCollectedMetric());
+
+        public void ReportLoggingEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildSupportabilitLoggingEventsRecollectedMetric(count));
+
+        public void ReportLoggingEventsSent(int count) => TrySend(_metricBuilder.TryBuildSupportabilitLoggingEventsSentMetric(count));
+
         #endregion
 
         public void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint)

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
@@ -140,5 +140,8 @@ namespace NewRelic.Agent.Core.AgentHealth
         void ReportInfiniteTracingSpanQueueSize(int queueSize);
 
         void IncrementLogLinesCount(string logLevel);
+        void ReportLoggingEventCollected();
+        void ReportLoggingEventsRecollected(int count);
+        void ReportLoggingEventsSent(int count);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -1,0 +1,207 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.WireModels;
+using NewRelic.Collections;
+using NewRelic.SystemInterfaces;
+
+namespace NewRelic.Agent.Core.Aggregators
+{
+    public interface ILogEventAggregator
+    {
+        void Collect(LogEventWireModel loggingEventWireModel);
+
+        void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority);
+    }
+
+    /// <summary>
+    /// An service for collecting and managing logging events.
+    /// </summary>
+    public class LogEventAggregator : AbstractAggregator<LogEventWireModel>, ILogEventAggregator
+    {
+        private const String EntityType = "SERVICE";
+        private const String PluginType = "nr-dotnet-agent";
+        private const double ReservoirReductionSizeMultiplier = 0.5;
+
+        private readonly IAgentHealthReporter _agentHealthReporter;
+        private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
+
+        private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> _logEvents = new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(0);
+
+        public LogEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
+            : base(dataTransportService, scheduler, processStatic)
+        {
+            _agentHealthReporter = agentHealthReporter;
+            ResetCollections(_configuration.LogEventsMaximumPerPeriod);
+        }
+
+        protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
+        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
+
+        public override void Collect(LogEventWireModel loggingEventWireModel)
+        {
+            _agentHealthReporter.ReportLoggingEventCollected();
+
+            _readerWriterLock.EnterReadLock();
+            try
+            {
+                AddEventToCollection(loggingEventWireModel);
+            }
+            finally
+            {
+                _readerWriterLock.ExitReadLock();
+            }
+        }
+
+        public void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority)
+        {
+            for (int i = 0; i < logEventWireModels.Count; i++)
+            {
+                _agentHealthReporter.ReportLoggingEventCollected();
+                logEventWireModels[i].Priority = priority;
+
+                _readerWriterLock.EnterReadLock();
+                try
+                {
+                    AddEventToCollection(logEventWireModels[i]);
+                }
+                finally
+                {
+                    _readerWriterLock.ExitReadLock();
+                }
+            }
+        }
+
+        protected override void Harvest()
+        {
+            ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> originalLogEvents;
+
+            _readerWriterLock.EnterWriteLock();
+            try
+            {
+                originalLogEvents = GetAndResetLogEvents(GetReservoirSize());
+            }
+            finally
+            {
+                _readerWriterLock.ExitWriteLock();
+            }
+
+            var aggregatedEvents = originalLogEvents.Where(node => node != null).Select(node => node.Data).ToList();
+
+            // Retrieve the number of add attempts before resetting the collection.
+            var eventHarvestData = new EventHarvestData(originalLogEvents.Size, originalLogEvents.GetAddAttemptsCount());
+
+            // if we don't have any events to publish then don't
+            if (aggregatedEvents.Count <= 0)
+            {
+                return;
+            }
+
+            // matches metadata so that utilization and this match
+            var hostname = !string.IsNullOrEmpty(_configuration.UtilizationFullHostName)
+                ? _configuration.UtilizationFullHostName
+                : _configuration.UtilizationHostName;
+
+            var modelsCollection = new LogEventWireModelCollection(
+                _configuration.ApplicationNames.ElementAt(0),
+                EntityType,
+                _configuration.EntityGuid,
+                hostname,
+                PluginType,
+                aggregatedEvents); ;
+
+            var responseStatus = DataTransportService.Send(modelsCollection);
+
+            HandleResponse(responseStatus, aggregatedEvents);
+        }
+
+        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+        {
+            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+            // limits are per 60 seconds, so we need to prorate the value to the faster-event-harvest.
+            ResetCollections(Convert.ToInt32(_configuration.LogEventsMaximumPerPeriod / (60 / HarvestCycle.TotalSeconds)));
+        }
+
+        #region Private Helpers
+
+        private void ResetCollections(int logEventCollectionCapacity)
+        {
+            GetAndResetLogEvents(logEventCollectionCapacity);
+        }
+
+        private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> GetAndResetLogEvents(int logEventCollectionCapacity)
+        {
+            return Interlocked.Exchange(ref _logEvents, new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(logEventCollectionCapacity));
+        }
+
+        private void AddEventToCollection(LogEventWireModel logEventWireModel)
+        {
+            _logEvents.Add(new PrioritizedNode<LogEventWireModel>(logEventWireModel));
+        }
+
+        private int GetReservoirSize()
+        {
+            return _logEvents.Size;
+        }
+
+        private void ReduceReservoirSize(int newSize)
+        {
+            if (newSize >= GetReservoirSize())
+                return;
+
+            _logEvents.Resize(newSize);
+        }
+
+        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<LogEventWireModel> logEvents)
+        {
+            switch (responseStatus)
+            {
+                case DataTransportResponseStatus.RequestSuccessful:
+                    _agentHealthReporter.ReportLoggingEventsSent(logEvents.Count);
+                    break;
+                case DataTransportResponseStatus.Retain:
+                    RetainEvents(logEvents);
+                    break;
+                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                    ReduceReservoirSize((int)(logEvents.Count * ReservoirReductionSizeMultiplier));
+                    RetainEvents(logEvents);
+                    break;
+                case DataTransportResponseStatus.Discard:
+                default:
+                    break;
+            }
+        }
+
+        private void RetainEvents(IEnumerable<LogEventWireModel> logEvents)
+        {
+            _agentHealthReporter.ReportLoggingEventsRecollected(logEvents.Count());
+
+            logEvents = logEvents.ToList();
+
+            foreach (var logEvent in logEvents)
+            {
+                if (logEvent != null)
+                {
+                    AddEventToCollection(logEvent);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
@@ -1013,6 +1013,10 @@ namespace NewRelic.Agent.Core.Metric
 
         private const string LoggingMetrics = "Logging";
         private const string LoggingMetricsDotnetLines = LoggingMetrics + PathSeparator + "lines";
+        private const string SupportabilityLoggingEventsPs = SupportabilityPs + "LoggingEvents" + PathSeparator;
+        public const string SupportabilityLoggingEventsSent = SupportabilityLoggingEventsPs + "TotalLoggingEventsSent";
+        public const string SupportabilityLoggingEventsCollected = SupportabilityLoggingEventsPs + "TotalLoggingEventsCollected";
+        public const string SupportabilityLoggingEventsRecollected = SupportabilityLoggingEventsPs + "TotalLoggingEventsRecollected";
 
         public static string GetLoggingMetricsLinesBySeverityName(string logLevel)
         {

--- a/src/Agent/NewRelic/Agent/Core/WireModels/IMetricBuilder.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/IMetricBuilder.cs
@@ -199,5 +199,11 @@ namespace NewRelic.Agent.Core.WireModels
         MetricWireModel TryBuildLoggingMetricsLinesCountBySeverityMetric(string logLevel, int count);
 
         MetricWireModel TryBuildLoggingMetricsLinesCountMetric(int count);
+
+        MetricWireModel TryBuildSupportabilitLoggingEventsCollectedMetric();
+
+        MetricWireModel TryBuildSupportabilitLoggingEventsRecollectedMetric(int loggingEventsRecollected);
+
+        MetricWireModel TryBuildSupportabilitLoggingEventsSentMetric(int loggingEventCount);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -970,6 +970,27 @@ namespace NewRelic.Agent.Core.WireModels
                 return BuildMetric(_metricNameService, proposedName, null, MetricDataWireModel.BuildCountData(count));
             }
 
+            public MetricWireModel TryBuildSupportabilitLoggingEventsCollectedMetric()
+            {
+                const string proposedName = MetricNames.SupportabilityLoggingEventsCollected;
+                var data = MetricDataWireModel.BuildCountData();
+                return BuildMetric(_metricNameService, proposedName, null, data);
+            }
+
+            public MetricWireModel TryBuildSupportabilitLoggingEventsRecollectedMetric(int loggingEventsRecollected)
+            {
+                const string proposedName = MetricNames.SupportabilityLoggingEventsRecollected;
+                var data = MetricDataWireModel.BuildCountData(loggingEventsRecollected);
+                return BuildMetric(_metricNameService, proposedName, null, data);
+            }
+
+            public MetricWireModel TryBuildSupportabilitLoggingEventsSentMetric(int loggingEventCount)
+            {
+                const string proposedName = MetricNames.SupportabilityLoggingEventsSent;
+                var data = MetricDataWireModel.BuildCountData(loggingEventCount);
+                return BuildMetric(_metricNameService, proposedName, null, data);
+            }
+
             #endregion
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
@@ -196,5 +196,24 @@ namespace NewRelic.Agent.Core.AgentHealth
                 () => Assert.AreEqual(3, allLines.Data.Value0)
                 );
         }
+
+        [Test]
+        public void ReportLoggingSupportabilityMetrics()
+        {
+            _agentHealthReporter.ReportLoggingEventCollected();
+            _agentHealthReporter.ReportLoggingEventsRecollected(1);
+            _agentHealthReporter.ReportLoggingEventsSent(2);
+            _agentHealthReporter.CollectMetrics();
+
+            var expectedMetricNamesAndValues = new Dictionary<string, long>
+            {
+                { "Supportability/LoggingEvents/TotalLoggingEventsCollected", 1 },
+                { "Supportability/LoggingEvents/TotalLoggingEventsRecollected", 1 },
+                { "Supportability/LoggingEvents/TotalLoggingEventsSent", 2 },
+            };
+            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+
+            CollectionAssert.IsSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
+        }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
@@ -1,0 +1,459 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using MoreLinq;
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.Attributes;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Fixtures;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Core.WireModels;
+using NewRelic.Collections;
+using NewRelic.Core;
+using NewRelic.SystemInterfaces;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.Aggregators
+{
+    [TestFixture]
+    public class LogEventAggregatorTests
+    {
+        private IDataTransportService _dataTransportService;
+        private IAgentHealthReporter _agentHealthReporter;
+        private LogEventAggregator _logEventAggregator;
+        private IProcessStatic _processStatic;
+        private ConfigurationAutoResponder _configurationAutoResponder;
+        private IScheduler _scheduler;
+        private Action _harvestAction;
+        private TimeSpan? _harvestCycle;
+        private static readonly TimeSpan ConfiguredHarvestCycle = TimeSpan.FromSeconds(5);
+
+        private const string TimeStampKey = "timestamp";
+
+        [SetUp]
+        public void SetUp()
+        {
+            var configuration = GetDefaultConfiguration();
+            Mock.Arrange(() => configuration.CollectorSendDataOnExit).Returns(true);
+            Mock.Arrange(() => configuration.CollectorSendDataOnExitThreshold).Returns(0);
+            Mock.Arrange(() => configuration.LogEventsHarvestCycle).Returns(ConfiguredHarvestCycle);
+            _configurationAutoResponder = new ConfigurationAutoResponder(configuration);
+
+            _dataTransportService = Mock.Create<IDataTransportService>();
+            _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
+            _processStatic = Mock.Create<IProcessStatic>();
+
+            _scheduler = Mock.Create<IScheduler>();
+            Mock.Arrange(() => _scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()))
+                .DoInstead<Action, TimeSpan, TimeSpan?>((action, harvestCycle, __) => { _harvestAction = action; _harvestCycle = harvestCycle; });
+            _logEventAggregator = new LogEventAggregator(_dataTransportService, _scheduler, _processStatic, _agentHealthReporter);
+
+            EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _logEventAggregator.Dispose();
+            _configurationAutoResponder.Dispose();
+        }
+
+        #region Configuration
+
+        [Test]
+        public void Collections_are_reset_on_configuration_update_event()
+        {
+            // Arrange
+            var configuration = GetDefaultConfiguration(int.MaxValue);
+            var sentEvents = null as LogEventWireModelCollection;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .DoInstead<LogEventWireModelCollection>(events => sentEvents = events);
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Act
+            EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(configuration, ConfigurationUpdateSource.Local));
+            _harvestAction();
+
+            // Assert
+            Assert.Null(sentEvents);
+        }
+
+        #endregion
+
+        [Test]
+        public void Events_send_on_harvest()
+        {
+            // Arrange
+            var sentEvents = null as LogEventWireModelCollection;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .DoInstead<LogEventWireModelCollection>(events => sentEvents = events);
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(2, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(3, "message1", "info", "spanid", "traceid")
+            };
+
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Assert.AreEqual(3, sentEvents.LoggingEvents.Count());
+            Assert.AreEqual(sentEvents.LoggingEvents, logEvents);
+        }
+
+        [Test]
+        public void Event_seen_reported_on_collect()
+        {
+            // Act
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Assert
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventCollected());
+        }
+
+        [Test]
+        public void Events_sent_reported_on_harvest()
+        {
+
+            // Arrange
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventCollected());
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventsSent(1));
+        }
+
+        [Test]
+        public void Events_are_not_sent_if_there_are_no_events_to_send()
+        {
+            // Arrange
+            var sendCalled = false;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sendCalled = true;
+                    return DataTransportResponseStatus.RequestSuccessful;
+                });
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Assert.False(sendCalled);
+        }
+
+        [Test]
+        public void Events_are_not_retained_after_harvest_if_response_equals_request_successful()
+        {
+            // Arrange
+            LogEventWireModelCollection sentEvents = null;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sentEvents = events;
+                    return DataTransportResponseStatus.RequestSuccessful;
+                });
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+            _harvestAction();
+            sentEvents = null; // reset
+
+            // Act- re-run Harvest to verify the Events are no longer there
+            _harvestAction();
+
+            // Assert
+            Assert.Null(sentEvents);
+        }
+
+        [Test]
+        public void Events_are_not_retained_after_harvest_if_response_equals_discard()
+        {
+            // Arrange
+            LogEventWireModelCollection sentEvents = null;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sentEvents = events;
+                    return DataTransportResponseStatus.Discard;
+                });
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+            _harvestAction();
+            sentEvents = null; // reset
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Assert.Null(sentEvents);
+        }
+
+        [Test]
+        public void Events_are_retained_after_harvest_if_response_equals_retain()
+        {
+            // Arrange
+            var sentEventCount = int.MinValue;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sentEventCount = events.LoggingEvents.Count();
+                    return DataTransportResponseStatus.Retain;
+                });
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(2, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+            _harvestAction();
+            sentEventCount = int.MinValue; // reset
+
+            // Act - re-run Harvest to verify the Events are still there
+            _harvestAction();
+
+            // Assert
+            Assert.AreEqual(2, sentEventCount);
+        }
+
+        [Test]
+        public void Half_of_the_events_are_retained_after_harvest_if_response_equals_post_too_big_error()
+        {
+            // Arrange
+            var sentEventCount = int.MinValue;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sentEventCount = events.LoggingEvents.Count();
+                    return DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard;
+                });
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(2, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+            _harvestAction();
+            sentEventCount = int.MinValue; // reset
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Assert.AreEqual(1, sentEventCount);
+        }
+
+        [Test]
+        public void Zero_events_are_retained_after_harvest_if_response_equals_post_too_big_error_with_only_one_event_in_post()
+        {
+            // Arrange
+            LogEventWireModelCollection sentEvents = null;
+            Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LogEventWireModelCollection>()))
+                .Returns<LogEventWireModelCollection>(events =>
+                {
+                    sentEvents = events;
+                    return DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard;
+                });
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+            _harvestAction();
+            sentEvents = null; // reset
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Assert.Null(sentEvents);
+        }
+
+        [Test]
+        public void When_no_events_are_published_then_no_events_are_reported_to_agent_health()
+        {
+            // Act
+            _harvestAction();
+
+            // Assert
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventCollected(), Occurs.Never());
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventsSent(Arg.IsAny<int>()), Occurs.Never());
+        }
+
+        [Test]
+        public void When_event_is_collected_then_events_seen_is_reported_to_agent_health()
+        {
+            // Act
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Assert
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventCollected());
+        }
+
+        [Test]
+        public void When_harvesting_events_then_event_sent_is_reported_to_agent_health()
+        {
+            // Arrange
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(2, "message1", "info", "spanid", "traceid"),
+                new LogEventWireModel(3, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Act
+            _harvestAction();
+
+            // Assert
+            Mock.Assert(() => _agentHealthReporter.ReportLoggingEventsSent(3));
+        }
+
+        [Test]
+        public void When_more_than_reservoir_size_events_are_reported_number_events_seen_is_accurate()
+        {
+            var expectedAddAttempts = 105;
+
+            for (var i = 0; i < expectedAddAttempts; i++)
+            {
+                var logEventsInner = new List<LogEventWireModel>
+                {
+                    new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+                };
+                _logEventAggregator.CollectWithPriority(logEventsInner, 1.0F);
+            }
+
+            // Access the private collection of events to get the number of add attempts.
+            var privateAccessor = new PrivateAccessor(_logEventAggregator);
+            var logEvents = privateAccessor.GetField("_logEvents") as ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>;
+            if (logEvents == null) throw new ArgumentNullException(nameof(logEvents));
+            var actualAddAttempts = logEvents.GetAddAttemptsCount();
+
+            _harvestAction();
+
+            Assert.AreEqual(expectedAddAttempts, actualAddAttempts);
+        }
+
+        [Test]
+        public void When_less_than_reservoir_size_events_are_reported_number_events_seen_is_accurate()
+        {
+            var expectedAddAttempts = 99;
+
+            for (var i = 0; i < expectedAddAttempts; i++)
+            {
+                var logEventsInner = new List<LogEventWireModel>
+                {
+                    new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+                };
+                _logEventAggregator.CollectWithPriority(logEventsInner, 1.0F);
+            }
+
+            // Access the private collection of events to get the number of add attempts.
+            var privateAccessor = new PrivateAccessor(_logEventAggregator);
+            var logEvents = privateAccessor.GetField("_logEvents") as ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>;
+            if (logEvents == null) throw new ArgumentNullException(nameof(logEvents));
+            var actualAddAttempts = logEvents.GetAddAttemptsCount();
+
+            _harvestAction();
+
+            Assert.AreEqual(expectedAddAttempts, actualAddAttempts);
+        }
+
+        [Test]
+        public void When_harvest_occurs_default_reservoir_size_is_reported_accurately()
+        {
+            const uint expectedReservoirSize = 100;
+
+            var logEvents = new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "message1", "info", "spanid", "traceid")
+            };
+            _logEventAggregator.CollectWithPriority(logEvents, 1.0F);
+
+            // Access the private collection of events to get the number of add attempts.
+            var privateAccessor = new PrivateAccessor(_logEventAggregator);
+            var actualReservoirSize = privateAccessor.CallMethod("GetReservoirSize");
+
+            _harvestAction();
+
+            Assert.AreEqual(expectedReservoirSize, actualReservoirSize);
+        }
+
+        [Test]
+        public void When_error_events_disabled_harvest_is_not_scheduled()
+        {
+            _configurationAutoResponder.Dispose();
+            _logEventAggregator.Dispose();
+            var configuration = Mock.Create<IConfiguration>();
+            Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(false);
+            _configurationAutoResponder = new ConfigurationAutoResponder(configuration);
+            _logEventAggregator = new LogEventAggregator(_dataTransportService, _scheduler, _processStatic, _agentHealthReporter);
+
+            EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());
+
+            Mock.Assert(() => _scheduler.StopExecuting(null, null), Args.Ignore());
+        }
+
+        [Test]
+        public void Harvest_cycle_should_match_configured_cycle()
+        {
+            Assert.AreEqual(ConfiguredHarvestCycle, _harvestCycle);
+        }
+
+        #region Helpers
+
+        private static IConfiguration GetDefaultConfiguration(int? versionNumber = null)
+        {
+            var configuration = Mock.Create<IConfiguration>();
+            Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
+            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(100);
+            Mock.Arrange(() => configuration.ApplicationNames).Returns(new List<string> { "appname1" });
+            if (versionNumber.HasValue)
+                Mock.Arrange(() => configuration.ConfigurationVersion).Returns(versionNumber.Value);
+            return configuration;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description

- Adds LogEventsAggregator using ErrorEventAggregator as a reference
- Adds new supportability metrics in AgentHealthReporter to track was is collected, sent, and recollect
- Adds tests for new supportability metrics
- Adds new test class for LogEventAggregator using ErrorEventAggregatorTests as a reference

Resolves #907

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
