### PR TITLE
Direct base64 decode rpm package signing key

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -239,10 +239,11 @@ jobs:
 
       - name: Get GPG Key
         id: write_gpgkey
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'gpg.tar.bz2'
-          encodedString: ${{ secrets.GPG_KEY }}
+        run: |
+          filePath="/tmp/gpg.tar.bz2"
+          echo "${{ secrets.GPG_KEY }}" | base64 -d > $filePath
+          echo "::set-output name=filePath::$filePath"
+        shell: bash
 
       - name: Move Artifacts and GPG Key to Staging Location
         run: |

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -300,7 +300,7 @@ jobs:
         shell: bash
 
       - name: Clear Fastly cache
-        if: ${{ success() }}
+        if: ${{ github.event.inputs.deploy == 'true' && success() }}
         run: |
           curl -i -X POST -H 'Fastly-Key:${{ secrets.FASTLY_TOKEN }}' ${{ secrets.FASTLY_URL }}
         shell: bash


### PR DESCRIPTION
## Description

Simplify the agent deploy workflow by using a native system command instead of a 3rd-party action to decode the apt/yum repo signing key from GHA secrets.

Additionally, don't reset the Fastly cache unless something was actually deployed.

Successfully tested running the deploy workflow from this branch and using the test (non-production) APT/YUM repos: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/2545770791

I verified that the newly deployed version (9.9.0) was able to be installed on Ubuntu using the test package source after running the deploy with no errors.

# Author Checklist
- [ ] ~Unit tests, Integration tests, and Unbounded tests completed~ Tested the deploy workflow using the test deploy repo
- [ ] ~Performance testing completed with satisfactory results (if required)~ N/A
- [ ] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~ N/A 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
