### PR TITLE
URLEncode entity name in local decoration

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LoggingHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LoggingHelpers.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Api;
+using System.Web;
 
 namespace NewRelic.Agent.Extensions.Logging
 {
@@ -20,7 +21,7 @@ namespace NewRelic.Agent.Extensions.Logging
             string entityName = string.Empty;
             if (metadata.ContainsKey(EntityName))
             {
-                entityName = metadata[EntityName];
+                entityName = HttpUtility.UrlEncode(metadata[EntityName]);
             }
 
             string entityGuid = string.Empty;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.RegularExpressions;
+using System.Web;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
@@ -20,7 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     {
         private readonly TFixture _fixture;
         private readonly bool _decorationEnabled;
-        private const string _applicationName = "LocalDecorationTestAppName";
+        private const string _applicationName = "Local Decoration Test App Name";
 
         public LocalDecorationTestsBase(TFixture fixture, ITestOutputHelper output, bool decorationEnabled, LayoutType layoutType, LoggingFramework loggingFramework) : base(fixture)
         {
@@ -66,7 +67,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 var hostname = match.Groups[2].Value;
                 var traceId = match.Groups[3].Value;
                 var spanId = match.Groups[4].Value;
-                var entityName = match.Groups[5].Value;
+                var entityName = HttpUtility.UrlDecode(match.Groups[5].Value);
 
                 Assert.NotNull(entityGuid);
                 Assert.NotNull(hostname);


### PR DESCRIPTION
## Description

The `entity.name` value written to the metadata blob in local decoration needs to be URL encoded.  Updated the integration tests for local decoration to account for this.