### PR TITLE
Code level metrics test stability

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using CommandLine;
 
@@ -53,6 +54,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
             SomeOtherMethod();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void SomeSlowMethod()
         {
             var stuff = string.Empty;
@@ -60,6 +62,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
             Thread.Sleep(2000); //needed for OtherTransaction test
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void SomeOtherMethod()
         {
             Thread.Sleep(20);

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/AspNetCoreMvcCodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/AspNetCoreMvcCodeAttributeTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -34,6 +35,8 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                     _fixture.Get();
                     _fixture.ThrowException();
                     _fixture.GetCallAsyncExternal();
+
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();
@@ -47,6 +50,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             var getIndexSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/HomeController/Index");
             var throwExceptionSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/HomeController/ThrowException");
             var callAsyncExternalSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/DetachWrapperController/CallAsyncExternal");
+
+            Assert.NotNull(getIndexSpan);
+            Assert.NotNull(throwExceptionSpan);
+            Assert.NotNull(callAsyncExternalSpan);
 
             NrAssert.Multiple
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkAspNetMvcCodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkAspNetMvcCodeAttributeTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -33,6 +34,8 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                 {
                     _fixture.Get();
                     _fixture.GetWithAsyncDisabled();
+
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/FrameworkCustomInstrumentationCodeAttributeTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -52,6 +53,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             var myCustomMetricNameSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "MyCustomMetricName");
             var someSlowMethodSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString().Contains("SomeSlowMethod"));
             var someOtherMethodSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString().Contains("SomeOtherMethod"));
+
+            Assert.NotNull(myCustomMetricNameSpan);
+            Assert.NotNull(someSlowMethodSpan);
+            Assert.NotNull(someOtherMethodSpan);
 
             NrAssert.Multiple
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/NetCoreCustomInstrumentationCodeAttributeTests.cs
@@ -11,6 +11,7 @@ using NewRelic.Agent.IntegrationTestHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
+using System;
 
 namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
 {
@@ -38,6 +39,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "IoBoundConfigureAwaitFalseAsync", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.OtherTransactionWrapperAsync", "IoBoundConfigureAwaitFalseAsync", 7);
 
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", AsyncUseCasesNamespace, "CustomMethodAsync1", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "CustomMethodAsync1");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();
@@ -51,6 +56,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             var ioBoundNoSpecialSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "IoBoundNoSpecialAsync");
             var ioBoundConfigureAwaitFalseSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "IoBoundConfigureAwaitFalseAsync");
             var customMethodAsync1Span = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "CustomMethodAsync1");
+
+            Assert.NotNull(ioBoundNoSpecialSpan);
+            Assert.NotNull(ioBoundConfigureAwaitFalseSpan);
+            Assert.NotNull(customMethodAsync1Span);
 
             NrAssert.Multiple
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/OwinWebApi2CodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/OwinWebApi2CodeAttributeTests.cs
@@ -36,6 +36,8 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                     _fixture.Get();
                     _fixture.Get404();
                     _fixture.Post();
+
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();
@@ -55,6 +57,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             var valuesGetSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/Values/Get");
             var valuesPostSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/Values/Post");
             var valuesGet404Span = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/Values/Get404");
+
+            Assert.NotNull(valuesGetSpan);
+            Assert.NotNull(valuesPostSpan);
+            Assert.NotNull(valuesGet404Span);
 
             NrAssert.Multiple
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/WebApi2CodeAttributeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CodeLevelMetrics/WebApi2CodeAttributeTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -36,6 +37,8 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
                     _fixture.GetIoBoundNoSpecialAsync();
                     _fixture.GetIoBoundConfigureAwaitFalseAsync();
                     _fixture.GetCpuBoundTasksAsync();
+
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();
@@ -49,6 +52,10 @@ namespace NewRelic.Agent.IntegrationTests.CodeLevelMetrics
             var getIoBoundNoSpecialSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/AsyncAwait/IoBoundNoSpecialAsync");
             var getIoBoundConfigureAwaitFalseSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/AsyncAwait/IoBoundConfigureAwaitFalseAsync");
             var getCpuBoundSpan = spanEvents.FirstOrDefault(se => se.IntrinsicAttributes["name"].ToString() == "DotNet/AsyncAwait/CpuBoundTasksAsync");
+
+            Assert.NotNull(getIoBoundNoSpecialSpan);
+            Assert.NotNull(getIoBoundConfigureAwaitFalseSpan);
+            Assert.NotNull(getCpuBoundSpan);
 
             NrAssert.Multiple
             (


### PR DESCRIPTION
Turns out one of the code level metrics tests has issues in CI. The tests weren't originally wired up to CI.

This PR attempts to resolve the one known issue, prevent another class of issue and make it easier to narrow in on individual problems.

- Waits for span event data log lines.
- Asserts each span is found.
- Prevents inlining of custom instrumented code.