### PR TITLE
Swap logs maxsamples config precedence

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1820,9 +1820,9 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return (int)EnvironmentOverrides(
-                    ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(), _localConfiguration.applicationLogging.forwarding.maxSamplesStored),
-                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED");
+                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(),
+                    EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.maxSamplesStored,
+                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED").GetValueOrDefault());
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1820,9 +1820,11 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                // This is different from the other faster event harvest settings since we want to ensure that local values are properly distributed across the harvest.
+                // Using the GetValueOrDefault to ensure that a value is provided if all other values are remvoed.
                 return ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(),
                     EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.maxSamplesStored,
-                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED").GetValueOrDefault());
+                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED").GetValueOrDefault(10000));
             }
         }
 


### PR DESCRIPTION
## Description

- After some lengthy discussions we decided to have the connect config take precedence over the local values since we want the maxSamplesSize to be spread over the individual faster event harvests.
- Includes setting the default value in the GetValueOrDefault as well to ensure we always get a good value.
- Not test changes since this just swaps precedence.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
