### PR TITLE
Fix fail to execute explain plan 

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Introduces [environment variables to enabled/disable cloud detection](https://github.com/newrelic/newrelic-dotnet-agent/issues/818) to facilitate customer use cases and reduce errors in logs. ([#1061](https://github.com/newrelic/newrelic-dotnet-agent/pull/1061))
 
 ### Fixes
-
+* Fixes Agent fails to execute explain plan for parameterized stored procedure. ([#1066](https://github.com/newrelic/newrelic-dotnet-agent/pull/1066)) 
 
 ## [9.7.1] - 2022-04-13
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs
@@ -385,6 +385,11 @@ namespace NewRelic.Parsing
         /// <returns>True if the plan should be executed.  False if the plan should be aborted.</returns>
         public static bool FixParameterizedSql(IDbCommand command)
         {
+            if (command.CommandType == CommandType.StoredProcedure)
+            {
+                return true;
+            }
+
             if (command.Parameters.Count == 0)
             {
                 return true; // no params, using raw sql statement.

--- a/tests/Agent/IntegrationTests/Shared/DbParameterData.cs
+++ b/tests/Agent/IntegrationTests/Shared/DbParameterData.cs
@@ -24,7 +24,6 @@ namespace NewRelic.Agent.IntegrationTests.Shared
             new DbParameter("date", "@typeDate", DateTime.MaxValue) { ExpectedValue = DateTime.MaxValue.ToString(CultureInfo.InvariantCulture)},
             new DbParameter("uniqueidentifier", "@typeGuid", Guid.Empty) { ExpectedValue = Guid.Empty.ToString() },
             new DbParameter("nvarchar(20)", "@typeNVarChar", "some string"),
-            new DbParameter("binary", "@typeBinary", new byte[] { 0, 1, 2 }) { ExpectedValue = new byte[0].ToString() },
             new DbParameter("int", "@typeEnumAsInt", DbParamTestingEnum.EnumValue1) { ExpectedValue = (int)DbParamTestingEnum.EnumValue1 },
             new DbParameter("nvarchar(20)", "@typeEnumAsNVarChar", DbParamTestingEnum.EnumValue2) { ExpectedValue = (int)DbParamTestingEnum.EnumValue2 },
             new DbParameter("nvarchar(20)", "@typeDbNull", DBNull.Value) { ExpectedValue = "Null" },
@@ -37,7 +36,6 @@ namespace NewRelic.Agent.IntegrationTests.Shared
             new DbParameter("int", "@typeSqlInt", new SqlInt32(32)) { ExpectedValue = 32 },
             new DbParameter("nvarchar(20)", "@typeCharArray", new [] { 't', 'e', 's', 't' }) { ExpectedValue = "test" },
             new DbParameter("nvarchar(20)", "@typeSqlChars", new SqlChars(new [] { 't', 'e', 's', 't' })) { ExpectedValue = "test" },
-            new DbParameter("binary", "@typeSqlBinary", new SqlBinary(new byte[]{ 0, 1, 3 })) { ExpectedValue = new SqlBinary(new byte[]{ 0, 1, 3 }).ToString() }
         };
 
         public static DbParameter[] MySqlParameters =

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -81,7 +81,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
                     TransactionName = _expectedTransactionName,
                     Sql = _fixture.ProcedureName,
                     DatastoreMetricName = $"Datastore/statement/MSSQL/{_fixture.ProcedureName.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParameters
+                    QueryParameters = expectedQueryParameters,
+                    HasExplainPlan = true
                 }
             };
 


### PR DESCRIPTION
## Description
This PR mostly resolves the scenario 1 from the issue #185. The reason why Agent fails to execute explain plan for this scenario is, unlike other sql commands, the command text for a parameterized stored procedure doesn't need to have parameters specified, our `bool FixParameterizedSql` function didn't work based on this difference. Since the `bool FixParameterizedSql` function turns parameterized SQLs to non-parameterized and parameterized stored procedures don't need this, in order to fix this, we need to make a special case for stored procedures.

PS: I removed the `binary` type in testing parameterized stored procedures because this type disables the explain plan creation ability in the agent.( https://github.com/newrelic/newrelic-dotnet-agent/blob/0cebc8545acdd8d09d72184cf29a9dd7f3a549f1/src/Agent/NewRelic/Agent/Parsing/SqlParser.cs#L411) We could have seen this issue if we didn't test `binary` type.

