### PR TITLE
CI Reliability: Increase collector timeout to 60 seconds, but wait there's more!

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Controllers/AsyncAwaitController.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Controllers/AsyncAwaitController.cs
@@ -45,6 +45,9 @@ namespace Owin2WebApi.Controllers
             await Task.Run(() => TaskRunBackgroundMethod());
             await Task.Factory.StartNew(TaskFactoryStartNewBackgroundMethod);
 
+            // Try to force this to be the slowest transaction
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
             return "Worked";
         }
 

--- a/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Controllers/AsyncAwaitController.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Controllers/AsyncAwaitController.cs
@@ -46,6 +46,9 @@ namespace Owin3WebApi.Controllers
             await Task.Run(() => TaskRunBackgroundMethod());
             await Task.Factory.StartNew(TaskFactoryStartNewBackgroundMethod);
 
+            // Try to force this to be the slowest transaction
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
             return "Worked";
         }
 

--- a/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Controllers/AsyncAwaitController.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Controllers/AsyncAwaitController.cs
@@ -45,6 +45,9 @@ namespace Owin4WebApi.Controllers
             await Task.Run(() => TaskRunBackgroundMethod());
             await Task.Factory.StartNew(TaskFactoryStartNewBackgroundMethod);
 
+            // Try to force this to be the slowest transaction
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
             return "Worked";
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -27,11 +27,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             _randomNumberDiety = new Random(seed);
         }
 
-
-        private static readonly object _lock = new object();
+        private static readonly object _usedPortLock = new object();
         public static int NextPort()
         {
-            lock (_lock)
+            lock (_usedPortLock)
             {
                 for (var countAttempts = 0; countAttempts < maxAttempts; countAttempts++)
                 {
@@ -53,9 +52,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         //but before the test app uses the assigned port.
         private static bool IsPortAvailable(int potentialPort)
         {
-            var tcpListener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
             try
             {
+                var tcpListener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
                 tcpListener.Start();
                 tcpListener.Stop();
                 return true;
@@ -66,6 +65,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public static bool TryReleasePort(int port)
         {
+            lock (_usedPortLock)
+            {
+                _usedPorts.Remove(port);
+            }
             return true;
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -16,21 +16,19 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         private const int maxPortID = 60000;
         private const int portPoolSize = maxPortID - minPortID;
         private const int maxAttempts = 200;
-
-        private static int _currentPortID;
+        private static Random RNJesus;
 
         static RandomPortGenerator()
         {
             var seed = Process.GetCurrentProcess().Id + AppDomain.CurrentDomain.Id + Environment.TickCount;
-            var rnd = new Random(seed);
-            _currentPortID = rnd.Next(portPoolSize);
+            RNJesus = new Random(seed);
         }
 
         public static int NextPort()
         {
             for (var countAttempts = 0; countAttempts < maxAttempts; countAttempts++)
             {
-                var potentialPort = (Interlocked.Increment(ref _currentPortID) % portPoolSize) + minPortID;
+                var potentialPort = RNJesus.Next(portPoolSize) + minPortID;
                 if (IsPortAvailable(potentialPort))
                 {
                     return potentialPort;

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -3,6 +3,8 @@
 
 
 using System;
+using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Sockets;
@@ -16,22 +18,29 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         private const int maxPortID = 60000;
         private const int portPoolSize = maxPortID - minPortID;
         private const int maxAttempts = 200;
-        private static Random RNJesus;
+        private static readonly Random _randomNumberDiety;
+        private static readonly HashSet<int> _usedPorts = new HashSet<int>();
 
         static RandomPortGenerator()
         {
             var seed = Process.GetCurrentProcess().Id + AppDomain.CurrentDomain.Id + Environment.TickCount;
-            RNJesus = new Random(seed);
+            _randomNumberDiety = new Random(seed);
         }
 
+
+        private static readonly object _lock = new object();
         public static int NextPort()
         {
-            for (var countAttempts = 0; countAttempts < maxAttempts; countAttempts++)
+            lock (_lock)
             {
-                var potentialPort = RNJesus.Next(portPoolSize) + minPortID;
-                if (IsPortAvailable(potentialPort))
+                for (var countAttempts = 0; countAttempts < maxAttempts; countAttempts++)
                 {
-                    return potentialPort;
+                    var potentialPort = _randomNumberDiety.Next(portPoolSize) + minPortID;
+                    if (!_usedPorts.Contains(potentialPort) && IsPortAvailable(potentialPort))
+                    {
+                        _usedPorts.Add(potentialPort);
+                        return potentialPort;
+                    }
                 }
             }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -439,7 +439,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "sendDataOnExit", "true");
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "sendDataOnExitThreshold", "0");
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "completeTransactionsOnThread", "true");
-            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "requestTimeout", "10000");
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "requestTimeout", "60000");
 
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
@@ -200,43 +200,32 @@ namespace NewRelic.Agent.IntegrationTests.Owin
 
             Assert.NotNull(metrics);
 
-            NrAssert.Multiple(
-                () => Assertions.MetricsExist(generalMetrics, metrics)
-            );
+            Assertions.MetricsExist(generalMetrics, metrics);
 
             var errorTraces = _fixture.AgentLog.GetErrorTraces().ToList();
             var errorEvents = _fixture.AgentLog.GetErrorEvents().ToList();
 
-            NrAssert.Multiple(
-                () => Assert.Single(errorTraces),
-                () => Assert.Single(errorTraces)
-            );
+            Assert.Single(errorTraces);
+            Assert.Single(errorEvents);
 
             var errorTrace = errorTraces.First();
             var errorEvent = errorEvents.First();
 
-            NrAssert.Multiple
-            (
-                () => Assert.Equal("500", errorTrace.ExceptionClassName),
-                () => Assert.Equal("500", errorEvent.IntrinsicAttributes["error.class"])
-            );
+            Assert.Equal("500", errorTrace.ExceptionClassName);
+            Assert.Equal("500", errorEvent.IntrinsicAttributes["error.class"]);
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(ioBoundNoSpecialAsyncMetrics, metrics),
-                () => Assertions.MetricsExist(ioBoundConfigureAwaitFalseAsyncMetrics, metrics),
-                () => Assertions.MetricsExist(cpuBoundTasksAsyncMetrics, metrics),
-                () => Assertions.MetricsExist(errorReponse, metrics)
-            );
+
+            Assertions.MetricsExist(ioBoundNoSpecialAsyncMetrics, metrics);
+            Assertions.MetricsExist(ioBoundConfigureAwaitFalseAsyncMetrics, metrics);
+            Assertions.MetricsExist(cpuBoundTasksAsyncMetrics, metrics);
+            Assertions.MetricsExist(errorReponse, metrics);
 
             Assertions.MetricsExist(customMiddlewareIoBoundNoSpecialAsyncMetrics, metrics);
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(manualTaskRunBlockedMetrics, metrics),
-                () => Assertions.MetricsExist(manualTaskFactoryStartNewMetrics, metrics),
-                () => Assertions.MetricsExist(manualNewThreadStartBlocked, metrics)
-            );
+
+            Assertions.MetricsExist(manualTaskRunBlockedMetrics, metrics);
+            Assertions.MetricsExist(manualTaskFactoryStartNewMetrics, metrics);
+            Assertions.MetricsExist(manualNewThreadStartBlocked, metrics);
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples().FirstOrDefault(sample => sample.Path == "WebTransaction/WebAPI/AsyncAwait/CpuBoundTasksAsync");
             var expectedTransactionTraceSegments = new List<string>
@@ -251,12 +240,9 @@ namespace NewRelic.Agent.IntegrationTests.Owin
                 { "request.uri", "/AsyncAwait/CpuBoundTasksAsync" },
             };
 
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceHasAttributes(expectedAttributes, TransactionTraceAttributeType.Agent, transactionSample)
-            );
+            Assert.NotNull(transactionSample);
+            Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample);
+            Assertions.TransactionTraceHasAttributes(expectedAttributes, TransactionTraceAttributeType.Agent, transactionSample);
         }
     }
 


### PR DESCRIPTION
## Description

CI reliability improvements:
- Increases the collector web request timeout to 60 seconds, from 10 seconds. This should improve CI stability with the staging collector timeouts we have experienced. 
- Increases transaction time for hopefully sampled transactions.
- Experimental changes to random port selection.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
