### PR TITLE
Azure Site Extension improvements

### DIFF
--- a/build/Packaging/AzureSiteExtension/CHANGELOG.md
+++ b/build/Packaging/AzureSiteExtension/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### New Features
 ### Fixes
+* Fixes Issue [#1005](https://github.com/newrelic/newrelic-dotnet-agent/issues/1005): site extension did not work when the the web app was set to run from a package, and broke after deployment of customer applications in some cases due to the agent being deployed to the site directory. [#1021](https://github.com/newrelic/newrelic-dotnet-agent/pull/1021)
 
 ## [1.5.2] - 2021-03-05
 ### Fixes

--- a/build/Packaging/AzureSiteExtension/Content/applicationHost.xdt
+++ b/build/Packaging/AzureSiteExtension/Content/applicationHost.xdt
@@ -5,15 +5,15 @@
       <environmentVariables xdt:Transform="InsertIfMissing">
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="COR_PROFILER" value="{71DA0A04-7777-4EC6-9643-7D28B46A8A41}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH" value="%HOME%\NewRelicAgent\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\newrelic\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="NEWRELIC_HOME" value="%HOME%\NewRelicAgent\newrelic" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\NewRelicAgent\Framework\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\Framework\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\Framework\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="NEWRELIC_HOME" value="%HOME%\NewRelicAgent\Framework" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="CORECLR_PROFILER" value="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\newrelic_core\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\newrelic_core\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_NEWRELIC_HOME" value="%HOME%\NewRelicAgent\newrelic_core" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\Core\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\Core\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_NEWRELIC_HOME" value="%HOME%\NewRelicAgent\Core" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </environmentVariables>
     </runtime>
   </system.webServer>

--- a/build/Packaging/AzureSiteExtension/Content/applicationHost.xdt
+++ b/build/Packaging/AzureSiteExtension/Content/applicationHost.xdt
@@ -5,15 +5,15 @@
       <environmentVariables xdt:Transform="InsertIfMissing">
         <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="COR_PROFILER" value="{71DA0A04-7777-4EC6-9643-7D28B46A8A41}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH" value="C:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH_32" value="C:\Home\site\wwwroot\newrelic\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="COR_PROFILER_PATH_64" value="C:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="NEWRELIC_HOME" value="C:\Home\site\wwwroot\newrelic" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH" value="%HOME%\NewRelicAgent\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\newrelic\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="COR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\newrelic\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="NEWRELIC_HOME" value="%HOME%\NewRelicAgent\newrelic" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="CORECLR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
         <add name="CORECLR_PROFILER" value="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_PROFILER_PATH_32" value="C:\Home\site\wwwroot\newrelic_core\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_PROFILER_PATH_64" value="C:\Home\site\wwwroot\newrelic_core\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
-        <add name="CORECLR_NEWRELIC_HOME" value="C:\Home\site\wwwroot\newrelic_core" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_PROFILER_PATH_32" value="%HOME%\NewRelicAgent\newrelic_core\x86\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_PROFILER_PATH_64" value="%HOME%\NewRelicAgent\newrelic_core\NewRelic.Profiler.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
+        <add name="CORECLR_NEWRELIC_HOME" value="%HOME%\NewRelicAgent\newrelic_core" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing"/>
       </environmentVariables>
     </runtime>
   </system.webServer>

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -84,19 +84,35 @@ function SaveNewRelicConfigAndCustomInstrumentationFiles($newRelicInstallPath)
 			Copy-Item -Path "$newRelicInstallPath\newrelic.config" -Destination "$newRelicInstallPath\saved_items"
 		}
 
-		WriteToInstallLog "Save the following existing custom instrumemtation files to the $newRelicInstallPath\saved_items folder."
+		WriteToInstallLog "Save the following existing custom instrumentation files to the $newRelicInstallPath\saved_items folder."
 		Get-ChildItem "$newRelicInstallPath\extensions\*.xml" -Exclude "NewRelic.Providers.*" | Out-File -FilePath "$(Split-Path -Parent $PSCommandPath)\install.log" -Append
 		Get-ChildItem "$newRelicInstallPath\extensions\*.xml" -Exclude "NewRelic.Providers.*" | Copy-Item -Destination "$newRelicInstallPath\saved_items"
 	}
 }
 
-function RestoreCustomerRelatedFiles($newRelicInstallPath)
+function RestoreCustomerRelatedFiles($newRelicInstallPath, $newRelicLegacyInstallPath)
 {
 	if (Test-Path -Path "$newRelicInstallPath\saved_items")
 	{
-		WriteToInstallLog "Restore newrelic.config and custom instrumemtation files from the saved_items folder."
+		WriteToInstallLog "Restore newrelic.config and custom instrumentation files from the saved_items folder."
 		Copy-Item -Path "$newRelicInstallPath\saved_items\newrelic.config" -Destination "$newRelicInstallPath\newrelic.config" -Force
 		Get-ChildItem "$newRelicInstallPath\saved_items\*.xml" | Copy-Item -Destination "$newRelicInstallPath\extensions"
+	}
+	# If there aren't any saved_items in the current install path, then this may be an upgrade between versions of the site extension
+	# that changed the storage path for where the new relic agent lives. The uninstall of the site extension removes the legacy storage
+	# locations, so this migration should only ever happen once.
+	elseif (Test-Path -Path $newRelicLegacyInstallPath)
+	{
+		WriteToInstallLog "Migrating newrelic.config and custom instrumentation files from old site extension storage location."
+		if (Test-Path -Path "$newRelicLegacyInstallPath\newrelic.config")
+		{
+			WriteToInstallLog "Migrating $newRelicLegacyInstallPath\newrelic.config to $newRelicInstallPath\newrelic.config."
+			Copy-Item -Path "$newRelicLegacyInstallPath\newrelic.config" -Destination "$newRelicInstallPath\newrelic.config" -Force
+		}
+
+		WriteToInstallLog "Migrating the following custom instrumentation files to the $newRelicInstallPath."
+		Get-ChildItem "$newRelicLegacyInstallPath\extensions\*.xml" -Exclude "NewRelic.Providers.*" | Out-File -FilePath "$(Split-Path -Parent $PSCommandPath)\install.log" -Append
+		Get-ChildItem "$newRelicLegacyInstallPath\extensions\*.xml" -Exclude "NewRelic.Providers.*" | Copy-Item -Destination "$newRelicInstallPath\extensions"
 	}
 }
 
@@ -116,7 +132,7 @@ function RenameExistingFilesAsSaveExtensionFiles($newRelicInstallPath)
 	}
 }
 
-function RemoveExistingSaveExtenstionFiles($newRelicInstallPath)
+function RemoveExistingSaveExtensionFiles($newRelicInstallPath)
 {
 	WriteToInstallLog "Remove existing *.save files from previous upgrade if there are any."
 	if(Test-Path $newRelicInstallPath)
@@ -125,11 +141,11 @@ function RemoveExistingSaveExtenstionFiles($newRelicInstallPath)
 	}
 }
 
-function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath)
+function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath, $newRelicLegacyInstallPath)
 {
 	###Remove existing *.save files from previous upgrade###
-	RemoveExistingSaveExtenstionFiles $newRelicInstallPath
-
+	RemoveExistingSaveExtensionFiles $newRelicInstallPath
+	
 	###Preserve existing newrelic.config and custom instrumemtation xml files###
 	SaveNewRelicConfigAndCustomInstrumentationFiles $newRelicInstallPath
 
@@ -148,7 +164,7 @@ function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath)
 	CopyDirectory $newRelicNugetContentPath $newRelicInstallPath
 
 	###Restore saved newrelic.config and custom instrumemtation files###
-	RestoreCustomerRelatedFiles $newRelicInstallPath
+	RestoreCustomerRelatedFiles $newRelicInstallPath $newRelicLegacyInstallPath
 
 	###Remove Linux Grpc library since it won't be used.
 	$linuxGrpcLib = "$newRelicInstallPath\libgrpc_csharp_ext.x64.so"
@@ -312,6 +328,7 @@ try
 	$packageNames = @($nugetPackageForFrameworkApp, $nugetPackageForCoreApp)
 	$stagingFolders = @("NewRelicPackage", "NewRelicCorePackage")
 	$newRelicInstallPaths = @("$env:HOME\NewRelicAgent\newrelic", "$env:HOME\NewRelicAgent\newrelic_core")
+	$newRelicLegacyInstallPaths = @("$env:WEBROOT_PATH\newrelic", "$env:WEBROOT_PATH\newrelic_core")
 	$newRelicNugetContentPaths = $(".\content\newrelic", ".\contentFiles\any\netstandard2.0\newrelic")
 
 	#Check to see if the old Agent is currently being used
@@ -321,6 +338,7 @@ try
 		$packageName = $packageNames[$i]
 		$stagingFolder = $stagingFolders[$i]
 		$newRelicInstallPath= $newRelicInstallPaths[$i]
+		$newRelicLegacyInstallPath = $newRelicLegacyInstallPaths[$i]
 		$newRelicNugetContentPath = $newRelicNugetContentPaths[$i]
 
 		if($packageName -eq "NewRelic.Agent" -and [System.Version]$agentVersion -lt [System.Version]"8.17.438")
@@ -344,7 +362,7 @@ try
 
 		cd "$packageName.$agentVersion"
 
-		InstallNewAgent $newRelicNugetContentPath $newRelicInstallPath
+		InstallNewAgent $newRelicNugetContentPath $newRelicInstallPath $newRelicLegacyInstallPath
 
 		CopyAgentInfo $newRelicInstallPath
 

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -141,7 +141,7 @@ function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath)
 	$xdoc.load($file)
 
 	#Set Agent log location
-	$xdoc.configuration.log.SetAttribute("directory", "c:\Home\LogFiles\NewRelic")
+	$xdoc.configuration.log.SetAttribute("directory", "$env:HOME\LogFiles\NewRelic")
 	$xdoc.Save($file)
 
 	WriteToInstallLog "Copy items from $(Resolve-Path $newRelicNugetContentPath) to $newRelicInstallPath"
@@ -311,7 +311,7 @@ try
 
 	$packageNames = @($nugetPackageForFrameworkApp, $nugetPackageForCoreApp)
 	$stagingFolders = @("NewRelicPackage", "NewRelicCorePackage")
-	$newRelicInstallPaths = @("$env:WEBROOT_PATH\newrelic", "$env:WEBROOT_PATH\newrelic_core")
+	$newRelicInstallPaths = @("$env:HOME\NewRelicAgent\newrelic", "$env:HOME\NewRelicAgent\newrelic_core")
 	$newRelicNugetContentPaths = $(".\content\newrelic", ".\contentFiles\any\netstandard2.0\newrelic")
 
 	#Check to see if the old Agent is currently being used

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -327,7 +327,7 @@ try
 
 	$packageNames = @($nugetPackageForFrameworkApp, $nugetPackageForCoreApp)
 	$stagingFolders = @("NewRelicPackage", "NewRelicCorePackage")
-	$newRelicInstallPaths = @("$env:HOME\NewRelicAgent\newrelic", "$env:HOME\NewRelicAgent\newrelic_core")
+	$newRelicInstallPaths = @("$env:HOME\NewRelicAgent\Framework", "$env:HOME\NewRelicAgent\Core")
 	$newRelicLegacyInstallPaths = @("$env:WEBROOT_PATH\newrelic", "$env:WEBROOT_PATH\newrelic_core")
 	$newRelicNugetContentPaths = $(".\content\newrelic", ".\contentFiles\any\netstandard2.0\newrelic")
 

--- a/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
+++ b/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
@@ -1,12 +1,7 @@
 :: Copyright 2020 New Relic Corporation. All rights reserved.
 :: SPDX-License-Identifier: Apache-2.0
 
-SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent\newrelic"
-IF EXIST %NEW_RELIC_FOLDER% (
-  rd /S /q %NEW_RELIC_FOLDER%
-)
-
-SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent\newrelic_core"
+SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent"
 IF EXIST %NEW_RELIC_FOLDER% (
   rd /S /q %NEW_RELIC_FOLDER%
 )

--- a/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
+++ b/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
@@ -5,3 +5,14 @@ SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent"
 IF EXIST %NEW_RELIC_FOLDER% (
   rd /S /q %NEW_RELIC_FOLDER%
 )
+
+:: Clean up legacy install locations (unfortunately the same location that the nuget agent is deployed)
+SET NEW_RELIC_FOLDER="%WEBROOT_PATH%\newrelic"
+IF EXIST %NEW_RELIC_FOLDER% (
+  rd /S /q %NEW_RELIC_FOLDER%
+)
+
+SET NEW_RELIC_FOLDER="%WEBROOT_PATH%\newrelic_core"
+IF EXIST %NEW_RELIC_FOLDER% (
+  rd /S /q %NEW_RELIC_FOLDER%
+)

--- a/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
+++ b/build/Packaging/AzureSiteExtension/Content/uninstall.cmd
@@ -1,12 +1,12 @@
 :: Copyright 2020 New Relic Corporation. All rights reserved.
 :: SPDX-License-Identifier: Apache-2.0
 
-SET NEW_RELIC_FOLDER="%WEBROOT_PATH%\newrelic"
+SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent\newrelic"
 IF EXIST %NEW_RELIC_FOLDER% (
   rd /S /q %NEW_RELIC_FOLDER%
 )
 
-SET NEW_RELIC_FOLDER="%WEBROOT_PATH%\newrelic_core"
+SET NEW_RELIC_FOLDER="%HOME%\NewRelicAgent\newrelic_core"
 IF EXIST %NEW_RELIC_FOLDER% (
   rd /S /q %NEW_RELIC_FOLDER%
 )


### PR DESCRIPTION
## Description

Closes #1005

Updates the location where the New Relic agent is deployed by our Azure Site Extension. This resolves the following issues:
1. Installs the agent to `%HOME%/NewRelicAgent` instead of `%WEBROOT_PATH%`. This allows the agent to install properly when a site is [Run From a ZIP Package](https://docs.microsoft.com/en-us/azure/app-service/deploy-run-package) and the site root is read only.
2. Uses the `%HOME%` environment variable for installation and profiler environment variables instead of assuming everything will live on the `C:\` drive. This will more gracefully handle cases where Azure uses a `D:\` root instead of a `C:\` root.
3. As the agent has been moved out of the `%WEBROOT_PATH%`, customers should experience fewer issues where deploying their application code deletes the profiler/agent.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
