### PR TITLE
Refactors local log decoration to use a single entry

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -70,12 +70,11 @@ namespace NewRelic.Providers.Wrapper.Logging
                 return;
             }
 
-            // the keys in the metadata match the ones used for decorating
-            var metadata = agent.GetLinkingMetadata();
-            foreach (var entry in metadata)
-            {
-                propertiesDictionary[entry.Key] = entry.Value ?? string.Empty;
-            }
+            // uses the foratted metadata to make a single entry
+            var formattedMetadata = LoggingHelpers.GetFormattedLinkingMetadata(agent);
+
+            // uses underscores to support other frameworks that do not allow hyphens (Serilog)
+            propertiesDictionary["NR_LINKING_METADATA"] = formattedMetadata;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/LoggingHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/LoggingHelpers.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using NewRelic.Agent.Api;
+
+namespace NewRelic.Providers.Wrapper.Logging
+{
+    public static class LoggingHelpers
+    {
+        public static string GetFormattedLinkingMetadata(IAgent agent)
+        {
+            var metadata = agent.GetLinkingMetadata();
+            var entries = new string[metadata.Count]; // keeps the array small and light
+            for (int i = 0; i < metadata.Count; i++)
+            {
+                var pair = metadata.ElementAt(i);
+                entries[i] = pair.Key + "=" + pair.Value; // faster than string.format or interpolation
+            }
+
+            return "NR-LINKING-METADATA: {" + string.Join(", ", entries) + "}";
+        }
+    }
+}


### PR DESCRIPTION
## Description

Refactors local log decoration to use a single entry which contains the entire metadata string in the proper format and with jsut the data that is available.  This me that if we are missing trace and span IDs, there will not be an empty or null entry in the properties list.  This also enables this to just work for Json layouts/sinks.

Adds a new LoggingHelpers static class with a single method currently.

No unit tests since its a wrapper change and no integration tests as of yet.

Closes #943 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
