### PR TITLE
Update and fix Home.csproj to make errors more visible

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -4,10 +4,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NewRelic.Home</RootNamespace>
     <AssemblyName>NewRelic.Home</AssemblyName>
+    <Description>This project is used to run build_home.ps1 to create the home folders.  It is empty on purpose.</Description>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Condition="'$(NR_DEV_BUILD_HOME)' != 'false'" Command="del /s /q &quot;$(TargetDir)*.*&quot;&#xD;&#xA;cd $(SolutionDir)Build&#xD;&#xA;powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File .\build_home.ps1 -Configuration $(ConfigurationName)" />
+    <Exec Condition="'$(NR_DEV_BUILD_HOME)' != 'false'" Command="del /s /q &quot;$(TargetDir)*.*&quot;" />
+    <Exec Condition="'$(NR_DEV_BUILD_HOME)' != 'false'" WorkingDirectory="$(SolutionDir)Build" Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File .\build_home.ps1 -Configuration $(ConfigurationName)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Description

- Splits out the commands in the Home project ()home builder) into individual commands
- Removes the "cd" portion of the "build_home.ps1" command and instead uses "WorkingDirectory" option.
- Added a description to the Home project csproj that explains what this does and why it is empty.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
