### PR TITLE
Fix timing issue with RestSharpClientTaskCancelled requests

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/RestAPIController.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/RestAPIController.cs
@@ -24,6 +24,12 @@ namespace BasicMvcApplication.Controllers
         // GET: api/RestAPI/5
         public Bird Get(int id)
         {
+            // If the ID is 4, this request is coming from the RestSharpClientTaskCancelled parent
+            // endpoint and we need to ensure that the client times out before the request succeeds
+            if (id == 4)
+            {
+                System.Threading.Thread.Sleep(100);
+            }    
             //System.IO.File.AppendAllText(@"C:\IntegrationTestWorkingDirectory\RestAPIController.log", $"GET api/RestAPI/{id} called" + System.Environment.NewLine);
             return new Bird { CommonName = "Northern Flicker", BandingCode = "NOFL" };
         }


### PR DESCRIPTION
## Description

This change should ensure that this code executes as expected: https://github.com/newrelic/newrelic-dotnet-agent/blob/ffcf0d4ce27efa7e35cf751658b16ccdffed55df/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/RestSharpController.cs#L171-L173

by ensuring that the client times out before the request to `RestAPI/4` returns successfully.

This should fix this CI failure seen recently (also seen locally, and I verified that it passes reliably locally after the change): https://github.com/newrelic/newrelic-dotnet-agent/runs/7784160572?check_suite_focus=true

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
