### PR TITLE
Updated forwarding env var to use correct name

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1822,7 +1822,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 return (int)EnvironmentOverrides(
                     ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(), _localConfiguration.applicationLogging.forwarding.maxSamplesStored),
-                    "NEW_RELIC_APPLICATION_LOGGING_MAX_SAMPLES_STORED");
+                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED");
             }
         }
 


### PR DESCRIPTION
## Description

Update the forward samples env var to use correct name:
OLD: `NEW_RELIC_APPLICATION_LOGGING_MAX_SAMPLES_STORED`
NEW: `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
