### PR TITLE
Update all ubuntu 18.04 runners to 22.04

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -149,7 +149,7 @@ jobs:
         id: runcmd
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu18.04
           githubToken: ${{ github.token }}
           install: |
             apt-get update -q -y
@@ -604,7 +604,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2.0.5
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu18.04
           githubToken: ${{ github.token }}
 
           env: |

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -80,7 +80,7 @@ jobs:
   build-linux-x64-profiler:
     needs: cancel-previous-workflow-runs
     name: Build Linux x64 Profiler
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
@@ -124,7 +124,7 @@ jobs:
   build-linux-arm64-profiler:
     needs: cancel-previous-workflow-runs
     name: Build Linux ARM64 Profiler
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
@@ -149,7 +149,7 @@ jobs:
         id: runcmd
         with:
           arch: aarch64
-          distro: ubuntu18.04
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
           install: |
             apt-get update -q -y
@@ -582,7 +582,7 @@ jobs:
   run-integration-tests-linux-arm64:
     needs: build-test-fullagent-msi
     name: Run IntegrationTests linux-arm64
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: false
 
     env:
@@ -604,7 +604,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v2.0.5
         with:
           arch: aarch64
-          distro: ubuntu18.04
+          distro: ubuntu20.04
           githubToken: ${{ github.token }}
 
           env: |
@@ -787,7 +787,7 @@ jobs:
     needs: build-test-fullagent-msi
     if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
     name: Create RPM Package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -849,7 +849,7 @@ jobs:
     needs: build-test-fullagent-msi
     if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
     name: Create Debian package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -80,7 +80,7 @@ jobs:
   build-linux-x64-profiler:
     needs: cancel-previous-workflow-runs
     name: Build Linux x64 Profiler
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
@@ -124,7 +124,7 @@ jobs:
   build-linux-arm64-profiler:
     needs: cancel-previous-workflow-runs
     name: Build Linux ARM64 Profiler
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
@@ -582,7 +582,7 @@ jobs:
   run-integration-tests-linux-arm64:
     needs: build-test-fullagent-msi
     name: Run IntegrationTests linux-arm64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: false
 
     env:
@@ -787,7 +787,7 @@ jobs:
     needs: build-test-fullagent-msi
     if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
     name: Create RPM Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -849,7 +849,7 @@ jobs:
     needs: build-test-fullagent-msi
     if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
     name: Create Debian package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Github is deprecating its `ubuntu-18.04` runners: https://github.com/actions/runner-images/issues/6002

Upgrade all workflow references of `ubuntu-18.04` to `ubuntu-22.04`.

Note: was not able to upgrade the `distro` parameter in the `run-on-arch` jobs for building and testing the ARM version of the Linux profiler, due to build problems.  Doing this will take more effort as it's unclear what the cause of the problem is, but it seems to be in the general area of cmake/clang/llvm tooling.  This doesn't seem to be a problem since we don't have any indication that the `run-on-arch` action is deprecating the `ubuntu18.04` distro option.