### PR TITLE
Drop eol frameworks tests

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/ConsoleInstrumentationLoaderCore.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/ConsoleInstrumentationLoaderCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Controllers/AgentListenerController.cs
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Controllers/AgentListenerController.cs
@@ -18,7 +18,7 @@ namespace MockNewRelic.Controllers
         private const string ReqeustHeaderKey = "NR-Session";
         private const string ReqeustHeaderValue = "TestHeaderValue";
         private static readonly Dictionary<string, string> _requestHeaderMap = new Dictionary<string, string> { { ReqeustHeaderKey, ReqeustHeaderValue } };
-        private static readonly CollectorResponseEnvelope<string> EmptyResponse = new CollectorResponseEnvelope<string>(null, null);
+        private static readonly string EmptyResponse = "{}";
 
         private static List<CollectedRequest> _collectedRequests = new List<CollectedRequest>();
         private static List<AgentCommand> _queuedCommands = new List<AgentCommand>();
@@ -49,7 +49,7 @@ namespace MockNewRelic.Controllers
         [HttpPost]
         [HttpPut]
         [Route("invoke_raw_method")]
-        public object InvokeRawMethod([FromBody] byte[] body)
+        public string InvokeRawMethod([FromBody] byte[] body)
         {
             var capturedRequest = CaptureRequest(body);
             _collectedRequests.Add(capturedRequest);
@@ -66,7 +66,8 @@ namespace MockNewRelic.Controllers
                             ["redirect_host"] = Request.Host.Host
                         };
                         var host = new CollectorResponseEnvelope<Dictionary<string, object>>(null, preconnectResponse);
-                        return host;
+
+                        return JsonConvert.SerializeObject(host);
                     }
                 case "connect":
                     {
@@ -93,7 +94,7 @@ namespace MockNewRelic.Controllers
                         serverConfig["request_headers_map"] = _requestHeaderMap;
 
                         var config = new CollectorResponseEnvelope<Dictionary<string, object>>(null, serverConfig);
-                        return config;
+                        return JsonConvert.SerializeObject(config);
                     }
                 case "get_agent_commands":
                     {
@@ -101,7 +102,7 @@ namespace MockNewRelic.Controllers
                         _queuedCommands = new List<AgentCommand>();
 
                         var result = new CollectorResponseEnvelope<List<AgentCommand>>(null, commands);
-                        return result;
+                        return JsonConvert.SerializeObject(result);
                     }
                 case "metric_data":
                     {

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/MockNewRelic.csproj
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/MockNewRelic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Program.cs
@@ -36,7 +36,7 @@ namespace MockNewRelic
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseKestrel(options =>
+                .ConfigureKestrel(options =>
                 {
                     options.Listen(IPAddress.Loopback, int.Parse(_port), listenOptions =>
                     {

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Startup.cs
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace MockNewRelic
 {
@@ -30,14 +31,19 @@ namespace MockNewRelic
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteService.cs
@@ -79,7 +79,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         {
             if (IsCoreApp && _publishApp)
             {
-                PublishWithDotnetExe(string.IsNullOrWhiteSpace(_targetFramework) ? "netcoreapp2.1" : _targetFramework);
+                PublishWithDotnetExe(string.IsNullOrWhiteSpace(_targetFramework) ? "netcoreapp3.1" : _targetFramework);
                 CopyNewRelicHomeCoreClrDirectoryToRemote();
             }
             else if (_publishApp)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -24,15 +24,6 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
     }
 
     [NetCoreTest]
-    public class DataUsageSupportabilityMetricsTestsCore21 : DataUsageSupportabilityMetricsTests<ConsoleDynamicMethodFixtureCore21>
-    {
-        public DataUsageSupportabilityMetricsTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class DataUsageSupportabilityMetricsTestsCore31 : DataUsageSupportabilityMetricsTests<ConsoleDynamicMethodFixtureCore31>
     {
         public DataUsageSupportabilityMetricsTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
@@ -24,21 +24,6 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
     }
 
     [NetCoreTest]
-    public class DotNetPerfMetricsTestsCore21 : DotNetPerfMetricsTests<ConsoleDynamicMethodFixtureCore21>
-    {
-        public DotNetPerfMetricsTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-
-        // GC metrics don't work in .NET Core <3.0
-        protected override string[] ExpectedMetricNames_GC => new string[]
-        {
-        };
-
-    }
-
-    [NetCoreTest]
     public class DotNetPerfMetricsTestsCore31 : DotNetPerfMetricsTests<ConsoleDynamicMethodFixtureCore31>
     {
         public DotNetPerfMetricsTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -115,13 +115,4 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
         {
         }
     }
-
-    [NetCoreTest]
-    public class InfiniteTracingNetCore21Tests : InfiniteTracingTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public InfiniteTracingNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -133,14 +133,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netJsonLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
     #endregion
 
     #region Json layout, decoration disabled
@@ -185,15 +177,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
@@ -248,15 +231,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netPatternLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
     #endregion
 
     #region Pattern layout, decoration disabled
@@ -301,15 +275,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
@@ -367,14 +332,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogJsonLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
     #endregion
 
     #region Json layout, decoration disabled
@@ -423,14 +380,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
     #endregion
 
     #region Pattern layout, decoration enabled
@@ -480,14 +429,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogPatternLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
 
     #endregion
 
@@ -538,15 +479,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
     #endregion
 
 
@@ -583,15 +515,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
     #endregion
 
     #region Json layout, decoration disabled
@@ -618,15 +541,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
@@ -663,15 +577,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
     #endregion
 
     #region Pattern layout, decoration disabled
@@ -698,15 +603,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
@@ -765,14 +661,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogJsonLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
     #endregion
 
     #region Json layout, decoration disabled
@@ -817,15 +705,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
         {
         }
@@ -880,15 +759,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         }
     }
 
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationEnabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogPatternLayoutDecorationEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
     #endregion
 
     #region Pattern layout, decoration disabled
@@ -933,15 +803,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationDisabledTestsNetCore22Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
             : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MaxSamplesStoredTests.cs
@@ -122,24 +122,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MaxSamplesStored
         }
     }
 
-    [NetCoreTest]
-    public class Log4netMaxSamplesStoredTestsNetCore22Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netMaxSamplesStoredTestsNetCore21Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public Log4netMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Log4net)
-        {
-        }
-    }
-
     #endregion
 
     #region MicrosoftLogging
@@ -166,24 +148,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MaxSamplesStored
     public class MicrosoftLoggingMaxSamplesStoredTestsNetCore31Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingMaxSamplesStoredTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingMaxSamplesStoredTestsNetCore22Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingMaxSamplesStoredTestsNetCore21Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public MicrosoftLoggingMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
             : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
         }
@@ -247,24 +211,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MaxSamplesStored
         }
     }
 
-    [NetCoreTest]
-    public class SerilogMaxSamplesStoredTestsNetCore22Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogMaxSamplesStoredTestsNetCore21Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public SerilogMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Serilog)
-        {
-        }
-    }
-
     #endregion
 
     #region NLog
@@ -318,24 +264,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MaxSamplesStored
     public class NLogMaxSamplesStoredTestsNetCore31Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogMaxSamplesStoredTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogMaxSamplesStoredTestsNetCore22Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogMaxSamplesStoredTestsNetCore21Tests : MaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NLogMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
             : base(fixture, output, LoggingFramework.NLog)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -564,14 +564,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
         #endregion
 
         #region Metrics and Forwarding Disabled
@@ -624,15 +616,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
         {
             public Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
                 : base(fixture, output, false, false, true, LoggingFramework.Log4net)
             {
             }
@@ -695,15 +678,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics Disabled, Forwarding Enabled
@@ -761,24 +735,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore22>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore21>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
         #endregion
     }
 
@@ -826,18 +782,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics and Forwarding Disabled
@@ -873,18 +817,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore31Tests(
                 ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
                 : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
             {
             }
@@ -930,18 +862,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics Disabled, Forwarding Enabled
@@ -977,30 +897,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(
                 ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore22>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(
-                ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
                 : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
             {
             }
@@ -1083,18 +979,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                 ConsoleDynamicMethodFixtureCore31>
         {
             public SerilogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public SerilogMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
                 ITestOutputHelper output)
                 : base(fixture, output, true, true, true, LoggingFramework.Serilog)
             {
@@ -1189,18 +1073,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics Enabled, Forwarding Disabled
@@ -1277,18 +1149,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics Disabled, Forwarding Enabled
@@ -1360,30 +1220,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(
                 ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore22>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(
-                ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(
-                ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
                 : base(fixture, output, false, true, true, LoggingFramework.Serilog)
             {
             }
@@ -1472,18 +1308,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public NLogMetricsAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics and Forwarding Disabled
@@ -1554,18 +1378,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                 ConsoleDynamicMethodFixtureCore31>
         {
             public NLogMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public NLogMetricsAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
                 ITestOutputHelper output)
                 : base(fixture, output, false, false, true, LoggingFramework.NLog)
             {
@@ -1648,18 +1460,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             }
         }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
         #endregion
 
         #region Metrics Disabled, Forwarding Enabled
@@ -1730,30 +1530,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                 ConsoleDynamicMethodFixtureCore31>
         {
             public NLogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore22>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore21>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture,
                 ITestOutputHelper output)
                 : base(fixture, output, false, true, true, LoggingFramework.NLog)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
@@ -109,24 +109,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
         }
     }
 
-    [NetCoreTest]
-    public class Log4netZeroMaxSamplesStoredTestsNetCore22Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public Log4netZeroMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netZeroMaxSamplesStoredTestsNetCore21Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public Log4netZeroMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Log4net)
-        {
-        }
-    }
-
     #endregion
 
     #region MicrosoftLogging
@@ -153,24 +135,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
     public class MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore31Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore22Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore21Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public MicrosoftLoggingZeroMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
             : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
         }
@@ -234,24 +198,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
         }
     }
 
-    [NetCoreTest]
-    public class SerilogZeroMaxSamplesStoredTestsNetCore22Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public SerilogZeroMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogZeroMaxSamplesStoredTestsNetCore21Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public SerilogZeroMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.Serilog)
-        {
-        }
-    }
-
     #endregion
 
     #region NLog
@@ -305,24 +251,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
     public class NLogZeroMaxSamplesStoredTestsNetCore31Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogZeroMaxSamplesStoredTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogZeroMaxSamplesStoredTestsNetCore22Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NLogZeroMaxSamplesStoredTestsNetCore22Tests(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogZeroMaxSamplesStoredTestsNetCore21Tests : ZeroMaxSamplesStoredTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NLogZeroMaxSamplesStoredTestsNetCore21Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
             : base(fixture, output, LoggingFramework.NLog)
         {
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public MockNewRelicFixture(RemoteApplication remoteApplication) : base(remoteApplication)
         {
-            MockNewRelicApplication = new RemoteService(ApplicationDirectoryName, ExecutableName, TargetFramework, ApplicationType.Bounded, true, true, true); ; ;
+            MockNewRelicApplication = new RemoteService(ApplicationDirectoryName, ExecutableName, TargetFramework, ApplicationType.Bounded, true, true, true);
 
             Actions(
                 setupConfiguration: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
@@ -17,12 +17,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
     {
         private const string ApplicationDirectoryName = @"MockNewRelic";
         private const string ExecutableName = @"MockNewRelic.exe";
+        private const string TargetFramework = "net6";
 
         public RemoteService MockNewRelicApplication { get; set; }
 
         public MockNewRelicFixture(RemoteApplication remoteApplication) : base(remoteApplication)
         {
-            MockNewRelicApplication = new RemoteService(ApplicationDirectoryName, ExecutableName, ApplicationType.Bounded, true, true, true);
+            MockNewRelicApplication = new RemoteService(ApplicationDirectoryName, ExecutableName, TargetFramework, ApplicationType.Bounded, true, true, true); ; ;
 
             Actions(
                 setupConfiguration: () =>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -74,21 +74,6 @@ namespace MultiFunctionApplicationHelpers
         }
     }
 
-
-    public class ConsoleDynamicMethodFixtureCore21 : ConsoleDynamicMethodFixtureCoreSpecificVersion
-    {
-        public ConsoleDynamicMethodFixtureCore21() : base("netcoreapp2.1")
-        {
-        }
-    }
-
-    public class ConsoleDynamicMethodFixtureCore22 : ConsoleDynamicMethodFixtureCoreSpecificVersion
-    {
-        public ConsoleDynamicMethodFixtureCore22() : base("netcoreapp2.2")
-        {
-        }
-    }
-
     public class ConsoleDynamicMethodFixtureCore31 : ConsoleDynamicMethodFixtureCoreSpecificVersion
     {
         public ConsoleDynamicMethodFixtureCore31() : base("netcoreapp3.1")

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -130,9 +130,9 @@
   </ItemGroup>
 
   <ItemGroup> <!-- Versions below 4.5 did not support netstandard 2.0 -->
-    <PackageReference Include="NLog" Version="4.6.8" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="NLog" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="NLog" Version="4.7.15" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="NLog" Version="4.5.9" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="NLog" Version="4.7.15" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="NLog" Version="5.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="NLog" Version="4.3.11" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NLog" Version="4.1.2" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NLog" Version="4.5.11" Condition="'$(TargetFramework)' == 'net48'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net5.0;net6.0;net462;net471;net48</TargetFrameworks>
-    <!--We have some tests that specifically need to test .NET Core 2.2 behavior, so disabling the warning about 2.2 being EOL-->
-    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462;net471;net48</TargetFrameworks>
     
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
@@ -26,9 +24,6 @@
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net48'" />
 
     <!-- log4net .NET core references -->
-    <PackageReference Include="log4net" Version="2.0.6 " Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="log4net" Version="2.0.8" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="log4net" Version="2.0.12" Condition="'$(TargetFramework)' == 'net5.0'" />
@@ -52,13 +47,6 @@
     <!-- Serilog .NET core references -->
     <!-- Can't go any earlier than 2.5.0 in .NET core due to minimum version required by
          Serilog.Extensions.Hosting dependency of Microsoft.Extensions.Logging -->
-    <PackageReference Include="Serilog" Version="2.5.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-
-    <PackageReference Include="Serilog" Version="2.5.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
 
     <PackageReference Include="Serilog" Version="2.8.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
@@ -107,8 +95,6 @@
     <PackageReference Include="RabbitMQ.Client" Version="3.5.2" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="RabbitMQ.Client" Version="5.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" Condition="'$(TargetFramework)' == 'net6.0'" />
@@ -116,9 +102,6 @@
     <PackageReference Include="NServiceBus" Version="6.5.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net48'" />
     <!-- NServiceBus 6.5 only appears to support .NET Framework. Uncomment for 'fun' -->
-    <!-- <PackageReference Include="NServiceBus" Version="6.5.10 " Condition="'$(TargetFramework)' == 'netcoreapp2.1'" /> -->
-    <PackageReference Include="NServiceBus" Version="7.5.0 " Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net6.0'" />
@@ -130,16 +113,6 @@
 
   <!-- Microsoft.Extensions.Logging supports netstandard 2.0 and up only -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="2.0.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="2.0.0" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
-
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
@@ -157,8 +130,6 @@
   </ItemGroup>
 
   <ItemGroup> <!-- Versions below 4.5 did not support netstandard 2.0 -->
-    <PackageReference Include="NLog" Version="4.5.10" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="NLog" Version="4.5.9" Condition="'$(TargetFramework)' == 'netcoreapp2.2'" />
     <PackageReference Include="NLog" Version="4.6.8" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="NLog" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="NLog" Version="4.7.15" Condition="'$(TargetFramework)' == 'net6.0'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
@@ -80,12 +80,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         private void CreateLogger()
         {
-#if NETCOREAPP2_1 || NETCOREAPP2_2 // .NET Core 2.1 & 2.2 don;t support LoggerFactory.Create
-            var loggerFactory = new LoggerFactory()
-                .AddSerilog()
-                .AddConsole(LogLevel.Debug);
-
-#else
             using var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder
@@ -95,7 +89,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                     .AddSerilog()
                     .AddConsole();
             });
-#endif
             logger = loggerFactory.CreateLogger<LoggingTester>();
         }
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <!--We have some tests that specifically need to test .NET Core 2.2 behavior, so disabling the warning about 2.2 being EOL-->
-    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/BasicMvcCoreApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/BasicMvcCoreApplication.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" />

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/BasicMvcCoreApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/BasicMvcCoreApplication.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" />
     <PackageReference Include="Npgsql" Version="4.0.5" />
   </ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/MicrosoftDataSqlClientController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/MicrosoftDataSqlClientController.cs
@@ -19,6 +19,7 @@ namespace BasicMvcApplication.Controllers
         private const string CountPersonMsSql = "SELECT COUNT(*) FROM {0} WITH(nolock)";
 
         [HttpGet]
+        [Route("MicrosoftDataSqlClient/MsSql")]
         public string MsSql(string tableName)
         {
             var teamMembers = new List<string>();
@@ -67,6 +68,7 @@ namespace BasicMvcApplication.Controllers
         }
 
         [HttpGet]
+        [Route("MicrosoftDataSqlClient/MsSqlAsync")]
         public async Task<string> MsSqlAsync(string tableName)
         {
             var teamMembers = new List<string>();
@@ -113,6 +115,8 @@ namespace BasicMvcApplication.Controllers
             return string.Join(",", teamMembers);
         }
 
+        [HttpGet]
+        [Route("MicrosoftDataSqlClient/MsSql_WithParameterizedQuery")]
         public string MsSql_WithParameterizedQuery(string tableName, bool paramsWithAtSign)
         {
             var teamMembers = new List<string>();
@@ -142,6 +146,7 @@ namespace BasicMvcApplication.Controllers
         }
 
         [HttpGet]
+        [Route("MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery")]
         public async Task<string> MsSqlAsync_WithParameterizedQuery(string tableName, bool paramsWithAtSign)
         {
             var teamMembers = new List<string>();
@@ -190,6 +195,7 @@ namespace BasicMvcApplication.Controllers
         }
 
         [HttpGet]
+        [Route("MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure")]
         public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/PostgresController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/PostgresController.cs
@@ -18,6 +18,7 @@ namespace BasicMvcCoreApplication.Controllers
     {
 
         [HttpGet]
+        [Route("Postgres/Postgres")]
         public string Postgres()
         {
             var teamMembers = new List<string>();
@@ -41,6 +42,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresAsync")]
         public async Task<string> PostgresAsync()
         {
             var teamMembers = new List<string>();
@@ -64,6 +66,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresParameterizedStoredProcedure")]
         public void PostgresParameterizedStoredProcedure(string procedureName)
         {
             CreateProcedure(procedureName);
@@ -94,6 +97,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresParameterizedStoredProcedureAsync")]
         public async Task PostgresParameterizedStoredProcedureAsync(string procedureName)
         {
             CreateProcedure(procedureName);
@@ -124,6 +128,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresExecuteScalar")]
         public string PostgresExecuteScalar()
         {
             using (var connection = new NpgsqlConnection(PostgresConfiguration.PostgresConnectionString))
@@ -136,6 +141,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresExecuteScalarAsync")]
         public async Task<string> PostgresExecuteScalarAsync()
         {
             using (var connection = new NpgsqlConnection(PostgresConfiguration.PostgresConnectionString))
@@ -148,6 +154,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresIteratorTest")]
         public void PostgresIteratorTest()
         {
             var teamMembers = new List<string>();
@@ -169,6 +176,7 @@ namespace BasicMvcCoreApplication.Controllers
         }
 
         [HttpGet]
+        [Route("Postgres/PostgresAsyncIteratorTest")]
         public async Task<List<string>> PostgresAsyncIteratorTest()
         {
             var teamMembers = new List<string>();

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Startup.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Startup.cs
@@ -27,7 +27,10 @@ namespace BasicMvcCoreApplication
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddMvc(options =>
+            {
+                options.SuppressAsyncSuffixInActionNames = false;
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Startup.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Startup.cs
@@ -27,28 +27,18 @@ namespace BasicMvcCoreApplication
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvc();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Home/Error");
-            }
-
             app.UseStaticFiles();
+            app.UseRouting();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                endpoints.MapControllers();
             });
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -97,24 +97,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbAsyncCmdHandlerTestsCore21 : NsbAsyncCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbAsyncCmdHandlerTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbAsyncCmdHandlerTestsCore22 : NsbAsyncCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbAsyncCmdHandlerTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbAsyncCmdHandlerTestsCore31 : NsbAsyncCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbAsyncCmdHandlerTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -97,24 +97,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbAsyncEventHandlerTestsCore21 : NsbAsyncEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbAsyncEventHandlerTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbAsyncEventHandlerTestsCore22 : NsbAsyncEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbAsyncEventHandlerTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbAsyncEventHandlerTestsCore31 : NsbAsyncEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbAsyncEventHandlerTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -97,24 +97,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbCmdHandlerTestsCore21 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbCmdHandlerTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbCmdHandlerTestsCore22 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbCmdHandlerTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbCmdHandlerTestsCore31 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbCmdHandlerTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -97,24 +97,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbEventHandlerTestsCore21 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbEventHandlerTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbEventHandlerTestsCore22 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbEventHandlerTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbEventHandlerTestsCore31 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbEventHandlerTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -91,24 +91,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbPublishTestsCore21 : NsbPublishTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbPublishTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbPublishTestsCore22 : NsbPublishTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbPublishTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbPublishTestsCore31 : NsbPublishTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbPublishTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -91,24 +91,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbSendTestsCore21 : NsbSendTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbSendTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbSendTestsCore22 : NsbSendTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbSendTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbSendTestsCore31 : NsbSendTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbSendTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -108,24 +108,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
     }
 
     [NetCoreTest]
-    public class NsbThrowingHandlerTestsCore21 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public NsbThrowingHandlerTestsCore21(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NsbThrowingHandlerTestsCore22 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCore22>
-    {
-        public NsbThrowingHandlerTestsCore22(ConsoleDynamicMethodFixtureCore22 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    [NetCoreTest]
     public class NsbThrowingHandlerTestsCore31 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NsbThrowingHandlerTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
@@ -101,13 +101,4 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
         }
     }
 
-    [NetCoreTest]
-    public class RabbitMqDistributedTracingNetCore510Tests : RabbitMqDistributedTracingTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public RabbitMqDistributedTracingNetCore510Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
@@ -147,13 +147,4 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq
         }
     }
 
-    [NetCoreTest]
-    public class RabbitMqNetCore510Tests : RabbitMqTestsBase<ConsoleDynamicMethodFixtureCore21>
-    {
-        public RabbitMqNetCore510Tests(ConsoleDynamicMethodFixtureCore21 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
 }


### PR DESCRIPTION
## Description
- Removes test coverage for .Net Core 2.0, 2.1 and 2.2 as well as .Net Framework <= 4.6.2 on both bounded and unbounded integration tests solutions.

- Migrates the MockCollector to .Net 6. For some reasons, the migration caused the mock collector's response unappeasable by the clients so I did some modification to make sure clients (agent) can parse it.

- Migrates the BasicMvcCoreApplication in the UnboundedApplications to .Net Core 3.1. 