### PR TITLE
Adds log decorating to log4net wrapper with config

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -4909,11 +4909,14 @@ namespace NewRelic.Agent.Core.Config
         
         private configurationLogSendingForwarding forwardingField;
         
+        private configurationLogSendingDecorating decoratingField;
+        
         /// <summary>
         /// configurationLogSending class constructor
         /// </summary>
         public configurationLogSending()
         {
+            this.decoratingField = new configurationLogSendingDecorating();
             this.forwardingField = new configurationLogSendingForwarding();
             this.metricsField = new configurationLogSendingMetrics();
         }
@@ -4939,6 +4942,18 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.forwardingField = value;
+            }
+        }
+        
+        public configurationLogSendingDecorating decorating
+        {
+            get
+            {
+                return this.decoratingField;
+            }
+            set
+            {
+                this.decoratingField = value;
             }
         }
         
@@ -5050,6 +5065,48 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationLogSendingForwarding Clone()
         {
             return ((configurationLogSendingForwarding)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationLogSendingDecorating
+    {
+        
+        private bool enabledField;
+        
+        /// <summary>
+        /// configurationLogSendingDecorating class constructor
+        /// </summary>
+        public configurationLogSendingDecorating()
+        {
+            this.enabledField = true;
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(true)]
+        public bool enabled
+        {
+            get
+            {
+                return this.enabledField;
+            }
+            set
+            {
+                this.enabledField = value;
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationLogSendingDecorating object
+        /// </summary>
+        public virtual configurationLogSendingDecorating Clone()
+        {
+            return ((configurationLogSendingDecorating)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1623,6 +1623,23 @@
                               </xs:attribute>
                           </xs:complexType>
                       </xs:element>
+                      <xs:element name="decorating" minOccurs="0" maxOccurs="1">
+                          <xs:annotation>
+                              <xs:documentation>
+                                  When enabled, local log messages will be decorated with logs-in-context data as they are written.
+                                  The method used to decorate the messages depends on the logging framework and may require additional configuration.
+                              </xs:documentation>
+                          </xs:annotation>
+                          <xs:complexType>
+                              <xs:attribute name="enabled" type="xs:boolean" default="true">
+                                  <xs:annotation>
+                                      <xs:documentation>
+                                          Controls whether or not local log messages are decorated with logs-in-context data. Defaults to true.
+                                      </xs:documentation>
+                                  </xs:annotation>
+                              </xs:attribute>
+                          </xs:complexType>
+                      </xs:element>
                   </xs:sequence>
               </xs:complexType>
           </xs:element>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1813,6 +1813,14 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
+        public virtual bool LogDecoratorEnabled
+        {
+            get
+            {
+                return EnvironmentOverrides(_localConfiguration.logSending.decorating.enabled, "NEW_RELIC_LOG_SENDING_DECORATING_ENABLED");
+            }
+        }
+
         #endregion
 
         private bool? _diagnosticsCaptureAgentTiming;

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -186,5 +186,6 @@ namespace NewRelic.Agent.Configuration
         bool LogEventCollectorEnabled { get; }
         int LogEventsMaximumPerPeriod { get; }
         TimeSpan LogEventsHarvestCycle { get; }
+        bool LogDecoratorEnabled { get; }
     }
 }


### PR DESCRIPTION
## Description

- Refactors log4net wrapper to make it more readable by pulling out the message forwarding and decorating into different methods.
- Adds log decoration to log4net wrapper
- Adds configuration for enable/disable of log decorating with env var
- No tests since we don't test wrappers in unit tests

Closes #914

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
