### PR TITLE
Fix three test apps that weren't actually waiting on their wait handles

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AgentApiExecutor/Program.cs
@@ -33,7 +33,8 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
                 return;
 
             // Create handle that RemoteApplication expects
-            new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
+            var eventWaitHandle =
+                new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
 
             CreatePidFile();
 
@@ -52,6 +53,10 @@ namespace NewRelic.Agent.IntegrationTests.Applications.AgentApiExecutor
             Api.Agent.NewRelic.NoticeError(new Exception("Rawr!"), errorAttributes);
 
             SomeOtherMethod();
+
+            // Wait for the test harness to tell us to shut down
+            eventWaitHandle.WaitOne(TimeSpan.FromMinutes(5));
+
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/Applications/ApiAppNameChange/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/ApiAppNameChange/Program.cs
@@ -26,13 +26,17 @@ namespace NewRelic.Agent.IntegrationTests.Applications.ApiAppNameChange
                 return;
 
             // Create handle that RemoteApplication expects
-            new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
+            var eventWaitHandle =
+                new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
 
             CreatePidFile();
 
             Api.Agent.NewRelic.SetApplicationName("AgentApi");
             Api.Agent.NewRelic.StartAgent();
             Api.Agent.NewRelic.SetApplicationName("AgentApi2");
+
+            // Wait for the test harness to tell us to shut down
+            eventWaitHandle.WaitOne(TimeSpan.FromMinutes(5));
         }
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/DistributedTracingApiApplication/Program.cs
@@ -54,7 +54,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
                 return;
 
             // Create handle that RemoteApplication expects
-            new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
+            var eventWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, "app_server_wait_for_all_request_done_" + program.Port);
 
             CreatePidFile();
 
@@ -71,6 +71,9 @@ namespace NewRelic.Agent.IntegrationTests.Applications.DistributedTracingApiAppl
                 var dtPayload = CallCreateDTPayload();
                 CallAcceptDTPayload(dtPayload);
             }
+
+            // wait for the test harness to tell us to shut down
+            eventWaitHandle.WaitOne(TimeSpan.FromMinutes(5));
         }
 
         [Transaction]


### PR DESCRIPTION
Potential fix for #1197 

I found that the test that had been failing semi-regularly in recent CI runs (`CustomInstrumentation.OtherTransaction`) with the "failed to send shutdown signal to $NAME_OF_APP_WAIT_HANDLE" error had a test app that wasn't actually waiting on its event wait handle...so it would be possible to encounter this error if the timing of things was just right.

~Draft PR to see if these changes actually fix the problem in CI~ The tests that had been failing before this didn't fail on the CI run for this PR, so it's ready for review.