### PR TITLE
Resolve issue where more logs were forwarded than desired from MEL

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -472,7 +472,7 @@ jobs:
           HttpClientInstrumentation.NetCore, HttpClientInstrumentation.NetFramework, Owin, ReJit.NetCore, 
           Logging.HsmAndCsp, Logging.LocalDecoration, Logging.MaxSamplesStored, Logging.ZeroMaxSamplesStored,
           Logging.MetricsAndForwarding.log4net, Logging.MetricsAndForwarding.MicrosoftLogging, 
-          Logging.MetricsAndForwarding.Serilog, Logging.MetricsAndForwarding.NLog,
+          Logging.MetricsAndForwarding.Serilog, Logging.MetricsAndForwarding.NLog, Logging.LogLevelDetection,
           ReJit.NetFramework, RemoteServiceFixtures, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, 
           WCF.Client.Self, WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self, RequestHeadersCapture.WCF, 
           RequestHeadersCapture.Owin, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.Asp35, RequestHeadersCapture.EnvironmentVariables, 

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -48,7 +48,7 @@ jobs:
             'Errors', 'HttpClientInstrumentation.NetCore', 'HttpClientInstrumentation.NetFramework', 'Owin', 'ReJit.NetCore', 'Logging.HsmAndCsp', 'Logging.LocalDecoration', 'Logging.MaxSamplesStored', 'Logging.ZeroMaxSamplesStored', \
             'Logging.MetricsAndForwarding.log4net', 'Logging.MetricsAndForwarding.MicrosoftLogging', 'Logging.MetricsAndForwarding.Serilog', 'Logging.MetricsAndForwarding.NLog', 'ReJit.NetFramework', 'RemoteServiceFixtures', 'RestSharp', \
             'WCF.Client.IIS.ASPDisabled', 'WCF.Client.IIS.ASPEnabled', 'WCF.Client.Self', 'WCF.Service.IIS.ASPDisabled', 'WCF.Service.IIS.ASPEnabled', 'WCF.Service.Self', 'RequestHeadersCapture.WCF', 'RequestHeadersCapture.Owin', \
-            'RequestHeadersCapture.AspNetCore', 'RequestHeadersCapture.Asp35', 'RequestHeadersCapture.EnvironmentVariables', 'RequestHandling', 'CodeLevelMetrics' ]"
+            'RequestHeadersCapture.AspNetCore', 'RequestHeadersCapture.Asp35', 'RequestHeadersCapture.EnvironmentVariables', 'RequestHandling', 'CodeLevelMetrics', 'Logging.LogLevelDetection' ]"
           else
             # Just use the supplied list of namespaces
             namespaces="[ ${{ github.event.inputs.integration-test-namespaces }} ]"

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Additional DEBUG-level logging of all environment variables.
 
 ### Fixes
-* Resolves an issue where log forwarding could drop logs in async scenarios. [#1174](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)
+* Resolves an issue where log forwarding could drop logs in async scenarios. [#1201](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)
+* Resolves an issue where more logs were forwarded than expected from Microsoft.Extensions.Logging. [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237)
 
 ## [10.0.0] - 2022-07-19
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
-            // There is no LogEvent equivilent in MSE Logging
+            // There is no LogEvent equivalent in MSE Logging
             RecordLogMessage(instrumentedMethodCall.MethodCall, agent);
 
             // need to return AfterWrappedMethodDelegate here since we have two different return options from this method.
@@ -37,9 +37,6 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
             // logs have been filtered to enabled levels
             var melLoggerInstance = (MEL.ILogger)methodCall.InvocationTarget;
             var logLevelIsEnabled = melLoggerInstance.IsEnabled((MEL.LogLevel)methodCall.MethodArguments[0]);
-
-            // TODO: Need to test what happens when the Serilog Provider (and possibly others) is used with MEL, as it
-            // TODO: subscribes to to ALL events in the pipeline with the intention of performing its own filtering.
 
             if (logLevelIsEnabled)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -557,7 +557,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         #endregion Metrics
 
-        #region Log Lines
+        #region In Agent Log Forwarding Log Lines Assertions
 
         public static void LogLineExists(ExpectedLogLine expectedLogLine, IEnumerable<LogLine> actualLogLines) => LogLinesExist(new[] { expectedLogLine }, actualLogLines);
 
@@ -590,6 +590,40 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 }
             }
 
+
+            Assert.True(succeeded, builder.ToString());
+        }
+
+        public static void LogLineDoesntExist(ExpectedLogLine unexpectedLogLine, IEnumerable<LogLine> actualLogLines) => LogLinesDontExist(new[] { unexpectedLogLine }, actualLogLines);
+
+        public static void LogLinesDontExist(IEnumerable<ExpectedLogLine> unexpectedLogLines, IEnumerable<LogLine> actualLogLines)
+        {
+            actualLogLines = actualLogLines.ToList();
+
+            var succeeded = true;
+            var builder = new StringBuilder();
+
+            if (!actualLogLines.Any() && actualLogLines.Any())
+            {
+                builder.AppendLine("Unable to validate expected Log Lines because actualLogLines has no items.");
+                succeeded = false;
+            }
+            else
+            {
+                foreach (var unexpectedLogLine in unexpectedLogLines)
+                {
+                    var matchedLogLine = TryFindLogLine(unexpectedLogLine, actualLogLines);
+                    if (matchedLogLine != null)
+                    {
+                        builder.Append($"Unexpected LogLine `{unexpectedLogLine}` was found in the Log payload.");
+                        builder.AppendLine();
+                        builder.AppendLine();
+
+                        succeeded = false;
+                        continue;
+                    }
+                }
+            }
 
             Assert.True(succeeded, builder.ToString());
         }
@@ -861,7 +895,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         #endregion Sql Traces
 
-        #region Log lines
+        #region Generic Agent Log Lines Assertions
 
         public static void LogLinesExist(IEnumerable<string> expectedLogLineRegexes, IEnumerable<string> actualLogLines)
         {
@@ -895,7 +929,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             Assert.True(errorMessages == string.Empty, errorMessages);
         }
 
-        #endregion Log lines
+        #endregion
 
         private static bool ValidateAttributeValues(KeyValuePair<string, object> expectedAttribute, object rawActualValue, StringBuilder builder, string wireModelTypeName)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -568,7 +568,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var succeeded = true;
             var builder = new StringBuilder();
 
-            if (!actualLogLines.Any() && actualLogLines.Any())
+            if (!actualLogLines.Any() && expectedLogLines.Any())
             {
                 builder.AppendLine("Unable to validate expected Log Lines because actualLogLines has no items.");
                 succeeded = false;
@@ -590,7 +590,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 }
             }
 
-
             Assert.True(succeeded, builder.ToString());
         }
 
@@ -603,25 +602,17 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var succeeded = true;
             var builder = new StringBuilder();
 
-            if (!actualLogLines.Any() && actualLogLines.Any())
+            foreach (var unexpectedLogLine in unexpectedLogLines)
             {
-                builder.AppendLine("Unable to validate expected Log Lines because actualLogLines has no items.");
-                succeeded = false;
-            }
-            else
-            {
-                foreach (var unexpectedLogLine in unexpectedLogLines)
+                var matchedLogLine = TryFindLogLine(unexpectedLogLine, actualLogLines);
+                if (matchedLogLine != null)
                 {
-                    var matchedLogLine = TryFindLogLine(unexpectedLogLine, actualLogLines);
-                    if (matchedLogLine != null)
-                    {
-                        builder.Append($"Unexpected LogLine `{unexpectedLogLine}` was found in the Log payload.");
-                        builder.AppendLine();
-                        builder.AppendLine();
+                    builder.Append($"Unexpected LogLine `{unexpectedLogLine}` was found in the Log payload.");
+                    builder.AppendLine();
+                    builder.AppendLine();
 
-                        succeeded = false;
-                        continue;
-                    }
+                    succeeded = false;
+                    continue;
                 }
             }
 
@@ -650,7 +641,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             return null;
         }
-        
+
         #endregion
 
         #region Transaction Events

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
@@ -11,4 +11,72 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         SerilogWeb,
         NLog
     }
+
+    public class LogUtils
+    {
+        public static string GetFrameworkName(LoggingFramework loggingFramework)
+        {
+            switch (loggingFramework)
+            {
+                case LoggingFramework.Log4net:
+                    return "log4net";
+                case LoggingFramework.MicrosoftLogging:
+                    return "MicrosoftLogging";
+                case LoggingFramework.SerilogWeb:
+                case LoggingFramework.Serilog:
+                    return "serilog";
+                case LoggingFramework.NLog:
+                    return "nlog";
+                default:
+                    return "unknown";
+            }
+        }
+
+        public static string GetLevelName(LoggingFramework loggingFramework, string level)
+        {
+            switch (loggingFramework)
+            {
+                // log4net names are the same as our internal names
+                case LoggingFramework.Log4net:
+                    return level;
+                case LoggingFramework.MicrosoftLogging:
+                    switch (level)
+                    {
+                        case "DEBUG":
+                            return "DEBUG";
+                        case "INFO":
+                            return "INFORMATION";
+                        case "WARN":
+                            return "WARNING";
+                        case "ERROR":
+                            return "ERROR";
+                        case "FATAL":
+                            return "CRITICAL";
+                        default:
+                            return level;
+                    }
+                case LoggingFramework.SerilogWeb:
+                case LoggingFramework.Serilog:
+                    switch (level)
+                    {
+                        case "DEBUG":
+                            return "DEBUG";
+                        case "INFO":
+                            return "INFORMATION";
+                        case "WARN":
+                            return "WARNING";
+                        case "ERROR":
+                            return "ERROR";
+                        case "FATAL":
+                            return "FATAL";
+                        default:
+                            return level;
+                    }
+                case LoggingFramework.NLog:
+                    return level;
+            }
+
+            return string.Empty;
+        }
+    }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
@@ -1,0 +1,274 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Logging.LogLevelDetection
+{
+    public abstract class LogLevelTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        public LogLevelTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
+            _fixture.AddCommand($"LoggingTester ConfigureWithInfoLevelEnabled");
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessage ShouldNotBeForwardedDebugMessage DEBUG");
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessage ShouldBeForwardedInfoMessage INFO");
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessage ShouldBeForwardedErrorMessage ERROR");
+
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    // applicationLogging metrics and forwarding enabled by default
+                    configModifier
+                    .EnableDistributedTrace()
+                    .SetLogLevel("debug");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromMinutes(2));
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void OnlyTwoLogLinesAreSent()
+        {
+            // TODO: Better assertions, this should work for now though
+            var logData = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
+            Assert.NotEmpty(logData);
+            Assert.Equal(2, logData.Length);
+        }
+    }
+
+    #region log4net
+
+    [NetFrameworkTest]
+    public class Log4netLogLevelFWLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public Log4netLogLevelFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netLogLevelFW471Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public Log4netLogLevelFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4netLogLevelFW462Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public Log4netLogLevelFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netLogLevelNetCoreLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4netLogLevelNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netLogLevelNetCore50Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4netLogLevelNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4netLogLevelTestsNetCore31Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4netLogLevelTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    #endregion
+
+    #region MicrosoftLogging
+
+    [NetCoreTest]
+    public class MicrosoftLoggingLogLevelTestsNetCoreLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MicrosoftLoggingLogLevelTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftLoggingLogLevelTestsNetCore50Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MicrosoftLoggingLogLevelTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftLoggingLogLevelTestsNetCore31Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MicrosoftLoggingLogLevelTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MicrosoftLoggingLogLevelTestsFWLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public MicrosoftLoggingLogLevelTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
+        {
+        }
+    }
+
+    #endregion
+
+    #region Serilog
+
+    [NetFrameworkTest]
+    public class SerilogLogLevelTestsFWLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public SerilogLogLevelTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class SerilogLogLevelTestsFW471Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public SerilogLogLevelTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class SerilogLogLevelTestsFW462Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public SerilogLogLevelTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SerilogLogLevelTestsNetCoreLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public SerilogLogLevelTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SerilogLogLevelTestsNetCore50Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public SerilogLogLevelTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SerilogLogLevelTestsNetCore31Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public SerilogLogLevelTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
+        {
+        }
+    }
+
+    #endregion
+
+    #region NLog
+
+    [NetFrameworkTest]
+    public class NLogLogLevelTestsFWLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public NLogLogLevelTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogLogLevelTestsFW471Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public NLogLogLevelTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogLogLevelTestsFW462Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public NLogLogLevelTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogLogLevelTestsNetCoreLatestTests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public NLogLogLevelTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogLogLevelTestsNetCore50Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public NLogLogLevelTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogLogLevelTestsNetCore31Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public NLogLogLevelTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    #endregion
+
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
@@ -211,6 +211,16 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LogLevelDetection
         }
     }
 
+    [NetCoreTest]
+    public class SerilogWebLogLevelTestsNetCore60Tests : LogLevelTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public SerilogWebLogLevelTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogWeb)
+        {
+        }
+    }
+
     #endregion
 
     #region NLog

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -487,7 +487,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                         case "ERROR":
                             return "ERROR";
                         case "FATAL":
-                            return "TRACE";
+                            return "CRITICAL";
                         default:
                             return level;
                     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -176,11 +176,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             var loggingMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + GetLevelName(_loggingFramework, "DEBUG"), callCount = 7 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + GetLevelName(_loggingFramework, "INFO"), callCount = 10 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + GetLevelName(_loggingFramework, "WARN"), callCount = 7 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + GetLevelName(_loggingFramework, "ERROR"), callCount = 7 },
-                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + GetLevelName(_loggingFramework, "FATAL"), callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + LogUtils.GetLevelName(_loggingFramework, "DEBUG"), callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + LogUtils.GetLevelName(_loggingFramework, "INFO"), callCount = 10 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + LogUtils.GetLevelName(_loggingFramework, "WARN"), callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + LogUtils.GetLevelName(_loggingFramework, "ERROR"), callCount = 7 },
+                new Assertions.ExpectedMetric { metricName = "Logging/lines/" + LogUtils.GetLevelName(_loggingFramework, "FATAL"), callCount = 7 },
 
                 new Assertions.ExpectedMetric { metricName = "Logging/lines", callCount = 38 },
             };
@@ -224,7 +224,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private void SupportabilityLoggingFrameworkMetricExists()
         {
-            var expectedFrameworkName = GetFrameworkName(_loggingFramework);
+            var expectedFrameworkName = LogUtils.GetFrameworkName(_loggingFramework);
             var actualMetrics = _fixture.AgentLog.GetMetrics();
             Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
         }
@@ -270,7 +270,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = TraceAttributeOutsideTransactionLogMessage, HasTraceId = false, HasSpanId = false }
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = TraceAttributeOutsideTransactionLogMessage, HasTraceId = false, HasSpanId = false }
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -287,7 +287,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = DifferentTraceAttributesInsideTransactionLogMessage, HasTraceId = true, HasSpanId = true }
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = DifferentTraceAttributesInsideTransactionLogMessage, HasTraceId = true, HasSpanId = true }
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -307,11 +307,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = InTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = InTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = InTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = InTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = InTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = InTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = InTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = InTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = InTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = InTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -328,11 +328,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -351,11 +351,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                 // Because of this the spanId/traceId members are not checked by not specifying true/false in the ExpectedLogLines
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitInTransactionDebugMessage},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitInTransactionInfoMessage},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitInTransactionWarningMessage},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitInTransactionErrorMessage},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitInTransactionFatalMessage},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitInTransactionDebugMessage},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitInTransactionInfoMessage},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitInTransactionWarningMessage},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitInTransactionErrorMessage},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitInTransactionFatalMessage},
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -372,11 +372,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = OutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = OutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = OutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = OutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = OutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = OutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = OutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = OutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = OutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = OutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
@@ -393,11 +393,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncOutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncOutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncOutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncOutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncOutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncOutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncOutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncOutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncOutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncOutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
@@ -414,11 +414,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitOutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitOutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitOutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitOutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitOutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitOutsideTransactionDebugMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitOutsideTransactionInfoMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitOutsideTransactionWarningMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitOutsideTransactionErrorMessage, HasSpanId = false, HasTraceId = false},
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitOutsideTransactionFatalMessage, HasSpanId = false, HasTraceId = false},
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
@@ -435,11 +435,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitWithDelayInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitWithDelayInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitWithDelayInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
-                new Assertions.ExpectedLogLine { Level = GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitWithDelayInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitWithDelayInTransactionDebugMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitWithDelayInTransactionInfoMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitWithDelayInTransactionWarningMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, HasTraceId = true, HasSpanId = true },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "FATAL"), LogMessage = AsyncNoAwaitWithDelayInTransactionFatalMessage, HasTraceId = true, HasSpanId = true },
                 };
 
                 var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
@@ -449,73 +449,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                 Assert.Equal(expectedLogLines.Length, logLines.Where(x => x.Message.StartsWith("AsyncNoAwaitWithDelayInTransaction")).Count());
             }
         }
-
-        private string GetFrameworkName(LoggingFramework loggingFramework)
-        {
-            switch (loggingFramework)
-            {
-                case LoggingFramework.Log4net:
-                    return "log4net";
-                case LoggingFramework.MicrosoftLogging:
-                    return "MicrosoftLogging";
-                case LoggingFramework.SerilogWeb:
-                case LoggingFramework.Serilog:
-                    return "serilog";
-                case LoggingFramework.NLog:
-                    return "nlog";
-                default:
-                    return "unknown";
-            }
-        }
-
-        private string GetLevelName(LoggingFramework loggingFramework, string level)
-        {
-            switch (loggingFramework)
-            {
-                // log4net names are the same as our internal names
-                case LoggingFramework.Log4net:
-                    return level;
-                case LoggingFramework.MicrosoftLogging:
-                    switch (level)
-                    {
-                        case "DEBUG":
-                            return "DEBUG";
-                        case "INFO":
-                            return "INFORMATION";
-                        case "WARN":
-                            return "WARNING";
-                        case "ERROR":
-                            return "ERROR";
-                        case "FATAL":
-                            return "CRITICAL";
-                        default:
-                            return level;
-                    }
-                case LoggingFramework.SerilogWeb:
-                case LoggingFramework.Serilog:
-                    switch (level)
-                    {
-                        case "DEBUG":
-                            return "DEBUG";
-                        case "INFO":
-                            return "INFORMATION";
-                        case "WARN":
-                            return "WARNING";
-                        case "ERROR":
-                            return "ERROR";
-                        case "FATAL":
-                            return "FATAL";
-                        default:
-                            return level;
-                    }
-                case LoggingFramework.NLog:
-                    return level;
-            }
-
-            return string.Empty;
-        }
-
-
     }
 
     #region log4net

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/ILoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/ILoggingAdapter.cs
@@ -12,6 +12,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public void Fatal(string message);
 
         public void Configure();
+        public void ConfigureWithInfoLevelEnabled();
         public void ConfigurePatternLayoutAppenderForDecoration();
         public void ConfigureJsonLayoutAppenderForDecoration();
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Reflection;
 using log4net;
 using log4net.Appender;
 using log4net.Config;
+using log4net.Core;
 using log4net.Layout;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
@@ -44,7 +46,14 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Configure()
         {
-            BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()));
+            BasicConfigurator.Configure(LogManager.GetRepository());
+        }
+
+        public void ConfigureWithInfoLevelEnabled()
+        {
+            Configure();
+            ((log4net.Repository.Hierarchy.Hierarchy)LogManager.GetRepository()).Root.Level = Level.Info;
+            ((log4net.Repository.Hierarchy.Hierarchy)LogManager.GetRepository()).RaiseConfigurationChanged(EventArgs.Empty);
         }
 
         public void ConfigurePatternLayoutAppenderForDecoration()
@@ -57,14 +66,12 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             consoleAppender.Layout = patternLayout;
             consoleAppender.ActivateOptions();
 
-            var callingAssembly = Assembly.GetCallingAssembly();
-
-            BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), consoleAppender);
+            BasicConfigurator.Configure(LogManager.GetRepository(), consoleAppender);
         }
 
         public void ConfigureJsonLayoutAppenderForDecoration()
         {
-#if NETCOREAPP2_2_OR_GREATER || NET471_OR_GREATER // Only supported in newer verisons of .NET
+#if NETCOREAPP2_2_OR_GREATER || NET471_OR_GREATER // Only supported in newer versions of .NET
             SerializedLayout serializedLayout = new SerializedLayout();
             serializedLayout.AddMember("NR_LINKING");
             serializedLayout.ActivateOptions();
@@ -73,7 +80,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             consoleAppender.Layout = serializedLayout;
             consoleAppender.ActivateOptions();
 
-            BasicConfigurator.Configure(LogManager.GetRepository(Assembly.GetCallingAssembly()), consoleAppender);
+            BasicConfigurator.Configure(LogManager.GetRepository(), consoleAppender);
 #else
             throw new System.NotImplementedException();
 #endif

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -51,6 +51,12 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         }
 
         [LibraryMethod]
+        public static void ConfigureWithInfoLevelEnabled()
+        {
+            _log.ConfigureWithInfoLevelEnabled();
+        }
+
+        [LibraryMethod]
         public static void ConfigurePatternLayoutAppenderForDecoration()
         {
             _log.ConfigurePatternLayoutAppenderForDecoration();

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
@@ -45,19 +45,18 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Configure()
         {
-            CreateLogger(LogLevel.Debug);
+            CreateMelLogger(LogLevel.Debug);
         }
 
         public void ConfigureWithInfoLevelEnabled()
         {
-            // TODO: Need to test what happens when Serilog Provider (and possibly others) is used with MEL, as it
-            // TODO: subscribes to to ALL events in the pipeline with the intention of performing its own filtering.
-            CreateLogger(LogLevel.Information);
+            CreateMelLogger(LogLevel.Information);
         }
 
-        // NOTE: We are using serilog in this case
+        
         public void ConfigurePatternLayoutAppenderForDecoration()
         {
+            // NOTE: This is a serilog logger we are setting up
             var serilogLogger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .Enrich.FromLogContext()
@@ -66,22 +65,22 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                 )
                 .CreateLogger();
 
-            CreateLogger(LogLevel.Debug, serilogLogger);
+            CreateMelLogger(LogLevel.Debug, serilogLogger);
         }
 
-        // NOTE: We are using serilog in this case
         public void ConfigureJsonLayoutAppenderForDecoration()
         {
+            // NOTE: This is a serilog logger we are setting up
             var serilogLogger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .Enrich.FromLogContext()
                 .WriteTo.Console(new JsonFormatter())
                 .CreateLogger();
 
-            CreateLogger(LogLevel.Debug, serilogLogger);
+            CreateMelLogger(LogLevel.Debug, serilogLogger);
         }
 
-        private void CreateLogger(LogLevel minimumLogLevel, Serilog.ILogger serilogLoggerImpl = null)
+        private void CreateMelLogger(LogLevel minimumLogLevel, Serilog.ILogger serilogLoggerImpl = null)
         {
             using var loggerFactory = LoggerFactory.Create(builder =>
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
@@ -40,8 +40,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Fatal(string message)
         {
-            // This seems odd...
-            logger.LogTrace(message);
+            logger.LogCritical(message);
         }
 
         public void Configure()
@@ -86,7 +85,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         {
             using var loggerFactory = LoggerFactory.Create(builder =>
             {
-                builder.AddFilter("Default", minimumLogLevel);
+                builder.SetMinimumLevel(minimumLogLevel);
 
                 // Either use serilog OR the built in console appender
                 if (serilogLoggerImpl != null)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
@@ -43,12 +43,17 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Configure()
         {
-            _log = GetLogger();
+            _log = GetLogger(LogLevel.Debug);
+        }
+
+        public void ConfigureWithInfoLevelEnabled()
+        {
+            _log = GetLogger(LogLevel.Info);
         }
 
         public void ConfigurePatternLayoutAppenderForDecoration()
         {
-            _log = GetLogger();
+            _log = GetLogger(LogLevel.Debug);
         }
 
         public void ConfigureJsonLayoutAppenderForDecoration()
@@ -61,10 +66,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                 }
             };
 
-            _log = _log = GetLogger(jsonLayout);
+            _log = _log = GetLogger(LogLevel.Debug, jsonLayout);
         }
 
-        private Logger GetLogger(Layout layoutOverride = null)
+        private Logger GetLogger(LogLevel minimumLogLevel, Layout layoutOverride = null)
         {
             var logFactory = new NLog.LogFactory();
             var logConfig = new NLog.Config.LoggingConfiguration();
@@ -76,9 +81,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             }
 
             logConfig.AddTarget("console", logConsole);
-            logConfig.LoggingRules.Add(new NLog.Config.LoggingRule("*", LogLevel.Debug, logConsole));
+            logConfig.LoggingRules.Add(new NLog.Config.LoggingRule("*", minimumLogLevel, logConsole));
             logFactory.Configuration = logConfig;
-            return logFactory.GetLogger("LoggingTest");
+            return logFactory.GetLogger("NLogLoggingTest");
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
@@ -51,6 +51,17 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             _log = loggerConfig.CreateLogger();
         }
 
+        public void ConfigureWithInfoLevelEnabled()
+        {
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig
+                .MinimumLevel.Information()
+                .WriteTo.Console();
+
+            _log = loggerConfig.CreateLogger();
+        }
+
         public void ConfigurePatternLayoutAppenderForDecoration()
         {
             var loggerConfig = new LoggerConfiguration();

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -18,7 +18,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 {
     class SerilogLoggingWebAdapter : ILoggingAdapter
     {
-        private HttpClient _client;
+        private static readonly HttpClient _client = new HttpClient();
         private string _uriBase;
 
         public SerilogLoggingWebAdapter()
@@ -52,17 +52,30 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Configure()
         {
-            _client = new HttpClient();
 
-            var loggerConfig = new LoggerConfiguration();
-
-            loggerConfig
+            var loggerConfig = new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Fatal)
                 .MinimumLevel.Debug()
                 .WriteTo.Console();
 
-            Log.Logger = loggerConfig.CreateLogger();
+            RunApplication(loggerConfig);
+        }
+
+        public void ConfigureWithInfoLevelEnabled()
+        {
+            var loggerConfig = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Fatal)
+                .MinimumLevel.Information()
+                .WriteTo.Console();
+
+            RunApplication(loggerConfig);
+        }
+
+        private void RunApplication(LoggerConfiguration loggerConfig)
+        { 
+            var logger = loggerConfig.CreateLogger();
 
             var port = RandomPortGenerator.NextPort();
             _uriBase = "http://localhost:" + port + "/";
@@ -74,7 +87,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             IHostBuilder CreateHostBuilder(string uriBase)
             {
                 return Host.CreateDefaultBuilder()
-                .UseSerilog()
+                .UseSerilog(logger)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                 webBuilder.UseStartup<Startup>();
@@ -106,7 +119,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-
             services.AddControllers();
         }
 


### PR DESCRIPTION
## Description

Our instrumentation point for Microsoft Extensions Logging in agent log forwarding is invoked before any of the built in log level filtering has taken place. Due to this, logs with a lower level than what was configured in MEL were being forwarded to New Relic. 

These changes resolve that issue by querying MEL to see if the level of observed log events are enabled or disabled.

Resolves #1230 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
