### PR TITLE
Placeholder integration test workflow

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -1,0 +1,14 @@
+name: Run Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  hello-world:
+    name: Placeholder job
+    runs-on: ubuntu-latest
+    steps:
+    - name: Hello World
+      run: echo "Hello world!"
+      shell: bash


### PR DESCRIPTION
In another branch I am working on a new manually-run workflow to run integration tests using the built assets from a previous all_solutions.yml workflow run.  This will let us more quickly and easily run integration tests in CI, improving developer productivity  in debugging and testing our ongoing CI instability issues.

GitHub Actions only lets you manually run workflows that exist on the main branch of your repo, although once there, you can choose to run a version of that workflow from another branch.  So, I need to get a placeholder version of this workflow merged to main so I can begin testing the real thing.