### PR TITLE
Update log_event_data json to use `trace.id` and `span.id`

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
@@ -18,8 +18,8 @@ namespace NewRelic.Agent.Core.JsonConverters
         private const string TimeStamp = "timestamp";
         private const string Message = "message";
         private const string Level = "level";
-        private const string SpanId = "spanid";
-        private const string TraceId = "traceid";
+        private const string SpanId = "span.id";
+        private const string TraceId = "trace.id";
 
         public override LogEventWireModelCollection ReadJson(JsonReader reader, Type objectType, LogEventWireModelCollection existingValue, bool hasExistingValue, JsonSerializer serializer)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
@@ -63,10 +63,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 
     public class LogAttributes
     {
-        [JsonProperty("spanid", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("span.id", NullValueHandling = NullValueHandling.Ignore)]
         public string Spanid { get; set; }
 
-        [JsonProperty("traceid", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("trace.id", NullValueHandling = NullValueHandling.Ignore)]
         public string Traceid { get; set; }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.Core.Utilities
             Assert.AreEqual(
                 "{\"common\":{\"attributes\":{\"entity.guid\":\"guid\",\"hostname\":\"hostname\"}}," +
                 "\"logs\":[{\"timestamp\":1,\"message\":\"message\",\"level\":\"level\"," +
-                "\"attributes\":{\"spanid\":\"spanId\",\"traceid\":\"traceId\"}}]}",
+                "\"attributes\":{\"span.id\":\"spanId\",\"trace.id\":\"traceId\"}}]}",
                 serialized);
         }
     }


### PR DESCRIPTION
## Description

We were adding `traceid` and `spanid` attributes to the JSON sent to the `log_event_data` collector endpoint instead of the expected `trace.id` and `span.id` attributes. This caused logs to not be linked properly to distributed traces, errors, or errors inbox.

I verified that changing this causes everything to work properly, and updated unit/integration tests for the new attribute name.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests complete

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
