### PR TITLE
Enable/disable cloud detection via environment variables

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 ### New Features
+* Introduces [environment variables to enabled/disable cloud detection](https://github.com/newrelic/newrelic-dotnet-agent/issues/818) to facilitate customer use cases and reduce errors in logs. ([#1061](https://github.com/newrelic/newrelic-dotnet-agent/pull/1061))
 ### Fixes
 
 ## [9.7.1] - 2022-04-13

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1733,32 +1733,32 @@ namespace NewRelic.Agent.Core.Configuration
 
         public bool UtilizationDetectAws
         {
-            get { return _localConfiguration.utilization.detectAws; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectAws, "NEW_RELIC_UTILIZATION_DETECT_AWS"); }
         }
 
         public bool UtilizationDetectAzure
         {
-            get { return _localConfiguration.utilization.detectAzure; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectAzure, "NEW_RELIC_UTILIZATION_DETECT_AZURE"); }
         }
 
         public bool UtilizationDetectGcp
         {
-            get { return _localConfiguration.utilization.detectGcp; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectGcp, "NEW_RELIC_UTILIZATION_DETECT_GCP"); }
         }
 
         public bool UtilizationDetectPcf
         {
-            get { return _localConfiguration.utilization.detectPcf; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectPcf, "NEW_RELIC_UTILIZATION_DETECT_PCF"); }
         }
 
         public bool UtilizationDetectDocker
         {
-            get { return _localConfiguration.utilization.detectDocker; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectDocker, "NEW_RELIC_UTILIZATION_DETECT_DOCKER"); }
         }
 
         public bool UtilizationDetectKubernetes
         {
-            get { return _localConfiguration.utilization.detectKubernetes; }
+            get { return EnvironmentOverrides(_localConfiguration.utilization.detectKubernetes, "NEW_RELIC_UTILIZATION_DETECT_KUBERNETES"); }
         }
 
         public int? UtilizationLogicalProcessors

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2363,6 +2363,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test
@@ -2384,6 +2387,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test
@@ -2405,6 +2411,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test
@@ -2426,6 +2435,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test
@@ -2447,6 +2459,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test
@@ -2468,6 +2483,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase("false", true, ExpectedResult = false)]
         [TestCase("false", false, ExpectedResult = false)]
         [TestCase("false", null, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", true, ExpectedResult = true)]
+        [TestCase("invalidEnvVarValue", false, ExpectedResult = false)]
+        [TestCase("invalidEnvVarValue", null, ExpectedResult = true)]
         [TestCase(null, true, ExpectedResult = true)]
         [TestCase(null, false, ExpectedResult = false)]
         [TestCase(null, null, ExpectedResult = true)] // true by default test

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -68,7 +68,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase(true, false, ExpectedResult = false)]
         [TestCase(false, true, ExpectedResult = false)]
         [TestCase(false, false, ExpectedResult = false)]
-        public bool TransactionEventsCanBeDisbledByServer(bool? server, bool local)
+        public bool TransactionEventsCanBeDisabledByServer(bool? server, bool local)
         {
             _localConfig.transactionEvents.enabled = local;
 
@@ -2357,75 +2357,130 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
         #region Utilization
 
-        [Test]
-        public void UtilizationDetectAwsIsTrueByDefault()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectKubernetesConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectAws);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_KUBERNETES")).Returns(environmentSetting);
+
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectKubernetes = localSetting.Value;
+            }
+
+            return _defaultConfig.UtilizationDetectKubernetes;
         }
 
-        [Test]
-        public void UtilizationDetectAzureIsTrueByDefault()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectAwsConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectAzure);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_AWS")).Returns(environmentSetting);
+
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectAws = localSetting.Value;
+            }
+
+            return _defaultConfig.UtilizationDetectAws;
         }
 
-        [Test]
-        public void UtilizationDetectPcfIsTrueByDefualt()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectAzureConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectPcf);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_AZURE")).Returns(environmentSetting);
+
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectAzure = localSetting.Value;
+            }
+
+            return _defaultConfig.UtilizationDetectAzure;
         }
 
-        [Test]
-        public void UtilizationDetectGcpIsTrueByDefault()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectPcfConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectGcp);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_PCF")).Returns(environmentSetting);
+
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectPcf = localSetting.Value;
+            }
+
+            return _defaultConfig.UtilizationDetectPcf;
         }
 
-        [Test]
-        public void UtilizationDetectDockerIsTrueByDefault()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectGcpConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectDocker);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_GCP")).Returns(environmentSetting);
+
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectGcp = localSetting.Value;
+            }
+
+            return _defaultConfig.UtilizationDetectGcp;
         }
 
-        [Test]
-        public void UtilizationDetectKubernetesIsTrueByDefault()
+        [TestCase("true", true, ExpectedResult = true)]
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("true", null, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("false", false, ExpectedResult = false)]
+        [TestCase("false", null, ExpectedResult = false)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        [TestCase(null, null, ExpectedResult = true)] // true by default test
+        public bool UtilizationDetectDockerConfigurationWorksProperly(string environmentSetting, bool? localSetting)
         {
-            Assert.IsTrue(_defaultConfig.UtilizationDetectKubernetes);
-        }
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_UTILIZATION_DETECT_DOCKER")).Returns(environmentSetting);
 
-        [Test]
-        public void UtilizationDetectAwsIsSetToFalse()
-        {
-            _localConfig.utilization.detectAws = false;
-            Assert.IsFalse(_defaultConfig.UtilizationDetectAws);
-        }
+            if (localSetting.HasValue)
+            {
+                _localConfig.utilization.detectDocker = localSetting.Value;
+            }
 
-        [Test]
-        public void UtilizationDetectAzureIsSetToFalse()
-        {
-            _localConfig.utilization.detectAzure = false;
-            Assert.IsFalse(_defaultConfig.UtilizationDetectAzure);
-        }
-
-        [Test]
-        public void UtilizationDetectPcfIsSetToFalse()
-        {
-            _localConfig.utilization.detectPcf = false;
-            Assert.IsFalse(_defaultConfig.UtilizationDetectPcf);
-        }
-
-        [Test]
-        public void UtilizationDetectGcpIsSetToFalse()
-        {
-            _localConfig.utilization.detectGcp = false;
-            Assert.IsFalse(_defaultConfig.UtilizationDetectGcp);
-        }
-
-        [Test]
-        public void UtilizationDetectDockerIsSetToFalse()
-        {
-            _localConfig.utilization.detectDocker = false;
-            Assert.IsFalse(_defaultConfig.UtilizationDetectDocker);
+            return _defaultConfig.UtilizationDetectDocker;
         }
 
         #endregion


### PR DESCRIPTION
## Description

Closes #818 

Introduces new boolean environment variables to enable/disable cloud detection:

- `NEW_RELIC_UTILIZATION_DETECT_DOCKER`
- `NEW_RELIC_UTILIZATION_DETECT_GCP`
- `NEW_RELIC_UTILIZATION_DETECT_PCF`
- `NEW_RELIC_UTILIZATION_DETECT_AZURE`
- `NEW_RELIC_UTILIZATION_DETECT_AWS`
- `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES`

When these environment variables are set to `true` or `false` (or another accepted value for boolean environment variables), the local configuration will be overridden. 

Replaces existing unit test coverage with more comprehensive test cases.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
