### PR TITLE
Adds configuration development doc 

### DIFF
--- a/docs/config-development.md
+++ b/docs/config-development.md
@@ -15,14 +15,14 @@ Updating the configuration consists of two steps:
 2. Update the class file via `xsd2code`.
 3. Add/restore the copyright to the class file.
 
-## Updating the XSD
+## Update the XSD
 
 Update the relevant XSD with new or modified configuration based on your needs.
 
 * `src\Agent\NewRelic\Agent\Core\Config\Configuration.xsd`
 * `src\Agent\NewRelic\Agent\Core\NewRelic.Agent.Core.Extension\Extension.xsd`
 
-## Updating the Class
+## Update the Class
 
 Once the relevant XSD file has been updated, run `xsd2Code` to update the class file.
 

--- a/docs/config-development.md
+++ b/docs/config-development.md
@@ -13,6 +13,7 @@ Updating the configuration consists of two steps:
 
 1. Update the relevant XSD file.
 2. Update the class file via `xsd2code`.
+3. Add/restore the copyright to the class file.
 
 ## Updating the XSD
 
@@ -37,4 +38,17 @@ $rootDirectory = Resolve-Path ".\"; .\build\Tools\xsd2code\xsd2code.exe "$rootDi
 
 ```powershell
 $rootDirectory = Resolve-Path ".\"; .\build\Tools\xsd2code\xsd2code.exe "$rootDirectory\src\Agent\NewRelic\Agent\Core\NewRelic.Agent.Core.Extension\Extension.xsd" NewRelic.Agent.Core.Extension Extension.cs /cl /ap /sc /xa
+```
+
+## Add the Copyright
+
+The `xsd2code` tool will not automatically generate (nor keep) the required copyright header at the top of the file.
+
+Add/restore the copyright header to the top of the updated class file.
+
+The current header is:
+
+```cs
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 ```

--- a/docs/config-development.md
+++ b/docs/config-development.md
@@ -1,0 +1,40 @@
+# Configuration Development
+
+The following configuration files are generated using Xsd2Code:
+
+* `src\Agent\NewRelic\Agent\Core\Config\Configuration.cs`
+* `src\Agent\NewRelic\Agent\Core\NewRelic.Agent.Core.Extension\Extension.cs`
+
+Please note the version of Xsd2Code included in the code base **requires .NET 3.5** to execute successfully.
+
+You can find Xsd2Code in the repository here: `.\build\Tools\xsd2code`.
+
+Updating the configuration consists of two steps:
+
+1. Update the relevant XSD file.
+2. Update the class file via `xsd2code`.
+
+## Updating the XSD
+
+Update the relevant XSD with new or modified configuration based on your needs.
+
+* `src\Agent\NewRelic\Agent\Core\Config\Configuration.xsd`
+* `src\Agent\NewRelic\Agent\Core\NewRelic.Agent.Core.Extension\Extension.xsd`
+
+## Updating the Class
+
+Once the relevant XSD file has been updated, run `xsd2Code` to update the class file.
+
+The following commands should be run from from the root of the repository using PowerShell.
+
+### Configuration.cs
+
+```powershell
+$rootDirectory = Resolve-Path ".\"; .\build\Tools\xsd2code\xsd2code.exe "$rootDirectory\src\Agent\NewRelic\Agent\Core\Config\Configuration.xsd" NewRelic.Agent.Core.Config Configuration.cs /cl /ap /sc /xa
+```
+
+### Extension.cs
+
+```powershell
+$rootDirectory = Resolve-Path ".\"; .\build\Tools\xsd2code\xsd2code.exe "$rootDirectory\src\Agent\NewRelic\Agent\Core\NewRelic.Agent.Core.Extension\Extension.xsd" NewRelic.Agent.Core.Extension Extension.cs /cl /ap /sc /xa
+```


### PR DESCRIPTION
## Description

Added documentation around how configuration classes are generated in the agent to the `/docs` folder.

 Currently, the only documentation exists in the readme file in `.\build\Tools\xsd2code` which requires knowing that we already use that or searching around once you see the code comments that the classes are generated. I only knew to go track this down due to previous times working on the agent. 

To help out future devs/open-source contributors, I recommend we have something with the docs so submitting as a PR.

This content is very duplicative of the readme but I figured I'd leave the readme with the utility so there is context directly there. Could also just link back from there but I don't think the duplication really hurts here. What is most likely to happen is changing tooling (or removing tooling) which would naturally update this doc and delete the other.

Also noted that this tool requires .NET 3.5 which is not required by any other setup instructions we have thus far.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
