### PR TITLE
CI Improvements

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Controllers/HomeController.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using AspNetCore3Features.Models;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace AspNetCore3Features.Controllers
 {
@@ -13,6 +14,8 @@ namespace AspNetCore3Features.Controllers
     {
         public IActionResult Index()
         {
+            // Tests expect this to be the traced transaction, so let's help them out
+            Thread.Sleep(1000);
             return View();
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -527,7 +527,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             Assert.True(succeeded, builder.ToString());
         }
 
-        private static Metric TryFindMetric(ExpectedMetric expectedMetric, IEnumerable<Metric> actualMetrics)
+        public static Metric TryFindMetric(ExpectedMetric expectedMetric, IEnumerable<Metric> actualMetrics)
         {
             foreach (var actualMetric in actualMetrics)
             {
@@ -544,7 +544,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return null;
         }
 
-        private static List<Metric> TryFindMetrics(ExpectedMetric expectedMetric, IEnumerable<Metric> actualMetrics)
+        public static List<Metric> TryFindMetrics(ExpectedMetric expectedMetric, IEnumerable<Metric> actualMetrics)
         {
             var foundMetrics = actualMetrics
                 .Where(actualMetric => (expectedMetric.IsRegexName && Regex.IsMatch(actualMetric.MetricSpec.Name, expectedMetric.metricName)) ||

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -86,6 +86,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             set { RemoteApplication.KeepWorkingDirectory = value; }
         }
 
+        // We think that the test retry loop may be masking real problems and/or actually causing them, so we've disabled it for now
         protected virtual int MaxTries => 1;
 
         public void DisableAsyncLocalCallStack()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -86,7 +86,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             set { RemoteApplication.KeepWorkingDirectory = value; }
         }
 
-        protected virtual int MaxTries => 3;
+        protected virtual int MaxTries => 1;
 
         public void DisableAsyncLocalCallStack()
         {

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ThreadProfileStressTests.cs
@@ -63,15 +63,20 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
             fixture.Initialize();
         }
 
-        [SkipUntilDateFact("2019-09-01", "This test is flaky and fails on the server almost all the time.")]
+        [Fact]
         public void Test()
         {
             NrAssert.Multiple(
                 () => Assert.Contains(@"""OTHER"":[[[""Native"",""Function Call"",0]", _threadProfileString),
                 () => Assert.Contains(@"[""ThreadProfileStressTest.Program"",""Main"",0]", _threadProfileString),
-                () => Assert.Contains(@"[""ThreadProfileStressTest.Program"",""DoTheThing"",0]", _threadProfileString),
-                () => Assert.Contains(@"[""ThreadProfileStressTest.Program"",""DoWork"",0]", _threadProfileString)
+                () => Assert.Contains(@"[""ThreadProfileStressTest.Program"",""DoTheThing"",0]", _threadProfileString)
             );
+
+            // This assertion has been commented out since the purpose of this test is to verify that the profiler doesn't CRASH
+            // when threads are frequently created/destroyed. In this stress scenario we are unable to capture stack traces for finalized
+            // threads. Ideally we would get atleast one sample with the 'DoWork' method, but the purpose of the test is to verify we don't crash
+
+            // Assert.Contains(@"[""ThreadProfileStressTest.Program"",""DoWork"",0]", _threadProfileString);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreGenericWebHostTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AspNetCore/AspNetCoreGenericWebHostTests.cs
@@ -39,6 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.AspNetCore
                     _fixture.ThrowException();
 
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.ErrorTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(2));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -1,8 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <RootNamespace>NewRelic.Agent.IntegrationTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.IntegrationTests</AssemblyName>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PublishIEDriver>true</PublishIEDriver>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,17 +29,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Selenium.Support" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
+    <PackageReference Include="Selenium.Support" Version="4.4.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />
+    <PackageReference Include="Selenium.WebDriver.IEDriver" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.0" />
     <PackageReference Include="xunit.core" Version="2.4.0" />
     <PackageReference Include="xunit.runner.console" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="WebDriver.IEDriverServer.win32" Version="3.150.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
@@ -59,12 +60,6 @@
     <ProjectReference Include="..\SharedApplications\WcfAppIisHosted\WcfAppIisHosted.csproj" />
   </ItemGroup>
   <Import Project="Test.targets" />
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Content Include="$(NuGetPackageRoot)\WebDriver.IEDriverServer.win32\3.150.1\content\IEDriverServer.exe">
-      <Link>IEDriverServer.exe</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebService.cs
@@ -3,6 +3,8 @@
 
 #if NETFRAMEWORK
 
+using System;
+using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using OpenQA.Selenium;
 using OpenQA.Selenium.IE;
@@ -17,6 +19,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             var driverService = InternetExplorerDriverService.CreateDefaultService();
             driverService.HideCommandPromptWindow = true;
             driverService.SuppressInitialDiagnosticInformation = true;
+            driverService.InitializationTimeout = TimeSpan.FromMinutes(2);
+            driverService.Port = RandomPortGenerator.NextPort();
 
             var options = new InternetExplorerOptions
             {
@@ -24,7 +28,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
                 IgnoreZoomLevel = true
             };
 
-            _driver = new InternetExplorerDriver(driverService, options);
+            _driver = new InternetExplorerDriver(driverService, options, TimeSpan.FromMinutes(2));
         }
 
         public void InvokeAsyncCall()

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersEnabledTests.cs
@@ -235,7 +235,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.EnvironmentVaria
                        .EnableSpanEvents(true);
 
                     fixture.EnvironmentVariables.Add("NEW_RELIC_ALLOW_ALL_HEADERS", "true");
-                    fixture.EnvironmentVariables.Add("NEW_RELIC_ATTRIBUTES_EXCLUDE", "request.headers.referer,request.headers.accept");
+                    fixture.EnvironmentVariables.Add("NEW_RELIC_ATTRIBUTES_EXCLUDE", "request.headers.referer,request.headers.accept,request.headers.cookie");
                 }
             );
 
@@ -279,7 +279,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.EnvironmentVaria
                        .EnableSpanEvents(true);
 
                     fixture.EnvironmentVariables.Add("NEW_RELIC_ALLOW_ALL_HEADERS", "true");
-                    fixture.EnvironmentVariables.Add("NEW_RELIC_ATTRIBUTES_EXCLUDE", "request.headers.referer, request.headers.accept");
+                    fixture.EnvironmentVariables.Add("NEW_RELIC_ATTRIBUTES_EXCLUDE", "request.headers.referer, request.headers.accept, request.headers.cookie");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -61,6 +61,7 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/PUT", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1},
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
@@ -84,25 +85,6 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assert.NotNull(transactionEventWithExternal)
             );
-
-            // The external call in the RestSharpClientTaskCancelled controller method will be reported as either an External, or ExternalTransaction depending on timing...
-            var atleastOneMustExist = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1 }
-            };
-
-            bool atleastOneMetricFound = false;
-            foreach( var metric in atleastOneMustExist )
-            {
-                if( Assertions.TryFindMetric(metric, metrics) != null )
-                {
-                    Assertions.MetricExists(metric, metrics);
-                    Assert.False(atleastOneMetricFound, $"Only one of the following metrics should have been found, but both were: {atleastOneMustExist[0]}, {atleastOneMustExist[1]}");
-                    atleastOneMetricFound = true;
-                }
-            }
-            Assert.True(atleastOneMetricFound, $"One of the following metrics should have been found, but none were: {atleastOneMustExist[0]}, {atleastOneMustExist[1]}");
 
             var agentWrapperErrorRegex = AgentLogBase.ErrorLogLinePrefixRegex + @"An exception occurred in a wrapper: (.*)";
             var wrapperError = _fixture.AgentLog.TryGetLogLine(agentWrapperErrorRegex);

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -27,6 +27,7 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
 
+                    configModifier.SetLogLevel("finest");
                     configModifier.EnableCat();
                     configModifier.ForceTransactionTraces();
                 },
@@ -60,7 +61,6 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/PUT", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1},
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
@@ -84,6 +84,25 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assert.NotNull(transactionEventWithExternal)
             );
+
+            // The external call in the RestSharpClientTaskCancelled controller method will be reported as either an External, or ExternalTransaction depending on timing...
+            var atleastOneMustExist = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1 }
+            };
+
+            bool atleastOneMetricFound = false;
+            foreach( var metric in atleastOneMustExist )
+            {
+                if( Assertions.TryFindMetric(metric, metrics) != null )
+                {
+                    Assertions.MetricExists(metric, metrics);
+                    Assert.False(atleastOneMetricFound, $"Only one of the following metrics should have been found, but both were: {atleastOneMustExist[0]}, {atleastOneMustExist[1]}");
+                    atleastOneMetricFound = true;
+                }
+            }
+            Assert.True(atleastOneMetricFound, $"One of the following metrics should have been found, but none were: {atleastOneMustExist[0]}, {atleastOneMustExist[1]}");
 
             var agentWrapperErrorRegex = AgentLogBase.ErrorLogLinePrefixRegex + @"An exception occurred in a wrapper: (.*)";
             var wrapperError = _fixture.AgentLog.TryGetLogLine(agentWrapperErrorRegex);

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
@@ -98,6 +98,7 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                 var url = (string)spanEvent.AgentAttributes["http.url"];
                 if (url.Contains("/RestAPI/4"))
                 {
+                    // When an id of 4 is supplied, the client is supposed to timeout before the server has a chance to respond, so no status code
                     Assert.DoesNotContain("http.statusCode", spanEvent.AgentAttributes.Keys);
                 }
                 else

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -150,7 +150,7 @@ namespace MultiFunctionApplicationHelpers
     {
         protected static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
-        protected override int MaxTries => 3;
+        protected override int MaxTries => 1;
 
         private List<string> _commands = new List<string>();
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
@@ -120,7 +120,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries
             var bindingNode = l.SelectSingleNode("configuration/system.applicationHost/sites/site/bindings/binding");
             bindingNode.Attributes["bindingInformation"].Value = $"*:{port}:";
 
-            var appPoolName = $"HWCTest{port}";
+            var appPoolName = $"HWCTest{port}-{Guid.NewGuid()}";
 
             var appPoolNode = l.SelectSingleNode("configuration/system.applicationHost/applicationPools/add");
             appPoolNode.Attributes["name"].Value = appPoolName;

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -389,8 +389,6 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 {
                     throw;
                 }
-
-
                 ConsoleMFLogger.Info("Ignoring TergetInvocationException -> WCF Fault Exception<ExceptionDetail>!");
             }
             catch (ProtocolException)
@@ -408,7 +406,11 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         private WcfClient CreateClientWithWebHttpBinding(Uri endpointAddress)
         {
             var webHttpBehavior = new WebHttpBehavior { DefaultBodyStyle = WebMessageBodyStyle.Bare, DefaultOutgoingRequestFormat = WebMessageFormat.Xml, DefaultOutgoingResponseFormat = WebMessageFormat.Xml };
-            var binding = new WebHttpBinding();
+            var binding = new WebHttpBinding
+            {
+                ReceiveTimeout = TimeSpan.FromMinutes(2)
+            };
+
             var endpoint = new EndpointAddress(endpointAddress);
             var client = new WcfClient(binding, endpoint);
             client.ChannelFactory.Endpoint.EndpointBehaviors.Add(webHttpBehavior);
@@ -418,14 +420,21 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
 
         private WcfClient CreateClientWithHttpBinding(Uri endpointAddress)
         {
-            var binding = new BasicHttpBinding();
+            var binding = new BasicHttpBinding()
+            {
+                ReceiveTimeout = TimeSpan.FromMinutes(2)
+            };
+
             var endpoint = new EndpointAddress(endpointAddress);
             return new WcfClient(binding, endpoint);
         }
 
         private WcfClient CreateClientWithWSHttpBinding(Uri endpointAddress, SecurityMode? securityMode = null)
         {
-            var binding = new WSHttpBinding();
+            var binding = new WSHttpBinding()
+            {
+                ReceiveTimeout = TimeSpan.FromMinutes(2)
+            };
 
             if (securityMode.HasValue)
                 binding.Security.Mode = securityMode.Value;
@@ -437,7 +446,11 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
 
         private WcfClient CreateClientWithNetTCPBinding(Uri endpointAddress)
         {
-            var binding = new NetTcpBinding();
+            var binding = new NetTcpBinding()
+            {
+                ReceiveTimeout = TimeSpan.FromMinutes(2)
+            };
+
             var endpoint = new EndpointAddress(endpointAddress);
 
             return new WcfClient(binding, endpoint);
@@ -446,6 +459,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         private WcfClient CreateClientWithCustomBinding(Uri endpointAddress, string configurationName = null)
         {
             var binding = WCFLibraryHelpers.GetCustomBinding(configurationName);
+            binding.ReceiveTimeout = TimeSpan.FromMinutes(2);
             var endpoint = new EndpointAddress(endpointAddress);
             return new WcfClient(binding, endpoint);
         }


### PR DESCRIPTION
## Description

I spent around 10 hours running CI on a powerful VM and dug in to any random failures I encountered locally. Here are the results of my adventures.

Resolves the following issues with CI runs:
- Adds a sleep to a AspNetCore3 test app to a method that is expected to be the traced transaction
- Eliminates test harness retries as the retry obfuscates the initial failure, and causes unrelated failures in some cases. This should allow us to see the actual failures. We may decide to turn retries back on, but for now I believe we should disable retries.
- Upgrades the selenium IE driver. I attempted to migrate to the Chrome driver, but there are issues with incompatibilities with the version of chrome on the GHA CI Runners... Since IE hasn't been updated in forever, it seems to work everywhere (except windows 11).
- Sets a custom (and available) port for the Selenium driver instead of relying on the default port to be available.
- Increase timeouts for selenium webdriver initialization based on timeouts encountered when running all Integration tests in parallel
- Changes a key assertion in the ThreadProfileStressTest that was failing on fast machines. The purpose of the test is to verify that we don't CRASH when threads are finalized before we have a chance to request call stacks. On fast/modern machines, these threads are almost always finalized by the time we try to get call stacks. The test was failing because we expected to be able to capture the callstack atleast once. This is why it worked on slower (CI) machines. This is the comment that I found which makes me believe this is the correct fix: https://github.com/newrelic/newrelic-dotnet-agent/blob/2ba99ea91ac20f79af40259e485949c6b3b1aac3/tests/Agent/IntegrationTests/Applications/ThreadProfileStressTest/Program.cs#L68-L72
- Add log delay check for transaction finalization to AspNetCore web tests
- Add an explicit exclude for `request.headers.cookie` to some tests that failed depending on which framework they were run in due to test client differences (worked in .NET Framework, failed in .NET Core).
- Harden a CAT test by allowing the same metric in two different forms based on a race condition in the test.
- Update HostedWebCore application to use unique application pool names
- Increase WCFClient timeouts based on failures seen during local parallel test runs

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [x] Perform code review