### PR TITLE
Make CatInbound integration test more reliable

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DefaultController.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DefaultController.cs
@@ -19,6 +19,13 @@ namespace BasicMvcApplication.Controllers
             return View();
         }
 
+        // GET: SlowAndLikelyTracedAction
+        public ActionResult SlowAndLikelyTracedAction()
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            return View("Index");
+        }
+
         // GET: Query
         public ActionResult Query(string data)
         {
@@ -121,7 +128,7 @@ namespace BasicMvcApplication.Controllers
 
         public string DoRedirect(string data)
         {
-            Response.Redirect("Index");
+            Response.Redirect("SlowAndLikelyTracedAction");
             return data;
         }
 


### PR DESCRIPTION
The test was calling two web methods and it was a toss up as to which one would take longer and be sampled. This new approach should be more reliable