### PR TITLE
Adds Micrsoft.Extensions.Logging providers wrapper and detection

### DIFF
--- a/FullAgent.sln
+++ b/FullAgent.sln
@@ -201,7 +201,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Home", "src\Agent\NewRelic\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CosmosDb", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\CosmosDb\CosmosDb.csproj", "{E10BF2F9-D5CA-4330-8169-ED30D861697E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logging", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\Logging\Logging.csproj", "{E696F7DF-D99F-4BD4-B757-531B5F5ECB36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logging", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\Logging\Logging.csproj", "{E696F7DF-D99F-4BD4-B757-531B5F5ECB36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicrosoftExtensionsLogging", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\MicrosoftExtensionsLogging\MicrosoftExtensionsLogging.csproj", "{710C7C7A-CD27-4F94-B2D3-9804BD848D57}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -421,6 +423,10 @@ Global
 		{E696F7DF-D99F-4BD4-B757-531B5F5ECB36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E696F7DF-D99F-4BD4-B757-531B5F5ECB36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E696F7DF-D99F-4BD4-B757-531B5F5ECB36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{710C7C7A-CD27-4F94-B2D3-9804BD848D57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{710C7C7A-CD27-4F94-B2D3-9804BD848D57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{710C7C7A-CD27-4F94-B2D3-9804BD848D57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{710C7C7A-CD27-4F94-B2D3-9804BD848D57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -487,10 +493,11 @@ Global
 		{5CF47B2E-9370-4FD8-B9BD-0D95D3EA167C} = {E3DAC9C6-AE41-4B37-A253-C621E568590E}
 		{E10BF2F9-D5CA-4330-8169-ED30D861697E} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
 		{E696F7DF-D99F-4BD4-B757-531B5F5ECB36} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
+		{710C7C7A-CD27-4F94-B2D3-9804BD848D57} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {D8B98070-6B8E-403C-A07F-A3F2E4A3A3D0}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35
+		SolutionGuid = {D8B98070-6B8E-403C-A07F-A3F2E4A3A3D0}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = FullAgent.vsmdi

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
@@ -1,0 +1,21 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Extensions.Logging
+{
+    public enum LogProvider
+    {
+        Log4Net,
+        Serilog,
+        NLog
+    }
+
+    public static class LogProviders
+    {
+        public static readonly bool[] RegisteredLogProvider = new bool[3];
+
+        public const string Log4NetProviderName = "Microsoft.Extensions.Logging.Log4NetProvider";
+
+        public const string SerilogProviderName = "Microsoft.Extensions.Logging.SerilogLoggerProvider";
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace NewRelic.Agent.Extensions.Logging
 {
     public enum LogProvider
@@ -12,7 +14,7 @@ namespace NewRelic.Agent.Extensions.Logging
 
     public static class LogProviders
     {
-        public static readonly bool[] RegisteredLogProvider = new bool[3];
+        public static readonly bool[] RegisteredLogProvider = new bool[Enum.GetNames(typeof(LogProvider)).Length];
 
         public const string Log4NetProviderName = "Microsoft.Extensions.Logging.Log4NetProvider";
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
+using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
 
@@ -23,7 +24,12 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Log4Net])
+            {
+                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            }
+
+            return new CanWrapResponse(false);
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
+using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
 
@@ -26,7 +27,12 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog])
+            {
+                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            }
+
+            return new CanWrapResponse(false);
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/Instrumentation.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2020 New Relic Corporation. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<extension xmlns="urn:newrelic-extension">
+  <instrumentation>
+    <tracerFactory name="LoggerFactoryWrapper">
+      <match assemblyName="Microsoft.Extensions.Logging" className="Microsoft.Extensions.Logging.LoggerFactory">
+        <exactMethodMatcher methodName=".ctor" parameters="System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.Logging.ILoggerProvider],Microsoft.Extensions.Options.IOptionsMonitor`1[Microsoft.Extensions.Logging.LoggerFilterOptions],Microsoft.Extensions.Options.IOptions`1[Microsoft.Extensions.Logging.LoggerFactoryOptions]"/>
+      </match>
+    </tracerFactory>
+  </instrumentation>
+</extension>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/LoggerFactoryWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/LoggerFactoryWrapper.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using Microsoft.Extensions.Logging;
+using NewRelic.Agent.Extensions.Logging;
+
+namespace MicrosoftExtensionsLogging
+{
+	public class LoggerFactoryWrapper : IWrapper
+    {
+        public bool IsTransactionRequired => false;
+
+        private const string WrapperName = "LoggerFactoryWrapper";
+
+        public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
+        {
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+        }
+
+        public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            var providers = (ILoggerProvider[])instrumentedMethodCall.MethodCall.MethodArguments[0];
+
+            if (providers != null)
+            {
+                for (int i = 0; i < providers.Length; i++)
+                {
+                    var provider = providers[i].ToString();
+                    if (provider == LogProviders.Log4NetProviderName)
+                    {
+                        LogProviders.RegisteredLogProvider[(int)LogProvider.Log4Net] = true;
+                    }
+                    else if (provider == LogProviders.SerilogProviderName)
+                    {
+                        LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog] = true;
+                    }
+                }
+            }
+
+            return Delegates.NoOp;
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</RootNamespace>
+    <AssemblyName>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</AssemblyName>
+    <Description>Logging Wrapper Provider for New Relic .NET Agent</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Instrumentation.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />
+    <ProjectReference Include="..\..\..\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description

- Adds Wrapper to instrument the constructor where logging providers are added to allow us to detect when an already instrumented logger is added and store that for later use.
- Adds a static class to holder an enum of the supported log providers, names that the providers use, and an array to store if the providers are in use.
- Updates the CanWrap for Log4net and Serilog to check if the wrapper should not be used since Micrsoft.Extensions.Logging  is in use.

Resolves #989 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
