### PR TITLE
Adds request method to CallVendorApi for IMDSv2

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
@@ -13,12 +13,12 @@ namespace NewRelic.Agent.Core.Utilization
     {
         private const int WebReqeustTimeout = 1000;
 
-        public virtual string CallVendorApi(Uri uri, string vendorName, IEnumerable<string> headers = null)
+        public virtual string CallVendorApi(Uri uri, string method, string vendorName, IEnumerable<string> headers = null)
         {
             try
             {
                 var request = WebRequest.Create(uri);
-                request.Method = "GET";
+                request.Method = method;
                 request.Timeout = WebReqeustTimeout;
 
                 if (headers != null)

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -51,6 +51,9 @@ namespace NewRelic.Agent.Core.Utilization
         private readonly IEnvironment _environment;
         private readonly VendorHttpApiRequestor _vendorHttpApiRequestor;
 
+        private const string GetMethod = "GET";
+        private const string PutMethod = "PUT";
+
         public VendorInfo(IConfiguration configuration, IAgentHealthReporter agentHealthReporter, IEnvironment environment, VendorHttpApiRequestor vendorHttpApiRequestor)
         {
             _configuration = configuration;
@@ -111,7 +114,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         private IVendorModel GetAwsVendorInfo()
         {
-            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(AwsUri), AwsName);
+            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(AwsUri), GetMethod, AwsName);
             if (responseString != null)
             {
                 return ParseAwsVendorInfo(responseString);
@@ -149,7 +152,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         private IVendorModel GetAzureVendorInfo()
         {
-            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(AzureUri), AzureName, new List<string> { AzureHeader });
+            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(AzureUri), GetMethod, AzureName, new List<string> { AzureHeader });
             if (responseString != null)
             {
                 return ParseAzureVendorInfo(responseString);
@@ -189,7 +192,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         private IVendorModel GetGcpVendorInfo()
         {
-            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(GcpUri), GcpName, new List<string> { GcpHeader });
+            var responseString = _vendorHttpApiRequestor.CallVendorApi(new Uri(GcpUri), GetMethod, GcpName, new List<string> { GcpHeader });
             if (responseString != null)
             {
                 return ParseGcpVendorInfo(responseString);

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorHttpApiRequestorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorHttpApiRequestorTests.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.Core.Utilization
             using (var logging = new TestUtilities.Logging())
             {
                 var requestor = new VendorHttpApiRequestor();
-                var response = requestor.CallVendorApi(BogusUri, "bogus");
+                var response = requestor.CallVendorApi(BogusUri, "GET", "bogus");
 
                 Assert.That(response, Is.Null);
                 Assert.True(logging.HasMessageThatContains("CallVendorApi"));


### PR DESCRIPTION
## Description

Closes #961

- Updates CallVendorApi to require passing in the request method you want it to use with the WebRequest
- Setup constants in VendorInfo for GET and PUT (put will be used shortly)
- Update the calls to CallVendorApi  to use new consts in VendorInfo 
- Updated the one test used CallVendorApi to include a method (GET)

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
