### PR TITLE
Support log4net back to version 1.2.10

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -47,8 +47,8 @@ namespace NewRelic.Providers.Wrapper.Logging
             var renderedMessage = getRenderedMessageFunc(logEvent);
 
             // We can either get this in Local or UTC
-            var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStampUtc");
-            var timestamp = getTimestampFunc(logEvent);
+            var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
+            var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -46,7 +46,7 @@ namespace NewRelic.Providers.Wrapper.Logging
             var getRenderedMessageFunc = _getRenderedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEvent.GetType(), "RenderedMessage");
             var renderedMessage = getRenderedMessageFunc(logEvent);
 
-            // We can either get this in Local or UTC
+            // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
             var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -15,8 +15,8 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
-    <PackageReference Include="log4net" Version="2.0.6" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="log4net" Version="1.2.10" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="log4net" Version="2.0.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="log4net" Version="2.0.6 " Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="log4net" Version="2.0.8" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />


### PR DESCRIPTION
## Description

Resolves #950 

There was an issue where our instrumentation for log4net wasn't working properly for versions < 2.0.6. After digging in to it, this was because we were trying to access a UTC timestamp that is not available in older versions.

We can now support log4net v1.2.10+ 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
