### PR TITLE
Set ExclusiveAddressUse to true in RandomPortGenerator

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -55,6 +55,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             try
             {
                 var tcpListener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
+                tcpListener.ExclusiveAddressUse = true; // This is necessary to make this check meaningful at all
                 tcpListener.Start();
                 tcpListener.Stop();
                 return true;


### PR DESCRIPTION
## Description

See issue #1214 for details on how we concluded that this change was necessary.  However, I believe that this is the solution to the random CI failures caused by port availability conflicts.  See the documentation for [TcpListener.ExclusiveAddressUse](https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcplistener.exclusiveaddressuse?view=net-6.0) for an explanation.  Setting this property to true appears to make our port availability check actually work as expected.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
