### PR TITLE
Refactor MetricStatsEngineQueue to MetricStatsCollectionQueue

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/IAllMetricStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/IAllMetricStatsCollection.cs
@@ -8,6 +8,6 @@ namespace NewRelic.Agent.Core.Aggregators
     /// </summary>
     public interface IAllMetricStatsCollection
     {
-        void AddMetricsToEngine(MetricStatsCollection engine);
+        void AddMetricsToCollection(MetricStatsCollection collection);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -1,17 +1,16 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Metric;
+using NewRelic.Agent.Core.Metrics;
 using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.WireModels;
-using NewRelic.SystemInterfaces;
-using NewRelic.Agent.Core.Metrics;
 using NewRelic.Core.Logging;
+using NewRelic.SystemInterfaces;
 
 namespace NewRelic.Agent.Core.Aggregators
 {
@@ -22,7 +21,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
     public class MetricAggregator : AbstractAggregator<IAllMetricStatsCollection>, IMetricAggregator
     {
-        private MetricStatsEngineQueue _metricStatsEngineQueue;
+        private MetricStatsCollectionQueue _metricStatsCollectionQueue;
         private readonly IMetricBuilder _metricBuilder;
         private readonly IMetricNameService _metricNameService;
         private readonly IEnumerable<IOutOfBandMetricSource> _outOfBandMetricSources;
@@ -42,10 +41,10 @@ namespace NewRelic.Agent.Core.Aggregators
                 }
             }
 
-            _metricStatsEngineQueue = CreateMetricStatsEngineQueue();
+            _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
         }
 
-        public MetricStatsEngineQueue StatsEngineQueue => _metricStatsEngineQueue;
+        public MetricStatsCollectionQueue StatsCollectionQueue => _metricStatsCollectionQueue;
 
         protected override bool IsEnabled => true;
 
@@ -56,7 +55,7 @@ namespace NewRelic.Agent.Core.Aggregators
             bool done = false;
             while (!done)
             {
-                done = _metricStatsEngineQueue.MergeMetric(metric);
+                done = _metricStatsCollectionQueue.MergeMetrics(metric);
             }
         }
         protected override void Harvest()
@@ -68,9 +67,9 @@ namespace NewRelic.Agent.Core.Aggregators
                 source.CollectMetrics();
             }
 
-            var oldMetrics = GetStatsEngineForHarvest();
+            var oldMetrics = GetStatsCollectionForHarvest();
 
-            oldMetrics.MergeUnscopedStats(_metricBuilder.TryBuildMetricHarvestAttemptMetric());
+            oldMetrics.MergeUnscopedStats(MetricNames.SupportabilityMetricHarvestTransmit, MetricDataWireModel.BuildCountData());
             var metricsToSend = oldMetrics.ConvertToJsonForSending(_metricNameService);
 
             var responseStatus = DataTransportService.Send(metricsToSend);
@@ -84,7 +83,7 @@ namespace NewRelic.Agent.Core.Aggregators
             // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
             // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
 
-            ReplaceStatsEngineQueue();
+            ReplaceStatsCollectionQueue();
         }
 
         #endregion
@@ -114,197 +113,27 @@ namespace NewRelic.Agent.Core.Aggregators
         }
 
         /// <summary>
-        /// Replaces the current MetricStatsEngineQueue with a new one and combines all the StatsEngines in the 
+        /// Replaces the current MetricStatsCollectionQueue with a new one and combines all the MetricStatsCollections in the 
         /// old queue into a single MetricStatsCollection that can serve as the source of aggregated metrics to
         /// send to the collector.
         /// </summary>
         /// <returns></returns>
-        private MetricStatsCollection GetStatsEngineForHarvest()
+        private MetricStatsCollection GetStatsCollectionForHarvest()
         {
-            MetricStatsEngineQueue oldMetricStatsEngineQueue = ReplaceStatsEngineQueue();
-            return oldMetricStatsEngineQueue.GetStatsEngineForHarvest();
+            MetricStatsCollectionQueue oldMetricStatsCollectionQueue = ReplaceStatsCollectionQueue();
+            return oldMetricStatsCollectionQueue.GetStatsCollectionForHarvest();
         }
 
-        private MetricStatsEngineQueue ReplaceStatsEngineQueue()
+        private MetricStatsCollectionQueue ReplaceStatsCollectionQueue()
         {
-            MetricStatsEngineQueue oldMetricStatsEngineQueue = _metricStatsEngineQueue;
-            _metricStatsEngineQueue = CreateMetricStatsEngineQueue();
-            return oldMetricStatsEngineQueue;
+            MetricStatsCollectionQueue oldMetricStatsCollectionQueue = _metricStatsCollectionQueue;
+            _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
+            return oldMetricStatsCollectionQueue;
         }
 
-        private MetricStatsEngineQueue CreateMetricStatsEngineQueue()
+        private MetricStatsCollectionQueue CreateMetricStatsCollectionQueue()
         {
-            return new MetricStatsEngineQueue();
-        }
-
-        /// <summary>
-        /// Ported, with some tweaks, from the Java Agent.  Allows the agent to use multiple StatsEngines (Dictionaries) to aggregate
-        /// metrics between harvests, so that a lock on a single Dictionary does not become a throughput bottleneck at high load.
-        /// At harvest time all the Dictionaries are combined.
-        /// </summary>
-        public class MetricStatsEngineQueue
-        {
-            private int _statsEngineCount;
-
-            private Queue<MetricStatsCollection> _statsEngineQueue;
-            // at harvest time readers drain and a write lock allows the entire queue to be swapped out
-            private readonly ReaderWriterLockSlim _lock;
-            // this lock is to ensure that only one reader at a time can dequeue/enqueue stats engines from/to the queue,
-            // since Queue is not threadsafe an ConcurrentQueue was not available until .NET 4.0
-            private readonly object _queueReadersLock;
-
-            internal MetricStatsEngineQueue()
-            {
-                _statsEngineQueue = new Queue<MetricStatsCollection>();
-                _lock = new ReaderWriterLockSlim();
-                _queueReadersLock = new object();
-            }
-
-            public int StatsEngineCount => _statsEngineCount;
-
-            /// <summary>
-            /// This MetricStatsEngineQueue uses a readwrite lock (allows multiple readers, but only one writer, at a time) to mediate
-            /// between metrics that need to merge into one of the engines (readers), and the harvest job (writer), which replaces the 
-            /// queue and merges the engines in the old queue to create the harvest payload.
-            /// 
-            /// In this method, get the read lock and call a method that will pick an engine and merge metric.
-            /// </summary>
-            /// <param name="metric"></param>
-            /// <returns></returns>
-            public bool MergeMetric(IAllMetricStatsCollection metric)
-            {
-                if (_lock.TryEnterReadLock(50))
-                {
-                    try
-                    {
-                        Queue<MetricStatsCollection> statsEngineQueue = this._statsEngineQueue;
-                        if (statsEngineQueue == null)
-                        {
-                            // We've already been harvested.  Caller should try again, at which point a whole new MetricStatsEngineQueue
-                            // will have been created for the next harvest cycle.
-                            return false;
-                        }
-                        MergeMetricUnderLock(statsEngineQueue, metric);
-                        return true;
-                    }
-                    finally
-                    {
-                        _lock.ExitReadLock();
-                    }
-                }
-                return false;
-            }
-
-            /// <summary>
-            /// Take a stats engine (metrics aggregate Dictionary) off the queue and merge metric into it, then put it back
-            /// on the queue.  Create one if all the existing ones are "checked out" -- others can use it later.
-            ///  
-            /// We are one of (possibly) several readers of the stats engine queue under the readwrite lock, so harvest will
-            /// wait for us to finish before fetching/replacing the entire queue
-            /// </summary>
-            /// <param name="statsEngineQueue"></param>
-            /// <param name="metric"></param>
-            private void MergeMetricUnderLock(Queue<MetricStatsCollection> statsEngineQueue, IAllMetricStatsCollection metrics)
-            {
-                MetricStatsCollection statsEngineToMergeWith = null;
-                try
-                {
-                    lock (_queueReadersLock)
-                    {
-                        if (statsEngineQueue.Count > 0)
-                        {
-                            statsEngineToMergeWith = statsEngineQueue.Dequeue();
-                        }
-                    }
-
-                    // make a new stats engine if there aren't enough to go around right now
-                    if (statsEngineToMergeWith == null)
-                    {
-                        statsEngineToMergeWith = CreateMetricStatsEngine();
-                        Interlocked.Increment(ref _statsEngineCount);
-                    }
-
-                    metrics.AddMetricsToEngine(statsEngineToMergeWith);
-                }
-                catch (Exception e)
-                {
-                    Log.Warn($"Exception dequeueing/creating stats engine: {e}");
-                }
-                finally
-                {
-                    if (statsEngineToMergeWith != null)
-                    {
-                        try
-                        {
-                            lock (_queueReadersLock)
-                            {
-                                statsEngineQueue.Enqueue(statsEngineToMergeWith);
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            // should never happen
-                            Log.Warn($"Exception returning stats engine to queue: {e}");
-                        }
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Null out the Queue contained in this MetricStatsEngineQueue under writelock so that any subsequent
-            /// attempts to read from the queue before this MetricStatsEngineQueue is replaced will fail.  Combine
-            /// all the StatsEngines in the old Queue according to the merge function, and return the result. 
-            /// </summary>
-            /// <returns></returns>
-            public MetricStatsCollection GetStatsEngineForHarvest()
-            {
-                Queue<MetricStatsCollection> statsEngineQueue;
-                _lock.EnterWriteLock();
-                try
-                {
-                    statsEngineQueue = this._statsEngineQueue;
-
-                    //
-                    // Clear the reference to the queue so that future calls to doStatsWork() get short-circuited.
-                    //
-                    this._statsEngineQueue = null;
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
-                }
-
-                //
-                // Operations on statsEngineQueue will only occur within an acquired readLock and we've short-circuited
-                // any threads that might be racing for it, so safe to do the bulk of the harvest work outside of writeLock.
-                //
-                return GetStatsEngineForHarvest(statsEngineQueue);
-            }
-
-            private MetricStatsCollection GetStatsEngineForHarvest(Queue<MetricStatsCollection> statsEngines)
-            {
-
-                MetricStatsCollection harvestMetricsStatsEngine = CreateMetricStatsEngine();
-
-                int actualStatsEngineCount = 0;
-                foreach (MetricStatsCollection statsEngine in statsEngines)
-                {
-                    harvestMetricsStatsEngine.Merge(statsEngine);
-                    actualStatsEngineCount++;
-                }
-
-                if (actualStatsEngineCount != _statsEngineCount)
-                {
-                    Log.Warn($"Error draining stats engine queue. Expected: {_statsEngineCount} actual: {actualStatsEngineCount}");
-                }
-
-                return harvestMetricsStatsEngine;
-            }
-
-            private MetricStatsCollection CreateMetricStatsEngine()
-            {
-                return new MetricStatsCollection();
-            }
+            return new MetricStatsCollectionQueue();
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         /// <summary>
         /// This MetricStatsCollectionQueue uses a ConcurrentQueue (allows multiple readers, but only one writer, at a time) to mediate
-        /// between metrics that need to merge into one of the coolections (readers), and the harvest job (writer), which replaces the 
+        /// between metrics that need to merge into one of the collections (readers), and the harvest job (writer), which replaces the 
         /// queue and merges the collections in the old queue to create the harvest payload.
         /// 
         /// </summary>
@@ -75,9 +75,9 @@ namespace NewRelic.Agent.Core.Aggregators
         }
 
         /// <summary>
-        /// Null out the ConcuurentQueue contained in this MetricStatsCollectionQueue so that any subsequent
+        /// Null out the ConcurrentQueue contained in this MetricStatsCollectionQueue so that any subsequent
         /// attempts to read from the queue before this MetricStatsCollectionQueue is replaced will fail.  Combine
-        /// all the MetricStatsCollections in the old ConcuurentQueue according to the merge function, and return the result. 
+        /// all the MetricStatsCollections in the old ConcurrentQueue according to the merge function, and return the result. 
         /// </summary>
         /// <returns></returns>
         public MetricStatsCollection GetStatsCollectionForHarvest()

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
@@ -1,0 +1,99 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Concurrent;
+using NewRelic.Core.Logging;
+
+namespace NewRelic.Agent.Core.Aggregators
+{
+    /// <summary>
+    /// Ported, with some tweaks, from the Java Agent.  Allows the agent to use multiple MetricStatsCollections to aggregate
+    /// metrics between harvests, so that a lock on a single MetricStatsCollection does not become a throughput bottleneck at high load.
+    /// At harvest time all the MetricStatsCollections are combined.
+    /// </summary>
+    public class MetricStatsCollectionQueue
+    {
+        private ConcurrentQueue<MetricStatsCollection> _statsCollectionQueue;
+
+        internal MetricStatsCollectionQueue()
+        {
+            _statsCollectionQueue = new ConcurrentQueue<MetricStatsCollection>();
+        }
+
+        /// <summary>
+        /// This MetricStatsCollectionQueue uses a ConcurrentQueue (allows multiple readers, but only one writer, at a time) to mediate
+        /// between metrics that need to merge into one of the coolections (readers), and the harvest job (writer), which replaces the 
+        /// queue and merges the collections in the old queue to create the harvest payload.
+        /// 
+        /// </summary>
+        /// <param name="metrics"></param>
+        /// <returns></returns>
+        public bool MergeMetrics(IAllMetricStatsCollection metrics)
+        {
+            var statsCollectionQueue = _statsCollectionQueue;
+            if (statsCollectionQueue == null)
+            {
+                // We've already been harvested.  Caller should try again, at which point a whole new MetricStatsCollectionQueue
+                // will have been created for the next harvest cycle.
+                return false;
+            }
+
+            AddMetricsToCollection(statsCollectionQueue, metrics);
+            return true;
+        }
+
+        /// <summary>
+        /// Take a MetricStatsCollection off the queue and merge metric(s) into it, then put it back
+        /// on the queue.  Create one if all the existing ones are "checked out" -- others can use it later.
+        ///  
+        /// We are one of (possibly) several readers of the MetricStatsCollection, so harvest will
+        /// wait for us to finish before fetching/replacing the entire queue
+        /// </summary>
+        /// <param name="statsCollectionQueue"></param>
+        /// <param name="metric"></param>
+        private void AddMetricsToCollection(ConcurrentQueue<MetricStatsCollection> statsCollectionQueue, IAllMetricStatsCollection metrics)
+        {
+            MetricStatsCollection statsCollectionToMergeWith = null;
+            try
+            {
+                if (!statsCollectionQueue.TryDequeue(out statsCollectionToMergeWith))
+                {
+                    statsCollectionToMergeWith = new MetricStatsCollection();
+                }
+
+                metrics.AddMetricsToCollection(statsCollectionToMergeWith);
+            }
+            catch (Exception e)
+            {
+                Log.Warn($"Exception dequeueing/creating stats collection: {e}");
+            }
+            finally
+            {
+                statsCollectionQueue.Enqueue(statsCollectionToMergeWith);
+            }
+        }
+
+        /// <summary>
+        /// Null out the ConcuurentQueue contained in this MetricStatsCollectionQueue so that any subsequent
+        /// attempts to read from the queue before this MetricStatsCollectionQueue is replaced will fail.  Combine
+        /// all the MetricStatsCollections in the old ConcuurentQueue according to the merge function, and return the result. 
+        /// </summary>
+        /// <returns></returns>
+        public MetricStatsCollection GetStatsCollectionForHarvest()
+        {
+            var statsCollectionQueue = _statsCollectionQueue;
+
+            // Clear the reference to the queue so that future calls to MergeMetric() get short-circuited.
+            _statsCollectionQueue = null;
+
+            var harvestMetricsStatsCollection = new MetricStatsCollection();
+            foreach (var statsCollection in statsCollectionQueue)
+            {
+                harvestMetricsStatsCollection.Merge(statsCollection);
+            }
+
+            return harvestMetricsStatsCollection;
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionMetricStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionMetricStatsCollection.cs
@@ -51,10 +51,10 @@ namespace NewRelic.Agent.Core.Aggregators
             }
         }
 
-        public void AddMetricsToEngine(MetricStatsCollection engine)
+        public void AddMetricsToCollection(MetricStatsCollection collection)
         {
-            engine.MergeUnscopedStats(ConvertMetricNames(unscopedStats));
-            engine.MergeScopedStats(transactionName.PrefixedName, ConvertMetricNames(scopedStats));
+            collection.MergeUnscopedStats(ConvertMetricNames(unscopedStats));
+            collection.MergeScopedStats(transactionName.PrefixedName, ConvertMetricNames(scopedStats));
         }
 
         private IEnumerable<KeyValuePair<string, MetricDataWireModel>> ConvertMetricNames(IEnumerable<KeyValuePair<MetricName, MetricDataWireModel>> metricData)

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -85,15 +85,15 @@ namespace NewRelic.Agent.Core.WireModels
             return MetricName + Data.ToString();
         }
 
-        public void AddMetricsToEngine(MetricStatsCollection engine)
+        public void AddMetricsToCollection(MetricStatsCollection collection)
         {
             if (string.IsNullOrEmpty(MetricName.Scope))
             {
-                engine.MergeUnscopedStats(this);
+                collection.MergeUnscopedStats(MetricName.Name, Data);
             }
             else
             {
-                engine.MergeScopedStats(MetricName.Scope, MetricName.Name, Data);
+                collection.MergeScopedStats(MetricName.Scope, MetricName.Name, Data);
             }
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
@@ -127,10 +127,10 @@ namespace NewRelic.Agent.Core.Aggregators
                         TimeSpan.FromSeconds(1), txStats);
             }
 
-            public void AddMetricsToEngine(MetricStatsCollection engine)
+            public void AddMetricsToCollection(MetricStatsCollection collection)
             {
                 Thread.Sleep(5);
-                txStats.AddMetricsToEngine(engine);
+                txStats.AddMetricsToCollection(collection);
             }
         }
 
@@ -177,20 +177,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 threads[i].Join();
             }
 
-            var queueCountBeforeHarvest = _metricAggregator.StatsEngineQueue.StatsEngineCount;
-
-            //Check if the queue got queued up when multiple threads use the queue.
-
-            if (queueCountBeforeHarvest == 1)
-                Assert.Inconclusive();
-            Assert.IsTrue(queueCountBeforeHarvest > 1);
-
             _harvestAction();
-
-            var queueCountAfterHarvest = _metricAggregator.StatsEngineQueue.StatsEngineCount;
-
-            //Check if the queue is empty after harvest.
-            Assert.IsTrue(queueCountAfterHarvest == 0);
 
             //Check the number of metrics being sent up.
             Assert.IsTrue(sentMetrics.Count() == 3, "Count was " + sentMetrics.Count());

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
@@ -27,35 +27,14 @@ namespace NewRelic.Agent.Core.Aggregators
         #region MergeUnscopedStats (PreCreated)
 
         [Test]
-        public void MergeUnscopedStats_OneStat()
-        {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
-            var count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
-            }
-            Assert.AreEqual(1, count);
-        }
-
-        [Test]
         public void MergeUnscopedStats_ChangeName()
         {
             IMetricNameService mNameService = Mock.Create<IMetricNameService>();
             Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(mNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(mNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -70,127 +49,6 @@ namespace NewRelic.Agent.Core.Aggregators
             Assert.AreEqual(1, count);
         }
 
-        [Test]
-        public void MergeUnscopedStats_PreDoneMetrics()
-        {
-            IMetricNameService mNameService = Mock.Create<IMetricNameService>();
-            Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(mNameService);
-            var count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
-            }
-            Assert.AreEqual(1, count);
-        }
-
-        [Test]
-        public void MergeUnscopedStats_OneStatEmptyString()
-        {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
-            var count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual("", current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
-            }
-            Assert.AreEqual(1, count);
-        }
-
-        [Test]
-        public void MergeUnscopedStats_TwoStatsSame()
-        {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1);
-            engine.MergeUnscopedStats(metric1);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
-            var count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(2, current.Data.Value0);
-                Assert.AreEqual(6, current.Data.Value1);
-                Assert.AreEqual(4, current.Data.Value2);
-            }
-            Assert.AreEqual(1, count);
-
-            MetricWireModel metric2 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-            engine.MergeUnscopedStats(metric2);
-            engine.MergeUnscopedStats(metric2);
-            stats = engine.ConvertToJsonForSending(_metricNameService);
-
-            count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(4, current.Data.Value0);
-                Assert.AreEqual(16, current.Data.Value1);
-                Assert.AreEqual(12, current.Data.Value2);
-            }
-            Assert.AreEqual(1, count);
-        }
-
-        [Test]
-        public void MergeUnscopedStats_TwoDifferentSame()
-        {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-            var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1);
-            engine.MergeUnscopedStats(metric2);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
-            var count = 0;
-
-            foreach (MetricWireModel current in stats)
-            {
-                count++;
-                if (current.MetricName.Name.Equals("DotNet/name"))
-                {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(5, current.Data.Value1);
-                    Assert.AreEqual(4, current.Data.Value2);
-                }
-                else if (current.MetricName.Name.Equals("DotNet/another"))
-                {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(3, current.Data.Value1);
-                    Assert.AreEqual(2, current.Data.Value2);
-                }
-                else
-                {
-                    Assert.Fail("Unexpected Metric: " + current.MetricName.Name);
-                }
-                Assert.AreEqual(null, current.MetricName.Scope);
-
-            }
-            Assert.AreEqual(2, count);
-        }
-
         #endregion MergeUnscopedStats (PreCreated)
 
         #region MergeUnscopedStats (NotCreated)
@@ -198,9 +56,9 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeUnscopedNotCreated_OneStat()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -221,11 +79,11 @@ namespace NewRelic.Agent.Core.Aggregators
             IMetricNameService mNameService = Mock.Create<IMetricNameService>();
             Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             var scopedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
             scopedStats[metric1.MetricName.Name] = metric1.Data;
-            engine.MergeScopedStats(metric1.MetricName.Scope, scopedStats);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(mNameService);
+            collection.MergeScopedStats(metric1.MetricName.Scope, scopedStats);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(mNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -244,9 +102,9 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeUnscopedNotCreated_OneStatEmptyString()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -265,10 +123,10 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeUnscopedNotCreated_TwoStatsSame()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -283,9 +141,9 @@ namespace NewRelic.Agent.Core.Aggregators
             Assert.AreEqual(1, count);
 
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-            engine.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
-            engine.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
-            stats = engine.ConvertToJsonForSending(_metricNameService);
+            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
+            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
+            stats = collection.ConvertToJsonForSending(_metricNameService);
 
             count = 0;
 
@@ -307,10 +165,10 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
-            var engine = new MetricStatsCollection();
-            engine.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            engine.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -346,9 +204,9 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeScopedStats_OneStat_StringData()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            var collection = new MetricStatsCollection();
+            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -367,11 +225,11 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeScopedStats_TwoStatsSame_StringData()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
-            engine.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
-            engine.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            var collection = new MetricStatsCollection();
+            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -392,11 +250,11 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(5)));
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
-            var engine = new MetricStatsCollection();
-            engine.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
-            engine.MergeScopedStats(metric2.MetricName.Scope, metric2.MetricName.Name, metric2.Data);
+            var collection = new MetricStatsCollection();
+            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            collection.MergeScopedStats(metric2.MetricName.Scope, metric2.MetricName.Name, metric2.Data);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -432,11 +290,11 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeScopedStats_OneStat()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            engine.MergeScopedStats(metric1.MetricName.Scope, txStats);
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            collection.MergeScopedStats(metric1.MetricName.Scope, txStats);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -455,13 +313,13 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeScopedStats_TwoStatsSame()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
             txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            engine.MergeScopedStats(metric1.MetricName.Scope, txStats);
+            collection.MergeScopedStats(metric1.MetricName.Scope, txStats);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -480,15 +338,15 @@ namespace NewRelic.Agent.Core.Aggregators
         public void MergeScopedStats_TwoStatsSeparateEngines()
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats2.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            engine.MergeScopedStats(metric1.MetricName.Scope, txStats1);
-            engine.MergeScopedStats(metric1.MetricName.Scope, txStats2);
+            collection.MergeScopedStats(metric1.MetricName.Scope, txStats1);
+            collection.MergeScopedStats(metric1.MetricName.Scope, txStats2);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -509,15 +367,15 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)));
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats2.Merge(metric2.MetricName.Name, metric2.Data, MetricDataWireModel.BuildAggregateData);
-            engine.MergeScopedStats(metric2.MetricName.Scope, txStats1);
-            engine.MergeScopedStats(metric2.MetricName.Scope, txStats2);
+            collection.MergeScopedStats(metric2.MetricName.Scope, txStats1);
+            collection.MergeScopedStats(metric2.MetricName.Scope, txStats2);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -553,7 +411,7 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric4 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "myotherscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(6)));
 
 
-            var engine = new MetricStatsCollection();
+            var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
@@ -563,12 +421,12 @@ namespace NewRelic.Agent.Core.Aggregators
             MetricStatsDictionary<string, MetricDataWireModel> txStats4 = new MetricStatsDictionary<string, MetricDataWireModel>();
             txStats4.Merge(metric4.MetricName.Name, metric4.Data, MetricDataWireModel.BuildAggregateData);
 
-            engine.MergeScopedStats(metric2.MetricName.Scope, txStats1);
-            engine.MergeScopedStats(metric2.MetricName.Scope, txStats2);
-            engine.MergeScopedStats(metric3.MetricName.Scope, txStats3);
-            engine.MergeScopedStats(metric4.MetricName.Scope, txStats4);
+            collection.MergeScopedStats(metric2.MetricName.Scope, txStats1);
+            collection.MergeScopedStats(metric2.MetricName.Scope, txStats2);
+            collection.MergeScopedStats(metric3.MetricName.Scope, txStats3);
+            collection.MergeScopedStats(metric4.MetricName.Scope, txStats4);
 
-            IEnumerable<MetricWireModel> stats = engine.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
@@ -625,25 +483,25 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric5 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4)));
             var metric6 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(6)));
 
-            var engine1 = new MetricStatsCollection();
+            var collection1 = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> scoped1 = new MetricStatsDictionary<string, MetricDataWireModel>();
             scoped1.Merge("DotNet/name1", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)), MetricDataWireModel.BuildAggregateData);
             scoped1.Merge("DotNet/name2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)), MetricDataWireModel.BuildAggregateData);
-            engine1.MergeUnscopedStats(metric5);
-            engine1.MergeScopedStats("engine1scope", scoped1);
+            collection1.MergeUnscopedStats(metric5.MetricName.Name, metric5.Data);
+            collection1.MergeScopedStats("collection1scope", scoped1);
 
-            var engine2 = new MetricStatsCollection();
+            var collection2 = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> scoped2 = new MetricStatsDictionary<string, MetricDataWireModel>();
             scoped2.Merge("DotNet/name3", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1)), MetricDataWireModel.BuildAggregateData);
             scoped2.Merge("DotNet/name4", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)), MetricDataWireModel.BuildAggregateData);
-            engine1.MergeUnscopedStats(metric6);
-            engine1.MergeScopedStats("engine2scope", scoped1);
+            collection1.MergeUnscopedStats(metric6.MetricName.Name, metric6.Data);
+            collection1.MergeScopedStats("collection2scope", scoped1);
 
-            var engine3 = new MetricStatsCollection();
-            engine3.Merge(engine1);
-            engine3.Merge(engine2);
+            var collection3 = new MetricStatsCollection();
+            collection3.Merge(collection1);
+            collection3.Merge(collection2);
 
-            IEnumerable<MetricWireModel> stats = engine3.ConvertToJsonForSending(_metricNameService);
+            IEnumerable<MetricWireModel> stats = collection3.ConvertToJsonForSending(_metricNameService);
             var count = 0;
             foreach (MetricWireModel current in stats)
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
@@ -40,10 +40,10 @@ namespace NewRelic.Agent.Core.WireModels
             Assert.AreEqual(3, data.Value1);
             Assert.AreEqual(2, data.Value2);
 
-            var engine = new MetricStatsCollection();
-            metric1.AddMetricsToEngine(engine);
+            var collection = new MetricStatsCollection();
+            metric1.AddMetricsToCollection(collection);
 
-            var actual = engine.ConvertToJsonForSending(_metricNameService);
+            var actual = collection.ConvertToJsonForSending(_metricNameService);
             var unscopedCount = 0;
             var scopedCount = 0;
             var theScope = string.Empty;
@@ -86,10 +86,10 @@ namespace NewRelic.Agent.Core.WireModels
             Assert.AreEqual(3, data.Value1);
             Assert.AreEqual(2, data.Value2);
 
-            var engine = new MetricStatsCollection();
-            metric1.AddMetricsToEngine(engine);
+            var collection = new MetricStatsCollection();
+            metric1.AddMetricsToCollection(collection);
 
-            var stats = engine.ConvertToJsonForSending(_metricNameService);
+            var stats = collection.ConvertToJsonForSending(_metricNameService);
 
             foreach (var current in stats)
             {
@@ -115,10 +115,10 @@ namespace NewRelic.Agent.Core.WireModels
             Assert.AreEqual(3, data.Value1);
             Assert.AreEqual(2, data.Value2);
 
-            var engine = new MetricStatsCollection();
-            metric1.AddMetricsToEngine(engine);
+            var collection = new MetricStatsCollection();
+            metric1.AddMetricsToCollection(collection);
 
-            var stats = engine.ConvertToJsonForSending(_metricNameService);
+            var stats = collection.ConvertToJsonForSending(_metricNameService);
 
             foreach (var current in stats)
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
@@ -74,12 +74,14 @@ namespace NewRelic.Agent.Core.WireModels
             Assert.AreEqual(2, scopedData.Value2);
         }
 
-        [Test]
-        public void AddMetricsToEngine_OneUnscopedMetricNull()
+        [TestCase("")]
+        [TestCase(null)]
+        public void AddMetricsToEngine_OneUnscopedMetricMissingScope(string empty)
         {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", null,
+            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", empty,
                 MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             Assert.That(metric1, Is.Not.Null);
+
             var data = metric1.Data;
             Assert.NotNull(data);
             Assert.AreEqual(1, data.Value0);
@@ -95,35 +97,6 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 Assert.AreEqual("DotNet/name", current.MetricName.Name);
                 Assert.AreEqual(null, current.MetricName.Scope);
-                var myData = current.Data;
-                Assert.AreEqual(1, myData.Value0);
-                Assert.AreEqual(3, myData.Value1);
-                Assert.AreEqual(2, myData.Value2);
-            }
-        }
-
-        [Test]
-        public void AddMetricsToEngine_OneUnscopedMetricEmptyString()
-        {
-            var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "",
-                MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
-            Assert.That(metric1, Is.Not.Null);
-
-            var data = metric1.Data;
-            Assert.NotNull(data);
-            Assert.AreEqual(1, data.Value0);
-            Assert.AreEqual(3, data.Value1);
-            Assert.AreEqual(2, data.Value2);
-
-            var collection = new MetricStatsCollection();
-            metric1.AddMetricsToCollection(collection);
-
-            var stats = collection.ConvertToJsonForSending(_metricNameService);
-
-            foreach (var current in stats)
-            {
-                Assert.AreEqual("DotNet/name", current.MetricName.Name);
-                Assert.AreEqual("", current.MetricName.Scope);
                 var myData = current.Data;
                 Assert.AreEqual(1, myData.Value0);
                 Assert.AreEqual(3, myData.Value1);


### PR DESCRIPTION
## Description

* Rename anything with "engine" to "collection", i.e. MetricStatsEngineQueue ->MetricStatsCollectionQueue
* Refactors MetricStatsEngineQueue 
  * Pulls this class out of MetricAggregator.cs into its own file
  * Renames MetricStatsEngineQueue to MetricStatsCollectionQueue
  * Changes the Queue<MetricStatsCollection> to a ConcurentQueue<MetricStatsCollection>
  * Remove all explicit lock statements and associated objects
  * Removes _statsEngineCount since that was only used for minor error check and testing.  This eliminates another lock and simplifies the class. Removed some code for this from MetricWireModel as well.
  * Removes some catch statements, one that was literally labelled as "should never happen".
* Cleaned up MetricAggregator after nested class removed
* Updated Unit tests to point at new MetricStatsCollectionQueue and rename any "engine" to "collection"
* Refactored MetricStatsCollection to remove an unnecessary Dictionary to help with locking, reduce allocations, and speed up harvest (miniscule)
* Update some dependent classes and unit tests to account for refactored MetricStatsCollection.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
