### PR TITLE
Removing unused serialization reference from NewRelic.OpenTracing.AmazonLambda.Tracer

### DIFF
--- a/src/AwsLambda/AwsLambdaOpenTracer/Tracer.csproj
+++ b/src/AwsLambda/AwsLambdaOpenTracer/Tracer.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.1.0" />
     <PackageReference Include="OpenTracing" Version="0.12.0" />
     <PackageReference Include="ILRepack" Version="2.0.16" />
   </ItemGroup>


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Encountering an issue attempting to package a lambda for x64 linux runtime usage.

Publish: Project.csproj : error NU1605: Detected package downgrade: System.Runtime.InteropServices from 4.3.0 to 4.1.0. Reference the package directly from the project to select a different version. 
... publish: Project.csproj : error NU1605:  Project -> NewRelic.OpenTracing.AmazonLambda.Tracer 1.3.0 -> Amazon.Lambda.Serialization.Json 1.1.0 -> NETStandard.Library 1.6.0 -> Microsoft.Win32.Primitives 4.0.1 -> runtime.unix.Microsoft.Win32.Primitives 4.3.0 -> System.Runtime.InteropServices (>= 4.3.0) 
... publish: Project.csproj : error NU1605:  Project -> NewRelic.OpenTracing.AmazonLambda.Tracer 1.3.0 -> Amazon.Lambda.Serialization.Json 1.1.0 -> NETStandard.Library 1.6.0 -> System.Runtime.InteropServices (>= 4.1.0)
... publish: Project.csproj : error NU1605: Detected package downgrade: System.Collections from 4.3.0 to 4.0.11. Reference the package directly from the project to select a different version. 

The New Relic Lamba Tracer is referencing an older version of Amazon's serialization that utilizes Newtonsoft.json.  It appears that this reference is unused within New Relic's tracer and can be removed.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
