### PR TITLE
Improve port availability check for integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -50,25 +50,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             try
             {
                 tcpListener.Start();
-                // we got the port, so can return (implicitly closes listener using finally block)
+                tcpListener.Stop();
                 return true;
             }
-            catch (Exception)
-            {
-                // we were unable to get the port
-                return false;
-            }
-            finally
-            {
-                try
-                {
-                    tcpListener.Stop();
-                }
-                catch (Exception)
-                {
-                    // Ignore errors stopping the listener
-                }
-            }
+            catch (Exception) { }
+            return false;
         }
 
         public static bool TryReleasePort(int port)


### PR DESCRIPTION
## Description

I noticed a random CI failure where we detected an available port, but the remote application was unable to claim said port when it actually tried starting up. After reviewing the existing logic, the attempt to release a port could fail, but the port could still be reported as available. This change requires the port to be successfully opened AND closed to be considered available.

The failure I saw in CI could still be a race condition for ports, but it doesn't look like it after reviewing logs. I believe this refactored port availability check will improve CI reliability. 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
