### PR TITLE
Added support for Labels to be set from AppSettings.json or web/app.config

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 
 ### New Features
+* Support of setting up labels via appsettings.json and app/web.config file. [#1204](https://github.com/newrelic/newrelic-dotnet-agent/pull/1204)
 
 ### Fixes
 * Resolves an issue where log forwarding could drop logs in async scenarios. [#1174](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1294,6 +1294,13 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
+                if (labels != null)
+                {
+                    Log.Info("Application labels from web.config or app.config.");
+                    return labels;
+                }
+
                 return EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1297,7 +1297,7 @@ namespace NewRelic.Agent.Core.Configuration
                 var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
                 if (labels != null)
                 {
-                    Log.Info("Application labels from web.config or app.config.");
+                    Log.Info("Application labels from web.config, app.config, or appsettings.json.");
                     return labels;
                 }
 


### PR DESCRIPTION
## Description
I have added support for Labels to be added/modified via AppSettings.json or app/web.config file. 
Our internal system does not allow to change of process variables or modification of other files than appsettings.json (cannot use newrelic.config).
So I cannot use the currently supported ways.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required) - should not be required for this PR
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
