### PR TITLE
Add environment variable overrides for Log Sending

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1783,8 +1783,8 @@ namespace NewRelic.Agent.Core.Configuration
         public virtual bool LogMetricsCollectorEnabled
         {
             get
-            {
-                return _localConfiguration.logSending.metrics.enabled;
+            { 
+                return EnvironmentOverrides(_localConfiguration.logSending.metrics.enabled, "NEW_RELIC_LOG_SENDING_METRICS_ENABLED");
             }
         }
 
@@ -1792,7 +1792,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return _localConfiguration.logSending.forwarding.enabled;
+                return EnvironmentOverrides(_localConfiguration.logSending.forwarding.enabled, "NEW_RELIC_LOG_SENDING_FORWARDING_ENABLED");
             }
         }
 
@@ -1808,7 +1808,8 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return _localConfiguration.logSending.forwarding.maxSamplesStored;
+                return EnvironmentOverrides(_localConfiguration.logSending.forwarding.maxSamplesStored, "NEW_RELIC_LOG_SENDING_MAX_SAMPLES_STORED")
+                    ?? _localConfiguration.logSending.forwarding.maxSamplesStored;
             }
         }
 


### PR DESCRIPTION
## Description

Resolves #924

Adds environment variable overrides for logging configuration options. I did not see any unit tests for env var overrides so did not add any.
