### PR TITLE
Fixes, updates,and adds NoticeError docs - removes 1000 character limit note in docs

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/NewRelic.cs
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.cs
@@ -290,7 +290,8 @@ namespace NewRelic.Api.Agent
         /// Supports web applications only.
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
@@ -337,7 +338,8 @@ namespace NewRelic.Api.Agent
         /// Supports web applications only.
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
@@ -384,7 +386,8 @@ namespace NewRelic.Api.Agent
         /// Supports web applications only.
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.
@@ -434,7 +437,8 @@ namespace NewRelic.Api.Agent
         /// Supports web applications only.
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="parameters">Custom parameters to include in the traced error.
         /// May be null.

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
@@ -263,7 +263,8 @@ namespace NewRelic.Agent.Core
         /// Supports web applications only. 
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="customAttributes">Custom parameters to include in the traced error.
         /// May be null.
@@ -280,6 +281,22 @@ namespace NewRelic.Agent.Core
             TryInvoke(work, apiName, apiMetric);
         }
 
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only. 
+        /// </summary>
+        /// <param name="message">The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+        /// <param name="customAttributes">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
         public static void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
         {
             const ApiMethod apiMetric = ApiMethod.NoticeError;
@@ -300,7 +317,8 @@ namespace NewRelic.Agent.Core
         /// Supports web applications only. 
         /// </summary>
         /// <param name="message">The message to be displayed in the traced error.
-        /// Only the first 1000 characters are retained.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
         /// </param>
         /// <param name="customAttributes">Custom parameters to include in the traced error.
         /// May be null.
@@ -317,6 +335,22 @@ namespace NewRelic.Agent.Core
             TryInvoke(work, apiName, apiMetric);
         }
 
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only. 
+        /// </summary>
+        /// <param name="message">The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+        /// <param name="customAttributes">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
         public static void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
         {
             const ApiMethod apiMetric = ApiMethod.NoticeError;

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
@@ -200,6 +200,19 @@ namespace NewRelic.Agent.Core.Api
             }
         }
 
+        /// <summary> Notice an error identified by an exception report it to the New Relic service. If
+        /// this method is called within a transaction, the exception will be reported with the
+        /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+        /// be created and reported to the New Relic service. Only the exception/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
+        ///
+        /// <param name="exception">	    The exception to be reported. Only part of the exception's
+        /// information may be retained to prevent the report from being too large. </param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
         public void NoticeError(Exception exception, IDictionary<string, object>? customAttributes)
         {
             exception = exception ?? throw new ArgumentNullException(nameof(exception));
@@ -246,8 +259,9 @@ namespace NewRelic.Agent.Core.Api
         ///
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
         ///
-        /// <param name="message">		    The message to be displayed in the traced error. Only the
-        /// first 1000 characters are retained. </param>
+        /// <param name="message">		    The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
         /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
         /// null. Only 10,000 characters of combined key/value data is retained. </param>
         public void NoticeError(string message, IDictionary<string, string>? customAttributes)
@@ -255,6 +269,25 @@ namespace NewRelic.Agent.Core.Api
             NoticeError(message, customAttributes, false);
         }
 
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only. 
+        /// </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        /// 
+        /// <param name="message">The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+        /// <param name="customAttributes">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
         public void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
         {
             message = message ?? throw new ArgumentNullException(nameof(message));
@@ -268,11 +301,44 @@ namespace NewRelic.Agent.Core.Api
             }
         }
 
+        /// <summary> Notice an error identified by a simple message and report it to the New Relic
+        /// service. If this method is called within a transaction, the exception will be reported with
+        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        ///
+        /// <param name="message">		    The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
         public void NoticeError(string message, IDictionary<string, object>? customAttributes)
         {
             NoticeError(message, customAttributes, false);
         }
 
+        /// <summary>
+        /// Notice an error identified by a simple message and report it to the New Relic service.
+        /// If this method is called within a transaction,
+        /// the exception will be reported with the transaction when it finishes.  
+        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+        /// Supports web applications only. 
+        /// </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        /// 
+        /// <param name="message">The message to be displayed in the traced error.
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+        /// <param name="customAttributes">Custom parameters to include in the traced error.
+        /// May be null.
+        /// Only 10,000 characters of combined key/value data is retained.
+        /// </param>
+        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
         public void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
         {
             message = message ?? throw new ArgumentNullException(nameof(message));

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
@@ -60,6 +60,19 @@ namespace NewRelic.Agent.Api
         /// null. Only 10,000 characters of combined key/value data is retained. </param>
         void NoticeError(Exception exception, IDictionary<string, string>? customAttributes);
 
+        /// <summary> Notice an error identified by an exception report it to the New Relic service. If
+        /// this method is called within a transaction, the exception will be reported with the
+        /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+        /// be created and reported to the New Relic service. Only the exception/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
+        ///
+        /// <param name="exception">	    The exception to be reported. Only part of the exception's
+        /// information may be retained to prevent the report from being too large. </param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
         void NoticeError(Exception exception, IDictionary<string, object>? customAttributes);
 
         /// <summary> Notice an error identified by an exception report it to the New Relic service. If
@@ -84,12 +97,27 @@ namespace NewRelic.Agent.Api
         ///
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
         ///
-        /// <param name="message">		    The message to be displayed in the traced error. Only the
-        /// first 1000 characters are retained. </param>
+        /// <param name="message">		    The message to be displayed in the traced error. 
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.</param>
         /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
         /// null. Only 10,000 characters of combined key/value data is retained. </param>
         void NoticeError(string message, IDictionary<string, string>? customAttributes);
 
+        /// <summary> Notice an error identified by a simple message and report it to the New Relic
+        /// service. If this method is called within a transaction, the exception will be reported with
+        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        ///
+        /// <param name="message">		    The message to be displayed in the traced error. 
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.</param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
         void NoticeError(string message, IDictionary<string, object>? customAttributes);
 
         /// <summary> Notice an error identified by a simple message and report it to the New Relic
@@ -101,14 +129,31 @@ namespace NewRelic.Agent.Api
         ///
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
         ///
-        /// <param name="message">    The message to be displayed in the traced error. Only the
-        /// first 1000 characters are retained. </param>
+        /// <param name="message">    The message to be displayed in the traced error. 
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.</param>
         /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
         /// null. Only 10,000 characters of combined key/value data is retained. </param>
         /// <param name="isExpected"> Marks the error expected.
         /// </param>
         void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected);
 
+        /// <summary> Notice an error identified by a simple message and report it to the New Relic
+        /// service. If this method is called within a transaction, the exception will be reported with
+        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+        /// first call to NoticeError during the course of a transaction is retained. Supports web
+        /// applications only. </summary>
+        ///
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+        ///
+        /// <param name="message">    The message to be displayed in the traced error. 
+        /// This method creates both Error Events and Error Traces.
+        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.</param>
+        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+        /// null. Only 10,000 characters of combined key/value data is retained. </param>
+        /// <param name="isExpected"> Marks the error expected.
+        /// </param>
         void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected);
 
         /// <summary> Set the name of the current transaction. Supports web applications only. </summary>


### PR DESCRIPTION
## Description

The docs indicate that there is a 1000 character limit for the message parameter. This is not correct.
My testing has show the following:

- This 1000 character limit doc was added to the code in v2.0.8 and expanded out into other areas in v8.28.
- The is no 1000 character limit for NoticeError
- NoticeError creates both Error Events and ErrorTraces
- The limit is different for Error Events and Error Traces
  - Error Events: The message is stored as an attribute with a limit of 255 characters per the Attribute spec.  The Errors spec defers to this for the limit.
  - Error Traces: There does not appear to be a limit on message outside of a total payload limit of 1MB.  I was able to send over a 1000 character message with no issues.

The UI displays data from both types in different areas and there is some overlap.  I had Errors Inbox to show one error with a message from an Error Event - limited to 255 chars and a different error shows the Error Trace message at over 1000 characters.   There must be some logic in the background that picks.

I am created a PR for the docs site to go along with our own changes to address this.

I also spread out the documentation blocks to to each NoticeError method so all are not covered.

Closes #1048

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
