### PR TITLE
Adds ability to remove deprecated instrumentation files post installation

### DIFF
--- a/build/Linux/build/deb/postinst
+++ b/build/Linux/build/deb/postinst
@@ -3,6 +3,10 @@
 PACKAGE_NAME='newrelic-netcore20-agent'
 NEWRELIC_HOME=/usr/local/${PACKAGE_NAME}
 
+# Deprecated instrumentation files to remove post install
+rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.Instrumentation.xml 2> /dev/null
+rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.dll 2> /dev/null
+
 # create logs dir
 mkdir -p $NEWRELIC_HOME/logs 2> /dev/null
 

--- a/build/Linux/build/rpm/newrelic-netcore20-agent.spec
+++ b/build/Linux/build/rpm/newrelic-netcore20-agent.spec
@@ -45,6 +45,10 @@ rm -rf %{buildroot}
 %post
 NEWRELIC_HOME=/usr/local/%{name}
 
+# Deprecated instrumentation files to remove post install
+rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.Instrumentation.xml 2> /dev/null
+rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.dll 2> /dev/null
+
 # create logs dir
 mkdir -p $NEWRELIC_HOME/logs 2> /dev/null
 

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -250,6 +250,13 @@ function RemoveNewRelicInstallArtifacts($fromDirectory)
 	}
 }
 
+function RemoveDeprecatedInstrumentationFiles($newRelicInstallPath)
+{
+	# Logging files
+	Remove-Item "$newRelicInstallPath\extensions\NewRelic.Providers.Wrapper.Logging.Instrumentation.xml" -ErrorAction Ignore
+	Remove-Item "$newRelicInstallPath\extensions\NewRelic.Providers.Wrapper.Logging.dll" -ErrorAction Ignore
+}
+
 try
 {
 	WriteToInstallLog "Start executing install.ps1"
@@ -365,6 +372,8 @@ try
 		InstallNewAgent $newRelicNugetContentPath $newRelicInstallPath $newRelicLegacyInstallPath
 
 		CopyAgentInfo $newRelicInstallPath
+
+		RemoveDeprecatedInstrumentationFiles $newRelicInstallPath
 
 		cd ..\..
 	}

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 
 ### New Features
-* Adds an internal list of deprecated instrumentation xml files which will cause the profiler to ignore deprecated instrumentation. This feature avoids an issue where orphaned deprecated log forwarding instrumentation could conflict with newer instrumentation. ([#1051](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))
+* Adds an internal list of deprecated instrumentation xml files which will cause the profiler to ignore deprecated instrumentation. This feature avoids an issue where orphaned deprecated log forwarding instrumentation could conflict with newer instrumentation. ([#1097](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))
+* Updates the following installation methods to check for and remove deprecated files. ([#1104](https://github.com/newrelic/newrelic-dotnet-agent/pull/1104))
+  * MSI Installer
+  * Azure Site Extension
+  * RPM package
+  * DEB package
 
 ### Fixes
-* Fixes an [issue with log forwarding](https://github.com/newrelic/newrelic-dotnet-agent/issues/1088) where an agent could momentarily forward logs even if the feature had been disabled at an account level. ([#1051](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))
+* Fixes an [issue with log forwarding](https://github.com/newrelic/newrelic-dotnet-agent/issues/1088) where an agent could momentarily forward logs even if the feature had been disabled at an account level. ([#1097](https://github.com/newrelic/newrelic-dotnet-agent/pull/1097))
 
 ## [9.8.0] - 2022-05-05
 

--- a/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
+++ b/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
@@ -228,6 +228,16 @@ namespace InstallerActions
             DeleteFile(@"C:\Windows\SysWOW64\NewRelic.IL.dll");
             DeleteFile(session.CustomActionData["NETAGENTCOMMONFOLDER"] + @"newrelic.xml");
 
+            // Delete old logging XMLs to prevent duplicate logs from being sent up.
+            DeleteFile(@"C:\ProgramData\New Relic\.NET Agent\Extensions\netcore\NewRelic.Providers.Wrapper.Logging.Instrumentation.xml");
+            DeleteFile(@"C:\ProgramData\New Relic\.NET Agent\Extensions\netframework\NewRelic.Providers.Wrapper.Logging.Instrumentation.xml");
+
+            // Delete old logging DLLs (from default locations) to prevent duplicate logs from being sent up.
+            DeleteFile(@"C:\Program Files\New Relic\.NET Agent\netcore\Extensions\NewRelic.Providers.Wrapper.Logging.dll");
+            DeleteFile(@"C:\Program Files\New Relic\.NET Agent\netframework\Extensions\NewRelic.Providers.Wrapper.Logging.dll");
+            DeleteFile(@"C:\Program Files (x86)\New Relic\.NET Agent\netcore\Extensions\NewRelic.Providers.Wrapper.Logging.dll");
+            DeleteFile(@"C:\Program Files (x86)\New Relic\.NET Agent\netframework\Extensions\NewRelic.Providers.Wrapper.Logging.dll");
+
             String newrelicHomePath = Environment.GetEnvironmentVariable("NEWRELIC_HOME");
             if (newrelicHomePath != null) DeleteFile(newrelicHomePath + @"\newrelic.xml");
 


### PR DESCRIPTION
## Description

- Updates MSI installer custom actions to remove the  deprecated logging instrumentation files from their default locations (what we have access to).  This is done using a preexisting system that won't throw errors if the files don't exist - it already has several.
- Updates the Azure  Site Extension script to add a new function that removes deprecated files .  This is called at the end of the install script.  Uses `ErrorAction Ignore` to prevent any errors from causing problems like in other areas of the script.
- Updates both the RPM and DEB install scripts to attempt to remove deprecated instrumentation from the `$NEWRELIC_HOME` directory (available in the script already).    Uses `2> /dev/null` to prevent any errors from causing problems like in other areas of the script.


**Note:** changelog has not been done - waiting on feedback to see what makes the cut.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
