### PR TITLE
Add top-level applicationLogging enabled/disabled config option

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -4911,6 +4911,8 @@ namespace NewRelic.Agent.Core.Config
         
         private configurationApplicationLoggingLocalDecorating localDecoratingField;
         
+        private bool enabledField;
+        
         /// <summary>
         /// configurationApplicationLogging class constructor
         /// </summary>
@@ -4919,6 +4921,7 @@ namespace NewRelic.Agent.Core.Config
             this.localDecoratingField = new configurationApplicationLoggingLocalDecorating();
             this.forwardingField = new configurationApplicationLoggingForwarding();
             this.metricsField = new configurationApplicationLoggingMetrics();
+            this.enabledField = false;
         }
         
         public configurationApplicationLoggingMetrics metrics
@@ -4954,6 +4957,20 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.localDecoratingField = value;
+            }
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        public bool enabled
+        {
+            get
+            {
+                return this.enabledField;
+            }
+            set
+            {
+                this.enabledField = value;
             }
         }
         

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1641,6 +1641,17 @@
                           </xs:complexType>
                       </xs:element>
                   </xs:sequence>
+
+                  <xs:attribute name="enabled" type="xs:boolean" default="false">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Controls whether any logging features are enabled.
+                              When set to 'false', all logging sub-features are disabled.
+                              Defaults to 'false'.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:attribute>
+
               </xs:complexType>
           </xs:element>
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1780,11 +1780,20 @@ namespace NewRelic.Agent.Core.Configuration
 
         #region Log Events and Metrics
 
+        public virtual bool ApplicationLoggingEnabled
+        {
+            get
+            {
+                return EnvironmentOverrides(_localConfiguration.applicationLogging.enabled, "NEW_RELIC_APPLICATION_LOGGING_ENABLED");
+            }
+        }
+
         public virtual bool LogMetricsCollectorEnabled
         {
             get
             { 
-                return EnvironmentOverrides(_localConfiguration.applicationLogging.metrics.enabled, "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED");
+                return ApplicationLoggingEnabled &&
+                    EnvironmentOverrides(_localConfiguration.applicationLogging.metrics.enabled, "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED");
             }
         }
 
@@ -1792,7 +1801,10 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return !SecurityPoliciesTokenExists && HighSecurityModeOverrides(false, EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED"));
+                return ApplicationLoggingEnabled &&
+                    !SecurityPoliciesTokenExists &&
+                    HighSecurityModeOverrides(false,
+                    EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED"));
             }
         }
 
@@ -1817,7 +1829,8 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return EnvironmentOverrides(_localConfiguration.applicationLogging.localDecorating.enabled, "NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED");
+                return ApplicationLoggingEnabled &&
+                    EnvironmentOverrides(_localConfiguration.applicationLogging.localDecorating.enabled, "NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED");
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -182,6 +182,7 @@ namespace NewRelic.Agent.Configuration
         int DatabaseStatementCacheCapcity { get; }
         bool ForceSynchronousTimingCalculationHttpClient { get; }
         bool ExcludeNewrelicHeader { get; }
+        bool ApplicationLoggingEnabled { get; }
         bool LogMetricsCollectorEnabled { get; }
         bool LogEventCollectorEnabled { get; }
         int LogEventsMaximumPerPeriod { get; }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -261,6 +261,17 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                     "displayName", customHostName);
         }
 
+        public NewRelicConfigModifier DisableApplicationLogging()
+        {
+            return EnableApplicationLogging(false);
+        }
+
+        public NewRelicConfigModifier EnableApplicationLogging(bool enable = true)
+        {
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging" }, "enabled", enable.ToString().ToLower());
+            return this;
+        }
+
         public NewRelicConfigModifier DisableLogMetrics()
         {
             return EnableLogMetrics(false);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netHSMOrCSPDisablesForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netHSMOrCSPDisablesForwardingTests.cs
@@ -35,6 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                     configModifier
+                    .EnableApplicationLogging()
                     .EnableLogForwarding()
                     .EnableLogMetrics()
                     .EnableDistributedTrace()

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMaxSamplesStoredTests.cs
@@ -34,6 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                     configModifier
+                    .EnableApplicationLogging()
                     .EnableLogForwarding()
                     .EnableLogMetrics()
                     .SetLogForwardingMaxSamplesStored(1)

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
@@ -65,7 +65,8 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 {
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
-                    configModifier.EnableLogMetrics(metricsEnabled)
+                    configModifier.EnableApplicationLogging()
+                    .EnableLogMetrics(metricsEnabled)
                     .EnableLogForwarding(forwardingEnabled)
                     .EnableDistributedTrace()
                     .SetLogLevel("debug");

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2424,6 +2424,37 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
+        public void ApplicationLogging_Enabled_IsFalseInLocalConfigByDefault()
+        {
+            Assert.IsFalse(_defaultConfig.ApplicationLoggingEnabled);
+        }
+
+        [TestCase(false, false, false, false, false, false, false)]
+        [TestCase(false, true, false, false, false, false, false)]
+        [TestCase(false, false, true, false, false, false, false)]
+        [TestCase(false, false, false, true, false, false, false)]
+        [TestCase(false, true, true, true, false, false, false)]
+        [TestCase(true, false, false, false, false, false, false)]
+        [TestCase(true, true, false, false, true, false, false)]
+        [TestCase(true, false, true, false, false, true, false)]
+        [TestCase(true, false, false, true, false, false, true)]
+        [TestCase(true, true, true, true, true, true, true)]
+        public void ApplicationLogging_Enabled_OverridesIndividualLoggingFeatures(bool applicationLoggingEnabledInConfig,
+            bool forwardingEnabledInConfig, bool metricsEnabledInConfig, bool localDecoratingEnabledInConfig,
+            bool forwardingActuallyEnabled, bool metricsActuallyEnabled, bool localDecoratingActuallyEnabled)
+        {
+            _localConfig.applicationLogging.enabled = applicationLoggingEnabledInConfig;
+            _localConfig.applicationLogging.forwarding.enabled = forwardingEnabledInConfig;
+            _localConfig.applicationLogging.metrics.enabled = metricsEnabledInConfig;
+            _localConfig.applicationLogging.localDecorating.enabled = localDecoratingEnabledInConfig;
+
+            Assert.AreEqual(_defaultConfig.ApplicationLoggingEnabled, applicationLoggingEnabledInConfig);
+            Assert.AreEqual(_defaultConfig.LogEventCollectorEnabled, forwardingActuallyEnabled);
+            Assert.AreEqual(_defaultConfig.LogMetricsCollectorEnabled, metricsActuallyEnabled);
+            Assert.AreEqual(_defaultConfig.LogDecoratorEnabled, localDecoratingActuallyEnabled);
+        }
+
+        [Test]
         public void ApplicationLogging_ForwardingEnabled_IsFalseInLocalConfigByDefault()
         {
             Assert.IsFalse(_defaultConfig.LogEventCollectorEnabled);


### PR DESCRIPTION
## Description

Closes #959.

1. The top-level `<applicationLogging>` config node is modified to have an `enabled` property with a default value of 'false'.
2. This enabled/disabled property overrides the enabled/disabled properties of the logging sub-features (metrics, forwarding, decorating).
3. New unit tests added and passing.
4. Integration tests updated and passing.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [X] ~Performance testing completed with satisfactory results (if required)~
- [X] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
