### PR TITLE
CI Stability Improvements

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/Program.cs
@@ -34,7 +34,7 @@ namespace AspNetCore3BasicWebApiApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3BasicWebApiApplication/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:46116",
-      "sslPort": 44301
+        "applicationUrl": "http://127.0.0.1:46116",
+        "sslPort": 44301
     }
   },
   "profiles": {
@@ -18,13 +18,13 @@
       }
     },
     "AspNetCore3BasicWebApiApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "launchBrowser": true,
+        "launchUrl": "weatherforecast",
+        "applicationUrl": "https://127.0.0.1:5001;http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCore3Features
                 {
                     webBuilder
                         .UseStartup<Startup>()
-                        .UseUrls($@"http://localhost:{_port}/");
+                        .UseUrls($@"http://127.0.0.1:{_port}/");
                 });
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore3Features/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 ﻿{
   "iisSettings": {
     "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:14770",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:14770",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCore3Features": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "launchBrowser": true,
+        "applicationUrl": "http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore5BasicWebApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore5BasicWebApiApplication/Program.cs
@@ -38,7 +38,7 @@ namespace AspNetCore5BasicWebApiApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore5BasicWebApiApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore5BasicWebApiApplication/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:50492",
-      "sslPort": 44384
+        "applicationUrl": "http://127.0.0.1:50492",
+        "sslPort": 44384
     }
   },
   "profiles": {
@@ -18,14 +18,14 @@
       }
     },
     "AspNet5BasicWebApiApplication": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": "true",
+        "launchBrowser": true,
+        "launchUrl": "swagger",
+        "applicationUrl": "https://127.0.0.1:5001;http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore6BasicWebApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore6BasicWebApiApplication/Program.cs
@@ -38,7 +38,7 @@ namespace AspNetCore6BasicWebApiApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCore6BasicWebApiApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCore6BasicWebApiApplication/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:50492",
-      "sslPort": 44384
+        "applicationUrl": "http://127.0.0.1:50492",
+        "sslPort": 44384
     }
   },
   "profiles": {
@@ -18,14 +18,14 @@
       }
     },
     "AspNet5BasicWebApiApplication": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "dotnetRunMessages": "true",
+        "launchBrowser": true,
+        "launchUrl": "swagger",
+        "applicationUrl": "https://127.0.0.1:5001;http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Program.cs
@@ -32,7 +32,7 @@ namespace AspNetCoreDistTracingApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls(string.Format(@"http://localhost:{0}/", _port))
+                .UseUrls(string.Format(@"http://127.0.0.1:{0}/", _port))
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:25508/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:25508/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCoreDistTracingApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:25509/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:25509/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreMvcAsyncApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:13144/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:13144/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCoreMvcAsyncApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:13145/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:13145/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreMvcBasicRequestsApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:52622/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:52622/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "BasicMvcCoreApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:52623/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:52623/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Program.cs
@@ -29,7 +29,7 @@ namespace AspNetCoreMvcCoreFrameworkApplication
         public static IWebHost BuildWebHost(string[] args, string port) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{port}/")
+                .UseUrls($@"http://127.0.0.1:{port}/")
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Properties/launchSettings.json
@@ -2,10 +2,10 @@
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:9125",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:9125",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -18,13 +18,13 @@
       }
     },
     "AspNetCoreMvcCoreFrameworkApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "api/values",
-      "applicationUrl": "http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "launchBrowser": true,
+        "launchUrl": "api/values",
+        "applicationUrl": "http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Program.cs
@@ -70,7 +70,7 @@ namespace AspNetCoreMvcFrameworkApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:4390/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:4390/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCoreMvcFrameworkApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:4391/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:4391/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Program.cs
@@ -52,7 +52,7 @@ namespace AspNetCoreMvcFrameworkAsyncApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:61843/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:61843/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCoreMvcFrameworkAsyncApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:61844/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:61844/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Program.cs
@@ -32,7 +32,7 @@ namespace AspNetCoreMvcRejitApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:57735/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:57735/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "AspNetCoreMvcRejitApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:57736/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:57736/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Program.cs
@@ -34,7 +34,7 @@ namespace AspNetCoreWebApiCustomAttributesApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls(string.Format(@"http://localhost:{0}/", _port))
+                .UseUrls(string.Format(@"http://127.0.0.1:{0}/", _port))
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:61986/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:61986/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -17,13 +17,13 @@
       }
     },
     "AspNetCoreWebApiCustomAttributesApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "api/values",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:61987/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "launchUrl": "api/values",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:61987/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/RedisController.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/RedisController.cs
@@ -12,7 +12,7 @@ namespace BasicMvcApplication.Controllers
     {
         public string Get()
         {
-            using (var client = new RedisClient("localhost"))
+            using (var client = new RedisClient("127.0.0.1"))
             {
                 client.ServerVersionNumber = 1;
 

--- a/tests/Agent/IntegrationTests/Applications/CustomAttributesWebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/CustomAttributesWebApi/Program.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.CustomAttributesWebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:24279/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:24279/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "MockNewRelic": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:24280/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:24280/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin2WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin3WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin4WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Controllers/RemoteController.cs
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Controllers/RemoteController.cs
@@ -14,14 +14,14 @@ namespace OwinRemotingClient.Controllers
         [Route("GetObjectTcp")]
         public string GetObjectTcp()
         {
-            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "tcp://localhost:7878/GetObject");
+            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "tcp://127.0.0.1:7878/GetObject");
             return GetObject(myMarshalByRefClassObj);
         }
 
         [Route("GetObjectHttp")]
         public string GetObjectHttp()
         {
-            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "http://localhost:7879/GetObject");
+            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "http://127.0.0.1:7879/GetObject");
             return GetObject(myMarshalByRefClassObj);
         }
 

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Program.cs
@@ -31,7 +31,7 @@ namespace OwinRemotingClient
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Program.cs
@@ -38,7 +38,7 @@ namespace SerilogSumologicApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:50817/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:50817/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "sumologictest": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:50818/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:50818/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/AppHost.cs
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/AppHost.cs
@@ -27,7 +27,7 @@ namespace ServiceStackApplication
             // This plugin attempts to serialize everything in HttpContext using ServiceStack.Text
             // It tests that we do not reintroduce a StackOverflow issue that can crash apps.
             // We don't formally take responsibility over this but we do our best to do no harm.
-            Plugins.Add(new SeqRequestLogsFeature { SeqUrl = "http://localhost:5341" });
+            Plugins.Add(new SeqRequestLogsFeature { SeqUrl = "http://127.0.0.1:5341" });
         }
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/ThreadProfileStressTest/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/ThreadProfileStressTest/Program.cs
@@ -27,11 +27,11 @@ namespace ThreadProfileStressTest
 
             _applicationName = Path.GetFileNameWithoutExtension(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath) + ".exe";
 
-            Console.WriteLine($"[{_applicationName}] Invoked with args: { string.Join(" ", args) }");
+            Console.WriteLine($"[{_applicationName}] Invoked with args: {string.Join(" ", args)}");
 
             var port = GetPortFromArgs(args) ?? DefaultPort;
 
-            Console.WriteLine($"[{_applicationName}] Parsed port: { port }");
+            Console.WriteLine($"[{_applicationName}] Parsed port: {port}");
 
             var eventWaitHandleName = "app_server_wait_for_all_request_done_" + port;
 

--- a/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
+++ b/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
@@ -102,7 +102,7 @@
 				<property id="2120" dataType="MultiSZ" userType="1" attributes="None" value="400,0,,,0&#xA;" />
 			</key>
 		</customMetadata>
-		<!-- The <listenerAdapters> section defines the protocols with which the Windows Process Activation Service (WAS) binds. -->
+		<!-- The <listenerAdapters> section defines the protocols with which the Windows Process Activation ServiceF (WAS) binds. -->
 		<listenerAdapters>
 			<add name="http" />
 		</listenerAdapters>
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="*:80:" />
+					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -67,7 +67,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 tcp4Listener.Stop();
 
                 var tcp6Listener = new TcpListener(System.Net.IPAddress.IPv6Any, potentialPort);
-				tcp6Listener.ExclusiveAddressUse = true;
+                tcp6Listener.ExclusiveAddressUse = true;
                 tcp6Listener.Start();
                 tcp6Listener.Stop();
 
@@ -117,10 +117,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public static bool TryReleasePort(int port)
         {
-            lock (_usedPortLock)
-            {
-                _usedPorts.Remove(port);
-            }
             return true;
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RandomPortGenerator.cs
@@ -7,6 +7,9 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -46,7 +49,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             throw new Exception($"Unable to obtain port after {maxAttempts} attempts.");
         }
 
-
         //Checks if something outside our current test run instance is currently using the port.
         //This does not prevent us from getting into a conflict with another process taking that port after this check,
         //but before the test app uses the assigned port.
@@ -54,13 +56,62 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         {
             try
             {
-                var tcpListener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
-                tcpListener.ExclusiveAddressUse = true; // This is necessary to make this check meaningful at all
-                tcpListener.Start();
-                tcpListener.Stop();
-                return true;
+                if (!IsPortAvailableAccordingToOS(potentialPort))
+                {
+                    return false;
+                }
+
+                var tcp4Listener = new TcpListener(System.Net.IPAddress.Any, potentialPort);
+                tcp4Listener.ExclusiveAddressUse = true;
+                tcp4Listener.Start();
+                tcp4Listener.Stop();
+
+                var tcp6Listener = new TcpListener(System.Net.IPAddress.IPv6Any, potentialPort);
+				tcp6Listener.ExclusiveAddressUse = true;
+                tcp6Listener.Start();
+                tcp6Listener.Stop();
+
+                // Try to create a HTTP listener if we can, since this is what most test apps do.
+                if (HttpListener.IsSupported)
+                {
+                    HttpListener listener = new HttpListener();
+                    listener.Prefixes.Add($"http://127.0.0.1:{potentialPort}/port-check-{Guid.NewGuid()}/");
+                    listener.Start();
+                    listener.Stop();
+                }
+
+                return WaitUntilPortIsReportedAvailable(potentialPort);
             }
             catch (Exception) { }
+            return false;
+        }
+
+        private static bool IsPortAvailableAccordingToOS(int port)
+        {
+            var activeListeners = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners();
+            if (activeListeners.Any(x => x.Port == port))
+            {
+                return false;
+            }
+
+            var activeConnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
+            if (activeConnections.Any(x => x.LocalEndPoint.Port == port))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool WaitUntilPortIsReportedAvailable(int port, int waitSecond = 5)
+        {
+            for (var waitDeadline = DateTime.Now + TimeSpan.FromSeconds(waitSecond); DateTime.Now < waitDeadline; Thread.Sleep(100))
+            {
+                if (IsPortAvailableAccordingToOS(port))
+                {
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -200,7 +200,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
         public int Port => _port ?? (_port = RandomPortGenerator.NextPort()).Value;
 
-        public readonly string DestinationServerName = Dns.GetHostName().ToLower();
+        public readonly string DestinationServerName = "127.0.0.1";
 
         private NewRelicConfigModifier _newRelicConfigModifier;
         public NewRelicConfigModifier NewRelicConfig => _newRelicConfigModifier ?? (_newRelicConfigModifier = new NewRelicConfigModifier(DestinationNewRelicConfigFilePath));

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteService.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 {
     public class RemoteService : RemoteApplication
     {
-        private static readonly ConcurrentDictionary<string, object> PublishCoreAppLocks = new ConcurrentDictionary<string, object>();
+        private static readonly object _dotnetPublishLockObject = new object();
 
         protected readonly string _executableName;
 
@@ -130,7 +130,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
             //We cannot run dotnet publish against the same directory concurrently.
             //Doing so causes the publish job to fail because it can't obtain a lock on files in the obj and bin directories.
-            lock (GetPublishLockObjectForCoreApp())
+            lock (_dotnetPublishLockObject)
             {
                 process.Start();
 
@@ -175,14 +175,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
             Console.WriteLine($"[{DateTime.Now}] Successfully published {projectFile} to {deployPath}");
         }
-
-        private object GetPublishLockObjectForCoreApp()
-        {
-            return PublishCoreAppLocks.GetOrAdd(ApplicationDirectoryName, _ => new object());
-        }
-
-
-
 
         public override void Start(string commandLineArguments, Dictionary<string, string> environmentVariables, bool captureStandardOutput = false, bool doProfile = true)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
@@ -182,7 +182,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             };
             var attributes = new[]
             {
-                new KeyValuePair<string, string>("bindingInformation", string.Format(@"*:{0}:", Port)),
+                new KeyValuePair<string, string>("bindingInformation", string.Format(@"127.0.0.1:{0}:", Port)),
             };
             CommonUtils.ModifyOrCreateXmlAttributes(DestinationApplicationHostConfigFilePath, string.Empty, nodes, attributes);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
@@ -42,6 +42,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                     _fixture.FirstCallApplication.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(15), ExpectedTransactionCount);
                     _fixture.SecondCallApplication.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(15), ExpectedTransactionCount);
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(15), ExpectedTransactionCount);
+
+                    // We need the metrics to be sent for this test
+                    _fixture.FirstCallApplication.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(60));
+                    _fixture.SecondCallApplication.AgentLog.WaitForLogLines(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(60));
                 }
             );
 
@@ -363,10 +367,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 
@@ -408,10 +412,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingSender/CallNext").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingReceiver/CallEnd").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
@@ -80,7 +80,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/CallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/CallNext/{nextUrl}").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/DistributedTracingController/MakeExternalCallUsingRestClient").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/RestAPI/Get").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -71,7 +71,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
                     _fixture.AddCommand("ProcessRunner AddArgument -m unittest");
                     _fixture.AddCommand("ProcessRunner AddSwitch -v");
                     _fixture.AddCommand($@"ProcessRunner WorkingDirectory {Path.Combine(_fixture.RemoteApplication.DestinationApplicationDirectoryPath, "trace-context", "test")}"); // python W3C tests are in test dir
-                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT http://localhost:{_fixture.RemoteApplication.Port}/test");
+                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT http://127.0.0.1:{_fixture.RemoteApplication.Port}/test");
                     _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable STRICT_LEVEL 1");
                     _fixture.AddCommand("ProcessRunner Start");
                     _fixture.AddCommand("ProcessRunner WaitforExit 30000");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
@@ -59,7 +59,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
             var senderAppSpanEvents = _fixture.AgentLog.GetSpanEvents();
             var receiverAppSpanEvents = _fixture.ReceiverApplication.AgentLog.GetSpanEvents();
 
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET")
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET")
                 .FirstOrDefault();
             Assert.Equal(externalSpanEvent.IntrinsicAttributes["guid"], receiverAppTxEvent.IntrinsicAttributes["parentSpanId"]);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3BasicWebApiApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3BasicWebApiApplicationFixture.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public string GetTraceId()
         {
-            var address = $"http://localhost:{Port}/api/default/GetTraceId";
+            var address = $"http://127.0.0.1:{Port}/api/default/GetTraceId";
             var webClient = new WebClient();
             var result = webClient.DownloadString(address);
             Assert.NotNull(result);

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3FeaturesFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCore3FeaturesFixture.cs
@@ -18,39 +18,39 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://127.0.0.1:{Port}/";
             DownloadStringAndAssertContains(address, "<html>");
         }
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://127.0.0.1:{Port}/Home/ThrowException";
             var webClient = new WebClient();
             Assert.Throws<System.Net.WebException>(() => webClient.DownloadString(address));
         }
 
         public void AccessCollectible()
         {
-            var address = $"http://localhost:{Port}/Collectible/AccessCollectible";
+            var address = $"http://127.0.0.1:{Port}/Collectible/AccessCollectible";
             var webClient = new WebClient();
             webClient.DownloadString(address);
         }
 
         public void AsyncStream()
         {
-            var address = $"http://localhost:{Port}/api/AsyncStream";
+            var address = $"http://127.0.0.1:{Port}/api/AsyncStream";
             DownloadStringAndAssertContains(address, "45");
         }
 
         public void InterfaceDefaultsGetWithAttributes()
         {
-            var address = $"http://localhost:{Port}/InterfaceDefaults/GetWithAttributes";
+            var address = $"http://127.0.0.1:{Port}/InterfaceDefaults/GetWithAttributes";
             DownloadStringAndAssertContains(address, "Done");
         }
 
         public void InterfaceDefaultsGetWithoutAttributes()
         {
-            var address = $"http://localhost:{Port}/InterfaceDefaults/GetWithoutAttributes";
+            var address = $"http://127.0.0.1:{Port}/InterfaceDefaults/GetWithoutAttributes";
             DownloadStringAndAssertContains(address, "Done");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreBasicWebApiApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreBasicWebApiApplicationFixture.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void MakeExternalCallUsingHttpClient(string baseAddress, string path)
         {
-            var address = $"http://localhost:{Port}/api/default/MakeExternalCallUsingHttpClient?baseAddress={baseAddress}&path={path}";
+            var address = $"http://127.0.0.1:{Port}/api/default/MakeExternalCallUsingHttpClient?baseAddress={baseAddress}&path={path}";
             using (var client = new HttpClient())
             {
                 var response = client.GetStringAsync(address).Result;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
@@ -41,9 +41,9 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ExecuteTraceRequestChain(string firstAppAction, string secondAppAction, string thirdAppAction, IEnumerable<KeyValuePair<string, string>> headers = null)
         {
-            var firstCallBaseUrl = $"http://localhost:{FirstCallApplication.Port}/FirstCall";
-            var secondCallBaseUrl = $"http://localhost:{SecondCallApplication.Port}/SecondCall";
-            var lastCallBaseUrl = $"http://localhost:{RemoteApplication.Port}/LastCall";
+            var firstCallBaseUrl = $"http://127.0.0.1:{FirstCallApplication.Port}/FirstCall";
+            var secondCallBaseUrl = $"http://127.0.0.1:{SecondCallApplication.Port}/SecondCall";
+            var lastCallBaseUrl = $"http://127.0.0.1:{RemoteApplication.Port}/LastCall";
 
             var lastCallUrl = $"{lastCallBaseUrl}/{thirdAppAction}";
             var secondCallUrl = $"{secondCallBaseUrl}/{secondAppAction}?nextUrl={lastCallUrl}";

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcAsyncTestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcAsyncTestsFixture.cs
@@ -17,43 +17,43 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetIoBoundConfigureAwaitFalseAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskRunBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/NewThreadStartBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcBasicRequestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcBasicRequestsFixture.cs
@@ -20,12 +20,12 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://127.0.0.1:{Port}/";
             DownloadStringAndAssertContains(address, "<html>");
         }
         public void GetCORSPreflight()
         {
-            var address = $"http://localhost:{Port}/Home/About";
+            var address = $"http://127.0.0.1:{Port}/Home/About";
             var request = (HttpWebRequest)WebRequest.Create(address);
             request.Method = "OPTIONS";
             request.Headers.Add("Origin", "http://example.com");
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void MakePostRequestWithCustomRequestHeader(Dictionary<string, string> customHeadersToAdd)
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://127.0.0.1:{Port}/";
             var request = (HttpWebRequest)WebRequest.Create(address);
             request.Method = "POST";
             request.Referer = "http://example.com/";
@@ -70,21 +70,21 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://127.0.0.1:{Port}/Home/ThrowException";
             var webClient = new WebClient();
             Assert.Throws<WebException>(() => webClient.DownloadString(address));
         }
 
         public void ThrowExceptionWithMessage(string exceptionMessage)
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ThrowExceptionWithMessage?exceptionMessage={exceptionMessage}";
+            var address = $"http://127.0.0.1:{Port}/ExpectedErrorTest/ThrowExceptionWithMessage?exceptionMessage={exceptionMessage}";
             var webClient = new WebClient();
             Assert.Throws<WebException>(() => webClient.DownloadString(address));
         }
 
         public void ReturnADesiredStatusCode(int statusCode)
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ReturnADesiredStatusCode?statusCode={statusCode}";
+            var address = $"http://127.0.0.1:{Port}/ExpectedErrorTest/ReturnADesiredStatusCode?statusCode={statusCode}";
             var webClient = new WebClient();
             Assert.Throws<WebException>(() => webClient.DownloadString(address));
         }
@@ -92,44 +92,44 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ThrowCustomException()
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ThrowCustomException";
+            var address = $"http://127.0.0.1:{Port}/ExpectedErrorTest/ThrowCustomException";
             var webClient = new WebClient();
             Assert.Throws<WebException>(() => webClient.DownloadString(address));
         }
 
         public void GetWithData(string requestParameter)
         {
-            var address = $"http://localhost:{Port}/Home/Query?data={requestParameter}";
+            var address = $"http://127.0.0.1:{Port}/Home/Query?data={requestParameter}";
             DownloadStringAndAssertContains(address, "<html>");
         }
 
         public void GetHttpClient()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClient";
+            var address = $"http://127.0.0.1:{Port}/Home/HttpClient";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetHttpClientTaskCancelled()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClientTaskCancelled";
+            var address = $"http://127.0.0.1:{Port}/Home/HttpClientTaskCancelled";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetHttpClientFactory()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClientFactory";
+            var address = $"http://127.0.0.1:{Port}/Home/HttpClientFactory";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetTypedHttpClient()
         {
-            var address = $"http://localhost:{Port}/Home/TypedHttpClient";
+            var address = $"http://127.0.0.1:{Port}/Home/TypedHttpClient";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCallAsyncExternal()
         {
-            var address = $"http://localhost:{Port}/DetachWrapper/CallAsyncExternal";
+            var address = $"http://127.0.0.1:{Port}/DetachWrapper/CallAsyncExternal";
             DownloadStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcCoreFrameworkFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcCoreFrameworkFixture.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/api/values";
+            var address = $"http://127.0.0.1:{Port}/api/values";
             DownloadStringAndAssertContains(address, "value1");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkAsyncTestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkAsyncTestsFixture.cs
@@ -19,43 +19,43 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetIoBoundConfigureAwaitFalseAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskRunBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/NewThreadStartBlocked";
             DownloadStringAndAssertEqual(address, "Worked");
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkFixture.cs
@@ -20,13 +20,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://127.0.0.1:{Port}/";
             DownloadStringAndAssertContains(address, "<html>");
         }
 
         public void GetCORSPreflight()
         {
-            var address = $"http://localhost:{Port}/Home/About";
+            var address = $"http://127.0.0.1:{Port}/Home/About";
             var request = (HttpWebRequest)WebRequest.Create(address);
             request.Method = "OPTIONS";
             request.Headers.Add("Origin", "http://example.com");
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://127.0.0.1:{Port}/Home/ThrowException";
             var webClient = new WebClient();
 
             Assert.Throws<System.Net.WebException>(() => webClient.DownloadString(address));
@@ -47,13 +47,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetWithData(string requestParameter)
         {
-            var address = $"http://localhost:{Port}/Home/Query?data={requestParameter}";
+            var address = $"http://127.0.0.1:{Port}/Home/Query?data={requestParameter}";
             DownloadStringAndAssertContains(address, "<html>");
         }
 
         public void GetCallAsyncExternal()
         {
-            var address = $"http://localhost:{Port}/DetachWrapper/CallAsyncExternal";
+            var address = $"http://127.0.0.1:{Port}/DetachWrapper/CallAsyncExternal";
             DownloadStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiCustomAttributesFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiCustomAttributesFixture.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = string.Format("http://localhost:{0}/api/CustomAttributes", Port);
+            var address = string.Format("http://127.0.0.1:{0}/api/CustomAttributes", Port);
             DownloadJsonAndAssertEqual(address, "success");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiWithCollectorFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiWithCollectorFixture.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/api/default/AwesomeName";
+            var address = $"http://127.0.0.1:{Port}/api/default/AwesomeName";
             DownloadStringAndAssertContains(address, "Chuck Norris");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/DTBasicMVCApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/DTBasicMVCApplicationFixture.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Initiate()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/Initiate";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/Initiate";
 
             using (WebClient client = new WebClient())
             {
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ReceiveDTPayload()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/ReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/ReceivePayload";
 
             //string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
             string payload =
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateMajorVersionMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityReceivePayload";
 
             // Version: [9999,1]
             string payload = "eyJ2IjpbOTk5OSwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiOTEyMyIsImFwIjoiNTE0MjQiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjE0ODI5NTk1MjU1NzciLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNTI5NDI0MTMwNjAzLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYifX0=";
@@ -66,7 +66,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateIgnoredNullMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = null;
             var header = new KeyValuePair<string, string>(DTHeaderHame, payload);
 
@@ -79,7 +79,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateParsePayloadMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImZvbyI6ImJhciIsYWMiOiI5MTIzIiwiYXAiOiI1MTQyNCIsImlkIjoiMjc4NTZmNzBkM2QzMTRiNyIsInRyIjoiMTQ4Mjk1OTUyNTU3NyIsInByIjowLjEyMzQsInNhIjpmYWxzZSwidGkiOjE1Mjk0MjQxMzA2MDMsInBhIjoiNWZhM2MwMTQ5OGUyNDRhNiJ9fQ==";
             var header = new KeyValuePair<string, string>(DTHeaderHame, payload);
 
@@ -92,7 +92,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateAcceptSuccessMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
             var header = new KeyValuePair<string, string>(DTHeaderHame, payload);
 
@@ -105,7 +105,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateUntrustedAccountMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityReceivePayload";
 
             //{"v":[0,1],"d":{"ty":"App","ac":"8675309","ap":"51424","pa":"5fa3c01498e244a6","id":"27856f70d3d314b7","tr":"3221bf09aa0bcf0d","pr":0.1234,"sa":false,"ti":1482959525577}}
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiODY3NTMwOSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
@@ -120,7 +120,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateCreateSuccessMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityCreatePayload";
+            var address = $"http://127.0.0.1:{Port}/DistributedTracing/SupportabilityCreatePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
             var header = new KeyValuePair<string, string>(DTHeaderHame, payload);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
                 setupConfiguration: () =>
                 {
                     //Always restore the New Relic config settings even if the mock collector is already running
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "host", "localhost");
+                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "host", "127.0.0.1");
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "port", MockNewRelicApplication.Port.ToString(CultureInfo.InvariantCulture));
 
                     //Increase the timeout for requests to the mock collector to 5 seconds - default is 2 seconds.
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public string WarmUpCollector()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/WarmUpCollector";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/WarmUpCollector";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Warming up collector via: {address}");
 
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public IEnumerable<CollectedRequest> GetCollectedRequests()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/CollectedRequests";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/CollectedRequests";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Get collected requests via: {address}");
 
@@ -88,7 +88,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void TriggerThreadProfile()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/TriggerThreadProfile";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/TriggerThreadProfile";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Trigger thread profile via: {address}");
 
@@ -98,7 +98,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void TriggerCustomInstrumentationEditorAgentCommand()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/TriggerCustomInstrumentationEditorAgentCommand";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/TriggerCustomInstrumentationEditorAgentCommand";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Trigger custom instrumentation editor via: {address}");
 
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void SetCustomInstrumentationEditorOnConnect()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/SetCustomInstrumentationEditorOnConnect";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/SetCustomInstrumentationEditorOnConnect";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Set custom instrumentation editor on connect via: {address}");
 
@@ -118,7 +118,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public HeaderValidationData GetRequestHeaderMapValidationData()
         {
-            var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/HeaderValidation";
+            var address = $"https://127.0.0.1:{MockNewRelicApplication.Port}/agent_listener/HeaderValidation";
 
             TestLogger?.WriteLine($"[MockNewRelicFixture] Get request_header_map HeaderValidation via: {address}");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MvcAsyncFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MvcAsyncFixture.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwait/CpuBoundTasksAsync";
             DownloadStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinWebApiFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinWebApiFixture.cs
@@ -160,18 +160,18 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         }
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwait/CpuBoundTasksAsync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwait/CustomMiddlewareIoBoundNoSpecialAsync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void ErrorResponse()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/ErrorResponse";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwait/ErrorResponse";
 
             var webClient = GetWebClient();
             try
@@ -187,19 +187,19 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskRunBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/NewThreadStartBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/RejitMvcApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/RejitMvcApplicationFixture.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             RemoteApplication.UseTieredCompilation = useTieredCompilation;
         }
 
-        public override string DestinationServerName => "localhost";
+        public override string DestinationServerName => "127.0.0.1";
     }
 
     public class AspNetCoreReJitMvcApplicationFixtureWithTieredCompilation : AspNetCoreReJitMvcApplicationFixture

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/SerilogSumologicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/SerilogSumologicFixture.cs
@@ -16,13 +16,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void SyncControllerMethod()
         {
-            var address = $"http://localhost:{Port}/Home/SyncControllerMethod";
+            var address = $"http://127.0.0.1:{Port}/Home/SyncControllerMethod";
             DownloadStringAndAssertContains(address, "<html>");
         }
 
         public void AsyncControllerMethod()
         {
-            var address = $"http://localhost:{Port}/Home/AsyncControllerMethod";
+            var address = $"http://127.0.0.1:{Port}/Home/AsyncControllerMethod";
             DownloadStringAndAssertContains(address, "<html>");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
@@ -128,8 +128,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         public void ExecuteTraceRequestChainHttpClient(IEnumerable<KeyValuePair<string, string>> headers = null)
         {
             // the test calls the senderUrl, passing in the receiverUrl as a parameter
-            var senderBaseUrl = $"http://localhost:{RemoteApplication.Port}";
-            var receiverBaseUrl = $"http://localhost:{ReceiverApplication.Port}";
+            var senderBaseUrl = $"http://127.0.0.1:{RemoteApplication.Port}";
+            var receiverBaseUrl = $"http://127.0.0.1:{ReceiverApplication.Port}";
 
             var receiverUrl = $"{receiverBaseUrl}/api/CallEnd";
             var senderUrl = $"{senderBaseUrl}/api/CallNext?nextUrl={receiverUrl}";
@@ -141,8 +141,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ExecuteTraceRequestChainRestSharp(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            var secondCallUrl = $"http://localhost:{ReceiverApplication.Port}/api/RestAPI";
-            var firstCallUrl = $"http://localhost:{SenderApplication.Port}/DistributedTracing/MakeExternalCallUsingRestClient?externalCallUrl={secondCallUrl}";
+            var secondCallUrl = $"http://127.0.0.1:{ReceiverApplication.Port}/api/RestAPI";
+            var firstCallUrl = $"http://127.0.0.1:{SenderApplication.Port}/DistributedTracing/MakeExternalCallUsingRestClient?externalCallUrl={secondCallUrl}";
 
             DownloadStringAndAssertEqual(firstCallUrl, "Worked", headers);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/WebApiAsyncFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/WebApiAsyncFixture.cs
@@ -29,67 +29,67 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncAwait/CpuBoundTasksAsync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskRunBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://127.0.0.1:{Port}/ManualAsync/NewThreadStartBlocked";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_AwaitedAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_AwaitedAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Async_AwaitedAsync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_FireAndForget()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_FireAndForget";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Async_FireAndForget";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_Sync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_Sync";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Async_Sync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_AwaitedAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_AwaitedAsync";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Sync_AwaitedAsync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_FireAndForget()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_FireAndForget";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Sync_FireAndForget";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_Sync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_Sync";
+            var address = $"http://127.0.0.1:{Port}/AsyncFireAndForget/Sync_Sync";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
         public void ExecuteResponseTimeTestOperation(int delayDurationSeconds)
         {
-            var address = $"http://localhost:{Port}/ResponseTime/CallsOtherMethod/{delayDurationSeconds}";
+            var address = $"http://127.0.0.1:{Port}/ResponseTime/CallsOtherMethod/{delayDurationSeconds}";
             DownloadJsonAndAssertEqual(address, "Worked");
         }
 
@@ -97,7 +97,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         {
             using (var httpClient = new HttpClient())
             {
-                var requestMessage = new HttpRequestMessage(method, $"http://localhost:{Port}/AsyncFireAndForget/Sync_Sync");
+                var requestMessage = new HttpRequestMessage(method, $"http://127.0.0.1:{Port}/AsyncFireAndForget/Sync_Sync");
                 var result = httpClient.SendAsync(requestMessage).Result;
 
                 return result.Content.ReadAsStringAsync().Result;
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         {
             try
             {
-                new WebClient().DownloadString($"http://localhost:{Port}/{Path}");
+                new WebClient().DownloadString($"http://127.0.0.1:{Port}/{Path}");
             }
             catch (WebException) { }
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"127.0.0.1:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
         };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -28,7 +28,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"127.0.0.1:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
             { "request.headers.foo", "bar" },
             { "request.headers.dashes-are-valid", "true" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
@@ -40,12 +40,12 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException", callCount = 2 },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData", callCount = 2 /*Begin/End + Event Based Async*/  },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException", callCount = 4 /*Begin/End + Event Based Async*/ },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData" , callCount = 1 },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException", callCount = 2  },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData", callCount = 1  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException", callCount = 2 },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData", callCount = 2 /*Begin/End + Event Based Async*/  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException", callCount = 4 /*Begin/End + Event Based Async*/ },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData" , callCount = 1 },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException", callCount = 2  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData", callCount = 1  },
 
                 new Assertions.ExpectedMetric(){ metricName = "DotNet/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException", callCount = _countClientInvocationMethodsToTest * 2 },
@@ -59,17 +59,17 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
 
             var catExcludedMetrics = new[]
             {
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/127.0.0.1/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
             };
 
@@ -140,12 +140,12 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS, metricName = $"ExternalApp/localhost/{CATCrossProcessID_Service}/all" },
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData",
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS, metricName = $"ExternalApp/127.0.0.1/{CATCrossProcessID_Service}/all" },
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/127.0.0.1/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData"},
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/127.0.0.1/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException",
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/127.0.0.1/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException"},
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/127.0.0.1/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException"},
 
                 new Assertions.ExpectedMetric(){ metricName = "Supportability/CrossApplicationTracing/Request/Create/Success" , callCount = countExpectedCreate },//16

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -65,7 +65,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             Log.Logger = loggerConfig.CreateLogger();
 
             var port = RandomPortGenerator.NextPort();
-            _uriBase = "http://localhost:" + port + "/";
+            _uriBase = "http://127.0.0.1:" + port + "/";
             var hostTask = CreateHostBuilder(_uriBase).Build().RunAsync();
 
             Console.WriteLine("URI: " + _uriBase);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/OwinService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/OwinService.cs
@@ -27,7 +27,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Owin
 
         public void StartService(int port)
         {
-            _service = WebApp.Start(url: $"http://localhost:{port}/", _startup.Configuration);
+            _service = WebApp.Start(url: $"http://127.0.0.1:{port}/", _startup.Configuration);
             Task.Delay(7000).Wait();
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
@@ -118,7 +118,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries
             virtualDirectoryNode.Attributes["physicalPath"].Value = HostedApplicationFolder;
 
             var bindingNode = l.SelectSingleNode("configuration/system.applicationHost/sites/site/bindings/binding");
-            bindingNode.Attributes["bindingInformation"].Value = $"*:{port}:";
+            bindingNode.Attributes["bindingInformation"].Value = $"127.0.0.1:{port}:";
 
             var appPoolName = $"HWCTest{port}-{Guid.NewGuid()}";
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
@@ -23,9 +23,9 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 case WCFBindingType.WebHttp:
                 case WCFBindingType.Custom:
                 case WCFBindingType.CustomClass:
-                    return new Uri($@"http://localhost:{port}/{relativeUrl}");
+                    return new Uri($@"http://127.0.0.1:{port}/{relativeUrl}");
                 case WCFBindingType.NetTcp:
-                    return new Uri($@"net.tcp://localhost:{port}/{relativeUrl}");
+                    return new Uri($@"net.tcp://127.0.0.1:{port}/{relativeUrl}");
                 default:
                     throw new NotSupportedException($"Binding Type {bindingTypeEnum}");
             }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="*:80:" />
+					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Program.cs
@@ -53,7 +53,7 @@ namespace BasicMvcCoreApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 ﻿{
   "iisSettings": {
     "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
+    "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:60383",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:60383",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -16,12 +16,12 @@
       }
     },
     "BasicMvcCoreApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "http://localhost:5000",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+        "commandName": "Project",
+        "launchBrowser": true,
+        "applicationUrl": "http://127.0.0.1:5000",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        }
     }
   }
 }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/MongoDB2_6CoreApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/MongoDB2_6CoreApplication/Program.cs
@@ -51,7 +51,7 @@ namespace MongoDB2_6CoreApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls(string.Format(@"http://localhost:{0}/", _port))
+                .UseUrls(string.Format(@"http://127.0.0.1:{0}/", _port))
                 .Build();
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/UnboundedApplications/MongoDB2_6CoreApplication/Properties/launchSettings.json
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/MongoDB2_6CoreApplication/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:5768/",
-      "sslPort": 0
+        "applicationUrl": "http://127.0.0.1:5768/",
+        "sslPort": 0
     }
   },
   "profiles": {
@@ -17,13 +17,13 @@
       }
     },
     "MongoDB2_6CoreApplication": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "launchUrl": "api/values",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:5769/"
+        "commandName": "Project",
+        "launchBrowser": true,
+        "launchUrl": "api/values",
+        "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+        },
+        "applicationUrl": "http://127.0.0.1:5769/"
     }
   }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixture.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixture.cs
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetMsSql()
         {
-            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSql?tableName={TableName}";
+            var address = $"http://127.0.0.1:{Port}/MicrosoftDataSqlClient/MsSql?tableName={TableName}";
 
             using (var webClient = new WebClient())
             {
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetMsSqlAsync()
         {
-            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlAsync?tableName={TableName}";
+            var address = $"http://127.0.0.1:{Port}/MicrosoftDataSqlClient/MsSqlAsync?tableName={TableName}";
 
             using (var webClient = new WebClient())
             {
@@ -54,7 +54,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetMsSql_WithParameterizedQuery(bool paramsWithAtSign)
         {
-            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
+            var address = $"http://127.0.0.1:{Port}/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
 
             using (var webClient = new WebClient())
             {
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetMsSqlAsync_WithParameterizedQuery(bool paramsWithAtSign)
         {
-            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
+            var address = $"http://127.0.0.1:{Port}/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
 
             using (var webClient = new WebClient())
             {
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetMsSqlParameterizedStoredProcedure(bool paramsWithAtSign)
         {
-            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure?procedureName={ProcedureName}&paramsWithAtSign={paramsWithAtSign}";
+            var address = $"http://127.0.0.1:{Port}/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure?procedureName={ProcedureName}&paramsWithAtSign={paramsWithAtSign}";
 
             using (var webClient = new WebClient())
             {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/PostgresBasicMvcCoreFixture.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/PostgresBasicMvcCoreFixture.cs
@@ -19,7 +19,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetPostgres()
         {
-            var address = $"http://localhost:{Port}/Postgres/Postgres";
+            var address = $"http://127.0.0.1:{Port}/Postgres/Postgres";
 
             using (var webClient = new WebClient())
             {
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void GetPostgresAsync()
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresAsync";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresAsync";
 
             using (var webClient = new WebClient())
             {
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresParameterizedStoredProcedure(string procedureName)
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresParameterizedStoredProcedure?procedureName={procedureName}";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresParameterizedStoredProcedure?procedureName={procedureName}";
 
             using (var webClient = new WebClient())
             {
@@ -52,7 +52,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresParameterizedStoredProcedureAsync(string procedureName)
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresParameterizedStoredProcedureAsync?procedureName={procedureName}";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresParameterizedStoredProcedureAsync?procedureName={procedureName}";
 
             using (var webClient = new WebClient())
             {
@@ -63,7 +63,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresExecuteScalar()
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresExecuteScalar";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresExecuteScalar";
 
             using (var webClient = new WebClient())
             {
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresExecuteScalarAsync()
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresExecuteScalarAsync";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresExecuteScalarAsync";
 
             using (var webClient = new WebClient())
             {
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresIteratorTest()
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresIteratorTest";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresIteratorTest";
 
             using (var webClient = new WebClient())
             {
@@ -96,7 +96,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 
         public void PostgresAsyncIteratorTest()
         {
-            var address = $"http://localhost:{Port}/Postgres/PostgresAsyncIteratorTest";
+            var address = $"http://127.0.0.1:{Port}/Postgres/PostgresAsyncIteratorTest";
 
             using (var webClient = new WebClient())
             {


### PR DESCRIPTION
- Changes to port availability check: Query OS for port usage, exhaustively claim port IPv4/6/HTTP.sys, wait for OS to report port as available again (this is overkill, but I wanted to be sure)
- Test apps now bind to `127.0.0.1` (IPv4 loopback) instead of `localhost` (possibly IPv6 loopback) or `*` (all interfaces). This reduces complexity, and has a nice side effect of fewer firewall popups during local test runs
- Add a process global lock for calls to `dotnet publish`