### PR TITLE
Add new API to set a custom span name

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 * Support of setting up labels via appsettings.json and app/web.config file. [#1204](https://github.com/newrelic/newrelic-dotnet-agent/pull/1204)
 * Additional DEBUG-level logging of all environment variables.
+* Adds a new `SetName()` method to the Agent API for spans that allows customization of segment/span/metric names for custom instrumentation. [#1238](https://github.com/newrelic/newrelic-dotnet-agent/pull/1238)
 
 ### Fixes
 * Resolves an issue where log forwarding could drop logs in async scenarios. [#1201](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)

--- a/src/Agent/NewRelic.Api.Agent/ISpan.cs
+++ b/src/Agent/NewRelic.Api.Agent/ISpan.cs
@@ -8,11 +8,19 @@ namespace NewRelic.Api.Agent
     /// </summary>
     public interface ISpan
     {
-        /// <summary> Add a key/value pair to the transaction.  These are reported in errors and
-        /// transaction traces.</summary>
-        ///
-        /// <param name="key">   The key name to add to the span attributes. Limited to 255-bytes.</param>
-        /// <param name="value"> The value to add to the current span.  Values are limited to 255-bytes.</param>
+        /// <summary>
+        /// Add a key/value pair to the span.
+        /// </summary>
+        /// <param name="key"> The key name to add to the span attributes. Limited to 255-bytes.</param>
+        /// <param name="value"> The value to add to the current span. Limited to 255-bytes.</param>
+        /// <returns>ISpan to support builder pattern</returns>
         ISpan AddCustomAttribute(string key, object value);
+
+        /// <summary>
+        /// Sets the name of the current span.
+        /// </summary>
+        /// <param name="name">The new name for the span.</param>
+        /// <returns>ISpan to support builder pattern</returns>
+        ISpan SetName(string name);
     }
 }

--- a/src/Agent/NewRelic.Api.Agent/NoOpSpan.cs
+++ b/src/Agent/NewRelic.Api.Agent/NoOpSpan.cs
@@ -9,5 +9,10 @@ namespace NewRelic.Api.Agent
         {
             return this;
         }
+
+        public ISpan SetName(string name)
+        {
+            return this;
+        }
     }
 }

--- a/src/Agent/NewRelic.Api.Agent/Span.cs
+++ b/src/Agent/NewRelic.Api.Agent/Span.cs
@@ -27,11 +27,31 @@ namespace NewRelic.Api.Agent
             try
             {
                 _wrappedSpan.AddCustomAttribute(key, value);
-                return this;
             }
             catch (RuntimeBinderException)
             {
                 _isAddCustomAttributeAvailable = false;
+            }
+
+            return this;
+        }
+
+        private static bool _isSetNameAvailable = true;
+
+        public ISpan SetName(string name)
+        {
+            if (!_isSetNameAvailable)
+            {
+                return _noOpSpan.SetName(name);
+            }
+
+            try
+            {
+                _wrappedSpan.SetName(name);
+            }
+            catch (RuntimeBinderException)
+            {
+                _isSetNameAvailable = false;
             }
 
             return this;

--- a/src/Agent/NewRelic/Agent/Core/Api/SpanBridgeApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/SpanBridgeApi.cs
@@ -11,7 +11,6 @@ namespace NewRelic.Agent.Core.Api
 {
     public class SpanBridgeApi
     {
-
         private readonly ISpan _span;
         private readonly IApiSupportabilityMetricCounters _apiSupportabilityMetricCounters;
         private readonly IConfigurationService _configSvc;
@@ -44,9 +43,31 @@ namespace NewRelic.Agent.Core.Api
                 }
                 catch (Exception)
                 {
-                    //Swallow the error
+                    // Swallow the error.. nom nom
                 }
+            }
 
+            return _span;
+        }
+
+        public object SetName(string name)
+        {
+            try
+            {
+                _apiSupportabilityMetricCounters.Record(ApiMethod.SpanSetName);
+
+                _span.SetName(name);
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    Log.Error($"Error in SetName: {ex}");
+                }
+                catch (Exception)
+                {
+                    // Swallow the error.. nom nom
+                }
             }
 
             return _span;

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/ApiSupportabilityMetricCounters.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/ApiSupportabilityMetricCounters.cs
@@ -36,7 +36,8 @@ namespace NewRelic.Agent.Core.Metric
         TransactionGetCurrentSpan = 22,
         SpanAddCustomAttribute = 23,
         InsertDistributedTraceHeaders = 24,
-        AcceptDistributedTraceHeaders = 25
+        AcceptDistributedTraceHeaders = 25,
+        SpanSetName = 26
     }
 
     public interface IApiSupportabilityMetricCounters : IOutOfBandMetricSource

--- a/src/Agent/NewRelic/Agent/Core/Segments/CustomSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/CustomSegmentData.cs
@@ -41,7 +41,13 @@ namespace NewRelic.Agent.Core.Segments
             var duration = segment.Duration.Value;
             var exclusiveDuration = TimeSpanMath.Max(TimeSpan.Zero, duration - durationOfChildren);
 
-            MetricBuilder.TryBuildCustomSegmentMetrics(Name, duration, exclusiveDuration, txStats);
+            var name = Name;
+            if (!string.IsNullOrWhiteSpace(segment.SegmentNameOverride))
+            {
+                name = segment.SegmentNameOverride;
+            }
+
+            MetricBuilder.TryBuildCustomSegmentMetrics(name, duration, exclusiveDuration, txStats);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Segments/MethodSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/MethodSegmentData.cs
@@ -50,7 +50,16 @@ namespace NewRelic.Agent.Core.Segments
         {
             var duration = segment.Duration.Value;
             var exclusiveDuration = TimeSpanMath.Max(TimeSpan.Zero, duration - durationOfChildren);
-            MetricBuilder.TryBuildMethodSegmentMetric(Type, Method, duration, exclusiveDuration, txStats);
+           
+            if (!string.IsNullOrWhiteSpace(segment.SegmentNameOverride))
+            {
+                MetricBuilder.TryBuildSimpleSegmentMetric(segment.SegmentNameOverride, duration, exclusiveDuration, txStats);
+            }
+            else
+            {
+                MetricBuilder.TryBuildMethodSegmentMetric(Type, Method, duration, exclusiveDuration, txStats);
+            }
+            
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
@@ -36,6 +36,8 @@ namespace NewRelic.Agent.Core.Segments
         public string UserCodeFunction { get => string.Empty; set { } }
         public string UserCodeNamespace { get => string.Empty; set { } }
 
+		public string SegmentNameOverride { get; set; } = null;
+		
         public void End() { }
         public void End(Exception ex) { }
         public void MakeCombinable() { }
@@ -53,6 +55,11 @@ namespace NewRelic.Agent.Core.Segments
         }
 
         public ISpan AddCustomAttribute(string key, object value)
+        {
+            return this;
+        }
+
+        public ISpan SetName(string name)
         {
             return this;
         }

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -72,6 +72,7 @@ namespace NewRelic.Agent.Core.Segments
             UniqueId = segment.UniqueId;
             ParentUniqueId = segment.ParentUniqueId;
             MethodCallData = segment.MethodCallData;
+            SegmentNameOverride = segment.SegmentNameOverride;
             _parameters = parameters;
             Combinable = segment.Combinable;
             IsLeaf = false;
@@ -225,8 +226,10 @@ namespace NewRelic.Agent.Core.Segments
         // customer code.
         public string UserCodeNamespace { get; set; } = null;
         public string UserCodeFunction { get; set; } = null;
-
-        private void Finish()
+		
+        public string SegmentNameOverride { get; set; }
+        
+		private void Finish()
         {
             var endTime = _transactionSegmentState.GetRelativeTime();
             RelativeEndTime = endTime;
@@ -328,6 +331,11 @@ namespace NewRelic.Agent.Core.Segments
 
         public string GetTransactionTraceName()
         {
+            if(!string.IsNullOrWhiteSpace(SegmentNameOverride))
+            {
+                return SegmentNameOverride;
+            }
+
             return Data.GetTransactionTraceName();
         }
 
@@ -377,6 +385,12 @@ namespace NewRelic.Agent.Core.Segments
 
             AttribDefs.GetCustomAttributeForSpan(key).TrySetValue(customAttribValues, value);
 
+            return this;
+        }
+
+        public ISpan SetName(string name)
+        {
+            SegmentNameOverride = name;
             return this;
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/Segments/SimpleSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/SimpleSegmentData.cs
@@ -43,7 +43,13 @@ namespace NewRelic.Agent.Core.Segments
             var duration = segment.Duration.Value;
             var exclusiveDuration = TimeSpanMath.Max(TimeSpan.Zero, duration - durationOfChildren);
 
-            MetricBuilder.TryBuildSimpleSegmentMetric(Name, duration, exclusiveDuration, txStats);
+            var name = Name;
+            if (!string.IsNullOrWhiteSpace(segment.SegmentNameOverride))
+            {
+                name = segment.SegmentNameOverride;
+            }
+
+            MetricBuilder.TryBuildSimpleSegmentMetric(name, duration, exclusiveDuration, txStats);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISegment.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISegment.cs
@@ -39,6 +39,12 @@ namespace NewRelic.Agent.Api
         string SpanId { get; }
 
         /// <summary>
+        /// Provides the ability to override a segment name. If this is anything other than null or empty,
+        /// then this value should be used as the segment/span name.
+        /// </summary>
+        string SegmentNameOverride { get; set; }
+
+        /// <summary>
         /// Ends this transaction segment.
         /// </summary>
         void End();

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISpan.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISpan.cs
@@ -10,5 +10,7 @@ namespace NewRelic.Agent.Api
     public interface ISpan
     {
         ISpan AddCustomAttribute(string key, object value);
+
+        ISpan SetName(string name);
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/ConsoleInstrumentationLoaderCore.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ConsoleInstrumentationLoaderCore/ConsoleInstrumentationLoaderCore.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.41.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\Shared\Shared.csproj" />
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>NewRelic.Agent.IntegrationTestHelpers</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.41.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="xunit" version="2.4.0" />

--- a/tests/Agent/IntegrationTests/IntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/IntegrationTests.sln
@@ -108,6 +108,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleMultiFunctionApplicationCore", "SharedApplications\ConsoleMultiFunctionApplicationCore\ConsoleMultiFunctionApplicationCore.csproj", "{4213F281-732C-4447-B347-1C46E3609986}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultiFunctionApplicationHelpers", "SharedApplications\Common\MultiFunctionApplicationHelpers\MultiFunctionApplicationHelpers.csproj", "{882747A5-5B57-4AD9-B209-D1F03A657DB9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B187563A-795B-4C70-A525-6470B88AD341} = {B187563A-795B-4C70-A525-6470B88AD341}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreMvcCoreFrameworkApplication", "Applications\AspNetCoreMvcCoreFrameworkApplication\AspNetCoreMvcCoreFrameworkApplication.csproj", "{63EC546C-650D-4CF4-94C4-A350D1D491FD}"
 EndProject
@@ -130,6 +133,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore5BasicWebApiApplication", "Applications\AspNetCore5BasicWebApiApplication\AspNetCore5BasicWebApiApplication.csproj", "{D11C4843-B0B9-4FB0-8D2F-DBE8604298D9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore6BasicWebApiApplication", "Applications\AspNetCore6BasicWebApiApplication\AspNetCore6BasicWebApiApplication.csproj", "{66138A9F-0B28-4CB3-9DF9-D22C19641043}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.Api.Agent", "..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj", "{B187563A-795B-4C70-A525-6470B88AD341}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -349,6 +354,10 @@ Global
 		{66138A9F-0B28-4CB3-9DF9-D22C19641043}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66138A9F-0B28-4CB3-9DF9-D22C19641043}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66138A9F-0B28-4CB3-9DF9-D22C19641043}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B187563A-795B-4C70-A525-6470B88AD341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B187563A-795B-4C70-A525-6470B88AD341}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B187563A-795B-4C70-A525-6470B88AD341}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B187563A-795B-4C70-A525-6470B88AD341}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
@@ -1,0 +1,96 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using MultiFunctionApplicationHelpers;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+
+namespace NewRelic.Agent.IntegrationTests.Api
+{
+    [NetFrameworkTest]
+    public class CustomSpanNameApiTestsFWLatest : CustomSpanNameApiTests<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public CustomSpanNameApiTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class CustomSpanNameApiTestsCoreLatest : CustomSpanNameApiTests<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public CustomSpanNameApiTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public abstract class CustomSpanNameApiTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    {
+        protected readonly TFixture Fixture;
+
+        public CustomSpanNameApiTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestLogger = output;
+
+            Fixture.AddCommand($"AttributeInstrumentation TransactionWithCustomSpanName CustomSpanName");
+            Fixture.AddCommand("RootCommands DelaySeconds 5");
+
+            Fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.ForceTransactionTraces();
+                }
+            );
+
+            Fixture.Initialize();
+        }
+
+        [Fact]
+        public void SupportabilityMetricExists()
+        {
+            var expectedMetric = new Assertions.ExpectedMetric { metricName = $"Supportability/ApiInvocation/SpanSetName", callCount = 1 };
+            Assertions.MetricExists(expectedMetric, Fixture.AgentLog.GetMetrics());
+        }
+
+        [Fact]
+        public void MethodMetricsHaveCustomSpanName()
+        {
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"DotNet/CustomSpanName", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"DotNet/CustomSpanName", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Internal.AttributeInstrumentation/TransactionWithCustomSpanName", callCount = 1 }
+            };
+
+            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+
+            Assertions.MetricsExist(expectedMetrics, metrics);
+        }
+
+        [Fact]
+        public void TransactionTraceContainsSegmentWithCustomSpanName()
+        {
+            var transactionTrace = Fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
+            Assert.NotNull(transactionTrace);
+
+            transactionTrace.TraceData.ContainsSegment("CustomSpanName");
+        }
+
+        [Fact]
+        public void SpanEventDataHasCustomSpanName()
+        {
+            var spanEvents = Fixture.AgentLog.GetSpanEvents();
+            Assert.Contains(spanEvents, x => (string)x.IntrinsicAttributes["name"] == "CustomSpanName");
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/Shared/Shared.csproj
+++ b/tests/Agent/IntegrationTests/Shared/Shared.csproj
@@ -48,6 +48,10 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.100.23" />
     <PackageReference Include="AWSSDK.Core" Version="3.3.101.14" />
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.41.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -100,7 +100,6 @@
     <PackageReference Include="Microsoft.Owin.Hosting" Version="4.1.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.41.1" />
     <PackageReference Include="Owin" Version="1.0.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
@@ -164,6 +163,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
     <ProjectReference Include="..\..\..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />
     <ProjectReference Include="..\..\..\Shared\Shared.csproj" />
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AttributeInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AttributeInstrumentation.cs
@@ -85,8 +85,12 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Internal
 
         [Trace]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        private static void DoSomeWork()
+        private static void DoSomeWork(string customSpanName = null)
         {
+            if (!string.IsNullOrEmpty(customSpanName))
+            {
+                NewRelic.Api.Agent.NewRelic.GetAgent().CurrentSpan.SetName(customSpanName);
+            }
         }
 
         [Trace]
@@ -118,6 +122,16 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Internal
         private static async Task<string> SpanOrTransactionBasedOnConfig()
         {
             return await Task.FromResult("New Transaction or span based on config.");
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TransactionWithCustomSpanName(string spanName)
+        {
+            Task.Delay(TimeSpan.FromMilliseconds(10)).Wait();
+
+            DoSomeWork(spanName);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="8.41.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Common\MultiFunctionApplicationHelpers\MultiFunctionApplicationHelpers.csproj" />
     <ProjectReference Include="..\Common\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />
   </ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.74
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnboundedIntegrationTests", "UnboundedIntegrationTests\UnboundedIntegrationTests.csproj", "{1E17AA8A-B8BA-4A64-892C-B58151293142}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -47,6 +47,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetStandardTestLibrary", "SharedApplications\Common\NetStandardTestLibrary\NetStandardTestLibrary.csproj", "{B64766CA-8731-493F-8417-61A70F783EB7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MongoDbApi", "UnboundedApplications\MongoDbApi\MongoDbApi.csproj", "{39F0F3D0-F672-4B3B-939B-08FA8E4FE722}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.Api.Agent", "..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj", "{1D93182F-CF1D-47A1-BC0F-4E27DE9ACEF9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -118,6 +120,10 @@ Global
 		{39F0F3D0-F672-4B3B-939B-08FA8E4FE722}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{39F0F3D0-F672-4B3B-939B-08FA8E4FE722}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{39F0F3D0-F672-4B3B-939B-08FA8E4FE722}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D93182F-CF1D-47A1-BC0F-4E27DE9ACEF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D93182F-CF1D-47A1-BC0F-4E27DE9ACEF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D93182F-CF1D-47A1-BC0F-4E27DE9ACEF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D93182F-CF1D-47A1-BC0F-4E27DE9ACEF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -137,7 +143,7 @@ Global
 		{39F0F3D0-F672-4B3B-939B-08FA8E4FE722} = {03BAC949-FAD7-4EE6-A2BD-45E3DE2407F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 		SolutionGuid = {656848E2-BFD2-4092-9328-C6CDF39B1274}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Description

Closes #1023 

Adds a `SetName()` method to ISpan in the agent API. Using this new API will change the Segment/Span/Metric names. As it wasn't obvious how to apply this over-ride to metrics for all segment types, metric names are only modified for CustomSegments, MethodSegments, and SimpleSegments (these are the segment types used by some built in instrumentation, custom instrumentation XML, and agent API custom instrumentation). 

Segment/Span names should be updated for all instrumented methods, but metric names will not be updated for DatastoreSegments, MessageBrokerSegments, or ExternalSegments (using to the agent API to even attempt to mutate these segment types would take great effort).

A new supportability metric is recorded/reported for this API usage: `Supportability/ApiInvocation/SpanSetname`

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
