### PR TITLE
Community: Added support for Labels to be set from AppSettings.json or web/app.config

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] changes
 
 ### New Features
+* Support of setting up labels via appsettings.json and app/web.config file. [#1204](https://github.com/newrelic/newrelic-dotnet-agent/pull/1204)
 
 ### Fixes
 * Resolves an issue where log forwarding could drop logs in async scenarios. [#1174](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1294,6 +1294,13 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
+                if (labels != null)
+                {
+                    Log.Info("Application labels from web.config, app.config, or appsettings.json.");
+                    return labels;
+                }
+
                 return EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1290,18 +1290,27 @@ namespace NewRelic.Agent.Core.Configuration
 
         #region Labels
 
+        private string _labels;
+        private bool _labelsChecked;
         public virtual string Labels
         {
             get
             {
-                var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
-                if (labels != null)
+                if (!_labelsChecked)
                 {
-                    Log.Info("Application labels from web.config, app.config, or appsettings.json.");
-                    return labels;
+                    var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
+                    if (labels != null)
+                    {
+                        Log.Info("Application labels from web.config, app.config, or appsettings.json.");
+                        _labels = labels;
+                    }
+                    else
+                    {
+                        _labels = EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
+                    }
+                    _labelsChecked = true;
                 }
-
-                return EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
+                return _labels;
             }
         }
 
@@ -1852,7 +1861,7 @@ namespace NewRelic.Agent.Core.Configuration
         public virtual bool LogMetricsCollectorEnabled
         {
             get
-            { 
+            {
                 return ApplicationLoggingEnabled &&
                     EnvironmentOverrides(_localConfiguration.applicationLogging.metrics.enabled, "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED");
             }


### PR DESCRIPTION
Internal PR for community contribution from @quigamdev : https://github.com/newrelic/newrelic-dotnet-agent/pull/1204.

.NET team added caching for the Labels field, and unit tests.

