### PR TITLE
Adds default capture of code level metric attributes

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -34,6 +34,8 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> CatReferringTransactionGuidForEvents { get; }
         AttributeDefinition<string, string> CatReferringTransactionGuidForTraces { get; }
         AttributeDefinition<string, string> ClientCrossProcessId { get; }
+        AttributeDefinition<string, string> CodeFunction { get; }
+        AttributeDefinition<string, string> CodeNamespace { get; }
         AttributeDefinition<string, string> Component { get; }
         AttributeDefinition<TimeSpan, double> CpuTime { get; }
         AttributeDefinition<string, string> CustomEventType { get; }
@@ -957,5 +959,25 @@ namespace NewRelic.Agent.Core.Attributes
             AttributeDefinitionBuilder.CreateString("type", AttributeClassification.Intrinsics)
                 .AppliesTo(AttributeDestinations.CustomEvent)
                 .Build(_attribFilter));
+
+        private AttributeDefinition<string, string> _codeFunction;
+        public AttributeDefinition<string, string> CodeFunction => _codeFunction ?? (
+            _codeFunction = AttributeDefinitionBuilder.CreateString(
+                "code.function",
+                AttributeClassification.AgentAttributes
+            )
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter)
+        );
+
+        private AttributeDefinition<string, string> _codeNamespace;
+        public AttributeDefinition<string, string> CodeNamespace => _codeNamespace ?? (
+            _codeNamespace = AttributeDefinitionBuilder.CreateString(
+                "code.namespace",
+                AttributeClassification.AgentAttributes
+            )
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter)
+        );
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -94,6 +94,8 @@ namespace NewRelic.Agent.Core.Config
         
         private configurationProcessHost processHostField;
         
+        private configurationCodeLevelMetrics codeLevelMetricsField;
+        
         private bool agentEnabledField;
         
         private bool rootAgentEnabledField;
@@ -113,6 +115,7 @@ namespace NewRelic.Agent.Core.Config
         /// </summary>
         public configuration()
         {
+            this.codeLevelMetricsField = new configurationCodeLevelMetrics();
             this.processHostField = new configurationProcessHost();
             this.utilizationField = new configurationUtilization();
             this.appSettingsField = new List<configurationAdd>();
@@ -561,6 +564,18 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.processHostField = value;
+            }
+        }
+        
+        public configurationCodeLevelMetrics codeLevelMetrics
+        {
+            get
+            {
+                return this.codeLevelMetricsField;
+            }
+            set
+            {
+                this.codeLevelMetricsField = value;
             }
         }
         
@@ -5443,6 +5458,48 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationProcessHost Clone()
         {
             return ((configurationProcessHost)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationCodeLevelMetrics
+    {
+        
+        private bool enabledField;
+        
+        /// <summary>
+        /// configurationCodeLevelMetrics class constructor
+        /// </summary>
+        public configurationCodeLevelMetrics()
+        {
+            this.enabledField = false;
+        }
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
+        public bool enabled
+        {
+            get
+            {
+                return this.enabledField;
+            }
+            set
+            {
+                this.enabledField = value;
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationCodeLevelMetrics object
+        /// </summary>
+        public virtual configurationCodeLevelMetrics Clone()
+        {
+            return ((configurationCodeLevelMetrics)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1788,6 +1788,25 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
+
+                <xs:element name="codeLevelMetrics" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Turns on/off capture of code level metric attributes.
+                        </xs:documentation>
+                    </xs:annotation>
+
+                    <xs:complexType>
+                        <xs:attribute name="enabled" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Set this to "true" to capture namespace and function information
+                                    on spans to enable code level metrics in CodeStream.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
             </xs:all>
 
             <xs:attribute name="agentEnabled" type="xs:boolean" default="true">

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2448,6 +2448,8 @@ namespace NewRelic.Agent.Core.Configuration
         public int DatabaseStatementCacheCapcity => _databaseStatementCacheCapcity ?? (_databaseStatementCacheCapcity =
             TryGetAppSettingAsIntWithDefault("SqlStatementCacheCapacity", DefaultSqlStatementCacheCapacity)).Value;
 
+        public bool CodeLevelMetricsEnabled =>  _localConfiguration.codeLevelMetrics.enabled;
+
         #endregion
 
         private const bool CaptureTransactionTraceAttributesDefault = true;

--- a/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
@@ -33,6 +33,9 @@ namespace NewRelic.Agent.Core.Segments
 
         public string TypeName => string.Empty;
 
+        public string UserCodeFunction { get => string.Empty; set { } }
+        public string UserCodeNamespace { get => string.Empty; set { } }
+
         public void End() { }
         public void End(Exception ex) { }
         public void MakeCombinable() { }

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -275,16 +275,19 @@ namespace NewRelic.Agent.Core.Segments
                 }
             }
 
-            var codeNamespace = !string.IsNullOrEmpty(this.UserCodeNamespace)
-                ? this.UserCodeNamespace
-                : this.MethodCallData.TypeName;
+            if (_configurationSubscriber.Configuration.CodeLevelMetricsEnabled)
+            {
+                var codeNamespace = !string.IsNullOrEmpty(this.UserCodeNamespace)
+                    ? this.UserCodeNamespace
+                    : this.MethodCallData.TypeName;
 
-            var codeFunction = !string.IsNullOrEmpty(this.UserCodeFunction)
-                ? this.UserCodeFunction
-                : this.MethodCallData.MethodName;
+                var codeFunction = !string.IsNullOrEmpty(this.UserCodeFunction)
+                    ? this.UserCodeFunction
+                    : this.MethodCallData.MethodName;
 
-            AttribDefs.CodeNamespace.TrySetValue(attribValues, codeNamespace);
-            AttribDefs.CodeFunction.TrySetValue(attribValues, codeFunction);
+                AttribDefs.CodeNamespace.TrySetValue(attribValues, codeNamespace);
+                AttribDefs.CodeFunction.TrySetValue(attribValues, codeFunction);
+            }
 
             Data.SetSpanTypeSpecificAttributes(attribValues);
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ISegmentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ISegmentExperimental.cs
@@ -30,5 +30,18 @@ namespace NewRelic.Agent.Api.Experimental
         /// <returns>The segment that the segmentData was added to.</returns>
         ISegmentExperimental MakeLeaf();
 
+        /// <summary>
+        /// Get or set the function (method) name for the user/customer code represented
+        /// by the instrumentation. This only needs set when the instrumentation point and
+        /// the customer code represented differ. For example, controller actions.
+        /// </summary>
+        string UserCodeFunction { get; set; }
+        /// <summary>
+        /// Get or set the namespace (type) name for the user/customer code represented
+        /// by the instrumentation. This only needs set when the instrumentation point and
+        /// the customer code represented differ. For example, controller actions.
+        /// </summary>
+        string UserCodeNamespace { get; set; }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -190,5 +190,6 @@ namespace NewRelic.Agent.Configuration
         bool LogDecoratorEnabled { get; }
         bool AppDomainCachingDisabled { get; }
         bool ForceNewTransactionOnNewThread { get; }
+        bool CodeLevelMetricsEnabled {  get; }
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
@@ -50,6 +50,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
             };
             Api.Agent.NewRelic.NoticeError(new Exception("Rawr!"), errorAttributes);
 
+            SomeOtherMethod();
         }
 
         private static void SomeSlowMethod()
@@ -57,6 +58,11 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
             var stuff = string.Empty;
             Api.Agent.NewRelic.GetAgent().CurrentTransaction.AddCustomAttribute("test", "test");
             Thread.Sleep(2000); //needed for OtherTransaction test
+        }
+
+        private static void SomeOtherMethod()
+        {
+            Thread.Sleep(20);
         }
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -314,5 +314,12 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "applicationLogging", "forwarding" }, "maxSamplesStored", samples.ToString());
             return this;
         }
+
+        public NewRelicConfigModifier SetCodeLevelMetricsEnabled(bool enabled = true)
+        {
+            CommonUtils.ModifyOrCreateXmlNodeInNewRelicConfig(_configFilePath, new[] { "configuration" }, "codeLevelMetrics", string.Empty);
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "codeLevelMetrics" }, "enabled", enabled.ToString().ToLower());
+            return this;
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributesTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
+{
+    [NetFrameworkTest]
+    public class FrameworkCustomInstrumentationCodeAttributesTest : NewRelicIntegrationTest<RemoteServiceFixtures.AgentApiExecutor>
+    {
+        private readonly RemoteServiceFixtures.AgentApiExecutor _fixture;
+
+        private const string ProgramNamespace = "NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor.Program";
+
+        public FrameworkCustomInstrumentationCodeAttributesTest(RemoteServiceFixtures.AgentApiExecutor fixture, ITestOutputHelper output)
+            : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+
+                    var instrumentationFilePath = Path.Combine(fixture.DestinationNewRelicExtensionsDirectoryPath, "CustomInstrumentation.xml");
+
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor", ProgramNamespace, "RealMain", "NewRelic.Providers.Wrapper.CustomInstrumentation.OtherTransactionWrapper", "MyCustomMetricName");
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor", ProgramNamespace, "SomeSlowMethod", "NewRelic.Agent.Core.Tracer.Factories.BackgroundThreadTracerFactory");
+
+                    // Use the default wrapper
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor", ProgramNamespace, "SomeOtherMethod");
+                }
+            );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
+
+            var myCustomMetricNameSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "MyCustomMetricName");
+            var someSlowMethodSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString().Contains("SomeSlowMethod"));
+            var someOtherMethodSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString().Contains("SomeOtherMethod"));
+
+            NrAssert.Multiple
+            (
+                () => Assertions.SpanEventHasAttributes(_expectedMyCustomMetricNameAttributes, SpanEventAttributeType.Agent, myCustomMetricNameSpan),
+                () => Assertions.SpanEventHasAttributes(_expectedSomeSlowMethodAttributes, SpanEventAttributeType.Agent, someSlowMethodSpan),
+                () => Assertions.SpanEventHasAttributes(_expectedSomeOtherMethodAttributes, SpanEventAttributeType.Agent, someOtherMethodSpan)
+            );
+        }
+
+        private readonly Dictionary<string, string> _expectedMyCustomMetricNameAttributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", ProgramNamespace },
+            { "code.function", "RealMain" }
+        };
+
+        private readonly Dictionary<string, string> _expectedSomeSlowMethodAttributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", ProgramNamespace },
+            { "code.function", "SomeSlowMethod" }
+        };
+
+        private readonly Dictionary<string, string> _expectedSomeOtherMethodAttributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", ProgramNamespace },
+            { "code.function", "SomeOtherMethod" }
+        };
+
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributesTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributesTest.cs
@@ -30,6 +30,7 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                 setupConfiguration: () =>
                 {
                     var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetCodeLevelMetricsEnabled();
 
                     var instrumentationFilePath = Path.Combine(fixture.DestinationNewRelicExtensionsDirectoryPath, "CustomInstrumentation.xml");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributesTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributesTests.cs
@@ -29,6 +29,9 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             (
                 setupConfiguration: () =>
                 {
+                    var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetCodeLevelMetricsEnabled();
+
                     var instrumentationFilePath = Path.Combine(fixture.DestinationNewRelicExtensionsDirectoryPath, "CustomInstrumentation.xml");
 
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "IoBoundNoSpecialAsync", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.OtherTransactionWrapperAsync", "IoBoundNoSpecialAsync", 7);

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributesTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributesTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
+{
+    [NetCoreTest]
+    public class NetCoreCustomInstrumentationCodeAttributesTests : NewRelicIntegrationTest<NetCoreAsyncTestsFixture>
+    {
+        private readonly NetCoreAsyncTestsFixture _fixture;
+
+        private const string AsyncUseCasesNamespace = "NetCoreAsyncApplication.AsyncUseCases";
+
+        public NetCoreCustomInstrumentationCodeAttributesTests(NetCoreAsyncTestsFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var instrumentationFilePath = Path.Combine(fixture.DestinationNewRelicExtensionsDirectoryPath, "CustomInstrumentation.xml");
+
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "IoBoundNoSpecialAsync", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.OtherTransactionWrapperAsync", "IoBoundNoSpecialAsync", 7);
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "IoBoundConfigureAwaitFalseAsync", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.OtherTransactionWrapperAsync", "IoBoundConfigureAwaitFalseAsync", 7);
+
+                    CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "CustomMethodAsync1", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "CustomMethodAsync1");
+                }
+            );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
+
+            var ioBoundNoSpecialSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "IoBoundNoSpecialAsync");
+            var ioBoundConfigureAwaitFalseSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "IoBoundConfigureAwaitFalseAsync");
+            var customMethodAsync1Span = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "CustomMethodAsync1");
+
+            NrAssert.Multiple
+            (
+                () => Assertions.SpanEventHasAttributes(_expectedIoBoundNoSpecialAttributes, SpanEventAttributeType.Agent, ioBoundNoSpecialSpan),
+                () => Assertions.SpanEventHasAttributes(_expectedioBoundConfigureAwaitFalseAttributes, SpanEventAttributeType.Agent, ioBoundConfigureAwaitFalseSpan),
+                () => Assertions.SpanEventHasAttributes(_expectedCustomMethodAsync1Attributes, SpanEventAttributeType.Agent, customMethodAsync1Span)
+            );
+        }
+
+        private readonly Dictionary<string, string> _expectedIoBoundNoSpecialAttributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", AsyncUseCasesNamespace },
+            { "code.function", "IoBoundNoSpecialAsync" }
+        };
+
+        private readonly Dictionary<string, string> _expectedioBoundConfigureAwaitFalseAttributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", AsyncUseCasesNamespace },
+            { "code.function", "IoBoundConfigureAwaitFalseAsync" }
+        };
+
+        private readonly Dictionary<string, string> _expectedCustomMethodAsync1Attributes = new Dictionary<string, string>()
+        {
+            { "code.namespace", AsyncUseCasesNamespace },
+            { "code.function", "CustomMethodAsync1" }
+        };
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -3079,6 +3079,20 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.ForceNewTransactionOnNewThread;
         }
 
+        [Test]
+        public void ShouldDefaultCodeLevelMetricsEnabledFalse()
+        {
+            Assert.AreEqual(false, _defaultConfig.CodeLevelMetricsEnabled);
+        }
+
+        [Test]
+        public void ShouldUpdateCodeLevelMetricsEnabled()
+        {
+            _localConfig.codeLevelMetrics.enabled = true;
+            Assert.AreEqual(true, _defaultConfig.CodeLevelMetricsEnabled);
+        }
+
+
         private void CreateDefaultConfiguration()
         {
             _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);


### PR DESCRIPTION
Plumbs in initial capture of `code.namespace` and `code.function` attributes on spans. Enables mapping of code of custom-instrumented methods.

* Captures instrumented method and type for all spans which apply to instrumented code (not artificial root spans). 
* Plumbs in ability to override to update instrumentation such as MVC Controllers to point to actual customer code.
* Introduces code level metric configuration with enabled defaulting to `false`.

Closes: https://github.com/newrelic/newrelic-dotnet-agent/issues/1090