### PR TITLE
Fixes sampling limits for log_event_data

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.Aggregators
             : base(dataTransportService, scheduler, processStatic)
         {
             _agentHealthReporter = agentHealthReporter;
-            ResetCollections(_configuration.LogEventsMaximumPerPeriod);
+            ResetCollections(_configuration.LogEventsMaxSamplesStored);
         }
 
         protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
@@ -98,7 +98,7 @@ namespace NewRelic.Agent.Core.Aggregators
             // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
             // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
 
-            ResetCollections(_configuration.LogEventsMaximumPerPeriod);
+            ResetCollections(_configuration.LogEventsMaxSamplesStored);
         }
 
         #region Private Helpers

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1816,7 +1816,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public virtual int LogEventsMaximumPerPeriod
+        public virtual int LogEventsMaxSamplesStored
         {
             get
             {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectModel.cs
@@ -176,6 +176,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 { "custom_event_data", configuration.CustomEventsMaximumSamplesStored },
                 { "error_event_data", configuration.ErrorCollectorMaxEventSamplesStored },
                 { "span_event_data", configuration.SpanEventsMaxSamplesStored },
+                { "log_event_data", configuration.LogEventsMaxSamplesStored },
             };
         }
     }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -185,7 +185,7 @@ namespace NewRelic.Agent.Configuration
         bool ApplicationLoggingEnabled { get; }
         bool LogMetricsCollectorEnabled { get; }
         bool LogEventCollectorEnabled { get; }
-        int LogEventsMaximumPerPeriod { get; }
+        int LogEventsMaxSamplesStored { get; }
         TimeSpan LogEventsHarvestCycle { get; }
         bool LogDecoratorEnabled { get; }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
@@ -447,7 +447,7 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var configuration = Mock.Create<IConfiguration>();
             Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
-            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(100);
+            Mock.Arrange(() => configuration.LogEventsMaxSamplesStored).Returns(100);
             Mock.Arrange(() => configuration.ApplicationNames).Returns(new List<string> { "appname1" });
             if (versionNumber.HasValue)
                 Mock.Arrange(() => configuration.ConfigurationVersion).Returns(versionNumber.Value);

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2479,7 +2479,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationLogging_ForwardingMaxSamplesStored_HasCorrectValue()
         {
             _localConfig.applicationLogging.forwarding.maxSamplesStored = 1;
-            Assert.AreEqual(1, _defaultConfig.LogEventsMaximumPerPeriod);
+            Assert.AreEqual(1, _defaultConfig.LogEventsMaxSamplesStored);
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             Mock.Arrange(() => configuration.TransactionTracerEnabled).Returns(true);
             Mock.Arrange(() => configuration.LogMetricsCollectorEnabled).Returns(true);
             Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
-            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(2000);
+            Mock.Arrange(() => configuration.LogEventsMaxSamplesStored).Returns(2000);
             Mock.Arrange(() => configuration.LogEventsHarvestCycle).Returns(TimeSpan.FromSeconds(5));
             return configuration;
         }


### PR DESCRIPTION
## Description

The max samples for log events is supposed to be 10000 per 60 seconds, not 5 seconds.  The config setting is correctly set at 10000, but that needs to be passed up during connect so that the 5 second samples limit (833) is passed back.

- Renamed LogEventsMaximumPerPeriod to LogEventsMaxSamplesStored to match the other settings.
- Adds log_event_data to harvest limits payload using during connect so that it pulls down the correct value

Note: the log_event_data limit has not be added to the connect payload so that raw 10000 value will be used.  If the connect payload is not added before our testing begins, we might want to consider setting it to 833 in the short term

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
