### PR TITLE
Update lambda tracer unit tests to netcoreapp3.1

### DIFF
--- a/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/AwsLambdaOpenTracerTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/AwsLambdaOpenTracerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>NewRelic.Tests.AwsLambda.AwsLambdaOpenTracerTests</RootNamespace>
     <AssemblyName>NewRelic.Tests.AwsLambda.AwsLambdaOpenTracerTests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>NewRelic.Tests.AwsLambda.AwsLambdaWrapperTests</RootNamespace>
     <AssemblyName>NewRelic.Tests.AwsLambda.AwsLambdaWrapperTests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/NewRelic.Core.Tests/NewRelic.Core.Tests.csproj
+++ b/tests/NewRelic.Core.Tests/NewRelic.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Update the AWS Lambda OpenTracer unit tests and associated `NewRelic.Core.Tests` dependency to target `netcoreapp3.1`.  This should fix CI failures caused by the removal of .NET Core 2.1 assets from the `windows-2019` GHA runner used: https://github.com/actions/virtual-environments/issues/4871

# Author Checklist
- [X] Unit tests, ~Integration tests, and Unbounded tests~ completed

# Reviewer Checklist
- [x] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
