### PR TITLE
Improve quality of log based assertions for collector requests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
@@ -411,26 +411,27 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private T SendDataOverWire<T>(ICollectorWire wire, string method, params object[] data)
         {
+            var requestGuid = Guid.NewGuid();
             try
             {
                 var serializedData = _serializer.Serialize(data);
-                var responseBody = wire.SendData(method, _connectionInfo, serializedData);
+                var responseBody = wire.SendData(method, _connectionInfo, serializedData, requestGuid);
                 return ParseResponse<T>(responseBody);
             }
             catch (Exceptions.HttpException ex)
             {
-                Log.DebugFormat("Received a {0} {1} response invoking method \"{2}\"", (int)ex.StatusCode, ex.StatusCode, method);
+                Log.DebugFormat("Request({0}): Received a {1} {2} response invoking method \"{3}\"", requestGuid, (int)ex.StatusCode, ex.StatusCode, method);
 
                 if (ex.StatusCode == HttpStatusCode.Gone)
                 {
-                    Log.Info("The server has requested that the agent disconnect. The agent is shutting down.");
+                    Log.InfoFormat("Request({0}): The server has requested that the agent disconnect. The agent is shutting down.", requestGuid);
                 }
 
                 throw;
             }
             catch (Exception ex)
             {
-                Log.DebugFormat("An error occurred invoking method \"{0}\": {1}", method, ex);
+                Log.DebugFormat("Request({0}): An error occurred invoking method \"{1}\": {2}", requestGuid, method, ex);
                 throw;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -62,11 +62,14 @@ namespace NewRelic.Agent.Core.DataTransport
 
         public string SendData(string method, ConnectionInfo connectionInfo, string serializedData)
         {
+            // Create a guid to uniquely identify this particular request in logs
+            var requestGuid = Guid.NewGuid();
+
             try
             {
                 var uri = GetUri(method, connectionInfo);
-
-                Log.DebugFormat("Invoking \"{0}\" with : {1}", method, serializedData);
+                
+                Log.DebugFormat("Request({0}): About to Invoke \"{1}\" with : {2}", requestGuid, method, serializedData);
                 AuditLog(Direction.Sent, Source.InstrumentedApp, uri);
                 AuditLog(Direction.Sent, Source.InstrumentedApp, serializedData);
 
@@ -81,7 +84,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 if (requestPayload.Data.Length > _configuration.CollectorMaxPayloadSizeInBytes)
                 {
                     // Log that the payload is being dropped. 
-                    Log.ErrorFormat("Dropped large payload: size: {0}, max_payload_size_bytes={1}", requestPayload.Data.Length, _configuration.CollectorMaxPayloadSizeInBytes);
+                    Log.ErrorFormat("Request({0}): Dropped large payload: size: {1}, max_payload_size_bytes={2}", requestGuid, requestPayload.Data.Length, _configuration.CollectorMaxPayloadSizeInBytes);
                     _agentHealthReporter.ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(method);
                     return "{}"; // mimics what is sent by NoOpCollectorWire
                 }
@@ -90,7 +93,10 @@ namespace NewRelic.Agent.Core.DataTransport
 
                 _agentHealthReporter.ReportSupportabilityDataUsage("Collector", method, uncompressedByteCount, new UTF8Encoding().GetBytes(response).Length);
 
-                Log.DebugFormat("Received : {0}", response);
+                // Possibly combine these logs? makes parsing harder in tests...
+                Log.DebugFormat("Request({0}): Invoked \"{1}\" with : {2}", requestGuid, method, serializedData);
+                Log.DebugFormat("Request({0}): Invocation of \"{1}\" yielded response : {2}", requestGuid, method, response);
+
                 AuditLog(Direction.Received, Source.Collector, response);
 
                 return response;
@@ -99,7 +105,7 @@ namespace NewRelic.Agent.Core.DataTransport
             {
                 var httpWebResponse = ex.Response as HttpWebResponse;
                 if (httpWebResponse != null)
-                    ThrowExceptionFromHttpWebResponse(serializedData, httpWebResponse);
+                    ThrowExceptionFromHttpWebResponse(serializedData, httpWebResponse, requestGuid);
 
                 if (_diagnoseConnectionError)
                     DiagnoseConnectionError(connectionInfo);
@@ -224,11 +230,11 @@ namespace NewRelic.Agent.Core.DataTransport
             }
         }
 
-        private static void ThrowExceptionFromHttpWebResponse(string serializedData, HttpWebResponse response)
+        private static void ThrowExceptionFromHttpWebResponse(string serializedData, HttpWebResponse response, Guid requestGuid)
         {
             if (response.StatusCode == HttpStatusCode.UnsupportedMediaType)
             {
-                Log.ErrorFormat("Invalid json: {0}.  Please report to support@newrelic.com", serializedData);
+                Log.ErrorFormat("Request({0}): had invalid json: {1}.  Please report to support@newrelic.com", requestGuid, serializedData);
             }
 
             // P17: Not supposed to read/use the exception message in the connect response body. We are still going to log it, carefully, since it is very useful for support.
@@ -237,12 +243,12 @@ namespace NewRelic.Agent.Core.DataTransport
                 using (var reader = new StreamReader(response.GetResponseStream(), ASCIIEncoding.ASCII))
                 {
                     var responseText = reader.ReadToEnd();
-                    Log.ErrorFormat("Received HTTP status code {0} with message {1}", response.StatusCode.ToString(), responseText);
+                    Log.ErrorFormat("Request({0}): received HTTP status code {1} with message {2}", requestGuid, response.StatusCode.ToString(), responseText);
                 }
             }
             catch (Exception exception)
             {
-                Log.ErrorFormat("Unable to parse repsonse body with {0}", exception.Message);
+                Log.ErrorFormat("Request({0}): Unable to parse response body with {1}", requestGuid, exception.Message);
             }
 
             throw new HttpException(response.StatusCode, response.StatusDescription);

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -60,11 +60,8 @@ namespace NewRelic.Agent.Core.DataTransport
             _agentHealthReporter = agentHealthReporter;
         }
 
-        public string SendData(string method, ConnectionInfo connectionInfo, string serializedData)
+        public string SendData(string method, ConnectionInfo connectionInfo, string serializedData, Guid requestGuid)
         {
-            // Create a guid to uniquely identify this particular request in logs
-            var requestGuid = Guid.NewGuid();
-
             try
             {
                 var uri = GetUri(method, connectionInfo);
@@ -234,7 +231,7 @@ namespace NewRelic.Agent.Core.DataTransport
         {
             if (response.StatusCode == HttpStatusCode.UnsupportedMediaType)
             {
-                Log.ErrorFormat("Request({0}): had invalid json: {1}.  Please report to support@newrelic.com", requestGuid, serializedData);
+                Log.ErrorFormat("Request({0}): Had invalid json: {1}.  Please report to support@newrelic.com", requestGuid, serializedData);
             }
 
             // P17: Not supposed to read/use the exception message in the connect response body. We are still going to log it, carefully, since it is very useful for support.
@@ -243,7 +240,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 using (var reader = new StreamReader(response.GetResponseStream(), ASCIIEncoding.ASCII))
                 {
                     var responseText = reader.ReadToEnd();
-                    Log.ErrorFormat("Request({0}): received HTTP status code {1} with message {2}", requestGuid, response.StatusCode.ToString(), responseText);
+                    Log.ErrorFormat("Request({0}): Received HTTP status code {1} with message {2}", requestGuid, response.StatusCode.ToString(), responseText);
                 }
             }
             catch (Exception exception)

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ICollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ICollectorWire.cs
@@ -1,10 +1,12 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace NewRelic.Agent.Core.DataTransport
 {
     public interface ICollectorWire
     {
-        string SendData(string method, ConnectionInfo connectionInfo, string serializedData);
+        string SendData(string method, ConnectionInfo connectionInfo, string serializedData, Guid requestGuid);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/NoOpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/NoOpCollectorWire.cs
@@ -1,11 +1,13 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace NewRelic.Agent.Core.DataTransport
 {
     public class NoOpCollectorWire : ICollectorWire
     {
-        public string SendData(string method, ConnectionInfo connectionInfo, string serializedData)
+        public string SendData(string method, ConnectionInfo connectionInfo, string serializedData, Guid requestGuid)
         {
             // Any valid JSON without an exception can be returned
             return "{}";

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string AgentReportingToLogLineRegex = InfoLogLinePrefixRegex + @"Reporting to: (.*)";
         public const string AgentConnectedLogLineRegex = InfoLogLinePrefixRegex + @"Agent fully connected.";
 
-        // Collector data capture regex's after succesful response
+        // Collector request data capture regex's after successful response
         public const string ConnectLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""connect"" with : (.*)";
         public const string TransactionSampleLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""transaction_sample_data"" with : (.*)";
         public const string MetricDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""metric_data"" with : (.*)";
@@ -42,10 +42,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string ErrorEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""error_event_data"" with : (.*)";
         public const string ThreadProfileDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""profile_data"" with : (.*)";
 
-        // Collector response content
+        // Collector responses
         public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":{""agent_run_id""(.*)";
         public const string ErrorResponseLogLinePrefixRegex = ErrorLogLinePrefixRegex + @"Request\(.{36}\): ";
-        //"Request({0}): Invocation of \"{1}\" yielded response : {2}"
 
         public const string ThreadProfileStartingLogLineRegex = InfoLogLinePrefixRegex + @"Starting a thread profiling session";
         public const string AgentWrapperApiCallLogLineRegex = DebugLogLinePrefixRegex + @"AgentWrapperApi call: (.*)\((.*)\)(?: - (.*))?";

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -29,28 +29,31 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string HarvestFinishedLogLineRegex = DebugLogLinePrefixRegex + @"Metric harvest finished.";
         public const string AgentReportingToLogLineRegex = InfoLogLinePrefixRegex + @"Reporting to: (.*)";
         public const string AgentConnectedLogLineRegex = InfoLogLinePrefixRegex + @"Agent fully connected.";
-        public const string ConnectLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""connect"" with : (.*)";
-        public const string ReceivedLogLineRegex = DebugLogLinePrefixRegex + @"Received : {""return_value""(.*)";
-        public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Received : {""return_value"":{""agent_run_id""(.*)";
-        public const string TransactionSampleLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""transaction_sample_data"" with : (.*)";
-        public const string MetricDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""metric_data"" with : (.*)";
-        public const string LogDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""log_event_data"" with : (.*)";
-        public const string ErrorTraceDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""error_data"" with : (.*)";
-        public const string SqlTraceDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""sql_trace_data"" with : (.*)";
-        public const string AnalyticsEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""analytic_event_data"" with : (.*)";
-        public const string AgentWrapperApiCallLogLineRegex = DebugLogLinePrefixRegex + @"AgentWrapperApi call: (.*)\((.*)\)(?: - (.*))?";
-        public const string ErrorEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""error_event_data"" with : (.*)";
-        public const string AgentInvokingMethodErrorLineRegex = DebugLogLinePrefixRegex + @"An error occurred invoking method";
-        public const string AgentConnectionErrorLineRegex = ErrorLogLinePrefixRegex + @"Unable to connect to the New Relic service at";
+
+        // Collector data capture regex's after succesful response
+        public const string ConnectLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""connect"" with : (.*)";
+        public const string TransactionSampleLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""transaction_sample_data"" with : (.*)";
+        public const string MetricDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""metric_data"" with : (.*)";
+        public const string LogDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""log_event_data"" with : (.*)";
+        public const string ErrorTraceDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""error_data"" with : (.*)";
+        public const string SqlTraceDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""sql_trace_data"" with : (.*)";
+        public const string AnalyticsEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""analytic_event_data"" with : (.*)";
+        public const string SpanEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""span_event_data"" with : (.*)";
+        public const string ErrorEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""error_event_data"" with : (.*)";
+        public const string ThreadProfileDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""profile_data"" with : (.*)";
+
+        // Collector response content
+        public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":{""agent_run_id""(.*)";
+        //"Request({0}): Invocation of \"{1}\" yielded response : {2}"
+
         public const string ThreadProfileStartingLogLineRegex = InfoLogLinePrefixRegex + @"Starting a thread profiling session";
-        public const string ThreadProfileDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""profile_data"" with : (.*)";
+        public const string AgentWrapperApiCallLogLineRegex = DebugLogLinePrefixRegex + @"AgentWrapperApi call: (.*)\((.*)\)(?: - (.*))?";
         public const string InstrumentationUpdateCommandLogLineRegex = DebugLogLinePrefixRegex + @"instrumentation_update command complete.";
         public const string RejitInstrumentationFileChanged = InfoLogLinePrefixRegex + @"Instrumentation change detected:(.*)";
         public const string InstrumentationRefreshFileWatcherStarted = InfoLogLinePrefixRegex + @"Starting instrumentation refresh from InstrumentationWatcher";
         public const string InstrumentationRefreshFileWatcherComplete = InfoLogLinePrefixRegex + @"Completed instrumentation refresh from InstrumentationWatcher";
         public const string ShutdownLogLineRegex = InfoLogLinePrefixRegex + @"The New Relic .NET Agent v.* has shutdown";
         public const string TransactionTransformCompletedLogLineRegex = FinestLogLinePrefixRegex + @"Transaction (.*) \((.*)\) transform completed.";
-        public const string SpanEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Invoking ""span_event_data"" with : (.*)";
         public const string TransactionEndedByGCFinalizerLogLineRegEx = DebugLogLinePrefixRegex + @"Transaction was garbage collected without ever ending(.*)";
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -44,6 +44,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         // Collector response content
         public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":{""agent_run_id""(.*)";
+        public const string ErrorResponseLogLinePrefixRegex = ErrorLogLinePrefixRegex + @"Request\(.{36}\): ";
         //"Request({0}): Invocation of \"{1}\" yielded response : {2}"
 
         public const string ThreadProfileStartingLogLineRegex = InfoLogLinePrefixRegex + @"Starting a thread profiling session";

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -40,7 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         public void Test()
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "received HTTP status code Gone with message {\"exception\":{\"message\":\"Account Security Violation: *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
@@ -138,14 +138,14 @@ namespace CompositeTests.CrossAgentTests.SecurityPolicies
         {
             var securityPolicies = JsonConvert.SerializeObject(testData.SecurityPolicies);
 
-            Mock.Arrange(() => _collectorWire.SendData("preconnect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>()))
+            Mock.Arrange(() => _collectorWire.SendData("preconnect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>(), Arg.IsAny<Guid>()))
                 .Returns("{'return_value': { 'redirect_host': '', 'security_policies': " + securityPolicies + "}}");
         }
 
         private void InitializeConnectResponse()
         {
             var jsonString = JsonConvert.SerializeObject(_compositeTestAgent.ServerConfiguration);
-            Mock.Arrange(() => _collectorWire.SendData("connect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>()))
+            Mock.Arrange(() => _collectorWire.SendData("connect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>(), Arg.IsAny<Guid>()))
                 .Returns((Func<string, ConnectionInfo, string, string>)((method, connectionInfo, serializedData) =>
                 {
                     _connectRawData = serializedData;

--- a/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
@@ -36,7 +37,7 @@ namespace CompositeTests
             var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic, configurationService);
 
             Mock.Arrange(() => collectorWireFactory.GetCollectorWire(null, Arg.IsAny<IAgentHealthReporter>())).IgnoreArguments().Returns(_collectorWire);
-            Mock.Arrange(() => _collectorWire.SendData("preconnect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>()))
+            Mock.Arrange(() => _collectorWire.SendData("preconnect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>(), Arg.IsAny<Guid>()))
                 .Returns("{'return_value': { 'redirect_host': ''}}");
 
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
@@ -159,7 +160,7 @@ namespace CompositeTests
             }
 
             var serverConfigJson = Newtonsoft.Json.JsonConvert.SerializeObject(_compositeTestAgent.ServerConfiguration);
-            Mock.Arrange(() => _collectorWire.SendData("connect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>()))
+            Mock.Arrange(() => _collectorWire.SendData("connect", Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>(), Arg.IsAny<Guid>()))
                 .Returns($"{{'return_value': {serverConfigJson} }}");
         }
 


### PR DESCRIPTION
## Description

Closes #1152 

Refactor log messages that are written for collector web requests to include a guid for continuity, and log before/after request.

Update test framework to inspect collector request payloads from SUCCESSFUL  requests only. This also eliminates race conditions where test applications were waiting on a log line that only indicated an external request was initiated, versus completed...

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
