### PR TITLE
Upgrade Lambda OpenTracer project dependencies

### DIFF
--- a/src/AwsLambda/AwsLambdaOpenTracer/Tracer.csproj
+++ b/src/AwsLambda/AwsLambdaOpenTracer/Tracer.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
-    <PackageReference Include="OpenTracing" Version="0.12.0" />
-    <PackageReference Include="ILRepack" Version="2.0.16" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
+    <PackageReference Include="ILRepack" Version="2.0.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AwsLambda/AwsLambdaWrapper/Wrapper.csproj
+++ b/src/AwsLambda/AwsLambdaWrapper/Wrapper.csproj
@@ -8,18 +8,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.S3Events" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="1.0.0" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.3" />
-    <PackageReference Include="OpenTracing" Version="0.12.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
+    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.76" />
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.73" />
   </ItemGroup>
 </Project>

--- a/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
@@ -12,19 +12,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.S3Events" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
-    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.101.8" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.7" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.100.18" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.3.52" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.3.76" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.73" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">


### PR DESCRIPTION
## Description

Upgrade dependencies of the AWS Lambda OpenTracer projects, due to a [reported CVE](https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678) in a sub-dependency of some of these project references.

The AWS unit tests are still passing after this change.

Some manual end-to-end testing of the Lambda product with these changes is required before merging.

# Author Checklist
- [X] Unit tests
- [ ] Manual end-to-end testing
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
