### PR TITLE
Setting from NR backend should override setting from MAX_EVENT_SAMPLES_STORED and MAX_TRANSACTION_SAMPLES_STORED env var

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * Resolves an issue where log forwarding could drop logs in async scenarios. [#1174](https://github.com/newrelic/newrelic-dotnet-agent/pull/1201)
+* Fixes an agent configuration bug where values set in the `MAX_EVENT_SAMPLES_STORED` and `MAX_TRANSACTION_SAMPLES_STORED` environment variables, which configure the maximum samples stored per one-minute harvest interval, were not being properly converted to apply to the five-second harvest interval for those data types. [#1239](https://github.com/newrelic/newrelic-dotnet-agent/pull/1239)
 
 ## [10.0.0] - 2022-07-19
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1528,10 +1528,8 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                return (int)EnvironmentOverrides(
-                    ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(),
-                        _localConfiguration.customEvents.maximumSamplesStored),
-                    "MAX_EVENT_SAMPLES_STORED");
+                var maxValue = _localConfiguration.customEvents.maximumSamplesStored;
+                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_EVENT_SAMPLES_STORED"));
             }
         }
 
@@ -1600,9 +1598,8 @@ namespace NewRelic.Agent.Core.Configuration
             get
             {
                 var maxValue = _localConfiguration.transactionEvents.maximumSamplesStored;
-                return (int)EnvironmentOverrides(
-                    ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestLimit(), maxValue),
-                    "MAX_TRANSACTION_SAMPLES_STORED");
+
+                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_TRANSACTION_SAMPLES_STORED"));
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1598,6 +1598,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
                 var maxValue = _localConfiguration.transactionEvents.maximumSamplesStored;
 
                 return ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_TRANSACTION_SAMPLES_STORED"));

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1528,6 +1528,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+               // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
                 var maxValue = _localConfiguration.customEvents.maximumSamplesStored;
                 return ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_EVENT_SAMPLES_STORED"));
             }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -893,6 +893,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         public int? SamplingTarget => _serverConfiguration.SamplingTarget;
 
+        // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
         public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
            EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
 
@@ -1124,6 +1125,8 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
+                // Faster Event Harvest configuration rules apply here, if/when we add an environment variable for this property we need to make sure that
+                // ServerOverrides takes precedence over EnvironmentOverrides
                 return ServerOverrides(_serverConfiguration.EventHarvestConfig?.ErrorEventHarvestLimit(), _localConfiguration.errorCollector.maxEventSamplesStored);
             }
         }
@@ -1528,7 +1531,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-               // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
+                // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
                 var maxValue = _localConfiguration.customEvents.maximumSamplesStored;
                 return ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_EVENT_SAMPLES_STORED"));
             }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2990,8 +2990,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Assert.AreEqual(10, _defaultConfig.CustomEventsMaximumSamplesStored);
         }
 
-        [TestCase("10", 20, 30, ExpectedResult = 10)]
-        [TestCase("10", null, 30, ExpectedResult = 10)]
+        [TestCase("10", 20, 30, ExpectedResult = 30)]
+        [TestCase("10", null, 30, ExpectedResult = 30)]
         [TestCase("10", 20, null, ExpectedResult = 10)]
         [TestCase("10", null, null, ExpectedResult = 10)]
         [TestCase(null, 20, 30, ExpectedResult = 30)]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -190,8 +190,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Assert.AreEqual(10, _defaultConfig.TransactionEventsMaximumSamplesStored);
         }
 
-        [TestCase("10", 20, 30, ExpectedResult = 10)]
-        [TestCase("10", null, 30, ExpectedResult = 10)]
+        [TestCase("10", 20, 30, ExpectedResult = 30)]
+        [TestCase("10", null, 30, ExpectedResult = 30)]
         [TestCase("10", 20, null, ExpectedResult = 10)]
         [TestCase("10", null, null, ExpectedResult = 10)]
         [TestCase(null, 20, 30, ExpectedResult = 30)]


### PR DESCRIPTION
## Description

At the current state, when MAX_EVENT_SAMPLES_STORED env var is set, the agent uses value from the env var for the preconnect request. The server replies with a smaller value (whatver the value sent up get divided by 12). However, the agent won't use the value from the server because our current logic allows the env to override any config values. This causes configuration mismatched as well as incorrect `...\EvenHarvest\CustomEventData\HarvestLimit` supportability metric value being reported.

The same story happens to the MAX_TRANSACTION_SAMPLES_STORED env var usage.

The right approach is to let the server config to dictate the final value that the agent will use.