### PR TITLE
Add back entity.name to log data payload and local decoration

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -84,6 +84,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 : _configuration.UtilizationHostName;
 
             var modelsCollection = new LogEventWireModelCollection(
+                _configuration.ApplicationNames.ElementAt(0),
                 _configuration.EntityGuid,
                 hostname,
                 aggregatedEvents); ;

--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
@@ -12,6 +12,7 @@ namespace NewRelic.Agent.Core.JsonConverters
     {
         private const string Common = "common";
         private const string Attributes = "attributes";
+        private const string EntityName = "entity.name";
         private const string EntityGuid = "entity.guid";
         private const string Hostname = "hostname";
         private const string Logs = "logs";
@@ -39,6 +40,8 @@ namespace NewRelic.Agent.Core.JsonConverters
             jsonWriter.WriteStartObject();
             jsonWriter.WritePropertyName(Attributes);
             jsonWriter.WriteStartObject();
+            jsonWriter.WritePropertyName(EntityName);
+            jsonWriter.WriteValue(value.EntityName);
             jsonWriter.WritePropertyName(EntityGuid);
             jsonWriter.WriteValue(value.EntityGuid);
             jsonWriter.WritePropertyName(Hostname);

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LogEventWireModelCollection.cs
@@ -10,14 +10,16 @@ namespace NewRelic.Agent.Core.WireModels
     [JsonConverter(typeof(LogEventWireModelCollectionJsonConverter))]
     public class LogEventWireModelCollection
     {
+        public string EntityName { get; }
         public string EntityGuid { get; }
 
         public string Hostname { get; }
 
         public IList<LogEventWireModel> LoggingEvents { get; }
 
-        public LogEventWireModelCollection(string entityGuid, string hostname, IList<LogEventWireModel> loggingEvents)
+        public LogEventWireModelCollection(string entityName, string entityGuid, string hostname, IList<LogEventWireModel> loggingEvents)
         {
+            EntityName = entityName;
             EntityGuid = entityGuid;
             Hostname = hostname;
             LoggingEvents = loggingEvents;

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LoggingHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LoggingHelpers.cs
@@ -7,6 +7,7 @@ namespace NewRelic.Agent.Extensions.Logging
 {
     public static class LoggingHelpers
     {
+        private const string EntityName = "entity.name";
         private const string EntityGuid = "entity.guid";
         private const string Hostname = "hostname";
         private const string TraceId = "trace.id";
@@ -14,8 +15,13 @@ namespace NewRelic.Agent.Extensions.Logging
 
         public static string GetFormattedLinkingMetadata(IAgent agent)
         {
-            // we don't use entity.name or entity.type
             var metadata = agent.GetLinkingMetadata();
+
+            string entityName = string.Empty;
+            if (metadata.ContainsKey(EntityName))
+            {
+                entityName = metadata[EntityName];
+            }
 
             string entityGuid = string.Empty;
             if (metadata.ContainsKey(EntityGuid))
@@ -43,7 +49,7 @@ namespace NewRelic.Agent.Extensions.Logging
 
             // This is a positional blob so we want the delimiters left in when no data is  present.
             // NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|
-            return "NR-LINKING|" + entityGuid + "|" + hostname + "|" + traceId + "|" + spanId + "|";
+            return "NR-LINKING|" + entityGuid + "|" + hostname + "|" + traceId + "|" + spanId + "|" + entityName + "|";
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/LogData.cs
@@ -39,6 +39,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 
     public class LogEventDataCommonAttributes
     {
+        [JsonProperty("entity.name")]
+        public string EntityName { get; set; }
+
         [JsonProperty("entity.guid")]
         public string EntityGuid { get; set; }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -314,7 +314,15 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging", "forwarding" }, "maxSamplesStored", samples.ToString());
             return this;
         }
+        public NewRelicConfigModifier SetApplicationName(string key)
+        {
+            CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(_configFilePath, new[] { "configuration", "application" },
+                "name", key);
+            return this;
+        }
 
-        
+
+
+
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -214,6 +214,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 Assert.NotNull(logEventData.Common);
                 Assert.NotNull(logEventData.Common.Attributes);
                 Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityGuid));
+                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityName));
                 Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.Hostname));
             }
             else

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
@@ -15,6 +15,7 @@ namespace NewRelic.Agent.Core.Utilities
         public void LogEventWireModelCollectionIsJsonSerializable()
         {
             var sourceObject = new LogEventWireModelCollection(
+                "myApplicationName",
                 "guid",
                 "hostname",
                 new List<LogEventWireModel>()
@@ -28,7 +29,7 @@ namespace NewRelic.Agent.Core.Utilities
             var serialized = JsonConvert.SerializeObject(sourceObject, Formatting.None);
 
             Assert.AreEqual(
-                "{\"common\":{\"attributes\":{\"entity.guid\":\"guid\",\"hostname\":\"hostname\"}}," +
+                "{\"common\":{\"attributes\":{\"entity.name\":\"myApplicationName\",\"entity.guid\":\"guid\",\"hostname\":\"hostname\"}}," +
                 "\"logs\":[{\"timestamp\":1,\"message\":\"message\",\"level\":\"level\"," +
                 "\"attributes\":{\"span.id\":\"spanId\",\"trace.id\":\"traceId\"}}]}",
                 serialized);

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LogEventWireModelCollectionTests.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using NewRelic.Agent.Core.Metrics;
-using NewRelic.Collections;
 using NUnit.Framework;
-using Telerik.JustMock;
 
 namespace NewRelic.Agent.Core.WireModels
 {
@@ -16,6 +13,7 @@ namespace NewRelic.Agent.Core.WireModels
         [Test]
         public void ConstructorTest()
         {
+            var entityName = "MyApplicationName";
             var entityGuid = Guid.NewGuid().ToString();
             var hostname = "TestHostname";
 
@@ -24,10 +22,11 @@ namespace NewRelic.Agent.Core.WireModels
                 new LogEventWireModel(1, "TestMessage", "TestLevel", "TestSpanId", "TestTraceId")
             };
 
-            var objectUnderTest = new LogEventWireModelCollection(entityGuid, hostname, loggingEvents);
+            var objectUnderTest = new LogEventWireModelCollection(entityName, entityGuid, hostname, loggingEvents);
 
             Assert.NotNull(objectUnderTest);
             Assert.AreEqual(entityGuid, objectUnderTest.EntityGuid);
+            Assert.AreEqual(entityName, objectUnderTest.EntityName);
             Assert.AreEqual(hostname, objectUnderTest.Hostname);
             Assert.AreEqual(1, objectUnderTest.LoggingEvents.Count);
 


### PR DESCRIPTION
## Description

Add `entity.name` (which is just the first (and usually only) application name the agent knows about) back to the log data payload and the local decoration metadata blob.

I updated the local decoration integration tests to be a bit more specific about the data it is looking for (not just asserting on the regex match, but asserting on the individual values as far as specifically as we can - in the case of the `entity.name` we know it should match the application name so we can be very specific about that one).

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] ~Performance testing completed with satisfactory results (if required)~ N/A
- [ ] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ N/A 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
