### PR TITLE
Resolve transaction trace aggregation race conditions

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 
+### Fixes
+* Resolves an issue with transaction trace aggregation where the slowest transaction trace was not always captured due to a race condition. ([#1166](https://github.com/newrelic/newrelic-dotnet-agent/pull/1166))
+
 ## [9.9.0] - 2022-06-08
 
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
@@ -68,15 +68,19 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     break;
+
                 case DataTransportResponseStatus.Retain:
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                case DataTransportResponseStatus.Discard:
-                default:
-                    // Feed collected samples back in if we didn't successfully send them
+                    // Retain collected samples if applicable
                     foreach (var traceSample in traceSamples)
                     {
                         Collect(traceSample);
                     }
+                    break;
+
+                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                case DataTransportResponseStatus.Discard:
+                default:
+                    Log.Warn($"Discarding {traceSamples.Count} transaction traces due to collector response.");
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
@@ -43,42 +43,41 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected override void Harvest()
         {
-            var traces = _transactionCollectors
+            var traceSamples = _transactionCollectors
                 .Where(t => t != null)
                 .SelectMany(t => t.GetCollectedSamples())
                 .Distinct()
+                .ToList();
+
+            var traceWireModels = traceSamples
                 .Select(t => t.CreateWireModel())
                 .ToList();
 
-            if (!traces.Any())
+            if (!traceWireModels.Any())
                 return;
 
-            LogUnencodedTraceData(traces);
+            LogUnencodedTraceData(traceWireModels);
 
-            var responseStatus = DataTransportService.Send(traces);
-            HandleResponse(responseStatus, traces);
+            var responseStatus = DataTransportService.Send(traceWireModels);
+            HandleResponse(responseStatus, traceSamples);
         }
 
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModel> traces)
+        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModelComponents> traceSamples)
         {
             switch (responseStatus)
             {
                 case DataTransportResponseStatus.RequestSuccessful:
-                    ClearTransactionTraces(); // Only clear traces after successfully sending data
                     break;
                 case DataTransportResponseStatus.Retain:
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                 case DataTransportResponseStatus.Discard:
                 default:
+                    // Feed collected samples back in if we didn't successfully send them
+                    foreach (var traceSample in traceSamples)
+                    {
+                        Collect(traceSample);
+                    }
                     break;
-            }
-        }
-
-        private void ClearTransactionTraces()
-        {
-            foreach (var transactionCollector in _transactionCollectors)
-            {
-                transactionCollector?.ClearCollectedSamples();
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/ITransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/ITransactionCollector.cs
@@ -23,7 +23,5 @@ namespace NewRelic.Agent.Core.TransactionTraces
         /// Returns an immutable enumerable of samples and clears the sample storage.
         /// </summary>
         IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples();
-
-        void ClearCollectedSamples();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
@@ -19,7 +19,7 @@ namespace NewRelic.Agent.Core.TransactionTraces
 
         public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
         {
-            if(transactionTraceWireModelComponents == null)
+            if (transactionTraceWireModelComponents == null)
             {
                 return;
             }

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
@@ -6,36 +6,43 @@ using System.Collections.Generic;
 using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 using System.Linq;
+using System.Collections.Concurrent;
+using System.Threading;
 
 namespace NewRelic.Agent.Core.TransactionTraces
 {
     public class SlowestTransactionCollector : ITransactionCollector, IDisposable
     {
-        private volatile TransactionTraceWireModelComponents _slowTransaction;
+        private volatile ConcurrentBag<TransactionTraceWireModelComponents> _slowTransactions = new ConcurrentBag<TransactionTraceWireModelComponents>();
 
         protected ConfigurationSubscriber ConfigurationSubscription = new ConfigurationSubscriber();
 
         public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
         {
             if (transactionTraceWireModelComponents.Duration <= ConfigurationSubscription.Configuration.TransactionTraceThreshold)
+            {
                 return;
+            }
 
-            if (_slowTransaction != null && _slowTransaction.Duration > transactionTraceWireModelComponents.Duration)
-                return;
-
-            _slowTransaction = transactionTraceWireModelComponents;
+            // If this is the slowest transaction so far, save it!
+            if (!_slowTransactions.Any(x => x.Duration > transactionTraceWireModelComponents.Duration))
+            {
+                _slowTransactions.Add(transactionTraceWireModelComponents);
+            }
         }
 
         public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
         {
-            var slowTransaction = _slowTransaction;
-            return slowTransaction == null ? Enumerable.Empty<TransactionTraceWireModelComponents>() :
-                new TransactionTraceWireModelComponents[] { slowTransaction };
-        }
+            var harvestedSlowTransactions = Interlocked.Exchange(ref _slowTransactions,
+                new ConcurrentBag<TransactionTraceWireModelComponents>());
 
-        public void ClearCollectedSamples()
-        {
-            _slowTransaction = null;
+            if (harvestedSlowTransactions.Count == 0)
+            {
+                return Enumerable.Empty<TransactionTraceWireModelComponents>();
+            }
+
+            var slowestTransaction = harvestedSlowTransactions.Aggregate((x, y) => x.Duration > y.Duration ? x : y);
+            return new TransactionTraceWireModelComponents[] { slowestTransaction };
         }
 
         public void Dispose()

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
@@ -19,6 +19,11 @@ namespace NewRelic.Agent.Core.TransactionTraces
 
         public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
         {
+            if(transactionTraceWireModelComponents == null)
+            {
+                return;
+            }
+
             if (transactionTraceWireModelComponents.Duration <= ConfigurationSubscription.Configuration.TransactionTraceThreshold)
             {
                 return;

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SyntheticsTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SyntheticsTransactionCollector.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.Transactions;
@@ -16,14 +17,22 @@ namespace NewRelic.Agent.Core.TransactionTraces
     {
         private volatile ConcurrentBag<TransactionTraceWireModelComponents> _collectedSamples = new ConcurrentBag<TransactionTraceWireModelComponents>();
 
-        private readonly ConfigurationSubscriber _configurationSubscription = new ConfigurationSubscriber();
-
         public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
         {
+            if (transactionTraceWireModelComponents == null)
+            {
+                return;
+            }
+
             if (!transactionTraceWireModelComponents.IsSynthetics)
+            {
                 return;
+            }
+
             if (_collectedSamples.Count >= SyntheticsHeader.MaxTraceCount)
+            {
                 return;
+            }
 
             _collectedSamples.Add(transactionTraceWireModelComponents);
         }
@@ -33,12 +42,10 @@ namespace NewRelic.Agent.Core.TransactionTraces
             var harvestedTransactions = Interlocked.Exchange(ref _collectedSamples,
                 new ConcurrentBag<TransactionTraceWireModelComponents>());
 
-            return harvestedTransactions;
+            // Due to race conditions in Collect, make sure we only return the MaxTraceCount
+            return harvestedTransactions.Take(SyntheticsHeader.MaxTraceCount);
         }
 
-        public void Dispose()
-        {
-            _configurationSubscription.Dispose();
-        }
+        public void Dispose() { }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/TransactionTraces/SlowestTransactionCollectorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/TransactionTraces/SlowestTransactionCollectorTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Transformers.TransactionTransformer;
+using NewRelic.Agent.Core.Utilities;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.TransactionTraces
+{
+    [TestFixture]
+    public class SlowestTransactionCollectorTests
+    {
+        public SlowestTransactionCollector ObjectUnderTest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var configuration = Mock.Create<IConfiguration>();
+            Mock.Arrange(() => configuration.TransactionTraceThreshold).Returns(TimeSpan.FromSeconds(5));
+            EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(configuration, ConfigurationUpdateSource.Unknown));
+            ObjectUnderTest = new SlowestTransactionCollector();
+        }
+
+        [Test]
+        public void DoesNotThrowWhenNullTransactionTraceIsCollected()
+        {
+            ObjectUnderTest.Collect(null);
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+            Assert.IsEmpty(samples);
+        }
+
+        [Test]
+        public void GettingCollectedSamplesWorksWhenEmpty()
+        {
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+            Assert.IsEmpty(samples);
+        }
+
+        [Test]
+        public void TransactionTraceIsCollectedWhenOverConfiguredThreshold()
+        {
+            var input = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(10), false, null);
+
+            ObjectUnderTest.Collect(input);
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+
+            Assert.AreEqual(1, samples.Length);
+            Assert.AreSame(input, samples[0]);
+        }
+
+        [Test]
+        public void TransactionTraceIsNotCollectedWhenUnderConfiguredThreshold()
+        {
+            var input = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(1), false, null);
+
+            ObjectUnderTest.Collect(input);
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+
+            Assert.IsEmpty(samples);
+        }
+
+        [Test]
+        public void SlowestTransactionTraceIsCollected()
+        {
+            var slowTransactionTrace = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(10), false, null);
+            var slowestTransactionTrace = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(15), false, null);
+
+            ObjectUnderTest.Collect(slowTransactionTrace);
+            ObjectUnderTest.Collect(slowestTransactionTrace);
+
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+
+            Assert.AreEqual(1, samples.Length);
+            Assert.AreSame(slowestTransactionTrace, samples[0]);
+        }
+
+        [Test]
+        public void FirstSlowTransactionTraceIsCollected()
+        {
+            var firstTransactionTrace = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(10), false, null);
+            var secondTransactionTrace = new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(10), false, null);
+
+            ObjectUnderTest.Collect(firstTransactionTrace);
+            ObjectUnderTest.Collect(secondTransactionTrace);
+
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+
+            Assert.AreEqual(1, samples.Length);
+            Assert.AreSame(firstTransactionTrace, samples[0]);
+        }
+
+        [Test]
+        public void SlowestTransactionTraceIsCollectedInThreadedScenario()
+        {
+            var transactionTraces = new List<TransactionTraceWireModelComponents>();
+            for(var i = 0; i < 1000; i++)
+            {
+                transactionTraces.Add(new TransactionTraceWireModelComponents(new TransactionMetricName("bleep", "bloop"), TimeSpan.FromSeconds(10 + i), false, null));
+            }
+
+            var collectionActions = new List<Action>();
+            foreach(var transactionTrace in transactionTraces)
+            {
+                collectionActions.Add(() => ObjectUnderTest.Collect(transactionTrace));
+            }
+
+            Parallel.Invoke(collectionActions.ToArray());
+
+            var samples = ObjectUnderTest.GetCollectedSamples().ToArray();
+
+            Assert.AreEqual(1, samples.Length);
+            Assert.AreSame(transactionTraces.Last(), samples[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

We have seen some test runs recently where the slowest transaction trace was not actually captured by the transaction trace aggregator. After reviewing the code there is a potential race condition where two transactions can be set as the 'slowest', but the actual slowest may not be retained due to a lack of locking.

This solution attempts to keep locking to a minimum, while ensuring we actually capture the slowest transaction.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
