### PR TITLE
Update Serilog wrapper to use new RecordLogMessage API shape

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -431,18 +431,18 @@ namespace NewRelic.Agent.Core
                 {
                     return;
                 }
-                var timestamp = getTimestamp(logEvent).ToUniversalTime();
+                var timestamp = getTimestamp(logEvent).ToUnixTimeMilliseconds();
 
                 var transaction = _transactionService.GetCurrentInternalTransaction();
                 if (transaction != null && transaction.IsValid)
                 {
                     // use transaction batching for messages in transactions
-                    transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
+                    transaction.LogEvents.Add(new LogEventWireModel(timestamp, logMessage, normalizedLevel, spanId, traceId));
                     return;
                 }
 
                 // non-transaction messages with proper sanitized priority value
-                _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
+                _logEventAggregator.Collect(new LogEventWireModel(timestamp,
                     logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
             }
 

--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -406,33 +406,46 @@ namespace NewRelic.Agent.Core
             _agentHealthReporter.ReportSupportabilityCountMetric(metricName, count);
         }
 
-        public void RecordLogMessage(string frameworkName, DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId)
+        public void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId)
         {
             _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
 
-            var normalizedLevel = string.IsNullOrWhiteSpace(logLevel) ? "UNKNOWN" : logLevel.ToUpper();
+            var normalizedLevel = string.Empty;
+            if (_configurationService.Configuration.LogMetricsCollectorEnabled ||
+                _configurationService.Configuration.LogEventCollectorEnabled)
+            {
+                var logLevel = getLogLevel(logEvent).ToString();
+                normalizedLevel = string.IsNullOrWhiteSpace(logLevel) ? "UNKNOWN" : logLevel.ToUpper();
+            }
+
             if (_configurationService.Configuration.LogMetricsCollectorEnabled)
             {
                 _agentHealthReporter.IncrementLogLinesCount(normalizedLevel);
             }
 
             // IOC container defaults to singleton so this will access the same aggregator
-            if (!_configurationService.Configuration.LogEventCollectorEnabled || string.IsNullOrWhiteSpace(logMessage))
+            if (_configurationService.Configuration.LogEventCollectorEnabled) 
             {
-                return;
+                var logMessage = getLogMessage(logEvent);
+                if (string.IsNullOrWhiteSpace(logMessage))
+                {
+                    return;
+                }
+                var timestamp = getTimestamp(logEvent).ToUniversalTime();
+
+                var transaction = _transactionService.GetCurrentInternalTransaction();
+                if (transaction != null && transaction.IsValid)
+                {
+                    // use transaction batching for messages in transactions
+                    transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
+                    return;
+                }
+
+                // non-transaction messages with proper sanitized priority value
+                _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
+                    logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
             }
 
-            var transaction = _transactionService.GetCurrentInternalTransaction();
-            if (transaction != null && transaction.IsValid)
-            {
-                // use transaction batching for messages in transactions
-                transaction.LogEvents.Add(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(), logMessage, normalizedLevel, spanId, traceId));
-                return;
-            }
-
-            // non-transaction messages with proper sanitized priority value
-            _logEventAggregator.Collect(new LogEventWireModel(timestamp.ToUnixTimeMilliseconds(),
-                logMessage, normalizedLevel, spanId, traceId, _transactionService.CreatePriority()));
         }
 
         #endregion

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.Aggregators
             : base(dataTransportService, scheduler, processStatic)
         {
             _agentHealthReporter = agentHealthReporter;
-            ResetCollections(_configuration.LogEventsMaximumPerPeriod);
+            ResetCollections(_configuration.LogEventsMaxSamplesStored);
         }
 
         protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
@@ -98,7 +98,7 @@ namespace NewRelic.Agent.Core.Aggregators
             // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
             // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
 
-            ResetCollections(_configuration.LogEventsMaximumPerPeriod);
+            ResetCollections(_configuration.LogEventsMaxSamplesStored);
         }
 
         #region Private Helpers

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1816,7 +1816,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public virtual int LogEventsMaximumPerPeriod
+        public virtual int LogEventsMaxSamplesStored
         {
             get
             {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectModel.cs
@@ -176,6 +176,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 { "custom_event_data", configuration.CustomEventsMaximumSamplesStored },
                 { "error_event_data", configuration.ErrorCollectorMaxEventSamplesStored },
                 { "span_event_data", configuration.SpanEventsMaxSamplesStored },
+                { "log_event_data", configuration.LogEventsMaxSamplesStored },
             };
         }
     }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -27,6 +27,6 @@ namespace NewRelic.Agent.Api.Experimental
         /// <param name="spanId">The span ID of the segment the log message occured within.</param>
         /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
         /// <param name="frameworkName">The name of the logging framework</param>
-        void RecordLogMessage(string frameworkName, DateTime timestamp, string logLevel, string logMessage, string spanId, string traceId);
+        void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -21,12 +21,13 @@ namespace NewRelic.Agent.Api.Experimental
         /// <summary>
         /// Records the log message in the transaction to later be forwarded if log forwarding is enabled.
         /// </summary>
-        /// <param name="timestamp">Timestamp from the log message.</param>
-        /// <param name="logLevel">Severity or level of the log message.</param>
-        /// <param name="logMessage">The log message.</param>
+        /// <param name="frameworkName">The name of the logging framework.</param>
+        /// <param name="logEvent">The logging event object.</param>
+        /// <param name="getTimestamp">A Func<object,DateTime> that knows how to get the timestamp from the logEvent.</param>
+        /// <param name="getLogLevel">A Func<object,object> that knows how to get the log level from the logEvent.</param>
+        /// <param name="getLogMessage">A Func<object,string> that knows how to get the log message from the logEvent</param>
         /// <param name="spanId">The span ID of the segment the log message occured within.</param>
         /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
-        /// <param name="frameworkName">The name of the logging framework</param>
         void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -185,7 +185,7 @@ namespace NewRelic.Agent.Configuration
         bool ApplicationLoggingEnabled { get; }
         bool LogMetricsCollectorEnabled { get; }
         bool LogEventCollectorEnabled { get; }
-        int LogEventsMaximumPerPeriod { get; }
+        int LogEventsMaxSamplesStored { get; }
         TimeSpan LogEventsHarvestCycle { get; }
         bool LogDecoratorEnabled { get; }
     }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -40,15 +40,12 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
 
             // RenderedMessage is get only
             var getRenderedMessageFunc = _getRenderedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEvent.GetType(), "RenderedMessage");
-            //var renderedMessage = getRenderedMessageFunc(logEvent);
 
             // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
-            //var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/Log4netWrapper.cs
@@ -40,19 +40,19 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
+            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level class has a ToString override we can use.
 
             // RenderedMessage is get only
             var getRenderedMessageFunc = _getRenderedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEvent.GetType(), "RenderedMessage");
-            var renderedMessage = getRenderedMessageFunc(logEvent);
+            //var renderedMessage = getRenderedMessageFunc(logEvent);
 
             // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEvent.GetType(), "TimeStamp");
-            var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
+            //var timestamp = getTimestampFunc(logEvent).ToUniversalTime();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, timestamp, logLevel, renderedMessage, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLogLevelFunc, getRenderedMessageFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, IAgent agent)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -43,11 +43,9 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level is an enum so ToString() works.
 
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTimeOffset>(logEvent.GetType(), "Timestamp");
             Func<object, DateTime> getDateTimeFunc = (logEvent) => getTimestampFunc(logEvent).UtcDateTime;
-            //var timestamp = getTimestampFunc(logEvent);
 
             Func<object, string> getMessageFunc = (logEvent) => ((dynamic)logEvent).RenderMessage();
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -43,16 +43,17 @@ namespace NewRelic.Providers.Wrapper.Logging
         private void RecordLogMessage(object logEvent, IAgent agent)
         {
             var getLogLevelFunc = _getLogLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEvent.GetType(), "Level");
-            var logLevel = getLogLevelFunc(logEvent).ToString(); // Level is an enum so ToString() works.
+            //var logLevel = getLogLevelFunc(logEvent).ToString(); // Level is an enum so ToString() works.
 
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTimeOffset>(logEvent.GetType(), "Timestamp");
-            var timestamp = getTimestampFunc(logEvent);
+            Func<object, DateTime> getDateTimeFunc = (logEvent) => getTimestampFunc(logEvent).UtcDateTime;
+            //var timestamp = getTimestampFunc(logEvent);
 
-            var renderedMessage = ((dynamic)logEvent).RenderMessage();
+            Func<object, string> getMessageFunc = (logEvent) => ((dynamic)logEvent).RenderMessage();
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, timestamp.DateTime, logLevel, (string)renderedMessage, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getDateTimeFunc, getLogLevelFunc, getMessageFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, IAgent agent)

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/LogEventAggregatorTests.cs
@@ -447,7 +447,7 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var configuration = Mock.Create<IConfiguration>();
             Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
-            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(100);
+            Mock.Arrange(() => configuration.LogEventsMaxSamplesStored).Returns(100);
             Mock.Arrange(() => configuration.ApplicationNames).Returns(new List<string> { "appname1" });
             if (versionNumber.HasValue)
                 Mock.Arrange(() => configuration.ConfigurationVersion).Returns(versionNumber.Value);

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2479,7 +2479,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationLogging_ForwardingMaxSamplesStored_HasCorrectValue()
         {
             _localConfig.applicationLogging.forwarding.maxSamplesStored = 1;
-            Assert.AreEqual(1, _defaultConfig.LogEventsMaximumPerPeriod);
+            Assert.AreEqual(1, _defaultConfig.LogEventsMaxSamplesStored);
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             Mock.Arrange(() => configuration.TransactionTracerEnabled).Returns(true);
             Mock.Arrange(() => configuration.LogMetricsCollectorEnabled).Returns(true);
             Mock.Arrange(() => configuration.LogEventCollectorEnabled).Returns(true);
-            Mock.Arrange(() => configuration.LogEventsMaximumPerPeriod).Returns(2000);
+            Mock.Arrange(() => configuration.LogEventsMaxSamplesStored).Returns(2000);
             Mock.Arrange(() => configuration.LogEventsHarvestCycle).Returns(TimeSpan.FromSeconds(5));
             return configuration;
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1325,7 +1325,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(true);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
 
@@ -1347,7 +1347,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var logEvent = logEvents?.FirstOrDefault()?.Data;
             Assert.AreEqual(1, logEvents.Count);
             Assert.IsNotNull(logEvent);
-            Assert.AreEqual(timpstampUnix, logEvent.TimeStamp);
+            Assert.AreEqual(timestampUnix, logEvent.TimeStamp);
             Assert.AreEqual(level, logEvent.Level);
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1294,15 +1294,20 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(false);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1323,12 +1328,17 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1352,9 +1362,14 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
                 .Returns(true);
 
             var timestamp = DateTime.Now;
-            var timpstampUnix = timestamp.ToUnixTimeMilliseconds();
+            var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+
+            Func<object, string> getLevelFunc = (l) => level;
+            Func<object, DateTime> getTimestampFunc = (l) => timestamp;
+            Func<object, string> getMessageFunc = (l) => message;
+
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
@@ -1364,12 +1379,12 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, timestamp, level, message, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, spanId, traceId);
 
             var logEvent = transaction.LogEvents?.FirstOrDefault();
             Assert.AreEqual(1, transaction.LogEvents.Count);
             Assert.IsNotNull(logEvent);
-            Assert.AreEqual(timpstampUnix, logEvent.TimeStamp);
+            Assert.AreEqual(timestampUnix, logEvent.TimeStamp);
             Assert.AreEqual(level, logEvent.Level);
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);


### PR DESCRIPTION
## Description

Update the Serilog wrapper to use the new shape of the `RecordLogMessage` API, as well as bring in other work from the upstream `logsinst-feature-branch` in preparation for merging `serilog-instrumentation-feature-branch` back into it.

# Author Checklist
- [X] Unit tests, Integration tests

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
