### PR TITLE
Truncate log event message string to 32Kb

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModel.cs
@@ -3,11 +3,16 @@
 
 using System;
 using NewRelic.Collections;
+using NewRelic.SystemExtensions;
 
 namespace NewRelic.Agent.Core.WireModels
 {
     public class LogEventWireModel : IHasPriority
     {
+        // Not sure yet if we want 32 kilobytes (32 * 1000) or 32 kibibytes (32 * 1024).
+        // Going with the more conservative option for now.
+        private const uint MaxMessageLengthInBytes = 32 * 1000;
+
         /// <summary>
         /// The UTC timestamp in unix milliseconds. 
         /// </summary>
@@ -52,7 +57,7 @@ namespace NewRelic.Agent.Core.WireModels
         public LogEventWireModel(long unixTimestampMS, string message, string level, string spanId, string traceId)
         {
             TimeStamp = unixTimestampMS;
-            Message = message;
+            Message = message.TruncateUnicodeStringByBytes(MaxMessageLengthInBytes);
             Level = level;
             SpanId = spanId;
             TraceId = traceId;
@@ -61,7 +66,7 @@ namespace NewRelic.Agent.Core.WireModels
         public LogEventWireModel(long unixTimestampMS, string message, string level, string spanId, string traceId, float priority)
         {
             TimeStamp = unixTimestampMS;
-            Message = message;
+            Message = message.TruncateUnicodeStringByBytes(MaxMessageLengthInBytes);
             Level = level;
             SpanId = spanId;
             TraceId = traceId;

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Text;
 using NewRelic.Agent.Core.Metrics;
 using NewRelic.Collections;
 using NUnit.Framework;
@@ -61,6 +62,20 @@ namespace NewRelic.Agent.Core.WireModels
 
             Assert.Throws<ArgumentException>(() => { objectUnderTest.Priority = priority; });
             Assert.AreEqual(startingPriority, objectUnderTest.Priority);
+        }
+
+        [Test]
+        public void MessageIsTruncatedTo32Kb()
+        {
+            var maxLogMessageLengthInBytes = 32 * 1000;
+            var reallyLongMessageString = new string('a', maxLogMessageLengthInBytes);
+            var tooLongMessageString = reallyLongMessageString + "a few too many chars";
+
+            var logEvent = new LogEventWireModel(0, tooLongMessageString, "INFO", "", "");
+
+            var messageStringFromLogEvent = logEvent.Message;
+
+            Assert.AreEqual(Encoding.UTF8.GetByteCount(messageStringFromLogEvent), maxLogMessageLengthInBytes);
         }
     }
 }


### PR DESCRIPTION
## Description

Resolves #941.  The log message part of the LogEventWireModel is truncated to 32K bytes. There's an open question as to whether this means 32 * 1000 (kilobytes) or 32 * 1024 (kibibytes) but I've gone with the more conservative 32 * 1000 at this point.

The story says that integration tests are required; I did a unit test and I think that should be sufficient.    I reused an well-tested internal method for truncating the message string.  I think an integration test would be overkill for this. 

# Author Checklist
- [X] Unit tests, ~Integration tests, and Unbounded tests completed~ See above remarks about testing
- [X] ~Performance testing completed with satisfactory results (if required)~
- [X] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
