### PR TITLE
Use kibibytes instead of kilobytes for log message limit

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModel.cs
@@ -9,9 +9,7 @@ namespace NewRelic.Agent.Core.WireModels
 {
     public class LogEventWireModel : IHasPriority
     {
-        // Not sure yet if we want 32 kilobytes (32 * 1000) or 32 kibibytes (32 * 1024).
-        // Going with the more conservative option for now.
-        private const uint MaxMessageLengthInBytes = 32 * 1000;
+        private const uint MaxMessageLengthInBytes = 32 * 1024;
 
         /// <summary>
         /// The UTC timestamp in unix milliseconds. 

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelTests.cs
@@ -67,7 +67,7 @@ namespace NewRelic.Agent.Core.WireModels
         [Test]
         public void MessageIsTruncatedTo32Kb()
         {
-            var maxLogMessageLengthInBytes = 32 * 1000;
+            var maxLogMessageLengthInBytes = 32 * 1024;
             var reallyLongMessageString = new string('a', maxLogMessageLengthInBytes);
             var tooLongMessageString = reallyLongMessageString + "a few too many chars";
 


### PR DESCRIPTION
## Description

Implement decision to use kibibytes for the log message limit

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed


# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)

