### PR TITLE
Serilog dupe stackframe fix

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 
 ### APM logs in context
-Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/), and additional configuration options are available [here]{https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all}. To learn about how to toggle log ingestion on or off by account see [here](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging).
+Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/), and additional configuration options are available [here](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all). To learn about how to toggle log ingestion on or off by account see [here](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging).
 
 ### New Features
 * Error messages in error traces and error events now retain up to 1023 characters instead of 255 characters. [#1058](https://github.com/newrelic/newrelic-dotnet-agent/pull/1058)

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] changes
+
+### APM logs in context
+Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/), and additional configuration options are available [here]{https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all}. To learn about how to toggle log ingestion on or off by account see [here](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging).
+
 ### New Features
 * Error messages in error traces and error events now retain up to 1023 characters instead of 255 characters. [#1058](https://github.com/newrelic/newrelic-dotnet-agent/pull/1058)
 * New environment variables have been added for AllowAllHeaders and Attributes configuration settings. See our [documentation](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#optional-environment-variables) for more details. [#1059](https://github.com/newrelic/newrelic-dotnet-agent/pull/1059)
@@ -14,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * Fixes Agent fails to execute explain plan for parameterized stored procedure. ([#1066](https://github.com/newrelic/newrelic-dotnet-agent/pull/1066)) 
+* Fixes getting duplicate logs using log forwarding and Serilog. [#1076](https://github.com/newrelic/newrelic-dotnet-agent/pull/1076)
+
+### Deprecations
+Microsoft has officially EOL .NET Framework versions 4.5.1, 4.5.2, and 4.6.1 on  Apr 26, 2022.
+The informational blog can be found [here](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022).  The official product lifecycle start and end dates can be found [here](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).  The dotnet agent support of these framework versions is will continue as is with the released versions.  In a future major release, we will target .NET framework 4.6.2 onwards.
 
 ## [9.7.1] - 2022-04-13
 ### Fixes

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -38,6 +38,9 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
+            // This block works around an issue we are seeing in Serilog where Dispatch is called up to 3 times for each log message
+            // When looking at a stack trace for the problem, the you will see up to 3 Dispatch methods one after the other
+            // This detects the duplicates and noops.
             var frame7 = new System.Diagnostics.StackFrame(7, false).GetMethod().Name;
             string potentialDispatchFrame;
             if (frame7 != DispatchName)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -38,7 +38,21 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
-            var potentialDispatchFrame = new System.Diagnostics.StackFrame(8, false).GetMethod().Name;
+            var frame7 = new System.Diagnostics.StackFrame(7, false).GetMethod().Name;
+            string potentialDispatchFrame;
+            if (frame7 != DispatchName)
+            {
+                // Frame 7 is not Dispatch. This means that an extra frame was in the stack called "UnsafeInvokeInternal" at frame 6
+                // Look at frame 9 for duplicates instead of at frame 8
+                potentialDispatchFrame = new System.Diagnostics.StackFrame(9, false).GetMethod().Name;
+            }
+            else
+            {
+                // Frame 7 is Dispatch, no extra frames
+                // Look at frame 8 for duplicates
+                potentialDispatchFrame = new System.Diagnostics.StackFrame(8, false).GetMethod().Name;
+            }
+
             if (potentialDispatchFrame == DispatchName)
             {
                 return Delegates.NoOp;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Logging/SerilogWrapper.cs
@@ -24,6 +24,7 @@ namespace NewRelic.Providers.Wrapper.Logging
         public bool IsTransactionRequired => false;
 
         private const string WrapperName = "serilog";
+        private const string DispatchName = "Dispatch";
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
@@ -37,6 +38,12 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
+            var potentialDispatchFrame = new System.Diagnostics.StackFrame(8, false).GetMethod().Name;
+            if (potentialDispatchFrame == DispatchName)
+            {
+                return Delegates.NoOp;
+            }
+
             var logEvent = instrumentedMethodCall.MethodCall.MethodArguments[0];
 
             RecordLogMessage(logEvent, agent);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
@@ -7,6 +7,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     {
         Log4net,
         Serilog,
-        MicrosoftLogging
+        MicrosoftLogging,
+        SerilogWeb
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -19,6 +19,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         private bool _metricsEnabled;
         private bool _forwardingEnabled;
         private LoggingFramework _loggingFramework;
+        private bool _canHaveLogsOutsideTransaction;
 
         private const string OutsideTransactionDebugMessage = "OutsideTransactionDebugLogMessage";
         private const string OutsideTransactionInfoMessage = "OutsideTransactionInfoLogMessage";
@@ -65,7 +66,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         private const string TraceAttributeOutsideTransactionLogMessage = "TraceAttributeOutsideTransactionLogMessage";
         private const string DifferentTraceAttributesInsideTransactionLogMessage = "DifferentTraceAttributesInsideTransactionLogMessage";
 
-        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, bool metricsEnabled, bool forwardingEnabled, LoggingFramework loggingFramework) : base(fixture)
+        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, bool metricsEnabled, bool forwardingEnabled, bool canHaveLogsOutsideTransaction, LoggingFramework loggingFramework) : base(fixture)
         {
             _fixture = fixture;
             _metricsEnabled = metricsEnabled;
@@ -73,6 +74,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
             _loggingFramework = loggingFramework;
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
+            _canHaveLogsOutsideTransaction = canHaveLogsOutsideTransaction;
 
             _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
             _fixture.AddCommand($"LoggingTester Configure");
@@ -243,7 +245,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         [Fact]
         public void LoggingWorksWithTraceAttributeOutsideTransaction()
         {
-            if (_forwardingEnabled)
+            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -350,7 +352,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         [Fact]
         public void LoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled)
+            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -372,7 +374,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         [Fact]
         public void AsyncLoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled)
+            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -394,7 +396,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         [Fact]
         public void AsyncNoAwaitLoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled)
+            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -443,6 +445,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                     return "log4net";
                 case LoggingFramework.MicrosoftLogging:
                     return "MicrosoftLogging";
+                case LoggingFramework.SerilogWeb:
                 case LoggingFramework.Serilog:
                     return "serilog";
                 default:
@@ -473,6 +476,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                         default:
                             return level;
                     }
+                case LoggingFramework.SerilogWeb:
                 case LoggingFramework.Serilog:
                     switch (level)
                     {
@@ -502,7 +506,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4NetMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -511,7 +515,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4NetMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -520,7 +524,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public Log4NetMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -529,7 +533,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -538,7 +542,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -547,7 +551,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -556,7 +560,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public Log4NetMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Log4net)
+            : base(fixture, output, true, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -567,7 +571,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4NetMetricsAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -576,7 +580,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4NetMetricsAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -585,7 +589,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public Log4NetMetricsAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -594,7 +598,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4NetMetricsAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -603,7 +607,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4NetMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -612,7 +616,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -621,7 +625,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public Log4NetMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Log4net)
+            : base(fixture, output, false, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -633,7 +637,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -642,7 +646,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -651,7 +655,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -660,7 +664,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -669,7 +673,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -678,7 +682,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -687,7 +691,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Log4net)
+            : base(fixture, output, true, false, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -699,7 +703,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -708,7 +712,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -717,7 +721,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -726,7 +730,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -735,7 +739,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -744,7 +748,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -753,7 +757,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore22>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -762,7 +766,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Log4net)
+            : base(fixture, output, false, true, true, LoggingFramework.Log4net)
         {
         }
     }
@@ -779,7 +783,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -788,7 +792,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -797,7 +801,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -806,7 +810,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -818,7 +822,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -827,7 +831,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -836,7 +840,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -845,7 +849,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -858,7 +862,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -867,7 +871,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -876,7 +880,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -885,7 +889,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -898,7 +902,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -907,7 +911,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -916,7 +920,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -925,7 +929,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore22>
     {
         public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -934,7 +938,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -951,7 +955,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -960,7 +964,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -969,7 +973,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public SerilogMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -978,7 +982,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -987,7 +991,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -996,7 +1000,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1005,10 +1009,20 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public SerilogMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, true, LoggingFramework.Serilog)
+            : base(fixture, output, true, true, true, LoggingFramework.Serilog)
         {
         }
     }
+
+    [NetCoreTest]
+    public class SerilogWebMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public SerilogWebMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, true, false, LoggingFramework.SerilogWeb)
+        {
+        }
+    }
+
     #endregion
 
     #region Metrics and Forwarding Disabled
@@ -1016,7 +1030,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogMetricsAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1025,7 +1039,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogMetricsAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1034,7 +1048,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public SerilogMetricsAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1043,7 +1057,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogMetricsAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1052,7 +1066,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1061,7 +1075,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1070,7 +1084,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public SerilogMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, false, LoggingFramework.Serilog)
+            : base(fixture, output, false, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1082,7 +1096,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1091,7 +1105,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1100,7 +1114,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1109,7 +1123,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1118,7 +1132,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1127,7 +1141,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1136,7 +1150,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, false, LoggingFramework.Serilog)
+            : base(fixture, output, true, false, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1148,7 +1162,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1157,7 +1171,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1166,7 +1180,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1175,7 +1189,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1184,7 +1198,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1193,7 +1207,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1202,7 +1216,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore22>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }
@@ -1211,7 +1225,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
     public class SerilogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
     {
         public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, true, LoggingFramework.Serilog)
+            : base(fixture, output, false, true, true, LoggingFramework.Serilog)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -72,6 +72,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 
+    <!-- Serilog Web App references NET6.0 only -->
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7">
       <NoWarn>NU1701</NoWarn>
@@ -151,7 +153,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Controllers/TestController.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Controllers/TestController.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+#if NET6_0
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class TestController : ControllerBase
+    {
+
+        private readonly ILogger<TestController> _logger;
+
+        public TestController(ILogger<TestController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public string Get(string logLevel, string message)
+        {
+            switch (logLevel.ToUpper())
+            {
+                case "INFO":
+                    _logger.LogInformation(message);
+                    break;
+                case "DEBUG":
+                    _logger.LogDebug(message);
+                    break;
+                case "WARN":
+                    _logger.LogWarning(message);
+                    break;
+                case "ERROR":
+                    _logger.LogError(message);
+                    break;
+                case "FATAL":
+                    _logger.LogCritical(message);
+                    break;
+                default:
+                    Console.WriteLine("Log level '" + logLevel + "' is not a tested log level.");
+                    break;
+            }
+
+            return message;
+        }
+    }
+}
+
+#endif

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -25,6 +25,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                 case "SERILOG":
                     _log = new SerilogLoggingAdapter();
                     break;
+                case "SERILOGWEB": // .NET 6.0 ONLY
+#if NET6_0    
+                    _log = new SerilogLoggingWebAdapter();
+#endif
+                    break;
                 case "MICROSOFTLOGGING":
 #if NETCOREAPP2_1_OR_GREATER
                     _log = new MicrosoftLoggingLoggingAdapter();

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -1,0 +1,135 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET6_0
+
+using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Serilog;
+using Serilog.Events;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
+{
+    class SerilogLoggingWebAdapter : ILoggingAdapter
+    {
+        private HttpClient _client;
+        private string _uriBase;
+
+        public SerilogLoggingWebAdapter()
+        {
+        }
+
+        public void Debug(string message)
+        {
+            var result = _client.GetStringAsync(_uriBase + "test?logLevel=DEBUG&message=" + message).Result;
+        }
+
+        public void Info(string message)
+        {
+            var result = _client.GetStringAsync(_uriBase + "test?logLevel=INFO&message=" + message).Result;
+        }
+
+        public void Warn(string message)
+        {
+            var result = _client.GetStringAsync(_uriBase + "test?logLevel=WARN&message=" + message).Result;
+        }
+
+        public void Error(string message)
+        {
+            var result = _client.GetStringAsync(_uriBase + "test?logLevel=ERROR&message=" + message).Result;
+        }
+
+        public void Fatal(string message)
+        {
+            var result = _client.GetStringAsync(_uriBase + "test?logLevel=FATAL&message=" + message).Result;
+        }
+
+        public void Configure()
+        {
+            _client = new HttpClient();
+
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig
+                .Enrich.FromLogContext()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Fatal)
+                .MinimumLevel.Debug()
+                .WriteTo.Console();
+
+            Log.Logger = loggerConfig.CreateLogger();
+
+            var port = RandomPortGenerator.NextPort();
+            _uriBase = "http://localhost:" + port + "/";
+            var hostTask = CreateHostBuilder(_uriBase).Build().RunAsync();
+
+            Console.WriteLine("URI: " + _uriBase);
+
+            // builder
+            IHostBuilder CreateHostBuilder(string uriBase)
+            {
+                return Host.CreateDefaultBuilder()
+                .UseSerilog()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                webBuilder.UseStartup<Startup>();
+                webBuilder.UseUrls(uriBase);
+                });
+            }
+        }
+
+        public void ConfigurePatternLayoutAppenderForDecoration()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ConfigureJsonLayoutAppenderForDecoration()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+            services.AddControllers();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+
+            app.UseSerilogRequestLogging();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates serilog wrapper to check for duplicate log entries by looking at the stackframes and checking for additional "Dispatch" methods.

There are two different versions of the stack trace, one that places the initial Dispatch method at 7 and one that places it at 8.  The logic in the wrapper handles this.

Tests all pass and performance is acceptable (let me know if you want to go over it)

Closes #1070 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
