### PR TITLE
Log4Net decoration integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -296,6 +296,18 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return this;
         }
 
+        public NewRelicConfigModifier DisableLogDecoration()
+        {
+            return EnableLogDecoration(false);
+        }
+
+        public NewRelicConfigModifier EnableLogDecoration(bool enable = true)
+        {
+            CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging" }, "localDecorating", string.Empty);
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging", "localDecorating" }, "enabled", enable.ToString().ToLower());
+            return this;
+        }
+
         public NewRelicConfigModifier SetLogForwardingMaxSamplesStored(int samples)
         {
             CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging" }, "forwarding", string.Empty);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netJsonLayoutDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netJsonLayoutDecorationTests.cs
@@ -1,0 +1,176 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Text.RegularExpressions;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Logging
+{
+    public abstract class Log4netJsonLayoutDecorationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+        private readonly bool _decorationEnabled;
+
+        public Log4netJsonLayoutDecorationTestsBase(TFixture fixture, ITestOutputHelper output, bool decorationEnabled) : base(fixture)
+        {
+            _decorationEnabled = decorationEnabled;
+            _fixture = fixture;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"Log4netTester ConfigureJsonLayoutAppenderForDecoration");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage DecorateMe DEBUG");
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier
+                    .EnableApplicationLogging()
+                    .EnableLogDecoration(_decorationEnabled)
+                    .EnableDistributedTrace()
+                    .SetLogLevel("debug");
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void LogIsDecorated()
+        {
+            // Sample decorated data we are looking for:
+            // "NR-LINKING-METADATA: {entity.guid=MjczMDcwfEFQTXxBUFBMSUNBVElPTnwxODQyMg, hostname=blah.hsd1.ca.comcast.net}"
+            var regex = new Regex("NR-LINKING-METADATA: {entity\\.guid=.*hostname=.*}");
+            if(_decorationEnabled)
+            {
+                Assert.Matches(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+            }
+            else
+            {
+                Assert.DoesNotMatch(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+            }
+        }
+    }
+
+    #region Enabled Tests
+    [NetFrameworkTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsFWLatestTests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsFW471Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsNetCoreLatestTests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsNetCore50Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsNetCore31Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationEnabledTestsNetCore22Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
+    {
+        public Log4netJsonLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+    #endregion
+
+    #region Disabled Tests
+    [NetFrameworkTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsFWLatestTests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsFW471Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsNetCoreLatestTests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsNetCore50Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netJsonLayoutDecorationDisabledTestsNetCore22Tests : Log4netJsonLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
+    {
+        public Log4netJsonLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+    #endregion
+
+
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netPatternLayoutDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netPatternLayoutDecorationTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Text.RegularExpressions;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Logging
+{
+    public abstract class Log4netPatternLayoutDecorationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        public Log4netPatternLayoutDecorationTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"Log4netTester ConfigurePatternLayoutAppenderForDecoration");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessage DecorateMe DEBUG");
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier
+                    .EnableApplicationLogging()
+                    .EnableLogDecoration()
+                    .EnableDistributedTrace()
+                    .SetLogLevel("debug");
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void LogIsDecorated()
+        {
+            // Sample decorated data we are looking for:
+            // "NR-LINKING-METADATA: {entity.guid=MjczMDcwfEFQTXxBUFBMSUNBVElPTnwxODQyMg, hostname=blah.hsd1.ca.comcast.net}"
+            var regex = new Regex("NR-LINKING-METADATA: {entity\\.guid=.*hostname=.*}");
+            Assert.Matches(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netPatternLayoutDecorationTestsFWLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netPatternLayoutDecorationTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netPatternLayoutDecorationTestsFW471Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public Log4netPatternLayoutDecorationTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netPatternLayoutDecorationTestsFW462Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public Log4netPatternLayoutDecorationTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationTestsNetCoreLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4netPatternLayoutDecorationTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationTestsNetCore50Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4netPatternLayoutDecorationTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationTestsNetCore31Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4netPatternLayoutDecorationTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationTestsNetCore22Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
+    {
+        public Log4netPatternLayoutDecorationTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationTestsNetCore21Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore21>
+    {
+        public Log4netPatternLayoutDecorationTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netPatternLayoutDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netPatternLayoutDecorationTests.cs
@@ -14,10 +14,12 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly TFixture _fixture;
+        private readonly bool _decorationEnabled;
 
-        public Log4netPatternLayoutDecorationTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        public Log4netPatternLayoutDecorationTestsBase(TFixture fixture, ITestOutputHelper output, bool decorationEnabled) : base(fixture)
         {
             _fixture = fixture;
+            _decorationEnabled = decorationEnabled;
             _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
@@ -32,7 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
 
                     configModifier
                     .EnableApplicationLogging()
-                    .EnableLogDecoration()
+                    .EnableLogDecoration(decorationEnabled)
                     .EnableDistributedTrace()
                     .SetLogLevel("debug");
                 }
@@ -47,79 +49,131 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             // Sample decorated data we are looking for:
             // "NR-LINKING-METADATA: {entity.guid=MjczMDcwfEFQTXxBUFBMSUNBVElPTnwxODQyMg, hostname=blah.hsd1.ca.comcast.net}"
             var regex = new Regex("NR-LINKING-METADATA: {entity\\.guid=.*hostname=.*}");
-            Assert.Matches(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+
+            if (_decorationEnabled)
+            {
+                Assert.Matches(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+            }
+            else
+            {
+                Assert.DoesNotMatch(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+            }
+        }
+    }
+
+    #region Enabled Tests
+
+    [NetFrameworkTest]
+    public class Log4netPatternLayoutDecorationEnabledTestsFWLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netPatternLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
         }
     }
 
     [NetFrameworkTest]
-    public class Log4netPatternLayoutDecorationTestsFWLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class Log4netPatternLayoutDecorationEnabledTestsFW471Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
-        public Log4netPatternLayoutDecorationTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationEnabledTestsNetCoreLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4netPatternLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationEnabledTestsNetCore50Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4netPatternLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationEnabledTestsNetCore31Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4netPatternLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netPatternLayoutDecorationEnabledTestsNetCore22Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
+    {
+        public Log4netPatternLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    #endregion
+
+    #region Disabled Tests
+
+    [NetFrameworkTest]
+    public class Log4netPatternLayoutDecorationDisabledTestsFWLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netPatternLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
     [NetFrameworkTest]
-    public class Log4netPatternLayoutDecorationTestsFW471Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
+    public class Log4netPatternLayoutDecorationDisabledTestsFW471Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
-        public Log4netPatternLayoutDecorationTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class Log4netPatternLayoutDecorationTestsFW462Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public Log4netPatternLayoutDecorationTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
     [NetCoreTest]
-    public class Log4netPatternLayoutDecorationTestsNetCoreLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class Log4netPatternLayoutDecorationDisabledTestsNetCoreLatestTests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public Log4netPatternLayoutDecorationTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
     [NetCoreTest]
-    public class Log4netPatternLayoutDecorationTestsNetCore50Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
+    public class Log4netPatternLayoutDecorationDisabledTestsNetCore50Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
-        public Log4netPatternLayoutDecorationTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
     [NetCoreTest]
-    public class Log4netPatternLayoutDecorationTestsNetCore31Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public Log4netPatternLayoutDecorationTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
     [NetCoreTest]
-    public class Log4netPatternLayoutDecorationTestsNetCore22Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
+    public class Log4netPatternLayoutDecorationDisabledTestsNetCore22Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
     {
-        public Log4netPatternLayoutDecorationTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        public Log4netPatternLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
         {
         }
     }
 
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationTestsNetCore21Tests : Log4netPatternLayoutDecorationTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public Log4netPatternLayoutDecorationTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net5.0;net6.0;net462;net471;net48</TargetFrameworks>
@@ -10,19 +10,41 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
 
+  <!-- Define constants for supported versions of log4net JSON formatter -->
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net471' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net48' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net5.0' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net6.0' ">LOG4NET_JSON_FORMATTER_SUPPORTED</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.24.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
+
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
+    
+    <!-- log4net .NET framework references -->
     <PackageReference Include="log4net" Version="1.2.10" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="log4net" Version="2.0.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="log4net" Version="2.0.5" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="log4net.Ext.Json" Version="1.2.15.14586" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net48'" />
+
+    <!-- log4net .NET core references -->
     <PackageReference Include="log4net" Version="2.0.6 " Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="log4net" Version="2.0.8" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="log4net" Version="2.0.12" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net6.0'" />
+
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
@@ -5,7 +5,9 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using log4net;
+using log4net.Appender;
 using log4net.Config;
+using log4net.Layout;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 
@@ -20,6 +22,20 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public static void Configure()
         {
             BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()));
+        }
+
+        [LibraryMethod]
+        public static void ConfigurePatternLayoutAppenderForDecoration()
+        {
+            PatternLayout patternLayout = new PatternLayout();
+            patternLayout.ConversionPattern = "%timestamp [%thread] %level %logger %ndc - %message %property{NR_LINKING_METADATA}%newline";
+            patternLayout.ActivateOptions();
+
+            ConsoleAppender consoleAppender = new ConsoleAppender();
+            consoleAppender.Layout = patternLayout;
+            consoleAppender.ActivateOptions();
+
+            BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), consoleAppender);
         }
 
         [LibraryMethod]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
@@ -24,6 +24,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()));
         }
 
+
         [LibraryMethod]
         public static void ConfigurePatternLayoutAppenderForDecoration()
         {
@@ -37,6 +38,22 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
             BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), consoleAppender);
         }
+
+#if LOG4NET_JSON_FORMATTER_SUPPORTED
+        [LibraryMethod]
+        public static void ConfigureJsonLayoutAppenderForDecoration()
+        {
+            SerializedLayout serializedLayout = new SerializedLayout();
+            serializedLayout.AddMember("NR_LINKING_METADATA");
+            serializedLayout.ActivateOptions();
+
+            ConsoleAppender consoleAppender = new ConsoleAppender();
+            consoleAppender.Layout = serializedLayout;
+            consoleAppender.ActivateOptions();
+
+            BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), consoleAppender);
+        }
+#endif
 
         [LibraryMethod]
         public static void CreateSingleLogMessage(string message, string level)


### PR DESCRIPTION
## Description

Closes: #916 

Tests log4net decoration with a layout formatter, and JSON formatter. The JSON formatter only works for newer versions of log4net starting at version 2.0.5, so only some framework/core versions are targetted.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
