### PR TITLE
Remove entity name and type

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -27,8 +27,6 @@ namespace NewRelic.Agent.Core.Aggregators
     /// </summary>
     public class LogEventAggregator : AbstractAggregator<LogEventWireModel>, ILogEventAggregator
     {
-        private const String EntityType = "SERVICE";
-        private const String PluginType = "nr-dotnet-agent";
         private const double ReservoirReductionSizeMultiplier = 0.5;
 
         private readonly IAgentHealthReporter _agentHealthReporter;
@@ -86,11 +84,8 @@ namespace NewRelic.Agent.Core.Aggregators
                 : _configuration.UtilizationHostName;
 
             var modelsCollection = new LogEventWireModelCollection(
-                _configuration.ApplicationNames.ElementAt(0),
-                EntityType,
                 _configuration.EntityGuid,
                 hostname,
-                PluginType,
                 aggregatedEvents); ;
 
             var responseStatus = DataTransportService.Send(modelsCollection);

--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
@@ -12,11 +12,8 @@ namespace NewRelic.Agent.Core.JsonConverters
     {
         private const string Common = "common";
         private const string Attributes = "attributes";
-        private const string EntityName = "entity.name";
-        private const string EntityType = "entity.type";
         private const string EntityGuid = "entity.guid";
         private const string Hostname = "hostname";
-        private const string PluginType = "plugin.type";
         private const string Logs = "logs";
         private const string TimeStamp = "timestamp";
         private const string Message = "message";
@@ -42,16 +39,10 @@ namespace NewRelic.Agent.Core.JsonConverters
             jsonWriter.WriteStartObject();
             jsonWriter.WritePropertyName(Attributes);
             jsonWriter.WriteStartObject();
-            jsonWriter.WritePropertyName(EntityName);
-            jsonWriter.WriteValue(value.EntityName);
-            jsonWriter.WritePropertyName(EntityType);
-            jsonWriter.WriteValue(value.EntityType);
             jsonWriter.WritePropertyName(EntityGuid);
             jsonWriter.WriteValue(value.EntityGuid);
             jsonWriter.WritePropertyName(Hostname);
             jsonWriter.WriteValue(value.Hostname);
-            jsonWriter.WritePropertyName(PluginType);
-            jsonWriter.WriteValue(value.PluginType);
             jsonWriter.WriteEndObject();
             jsonWriter.WriteEndObject();
 

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModelCollection.cs
@@ -10,25 +10,16 @@ namespace NewRelic.Agent.Core.WireModels
     [JsonConverter(typeof(LogEventWireModelCollectionJsonConverter))]
     public class LogEventWireModelCollection
     {
-        public string EntityName { get; }
-
-        public string EntityType { get; }
-
         public string EntityGuid { get; }
 
         public string Hostname { get; }
 
-        public string PluginType { get; }
-
         public IList<LogEventWireModel> LoggingEvents { get; }
 
-        public LogEventWireModelCollection(string entityName, string entityType, string entityGuid, string hostname, string pluginType, IList<LogEventWireModel> loggingEvents)
+        public LogEventWireModelCollection(string entityGuid, string hostname, IList<LogEventWireModel> loggingEvents)
         {
-            EntityName = entityName;
-            EntityType = entityType;
             EntityGuid = entityGuid;
             Hostname = hostname;
-            PluginType = pluginType;
             LoggingEvents = loggingEvents;
         }
     }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/LoggingHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/LoggingHelpers.cs
@@ -11,6 +11,9 @@ namespace NewRelic.Providers.Wrapper.Logging
         public static string GetFormattedLinkingMetadata(IAgent agent)
         {
             var metadata = agent.GetLinkingMetadata();
+            metadata.Remove("entity.name");
+            metadata.Remove("entity.type");
+
             var entries = new string[metadata.Count]; // keeps the array small and light
             for (int i = 0; i < metadata.Count; i++)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
@@ -39,20 +39,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 
     public class LogEventDataCommonAttributes
     {
-        [JsonProperty("entity.name")]
-        public string EntityName { get; set; }
-
-        [JsonProperty("entity.type")]
-        public string EntityType { get; set; }
-
         [JsonProperty("entity.guid")]
         public string EntityGuid { get; set; }
 
         [JsonProperty("hostname")]
         public string Hostname { get; set; }
-
-        [JsonProperty("plugin.type")]
-        public string PluginType { get; set; }
     }
 
     public class LogLine

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMaxSamplesStoredTests.cs
@@ -54,10 +54,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             Assert.NotNull(logData.Common);
             Assert.NotNull(logData.Common.Attributes);
             Assert.False(string.IsNullOrWhiteSpace(logData.Common.Attributes.EntityGuid));
-            Assert.False(string.IsNullOrWhiteSpace(logData.Common.Attributes.EntityName));
-            Assert.False(string.IsNullOrWhiteSpace(logData.Common.Attributes.EntityType));
             Assert.False(string.IsNullOrWhiteSpace(logData.Common.Attributes.Hostname));
-            Assert.Equal("nr-dotnet-agent", logData.Common.Attributes.PluginType);
 
             // Since we set the maximum number of log lines stored to 1 in setupConfiguration, there should only be one log line
             Assert.Single(logData.Logs);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
@@ -172,10 +172,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 Assert.NotNull(logEventData.Common);
                 Assert.NotNull(logEventData.Common.Attributes);
                 Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityGuid));
-                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityName));
-                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityType));
                 Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.Hostname));
-                Assert.Equal("nr-dotnet-agent", logEventData.Common.Attributes.PluginType);
             }
             else
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
@@ -15,11 +15,8 @@ namespace NewRelic.Agent.Core.Utilities
         public void LogEventWireModelCollectionIsJsonSerializable()
         {
             var sourceObject = new LogEventWireModelCollection(
-                "name",
-                "type",
                 "guid",
                 "hostname",
-                "plugintype",
                 new List<LogEventWireModel>()
                 {
                     new LogEventWireModel(1, "message", "level", "spanId", "traceId")
@@ -31,9 +28,9 @@ namespace NewRelic.Agent.Core.Utilities
             var serialized = JsonConvert.SerializeObject(sourceObject, Formatting.None);
 
             Assert.AreEqual(
-                "{\"common\":{\"attributes\":{\"entity.name\":\"name\",\"entity.type\":\"type\",\"entity.guid\":\"guid\"," +
-                "\"hostname\":\"hostname\",\"plugin.type\":\"plugintype\"}},\"logs\":[{\"timestamp\":1,\"message\":\"message\"," +
-                "\"level\":\"level\",\"attributes\":{\"spanid\":\"spanId\",\"traceid\":\"traceId\"}}]}",
+                "{\"common\":{\"attributes\":{\"entity.guid\":\"guid\",\"hostname\":\"hostname\"}}," +
+                "\"logs\":[{\"timestamp\":1,\"message\":\"message\",\"level\":\"level\"," +
+                "\"attributes\":{\"spanid\":\"spanId\",\"traceid\":\"traceId\"}}]}",
                 serialized);
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelCollectionTests.cs
@@ -16,25 +16,19 @@ namespace NewRelic.Agent.Core.WireModels
         [Test]
         public void ConstructorTest()
         {
-            var entityName = "TestEntityName";
-            var entityType = "TestEntityType";
             var entityGuid = Guid.NewGuid().ToString();
             var hostname = "TestHostname";
-            var pluginType = "testPluginType";
 
             var loggingEvents = new List<LogEventWireModel>
             {
                 new LogEventWireModel(1, "TestMessage", "TestLevel", "TestSpanId", "TestTraceId")
             };
 
-            var objectUnderTest = new LogEventWireModelCollection(entityName, entityType, entityGuid, hostname, pluginType, loggingEvents);
+            var objectUnderTest = new LogEventWireModelCollection(entityGuid, hostname, loggingEvents);
 
             Assert.NotNull(objectUnderTest);
-            Assert.AreEqual(entityName, objectUnderTest.EntityName);
-            Assert.AreEqual(entityType, objectUnderTest.EntityType);
             Assert.AreEqual(entityGuid, objectUnderTest.EntityGuid);
             Assert.AreEqual(hostname, objectUnderTest.Hostname);
-            Assert.AreEqual(pluginType, objectUnderTest.PluginType);
             Assert.AreEqual(1, objectUnderTest.LoggingEvents.Count);
 
             var loggingEvent = objectUnderTest.LoggingEvents[0];


### PR DESCRIPTION
## Description

Closes #951 by removing `entity.name`, `entity.type`, and `plugin.type` from both in-agent log forwarding and local log decoration.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [X] ~Performance testing completed with satisfactory results (if required)~
- [X] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
