### PR TITLE
High security mode or configurable security policies disable log forwarding

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -418,7 +418,7 @@ namespace NewRelic.Agent.Core
             if (!_configurationService.Configuration.LogEventCollectorEnabled || string.IsNullOrWhiteSpace(logMessage))
             {
                 return;
-            }           
+            }
 
             var transaction = _transactionService.GetCurrentInternalTransaction();
             if (transaction != null && transaction.IsValid)

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -583,7 +583,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             ReportAgentInfo();
             CollectInfiniteTracingMetrics();
             CollectLoggingMetrics();
-			CollectSupportabilityDataUsageMetrics();
+            CollectSupportabilityDataUsageMetrics();
         }
 
         public void RegisterPublishMetricHandler(PublishMetricDelegate publishMetricDelegate)

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1792,7 +1792,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED");
+                return !SecurityPoliciesTokenExists && HighSecurityModeOverrides(false, EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED"));
             }
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netHSMOrCSPDisablesForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netHSMOrCSPDisablesForwardingTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Logging
+{
+    public abstract class Log4netHSMOrCSPDisablesForwardingTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        public Log4netHSMOrCSPDisablesForwardingTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"Log4netTester Configure");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage One DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage Two INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage Three WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage Four ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage GetYourLogsOnTheDanceFloor FATAL");
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier
+                    .EnableLogForwarding()
+                    .EnableLogMetrics()
+                    .EnableDistributedTrace()
+                    .SetLogLevel("debug");
+
+                    if (typeof(TFixture).ToString().Contains("HSM"))
+                    {
+                        // Set HSM to "true"
+                        configModifier.SetHighSecurityMode(true);
+                    }
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void NoLogDataIsSent()
+        {
+            var logData = _fixture.AgentLog.GetLogEventData().FirstOrDefault();
+            Assert.Null(logData);
+
+            // Making sure logging metrics aren't disabled
+            var loggingMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = "Logging/lines", callCount = 5 },
+            };
+
+            var actualMetrics = _fixture.AgentLog.GetMetrics();
+            Assertions.MetricsExist(loggingMetrics, actualMetrics);
+
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netHSMDisablesForwardingTestsFWLatestTests : Log4netHSMOrCSPDisablesForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatestHSM>
+    {
+        public Log4netHSMDisablesForwardingTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatestHSM fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netCSPDisablesForwardingTestsFWLatestTests : Log4netHSMOrCSPDisablesForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatestCSP>
+    {
+        public Log4netCSPDisablesForwardingTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatestCSP fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netHSMDisablesForwardingTestsNetCoreLatestTests : Log4netHSMOrCSPDisablesForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatestHSM>
+    {
+        public Log4netHSMDisablesForwardingTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatestHSM fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+    [NetCoreTest]
+    public class Log4netCSPDisablesForwardingTestsNetCoreLatestTests : Log4netHSMOrCSPDisablesForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatestCSP>
+    {
+        public Log4netCSPDisablesForwardingTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatestCSP fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -16,6 +16,29 @@ namespace MultiFunctionApplicationHelpers
         }
     }
 
+
+    /// <summary>
+    /// Use this fixture for High Security Mode tests
+    /// </summary>
+    public class ConsoleDynamicMethodFixtureFWLatestHSM : ConsoleDynamicMethodFixtureFW48
+    {
+        public override string TestSettingCategory { get { return "HSM"; } }
+        public ConsoleDynamicMethodFixtureFWLatestHSM()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Use this fixture for Configurable Security Policy tests
+    /// </summary>
+    public class ConsoleDynamicMethodFixtureFWLatestCSP : ConsoleDynamicMethodFixtureFW48
+    {
+        public override string TestSettingCategory { get { return "CSP"; } }
+        public ConsoleDynamicMethodFixtureFWLatestCSP()
+        {
+        }
+    }
+
     public class ConsoleDynamicMethodFixtureFW48 : ConsoleDynamicMethodFixtureFWSpecificVersion
     {
         public ConsoleDynamicMethodFixtureFW48() : base("net48")
@@ -98,6 +121,30 @@ namespace MultiFunctionApplicationHelpers
         public ConsoleDynamicMethodFixtureCoreLatest()
         {
         }
+    }
+
+    /// <summary>
+    /// Use this fixture for High Security Mode tests
+    /// </summary>
+    public class ConsoleDynamicMethodFixtureCoreLatestHSM : ConsoleDynamicMethodFixtureCore60
+    {
+        public override string TestSettingCategory { get { return "HSM"; } }
+        public ConsoleDynamicMethodFixtureCoreLatestHSM()
+        {
+        }
+
+    }
+
+    /// <summary>
+    /// Use this fixture for Configurable Security Policy tests
+    /// </summary>
+    public class ConsoleDynamicMethodFixtureCoreLatestCSP : ConsoleDynamicMethodFixtureCore60
+    {
+        public override string TestSettingCategory { get { return "CSP"; } }
+        public ConsoleDynamicMethodFixtureCoreLatestCSP()
+        {
+        }
+
     }
 
     public abstract class ConsoleDynamicMethodFixtureCoreSpecificVersion : ConsoleDynamicMethodFixture

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2430,6 +2430,15 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
+        public void ApplicationLogging_ForwardingEnabled_IsOverriddenByHighSecurityMode()
+        {
+            _localConfig.applicationLogging.forwarding.enabled = true;
+            _localConfig.highSecurity.enabled = true;
+
+            Assert.IsFalse(_defaultConfig.LogEventCollectorEnabled);
+        }
+
+        [Test]
         public void ApplicationLogging_LocalDecordingEnabled_IsFalseInLocalConfigByDefault()
         {
             Assert.IsFalse(_defaultConfig.LogDecoratorEnabled);


### PR DESCRIPTION
## Description

Resolves #938.  If HSM or CSP (LASP) are enabled, log forwarding is disabled (but not metrics or local decorating).

Notes:
1. I added a unit test for HSM disabling log forwarding.  I wanted to add a similar test for CSP, but couldn't get it to work.  Any ideas appreciated.
2. For the integration tests, it was necessary to introduce some new ConsoleMF fixture types, to use the HSM and CSP test settings (which end up having the test application connect to staging with different license keys, to get the correct server side settings for HSM or CSP).  This parallels an existing pattern for other test applications used in HSM/CSP testing: https://github.com/newrelic/newrelic-dotnet-agent/blob/8db3371d441ff510dd190226ecc84d5b9bc48889/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicMvcApplicationTestFixture.cs#L496
3. I only did the integration tests for the latest versions of .NET Framework and Core; I don't think we need to exhaustively test this for all frameworks and/or versions of Log4Net since it's internal agent logic being tested.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [X] ~Performance testing completed with satisfactory results (if required)~
- [X] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
