### PR TITLE
Revert Linux profiler build process to fix Alpine Linux crash

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 ### New Features
 ### Fixes
+* Fixes [application crashes on Alpine Linux](https://github.com/newrelic/newrelic-dotnet-agent/issues/918) introduced in 9.5.0. ([#929]https://github.com/newrelic/newrelic-dotnet-agent/pull/929)
 
 ## [9.5.0] - 2022-02-01
 ### New Features

--- a/src/Agent/NewRelic/Profiler/build/build.ps1
+++ b/src/Agent/NewRelic/Profiler/build/build.ps1
@@ -65,5 +65,5 @@ if ($buildLinux) {
     ExitIfFailLastExitCode
 
     if (!(Test-Path $linuxamd64OutputPath)) { New-Item $linuxamd64OutputPath -ItemType Directory }
-    Move-Item "$profilerRoot\libNewRelicProfiler.so" "$linuxamd64OutputPath"
+    Move-Item -Force "$profilerRoot\libNewRelicProfiler.so" "$linuxamd64OutputPath"
 }

--- a/src/Agent/NewRelic/Profiler/linux/Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Dockerfile
@@ -1,36 +1,43 @@
 # This builds an Ubuntu image, clones the coreclr github repo and builds it.
 # It then sets up the environment for compiling the New Relic .NET profiler.
-FROM ubuntu:18.04
+FROM ubuntu:14.04
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   wget \
   curl \
   git \
   dos2unix \
-  gnupg
-  
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | tee /etc/apt/sources.list.d/llvm.list
+  software-properties-common
+
+# Current ca-certificates packages has an expired root CA cert - remove it.
+RUN sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
+RUN update-ca-certificates
+
+RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get update
-
-# Putting this on it's own line, tzdata is a dependency of one of the packages being installed below
-# and it needs to be told what timezone it is in.  Just use UTC.
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-
-RUN apt-get install -y \
-  cmake llvm-7 clang-7 lldb-7 liblldb-7-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libnuma-dev libkrb5-dev \
-  libc++-dev \
-  uuid-dev \
-  zlib1g-dev \
-  locales \
-  locales-all
 
 # The CoreCLR build notes say their repos should be pulled into a `git` directory.
-# Not sure how necessary that is.
+# That probably isn't necessary, but whatever.
 RUN mkdir /root/git
 WORKDIR /root/git
 
-RUN git clone --branch release/3.1 https://github.com/dotnet/coreclr.git
+RUN git clone --branch release/3.0 https://github.com/dotnet/coreclr.git
 
-RUN ln -sf /usr/bin/clang-7 /usr/bin/cc; ln -sf /usr/bin/clang++-7 /usr/bin/c++
+# Install the build tools that the profiler requires
+RUN apt-get update && apt-get install -y \
+  make \
+  binutils \
+  libc++-dev \
+  clang-3.9 \
+  lldb-3.9
+
+# Remove expired root CA cert
+RUN sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g' /etc/ca-certificates.conf
+RUN update-ca-certificates
+
+# Install cmake 3.9
+RUN curl -sSL https://cmake.org/files/v3.9/cmake-3.9.0-rc3-Linux-x86_64.tar.gz | tar -xzC /opt
+RUN ln -s /opt/cmake-3.9.0-rc3-Linux-x86_64/bin/cmake /usr/local/sbin/cmake
+
+RUN rm /usr/bin/cc;   ln -s /usr/bin/clang-3.9 /usr/bin/cc
+RUN rm /usr/bin/c++;  ln -s /usr/bin/clang++-3.9 /usr/bin/c++

--- a/src/Agent/NewRelic/Profiler/linux/Dockerfile.new
+++ b/src/Agent/NewRelic/Profiler/linux/Dockerfile.new
@@ -1,0 +1,39 @@
+# This builds an Ubuntu image, clones the coreclr github repo and builds it.
+# It then sets up the environment for compiling the New Relic .NET profiler.
+
+# **WARNING** this will not build a profiler that works on Alpine Linux.
+# See https://github.com/newrelic/newrelic-dotnet-agent/issues/918
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y \
+  wget \
+  curl \
+  git \
+  dos2unix \
+  gnupg
+  
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | tee /etc/apt/sources.list.d/llvm.list
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-get update
+
+# Putting this on it's own line, tzdata is a dependency of one of the packages being installed below
+# and it needs to be told what timezone it is in.  Just use UTC.
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+
+RUN apt-get install -y \
+  cmake llvm-7 clang-7 lldb-7 liblldb-7-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libnuma-dev libkrb5-dev \
+  libc++-dev \
+  uuid-dev \
+  zlib1g-dev \
+  locales \
+  locales-all
+
+# The CoreCLR build notes say their repos should be pulled into a `git` directory.
+# Not sure how necessary that is.
+RUN mkdir /root/git
+WORKDIR /root/git
+
+RUN git clone --branch release/3.1 https://github.com/dotnet/coreclr.git
+
+RUN ln -sf /usr/bin/clang-7 /usr/bin/cc; ln -sf /usr/bin/clang++-7 /usr/bin/c++

--- a/src/Agent/NewRelic/Profiler/linux/README.md
+++ b/src/Agent/NewRelic/Profiler/linux/README.md
@@ -1,0 +1,16 @@
+## Linux profiler build Dockerfiles
+
+`Dockerfile` is currently the "old" Linux profiler build container that uses very out-of-date Ubuntu and llvm toolchain versions.
+However, it still works to build the profiler for Linux, including Alpine Linux.
+
+`Dockerfile.new` is a build container that uses more up-to-date Ubuntu and llvm versions and works to build the profiler for
+`glibc`-based Linux distros like Ubuntu and Centos.  However, the profiler built from this container will not work on `musl`-based
+Linux distros like Alpine.
+
+`Dockerfile.debug` is like `Dockerfile.new` but does some extra things to support debugging the profiler, but this was copied from
+an old process and it is a work in progress.
+
+We want to eventually figure out how to build the profiler using the newer llvm toolchain in a way that works on all Linux versions
+supported by Microsoft for .NET, including Alpine.
+
+Information correct as of 2022-02-03.


### PR DESCRIPTION
## Description

This fixes #918 where the agent was segfaulting customer application on Alpine Linux in release 9.5.0.

Summary of changes:
1. Revert to previous Linux profiler build container image.
2. Store the newer-but-broken profiler build container image as `Dockerfile.new` and add a README.md to describe what's going on.
3. New checked-in `libNewRelicProfiler.so` for dev builds.

I tested the new `libNewRelicProfiler.so` with integration tests on both Ubuntu and Alpine and it appears to be working as expected.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
