### PR TITLE
error.message accepts uo to 1023 chars insread of 255 with unit tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinition.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinition.cs
@@ -13,7 +13,8 @@ namespace NewRelic.Agent.Core.Attributes
 {
     public static class AttributeDefinitionBuilder
     {
-        private const int _stringValueMaxLengthBytes = 255;
+        private const int StringValueMaxLengthBytes = 255;
+        private const int ErrorMessageMaxLengthBytes = 1023;
 
         public static AttributeDefinitionBuilder<TInput, TOutput> Create<TInput, TOutput>(string name, AttributeClassification classification)
         {
@@ -29,13 +30,19 @@ namespace NewRelic.Agent.Core.Attributes
         public static AttributeDefinitionBuilder<TInput, string> CreateString<TInput>(string name, AttributeClassification classification)
         {
             return new AttributeDefinitionBuilder<TInput, string>(name, classification)
-                .WithPostProcessing((v) => v.TruncateUnicodeStringByBytes(_stringValueMaxLengthBytes));
+                .WithPostProcessing((v) => v.TruncateUnicodeStringByBytes(StringValueMaxLengthBytes));
         }
 
         public static AttributeDefinitionBuilder<string, string> CreateString(string name, AttributeClassification classification)
         {
             return Create<string>(name, classification)
-                .WithPostProcessing((v) => v.TruncateUnicodeStringByBytes(_stringValueMaxLengthBytes));
+                .WithPostProcessing((v) => v.TruncateUnicodeStringByBytes(StringValueMaxLengthBytes));
+        }
+
+        public static AttributeDefinitionBuilder<string, string> CreateErrorMessage(string name, AttributeClassification classification)
+        {
+            return Create<string>(name, classification)
+                .WithPostProcessing((v) => v.TruncateUnicodeStringByBytes(ErrorMessageMaxLengthBytes));
         }
 
         public static AttributeDefinitionBuilder<TInput, double> CreateDouble<TInput>(string name, AttributeClassification classification)

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -493,7 +493,7 @@ namespace NewRelic.Agent.Core.Attributes
 
         private AttributeDefinition<string, string> _spanErrorMessage;
         public AttributeDefinition<string, string> SpanErrorMessage => _spanErrorMessage ?? (_spanErrorMessage =
-            AttributeDefinitionBuilder.CreateString("error.message", AttributeClassification.AgentAttributes)
+            AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.AgentAttributes)
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 
@@ -762,7 +762,7 @@ namespace NewRelic.Agent.Core.Attributes
 
         private AttributeDefinition<string, string> _errorDotMessage;
         public AttributeDefinition<string, string> ErrorDotMessage => _errorDotMessage ?? (_errorDotMessage =
-            AttributeDefinitionBuilder.CreateString("error.message", AttributeClassification.Intrinsics)
+            AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.Intrinsics)
                     .AppliesTo(AttributeDestinations.ErrorEvent)
                 .Build(_attribFilter));
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

* Renames the "CreateString" method used by errors into "CreateErrorMessage".
* CreateErrorMessage takes a new const for the length which is set at 1023 instead 255
* Added unit tests to test error length and one for other strings length.
* Unit and Integration tests pass locally

Closes #1007

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
