### PR TITLE
Integration test framework should skip copying a `logs` subfolder of the home dirs

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
@@ -53,7 +53,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 // (On a development machine, the Extensions directory of the New Relic Home may contain
                 // custom instrumentation, too, which can get copied over and cause confusing test results;
                 // but there's no easy solution to this one, so ... don't do that.)
-                if (subdirectory.Name == "Logs")
+                if (subdirectory.Name.ToLower() == "logs")
                     continue;
                 var destinationSubdirectoryPath = Path.Combine(destinationDirectoryPath, subdirectory.Name);
                 CopyDirectory(subdirectory.FullName, destinationSubdirectoryPath, searchPattern);


### PR DESCRIPTION
This is a minor fix for a source of local integration test failures I've been seeing off and on for a while now.

1. The test harness, as part of the setting up each individual test, copies both the test application bits and the appropriate `newrelichome_` folder from `$repo_root/src/Agent` to a temp directory.
2. It's possible for there to already be existing log files in one or more of the homedirs.
3. Those existing logs can cause problems for the test logic since it assumes it's starting from a clean slate.
4. We already had logic to skip copying those logs if they were in a dir called `Logs` but apparently we can also get them in a dir called `logs`, so this PR modifies that logic to be case-insensitive.


