### PR TITLE
Fix browser monitoring writer

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 
+### Fixes
+* Resolves an issue where the .NET agent incorrectly injects the browser agent script inside Html pages. [#1247](https://github.com/newrelic/newrelic-dotnet-agent/pull/1247)
+
 ## [10.1.0] - 2022-09-12
 
 ### New Features

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -68,9 +68,18 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             // Check if we found the tags and based on which comes last AND that this happens INSIDE the HEAD tag - do a replace on that.
             if ((xUaCompatibleFilterMatch.Success || charsetFilterMatch.Success) && (xUaCompatibleFilterMatch.Index < closingHeadTagIndex || charsetFilterMatch.Index > closingHeadTagIndex))
             {
-                var contentSubString = xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index ? content.Substring(xUaCompatibleFilterMatch.Index, xUaCompatibleFilterMatch.Length) : content.Substring(charsetFilterMatch.Index, charsetFilterMatch.Length);
+                var match = charsetFilterMatch;
+                if(xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index)
+                {
+                    match = xUaCompatibleFilterMatch;
+                }
+
+                var contentSubString = content.Substring(match.Index, match.Length);
                 var jsScriptWithContentSubString = string.Format("{0}{1}", contentSubString, _getJsScript());
-                return xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index ? XUaCompatibleFilter.Replace(content, jsScriptWithContentSubString, 1) : CharsetFilter.Replace(content, jsScriptWithContentSubString, 1);
+
+                return content.Remove(match.Index, match.Length).Insert(match.Index, jsScriptWithContentSubString);
+        
+                //return xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index ? XUaCompatibleFilter.Replace(content, jsScriptWithContentSubString, 1) : CharsetFilter.Replace(content, jsScriptWithContentSubString, 1);
             }
 
             // Found both HEAD tags, no  meta tags, get index immediately after the <HEAD>. Find first '>' which will be end of head opening tag.

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -78,8 +78,6 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
                 var jsScriptWithContentSubString = string.Format("{0}{1}", contentSubString, _getJsScript());
 
                 return content.Remove(match.Index, match.Length).Insert(match.Index, jsScriptWithContentSubString);
-        
-                //return xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index ? XUaCompatibleFilter.Replace(content, jsScriptWithContentSubString, 1) : CharsetFilter.Replace(content, jsScriptWithContentSubString, 1);
             }
 
             // Found both HEAD tags, no  meta tags, get index immediately after the <HEAD>. Find first '>' which will be end of head opening tag.

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/JavaScriptAgent.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/JavaScriptAgent.cs
@@ -19,5 +19,13 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var json = match.Groups[1].Value;
             return JsonConvert.DeserializeObject<Dictionary<string, string>>(json) ?? new Dictionary<string, string>();
         }
+
+        public static string GetJavaScriptAgentScriptFromSource(string source)
+        {
+            const string regex = @"<script type=""text/javascript"">(.*?)</script>";
+            var match = Regex.Matches(source, regex)[1]; //specifically look for the 2nd match. The first match contains settings. The 2nd match contains the actual browser agent.
+            Assert.True(match.Success, "Did not find a match for the JavaScript agent config in the provided page.");
+            return match.Groups[1].Value;
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/ConnectResponseData.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Models/ConnectResponseData.cs
@@ -89,7 +89,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 
         [JsonProperty("js_agent_loader_version")]
         public string JsAgentLoaderVersion { get; set; }
-
+        
         [JsonProperty("js_agent_file")]
         public string JsAgentFile { get; set; }
 
@@ -110,5 +110,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers.Models
 
         [JsonProperty("browser_monitoring.debug")]
         public string BrowserMonitoringDebug { get; set; }
+
+        [JsonProperty("js_agent_loader")]
+        public string JsAgentLoader { get; set; }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection.cs
@@ -1,0 +1,58 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.AgentFeatures
+{
+    [NetFrameworkTest]
+    public class BrowserAgentAutoInjection : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    {
+        private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
+
+        private string _htmlContent;
+
+        public BrowserAgentAutoInjection(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+            : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.AutoInstrumentBrowserMonitoring(true);
+                    configModifier.BrowserMonitoringEnableAttributes(true);
+
+                },
+                exerciseApplication: () =>
+                {
+                    _htmlContent = _fixture.Get();
+                }
+            );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            NrAssert.Multiple(
+                () => Assert.NotNull(_htmlContent)
+            );
+
+            var connecResponsetData = _fixture.AgentLog.GetConnectResponseData();
+
+            var jsAgentFromConnectResponse = connecResponsetData.JsAgentLoader;
+
+            var jsAgentFromHtmlContent = JavaScriptAgent.GetJavaScriptAgentScriptFromSource(_htmlContent);
+
+            Assert.Equal(jsAgentFromConnectResponse, jsAgentFromHtmlContent);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection.cs
@@ -46,9 +46,9 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
                 () => Assert.NotNull(_htmlContent)
             );
 
-            var connecResponsetData = _fixture.AgentLog.GetConnectResponseData();
+            var connecResponseData = _fixture.AgentLog.GetConnectResponseData();
 
-            var jsAgentFromConnectResponse = connecResponsetData.JsAgentLoader;
+            var jsAgentFromConnectResponse = connecResponseData.JsAgentLoader;
 
             var jsAgentFromHtmlContent = JavaScriptAgent.GetJavaScriptAgentScriptFromSource(_htmlContent);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DisableBrowserAutoInjectionWhenGetBrowserTimingHeaderIsCalled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/DisableBrowserAutoInjectionWhenGetBrowserTimingHeaderIsCalled.cs
@@ -11,14 +11,14 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.IntegrationTests.AgentFeatures
 {
     [NetFrameworkTest]
-    public class GetBrowserTimingHeaderAutoOn : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public class DisableBrowserAutoInjectionWhenGetBrowserTimingHeaderIsCalled : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
     {
         private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
 
         private string _browserTimingHeader;
         private string _htmlContentAfterCallToGetBrowserTiming;
 
-        public GetBrowserTimingHeaderAutoOn(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
+        public DisableBrowserAutoInjectionWhenGetBrowserTimingHeaderIsCalled(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output)
             : base(fixture)
         {
             _fixture = fixture;

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -9,7 +9,8 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
     public class Class_BrowserMonitoringWriter
     {
         private readonly string _jsScript =
-                            "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\",\"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
+                    "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
+
         [Test]
         public void empty_input_results_in_empty_output()
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -9,7 +9,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
     public class Class_BrowserMonitoringWriter
     {
         private readonly string _jsScript =
-                    "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
+                    "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"customString\":\"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
 
         [Test]
         public void empty_input_results_in_empty_output()


### PR DESCRIPTION
## Description

We identified a defect in the .Net agent with v1219 of the Browser agent. The newest browser agent script includes polyfills to help support some of the older browsers in use. As part of this the javascript includes `$1` and the .Net agent replaces that with the matched `<meta http-equiv="X-UA-Compatible" content="IE=edge" />` tag found. This is because of the use of the `Regex.Replace` method. 

This was reported through a customer case during the rollout of v1219 of the browser agent before the release was rolled back.
