### PR TITLE
Async Log4net forwarding integration test coverage

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -602,13 +602,13 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                     continue;
                 if (expectedLogLine.LogMessage != actualLogLine.Message)
                     continue;
-                if (expectedLogLine.HasSpanId && string.IsNullOrWhiteSpace(actualLogLine.Attributes.Spanid))
+                if (expectedLogLine.HasSpanId.HasValue && expectedLogLine.HasSpanId.Value && string.IsNullOrWhiteSpace(actualLogLine.Attributes.Spanid))
                     continue;
-                if (!expectedLogLine.HasSpanId && !string.IsNullOrWhiteSpace(actualLogLine.Attributes.Spanid))
+                if (expectedLogLine.HasSpanId.HasValue && !expectedLogLine.HasSpanId.Value && !string.IsNullOrWhiteSpace(actualLogLine.Attributes.Spanid))
                     continue;
-                if (expectedLogLine.HasTraceId && string.IsNullOrWhiteSpace(actualLogLine.Attributes.Traceid))
+                if (expectedLogLine.HasTraceId.HasValue && expectedLogLine.HasTraceId.Value && string.IsNullOrWhiteSpace(actualLogLine.Attributes.Traceid))
                     continue;
-                if (!expectedLogLine.HasTraceId && !string.IsNullOrWhiteSpace(actualLogLine.Attributes.Traceid))
+                if (expectedLogLine.HasTraceId.HasValue && !expectedLogLine.HasTraceId.Value && !string.IsNullOrWhiteSpace(actualLogLine.Attributes.Traceid))
                     continue;
 
                 return actualLogLine;
@@ -1009,8 +1009,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         {
             public string LogMessage = null;
             public string LogLevel = null;
-            public bool HasSpanId = false;
-            public bool HasTraceId = false;
+            public bool? HasSpanId = null;
+            public bool? HasTraceId = null;
 
             public override string ToString()
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
@@ -61,7 +61,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         private const string AsyncNoAwaitWithDelayInTransactionErrorMessage = "AsyncNoAwaitWithDelayInTransactionErrorLogMessage";
         private const string AsyncNoAwaitWithDelayInTransactionFatalMessage = "AsyncNoAwaitWithDelayInTransactionFatalLogMessage";
 
-
         public Log4NetMetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, bool metricsEnabled, bool forwardingEnabled) : base(fixture)
         {
             _fixture = fixture;
@@ -71,8 +70,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"Log4netTester Configure");
-
-
 
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionDebugMessage} DEBUG");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionInfoMessage} INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Log4netMetricsAndForwardingTests.cs
@@ -25,11 +25,41 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         private const string OutsideTransactionErrorMessage = "OutsideTransactionErrorLogMessage";
         private const string OutsideTransactionFatalMessage = "OutsideTransactionFatalLogMessage";
 
+        private const string AsyncOutsideTransactionDebugMessage = "AsyncOutsideTransactionDebugLogMessage";
+        private const string AsyncOutsideTransactionInfoMessage = "AsyncOutsideTransactionInfoLogMessage";
+        private const string AsyncOutsideTransactionWarningMessage = "AsyncOutsideTransactionWarningLogMessage";
+        private const string AsyncOutsideTransactionErrorMessage = "AsyncOutsideTransactionErrorLogMessage";
+        private const string AsyncOutsideTransactionFatalMessage = "AsyncOutsideTransactionFatalLogMessage";
+
+        private const string AsyncNoAwaitOutsideTransactionDebugMessage = "AsyncNoAwaitOutsideTransactionDebugLogMessage";
+        private const string AsyncNoAwaitOutsideTransactionInfoMessage = "AsyncNoAwaitOutsideTransactionInfoLogMessage";
+        private const string AsyncNoAwaitOutsideTransactionWarningMessage = "AsyncNoAwaitOutsideTransactionWarningLogMessage";
+        private const string AsyncNoAwaitOutsideTransactionErrorMessage = "AsyncNoAwaitOutsideTransactionErrorLogMessage";
+        private const string AsyncNoAwaitOutsideTransactionFatalMessage = "AsyncNoAwaitOutsideTransactionFatalLogMessage";
+
         private const string InTransactionDebugMessage = "InTransactionDebugLogMessage";
         private const string InTransactionInfoMessage = "InTransactionInfoLogMessage";
         private const string InTransactionWarningMessage = "InTransactionWarningLogMessage";
         private const string InTransactionErrorMessage = "InTransactionErrorLogMessage";
         private const string InTransactionFatalMessage = "InTransactionFatalLogMessage";
+
+        private const string AsyncInTransactionDebugMessage = "AsyncInTransactionDebugLogMessage";
+        private const string AsyncInTransactionInfoMessage = "AsyncInTransactionInfoLogMessage";
+        private const string AsyncInTransactionWarningMessage = "AsyncInTransactionWarningLogMessage";
+        private const string AsyncInTransactionErrorMessage = "AsyncInTransactionErrorLogMessage";
+        private const string AsyncInTransactionFatalMessage = "AsyncInTransactionFatalLogMessage";
+
+        private const string AsyncNoAwaitInTransactionDebugMessage = "AsyncNoAwaitInTransactionDebugLogMessage";
+        private const string AsyncNoAwaitInTransactionInfoMessage = "AsyncNoAwaitInTransactionInfoLogMessage";
+        private const string AsyncNoAwaitInTransactionWarningMessage = "AsyncNoAwaitInTransactionWarningLogMessage";
+        private const string AsyncNoAwaitInTransactionErrorMessage = "AsyncNoAwaitInTransactionErrorLogMessage";
+        private const string AsyncNoAwaitInTransactionFatalMessage = "AsyncNoAwaitInTransactionFatalLogMessage";
+
+        private const string AsyncNoAwaitWithDelayInTransactionDebugMessage = "AsyncNoAwaitWithDelayInTransactionDebugLogMessage";
+        private const string AsyncNoAwaitWithDelayInTransactionInfoMessage = "AsyncNoAwaitWithDelayInTransactionInfoLogMessage";
+        private const string AsyncNoAwaitWithDelayInTransactionWarningMessage = "AsyncNoAwaitWithDelayInTransactionWarningLogMessage";
+        private const string AsyncNoAwaitWithDelayInTransactionErrorMessage = "AsyncNoAwaitWithDelayInTransactionErrorLogMessage";
+        private const string AsyncNoAwaitWithDelayInTransactionFatalMessage = "AsyncNoAwaitWithDelayInTransactionFatalLogMessage";
 
 
         public Log4NetMetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, bool metricsEnabled, bool forwardingEnabled) : base(fixture)
@@ -41,11 +71,26 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"Log4netTester Configure");
+
+
+
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionDebugMessage} DEBUG");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionInfoMessage} INFO");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionWarningMessage} WARN");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionErrorMessage} ERROR");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessage {OutsideTransactionFatalMessage} FATAL");
+
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsync {AsyncOutsideTransactionDebugMessage} DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsync {AsyncOutsideTransactionInfoMessage} INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsync {AsyncOutsideTransactionWarningMessage} WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsync {AsyncOutsideTransactionErrorMessage} ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsync {AsyncOutsideTransactionFatalMessage} FATAL");
+
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsyncNoAwait {AsyncNoAwaitOutsideTransactionDebugMessage} DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsyncNoAwait {AsyncNoAwaitOutsideTransactionInfoMessage} INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsyncNoAwait {AsyncNoAwaitOutsideTransactionWarningMessage} WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsyncNoAwait {AsyncNoAwaitOutsideTransactionErrorMessage} ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageAsyncNoAwait {AsyncNoAwaitOutsideTransactionFatalMessage} FATAL");
 
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransaction {InTransactionDebugMessage} DEBUG");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransaction {InTransactionInfoMessage} INFO");
@@ -53,10 +98,31 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransaction {InTransactionErrorMessage} ERROR");
             _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransaction {InTransactionFatalMessage} FATAL");
 
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsync {AsyncInTransactionDebugMessage} DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsync {AsyncInTransactionInfoMessage} INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsync {AsyncInTransactionWarningMessage} WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsync {AsyncInTransactionErrorMessage} ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsync {AsyncInTransactionFatalMessage} FATAL");
+
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwait {AsyncNoAwaitInTransactionDebugMessage} DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwait {AsyncNoAwaitInTransactionInfoMessage} INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwait {AsyncNoAwaitInTransactionWarningMessage} WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwait {AsyncNoAwaitInTransactionErrorMessage} ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwait {AsyncNoAwaitInTransactionFatalMessage} FATAL");
+
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay {AsyncNoAwaitWithDelayInTransactionDebugMessage} DEBUG");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay {AsyncNoAwaitWithDelayInTransactionInfoMessage} INFO");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay {AsyncNoAwaitWithDelayInTransactionWarningMessage} WARN");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay {AsyncNoAwaitWithDelayInTransactionErrorMessage} ERROR");
+            _fixture.AddCommand($"Log4netTester CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay {AsyncNoAwaitWithDelayInTransactionFatalMessage} FATAL");
+
+            // Give the unawaited async logs some time to catch up
+            _fixture.AddCommand($"RootCommands DelaySeconds 5");
+
             // This is necessary for the data usage metric assertions to work.  Only need to do it if forwarding is enabled.
             if (_forwardingEnabled)
             {
-                _fixture.AddCommand($"RootCommands DelaySeconds 60");
+                _fixture.AddCommand($"RootCommands DelaySeconds 55");
             }
 
             _fixture.Actions
@@ -81,13 +147,13 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         {
             var loggingMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/DEBUG", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/INFO", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/WARN", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/ERROR", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/FATAL", callCount = 2 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/DEBUG", callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/INFO", callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/WARN", callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/ERROR", callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/FATAL", callCount = 7 },
 
-                new Assertions.ExpectedMetric { metricName = "Logging/lines", callCount = 10 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines", callCount = 35 },
             };
 
             var actualMetrics = _fixture.AgentLog.GetMetrics();
@@ -183,7 +249,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
             if (_forwardingEnabled)
             {
-                Assert.Equal(10, logLines.Length);
+                Assert.Equal(35, logLines.Length);
 
                 foreach (var logLine in logLines)
                 {
@@ -209,7 +275,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = InTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
                 new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = InTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
                 new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = InTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = InTransactionFatalMessage, HasTraceId = true, HasSpanId = true }
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = InTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -217,6 +283,51 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 Assertions.LogLinesExist(expectedLogLines, logLines);
 
                 Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("InTransaction")).Count());
+            }
+        }
+
+        [Fact]
+        public void AsyncLoggingWorksInsideTransaction()
+        {
+            if (_forwardingEnabled)
+            {
+                var expectedLogLines = new Assertions.ExpectedLogLine[]
+                {
+                new Assertions.ExpectedLogLine { LogLevel = "DEBUG", LogMessage = AsyncInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = AsyncInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = AsyncInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = AsyncInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = AsyncInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
+                };
+
+                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+
+                Assertions.LogLinesExist(expectedLogLines, logLines);
+
+                Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncInTransaction")).Count());
+            }
+        }
+
+        [Fact]
+        public void AsyncNoAwaitLoggingWorksInsideTransaction()
+        {
+            if (_forwardingEnabled)
+            {
+                // NOTE: since the log is not awaited, it shows up outside the transaction
+                var expectedLogLines = new Assertions.ExpectedLogLine[]
+                {
+                new Assertions.ExpectedLogLine { LogLevel = "DEBUG", LogMessage = AsyncNoAwaitInTransactionDebugMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = AsyncNoAwaitInTransactionInfoMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = AsyncNoAwaitInTransactionWarningMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = AsyncNoAwaitInTransactionErrorMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = AsyncNoAwaitInTransactionFatalMessage},
+                };
+
+                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+
+                Assertions.LogLinesExist(expectedLogLines, logLines);
+
+                Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncNoAwaitInTransaction")).Count());
             }
         }
 
@@ -239,6 +350,72 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 Assertions.LogLinesExist(expectedLogLines, logLines);
 
                 Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("OutsideTransaction")).Count());
+            }
+        }
+
+        [Fact]
+        public void AsyncLoggingWorksOutsideTransaction()
+        {
+            if (_forwardingEnabled)
+            {
+                var expectedLogLines = new Assertions.ExpectedLogLine[]
+                {
+                new Assertions.ExpectedLogLine { LogLevel = "DEBUG", LogMessage = AsyncOutsideTransactionDebugMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = AsyncOutsideTransactionInfoMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = AsyncOutsideTransactionWarningMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = AsyncOutsideTransactionErrorMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = AsyncOutsideTransactionFatalMessage},
+                };
+
+                var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
+
+                Assertions.LogLinesExist(expectedLogLines, logLines);
+
+                Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncOutsideTransaction")).Count());
+            }
+        }
+
+        [Fact]
+        public void AsyncNoAwaitLoggingWorksOutsideTransaction()
+        {
+            if (_forwardingEnabled)
+            {
+                var expectedLogLines = new Assertions.ExpectedLogLine[]
+                {
+                new Assertions.ExpectedLogLine { LogLevel = "DEBUG", LogMessage = AsyncNoAwaitOutsideTransactionDebugMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = AsyncNoAwaitOutsideTransactionInfoMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = AsyncNoAwaitOutsideTransactionWarningMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = AsyncNoAwaitOutsideTransactionErrorMessage},
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = AsyncNoAwaitOutsideTransactionFatalMessage},
+                };
+
+                var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
+
+                Assertions.LogLinesExist(expectedLogLines, logLines);
+
+                Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncNoAwaitOutsideTransaction")).Count());
+            }
+        }
+
+        [Fact]
+        public void AsyncNoAwaitWithDelayLoggingWorksInsideTransaction()
+        {
+            if (_forwardingEnabled)
+            {
+                var expectedLogLines = new Assertions.ExpectedLogLine[]
+                {
+                new Assertions.ExpectedLogLine { LogLevel = "DEBUG", LogMessage = AsyncNoAwaitWithDelayInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "INFO", LogMessage = AsyncNoAwaitWithDelayInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "WARN", LogMessage = AsyncNoAwaitWithDelayInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "ERROR", LogMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { LogLevel = "FATAL", LogMessage = AsyncNoAwaitWithDelayInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
+                };
+
+                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+
+                Assertions.LogLinesExist(expectedLogLines, logLines);
+
+                Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncNoAwaitWithDelayInTransaction")).Count());
             }
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
@@ -125,11 +125,27 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-
         public static async Task CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay(string message, string level)
         {
             _ = Task.Run(() => CreateSingleLogMessage(message, level));
             await Task.Delay(1000);
+        }
+
+        [LibraryMethod]
+        [Trace]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void CreateSingleLogMessageWithTraceAttribute(string message, string level)
+        {
+            CreateSingleLogMessage(message, level);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void CreateTwoLogMessagesInTransactionWithDifferentTraceAttributes(string message, string level)
+        {
+            CreateSingleLogMessage(message, level);
+            CreateSingleLogMessageWithTraceAttribute(message, level);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4netTester.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using log4net;
 using log4net.Appender;
 using log4net.Config;
@@ -88,6 +89,47 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public static void CreateSingleLogMessageInTransaction(string message, string level)
         {
             CreateSingleLogMessage(message, level);
+        }
+
+        [LibraryMethod]
+        public static async Task CreateSingleLogMessageAsync(string message, string level)
+        {
+            await Task.Run(() => CreateSingleLogMessage(message, level));
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task CreateSingleLogMessageInTransactionAsync(string message, string level)
+        {
+            await Task.Run(() => CreateSingleLogMessage(message, level));
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        [LibraryMethod]
+        public static async Task CreateSingleLogMessageAsyncNoAwait(string message, string level)
+        {
+            _ = Task.Run(() => CreateSingleLogMessage(message, level));
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+
+        public static async Task CreateSingleLogMessageInTransactionAsyncNoAwait(string message, string level)
+        {
+            _ = Task.Run(() => CreateSingleLogMessage(message, level));
+        }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+
+        public static async Task CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay(string message, string level)
+        {
+            _ = Task.Run(() => CreateSingleLogMessage(message, level));
+            await Task.Delay(1000);
         }
     }
 }


### PR DESCRIPTION
## Description

Closes #972 

Adds async use case test coverage for log4net forwarding.

The only undesirable finding is that if logs are delegated to a background thread and not awaited, then they will not show up as part of a transaction that initiated them. I do not think there is much we can do about this.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
