### PR TITLE
Avoid unnecessary work in logging wrappers

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -431,18 +431,18 @@ namespace NewRelic.Agent.Core
                 {
                     return;
                 }
-                var timestamp = getTimestamp(logEvent).ToUniversalTime();
+                var timestamp = getTimestamp(logEvent).ToUnixTimeMilliseconds();
 
                 var transaction = _transactionService.GetCurrentInternalTransaction();
                 if (transaction != null && transaction.IsValid)
                 {
                     // use transaction batching for messages in transactions
-                    transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
+                    transaction.LogEvents.Add(new LogEventWireModel(timestamp, logMessage, normalizedLevel, spanId, traceId));
                     return;
                 }
 
                 // non-transaction messages with proper sanitized priority value
-                _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
+                _logEventAggregator.Collect(new LogEventWireModel(timestamp,
                     logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
             }
 

--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -406,33 +406,46 @@ namespace NewRelic.Agent.Core
             _agentHealthReporter.ReportSupportabilityCountMetric(metricName, count);
         }
 
-        public void RecordLogMessage(string frameworkName, DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId)
+        public void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId)
         {
             _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
 
-            var normalizedLevel = string.IsNullOrWhiteSpace(logLevel) ? "UNKNOWN" : logLevel.ToUpper();
+            var normalizedLevel = string.Empty;
+            if (_configurationService.Configuration.LogMetricsCollectorEnabled ||
+                _configurationService.Configuration.LogEventCollectorEnabled)
+            {
+                var logLevel = getLogLevel(logEvent).ToString();
+                normalizedLevel = string.IsNullOrWhiteSpace(logLevel) ? "UNKNOWN" : logLevel.ToUpper();
+            }
+
             if (_configurationService.Configuration.LogMetricsCollectorEnabled)
             {
                 _agentHealthReporter.IncrementLogLinesCount(normalizedLevel);
             }
 
             // IOC container defaults to singleton so this will access the same aggregator
-            if (!_configurationService.Configuration.LogEventCollectorEnabled || string.IsNullOrWhiteSpace(logMessage))
+            if (_configurationService.Configuration.LogEventCollectorEnabled) 
             {
-                return;
+                var logMessage = getLogMessage(logEvent);
+                if (string.IsNullOrWhiteSpace(logMessage))
+                {
+                    return;
+                }
+                var timestamp = getTimestamp(logEvent).ToUniversalTime();
+
+                var transaction = _transactionService.GetCurrentInternalTransaction();
+                if (transaction != null && transaction.IsValid)
+                {
+                    // use transaction batching for messages in transactions
+                    transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
+                    return;
+                }
+
+                // non-transaction messages with proper sanitized priority value
+                _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
+                    logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
             }
 
-            var transaction = _transactionService.GetCurrentInternalTransaction();
-            if (transaction != null && transaction.IsValid)
-            {
-                // use transaction batching for messages in transactions
-                transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
-                return;
-            }
-
-            // non-transaction messages with proper sanitized priority value
-            _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
-                logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
         }
 
         #endregion

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -27,6 +27,6 @@ namespace NewRelic.Agent.Api.Experimental
         /// <param name="spanId">The span ID of the segment the log message occured within.</param>
         /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
         /// <param name="frameworkName">The name of the logging framework</param>
-        void RecordLogMessage(string frameworkName, DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId);
+        void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -21,12 +21,13 @@ namespace NewRelic.Agent.Api.Experimental
         /// <summary>
         /// Records the log message in the transaction to later be forwarded if log forwarding is enabled.
         /// </summary>
-        /// <param name="timestamp">Timestamp from the log message.</param>
-        /// <param name="logLevel">Severity or level of the log message.</param>
-        /// <param name="logMessage">The log message.</param>
+        /// <param name="frameworkName">The name of the logging framework.</param>
+        /// <param name="logEvent">The logging event object.</param>
+        /// <param name="getTimestamp">A Func<object,DateTime> that knows how to get the timestamp from the logEvent.</param>
+        /// <param name="getLogLevel">A Func<object,object> that knows how to get the log level from the logEvent.</param>
+        /// <param name="getLogMessage">A Func<object,string> that knows how to get the log message from the logEvent</param>
         /// <param name="spanId">The span ID of the segment the log message occured within.</param>
         /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
-        /// <param name="frameworkName">The name of the logging framework</param>
         void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -40,15 +40,12 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
 
             // RenderedMessage is get only
             var getRenderedMessageFunc = _getRenderedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEvent.GetType(), "RenderedMessage");
-            //var renderedMessage = getRenderedMessageFunc(logEvent);
 
             // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
-            //var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -40,19 +40,19 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
+            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
 
             // RenderedMessage is get only
             var getRenderedMessageFunc = _getRenderedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEvent.GetType(), "RenderedMessage");
-            var renderedMessage = getRenderedMessageFunc(logEvent);
+            //var renderedMessage = getRenderedMessageFunc(logEvent);
 
             // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
-            var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
+            //var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, timestamp, logLevel, renderedMessage, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLogLevelFunc, getRenderedMessageFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, IAgent agent)

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1325,7 +1325,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(true);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
 
@@ -1347,7 +1347,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var logEvent = logEvents?.FirstOrDefault()?.Data;
             Assert.AreEqual(1, logEvents.Count);
             Assert.IsNotNull(logEvent);
-            Assert.AreEqual(timpstampUnix, logEvent.TimeStamp);
+            Assert.AreEqual(timestampUnix, logEvent.TimeStamp);
             Assert.AreEqual(level, logEvent.Level);
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1294,15 +1294,20 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(false);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1323,12 +1328,17 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1352,9 +1362,14 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(true);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
@@ -1364,12 +1379,12 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             var logEvent = transaction.LogEvents?.FirstOrDefault();
             Assert.AreEqual(1, transaction.LogEvents.Count);
             Assert.IsNotNull(logEvent);
-            Assert.AreEqual(timpstampUnix, logEvent.TimeStamp);
+            Assert.AreEqual(timestampUnix, logEvent.TimeStamp);
             Assert.AreEqual(level, logEvent.Level);
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);


### PR DESCRIPTION
## Description

This PR updates the `RecordLogMessage()` experimental agent API to take getter functions that know how to extract the timestamp, log level and log message from an arbitrary log event object, rather than those values themselves.  This allows us to avoid doing unnecessary and expensive reflection work to get values if they aren't needed due to config settings.

I went with this approach rather than just putting the config checks in the wrapper itself for two reasons:
1. Per the current logging instrumentation engineering brief/design doc, we need to create a supportability metric that indicates that our instrumentation matched a given logging framework, even if all logging features are disabled by config.  That happens at the very top of `RecordLogMessage`, and so we can't short-circuit calling this method based on config.
2. It keeps the logic of what to do based on config settings centralized in this API rather than duplicated in all the wrappers.

Some numbers to show that this change has an improvement (taken from running a logging benchmarking app that logs ~1 million log lines as fast as possible, so the total execution time is the measure of performance - smaller is better):

| Agent Version | Config Options | Execution Time (s) |
| --------------- | ----------------- | ----------------- |
| Main Agent | N/A | 47.4 |
| Current feature branch | Overall Logging Feature and Metrics Enabled | 64.27 |
| Current feature branch | All logging features disabled | 61.38 |
| This PR | Overall Logging Feature and Metrics Enabled | 63.55 |
| This PR | All logging features disabled | 52.68 |


# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [X] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
