### PR TITLE
Add missing Microsoft.Data.SqlClient instrumentation for .NET Framework

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 
+### Fixes
+* Resolves an issue where some instrumentation was missing for Microsoft.Data.SqlClient in .NET Framework. [#1248](https://github.com/newrelic/newrelic-dotnet-agent/pull/1248)
+
 ## [10.1.0] - 2022-09-12
 
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -47,6 +47,7 @@ SPDX-License-Identifier: Apache-2.0
       <!-- MS SQL flagship data access driver -->
       <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlCommand">
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior" />
+        <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior,System.String" />
         <exactMethodMatcher methodName="ExecuteNonQuery" />
         <exactMethodMatcher methodName="ExecuteScalar" />
         <exactMethodMatcher methodName="ExecuteXmlReader" />
@@ -140,6 +141,7 @@ SPDX-License-Identifier: Apache-2.0
       <!-- MS SQL flagship data access driver -->
       <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlCommand">
         <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="InternalExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteXmlReaderAsync" parameters="System.Threading.CancellationToken" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -44,9 +44,11 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteXmlReader" />
       </match>
 
-      <!-- MS SQL flagship data access driver -->
+      <!-- MS SQL flagship data access driver (core & framework via nuget) -->
       <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlCommand">
+        <!-- This form of ExecuteReader works for the .NET Core/Platform implementation -->
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior" />
+        <!-- This form of ExecuteReader works for the .NET Framework implementation -->
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior,System.String" />
         <exactMethodMatcher methodName="ExecuteNonQuery" />
         <exactMethodMatcher methodName="ExecuteScalar" />
@@ -138,9 +140,11 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteXmlReaderAsync" parameters="System.Threading.CancellationToken" />
       </match>
 
-      <!-- MS SQL flagship data access driver -->
+      <!-- MS SQL flagship data access driver (core & framework via nuget) -->
       <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlCommand">
+        <!-- This form of ExecuteReaderAsync works for the .NET Core/Platform implementation -->
         <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
+        <!-- This form of (Internal)ExecuteReaderAsync works for the .NET Framework implementation -->
         <exactMethodMatcher methodName="InternalExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -122,7 +122,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
-      <Version>4.5.5</Version>
+      <Version>4.5.2</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.5.2</Version>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -88,6 +88,9 @@
     <PackageReference Include="Microsoft.AspNet.WebPages">
       <Version>3.2.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.SqlClient">
+      <Version>3.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Web.Infrastructure">
       <Version>1.0.0.0</Version>
     </PackageReference>
@@ -119,7 +122,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
-      <Version>4.5.2</Version>
+      <Version>4.5.5</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.5.2</Version>
@@ -149,6 +152,7 @@
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="Controllers\CouchbaseController.cs" />
     <Compile Include="Controllers\IbmDb2Controller.cs" />
+    <Compile Include="Controllers\MicrosoftDataSqlClientController.cs" />
     <Compile Include="Controllers\PostgresController.cs" />
     <Compile Include="Controllers\OracleController.cs" />
     <Compile Include="Controllers\MsSqlController.cs" />

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/MicrosoftDataSqlClientController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/MicrosoftDataSqlClientController.cs
@@ -1,0 +1,277 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using NewRelic.Agent.IntegrationTests.Shared;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using System;
+
+namespace BasicMvcApplication.Controllers
+{
+    public class MicrosoftDataSqlClientController : Controller
+    {
+        private const string InsertPersonMsSql = "INSERT INTO {0} (FirstName, LastName, Email) VALUES('Testy', 'McTesterson', 'testy@mctesterson.com')";
+        private const string DeletePersonMsSql = "DELETE FROM {0} WHERE Email = 'testy@mctesterson.com'";
+        private const string CountPersonMsSql = "SELECT COUNT(*) FROM {0} WITH(nolock)";
+
+        [HttpGet]
+        //[Route("MicrosoftDataSqlClient/MsSql")]
+        public string MsSql(string tableName)
+        {
+            try
+            {
+                var teamMembers = new List<string>();
+
+                using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
+                    {
+
+                        using (var reader = command.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                if (reader.NextResult())
+                                {
+                                    teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                }
+                            }
+                        }
+                    }
+
+                    var insertSql = string.Format(InsertPersonMsSql, tableName);
+                    var countSql = string.Format(CountPersonMsSql, tableName);
+                    var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                    using (var command = new SqlCommand(insertSql, connection))
+                    {
+                        var insertCount = command.ExecuteNonQuery();
+                    }
+
+                    using (var command = new SqlCommand(countSql, connection))
+                    {
+                        var teamMemberCount = command.ExecuteScalar();
+                    }
+
+                    using (var command = new SqlCommand(deleteSql, connection))
+                    {
+                        var deleteCount = command.ExecuteNonQuery();
+                    }
+                }
+
+                return string.Join(",", teamMembers);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error in MsSql controller method: " + ex.Message);
+                throw;
+            }
+        }
+
+        [HttpGet]
+        //[Route("MicrosoftDataSqlClient/MsSqlAsync")]
+        public async Task<string> MsSqlAsync(string tableName)
+        {
+            try
+            {
+                var teamMembers = new List<string>();
+
+                using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
+                    {
+                        using (var reader = await command.ExecuteReaderAsync())
+                        {
+                            while (await reader.ReadAsync())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                if (await reader.NextResultAsync())
+                                {
+                                    teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                }
+                            }
+                        }
+                    }
+
+                    var insertSql = string.Format(InsertPersonMsSql, tableName);
+                    var countSql = string.Format(CountPersonMsSql, tableName);
+                    var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                    using (var command = new SqlCommand(insertSql, connection))
+                    {
+                        var insertCount = await command.ExecuteNonQueryAsync();
+                    }
+
+                    using (var command = new SqlCommand(countSql, connection))
+                    {
+                        var teamMemberCount = await command.ExecuteScalarAsync();
+                    }
+
+                    using (var command = new SqlCommand(deleteSql, connection))
+                    {
+                        var deleteCount = await command.ExecuteNonQueryAsync();
+                    }
+                }
+
+                return string.Join(",", teamMembers);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error in MsSqlAsync controller method: " + ex.Message);
+                throw;
+            }
+        }
+
+        [HttpGet]
+        //[Route("MicrosoftDataSqlClient/MsSql_WithParameterizedQuery")]
+        public string MsSql_WithParameterizedQuery(string tableName, bool paramsWithAtSign)
+        {
+            try
+            {
+                var teamMembers = new List<string>();
+
+                using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
+                    {
+                        command.Parameters.Add(new SqlParameter(paramsWithAtSign ? "@FN" : "FN", "O'Keefe"));
+                        using (var reader = command.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                if (reader.NextResult())
+                                {
+                                    teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return string.Join(",", teamMembers);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error in MsSql_WithParameterizedQuery controller method: " + ex.Message);
+                throw;
+            }
+        }
+
+        [HttpGet]
+        //[Route("MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery")]
+        public async Task<string> MsSqlAsync_WithParameterizedQuery(string tableName, bool paramsWithAtSign)
+        {
+            try
+            {
+                var teamMembers = new List<string>();
+
+                using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+                {
+                    connection.Open();
+
+                    using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
+                    {
+                        command.Parameters.Add(new SqlParameter(paramsWithAtSign ? "@FN" : "FN", "O'Keefe"));
+                        using (var reader = await command.ExecuteReaderAsync())
+                        {
+                            while (await reader.ReadAsync())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                if (await reader.NextResultAsync())
+                                {
+                                    teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                                }
+                            }
+                        }
+                    }
+
+                    var insertSql = string.Format(InsertPersonMsSql, tableName);
+                    var countSql = string.Format(CountPersonMsSql, tableName);
+                    var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                    using (var command = new SqlCommand(insertSql, connection))
+                    {
+                        var insertCount = await command.ExecuteNonQueryAsync();
+                    }
+
+                    using (var command = new SqlCommand(countSql, connection))
+                    {
+                        var teamMemberCount = await command.ExecuteScalarAsync();
+                    }
+
+                    using (var command = new SqlCommand(deleteSql, connection))
+                    {
+                        var deleteCount = await command.ExecuteNonQueryAsync();
+                    }
+                }
+
+                return string.Join(",", teamMembers);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error in MsSqlAsync_WithParameterizedQuery controller method: " + ex.Message);
+                throw;
+            }
+        }
+
+        [HttpGet]
+        //[Route("MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure")]
+        public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
+        {
+            try
+            {
+                EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
+
+                using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+                using (var command = new SqlCommand(procedureName, connection))
+                {
+                    connection.Open();
+                    command.CommandType = CommandType.StoredProcedure;
+                    foreach (var parameter in DbParameterData.MsSqlParameters)
+                    {
+                        var paramName = paramsWithAtSign
+                            ? parameter.ParameterName
+                            : parameter.ParameterName.TrimStart('@');
+
+                        command.Parameters.Add(new SqlParameter(paramName, parameter.Value));
+                    }
+
+                    return command.ExecuteNonQuery();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error in MsSqlParameterizedStoredProcedure controller method: " + ex.Message);
+                throw;
+            }
+        }
+
+        private static readonly string CreateProcedureStatement = @"CREATE OR ALTER PROCEDURE [dbo].[{0}] {1} AS RETURN 0";
+
+        private void EnsureProcedure(string procedureName, DbParameter[] dbParameters)
+        {
+            var parameters = string.Join(", ", dbParameters.Select(x => $"{x.ParameterName} {x.DbTypeName}"));
+            var statement = string.Format(CreateProcedureStatement, procedureName, parameters);
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var command = new SqlCommand(statement, connection))
+            {
+                connection.Open();
+                command.ExecuteNonQuery();
+            }
+        }
+
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
@@ -19,7 +19,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     {
         private readonly RemoteServiceFixtures.MsSqlBasicMvcFixture _fixture;
 
-        public EnterpriseLibraryMsSqlTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
+        public EnterpriseLibraryMsSqlTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncLegacyAspPipelineTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncLegacyAspPipelineTests.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     {
         private readonly RemoteServiceFixtures.MsSqlBasicMvcFixture _fixture;
 
-        public MsSqlAsyncLegacyAspPipelineTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture)
+        public MsSqlAsyncLegacyAspPipelineTests(RemoteServiceFixtures.MsSqlBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
@@ -196,21 +196,44 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    #region Microsoft.Data.SqlClient Tests
+
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryFramework : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlAsync_WithParameterizedQuery", true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFramework : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
+    {
+        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlAsync_WithParameterizedQuery", false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    {
+        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", true)
         {
         }
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSign(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", false)
         {
         }
     }
+
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncParameterizedQueryTests.cs
@@ -202,7 +202,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryFramework : MsSqlAsyncTestsParameterizedQueryBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
     {
         public MicrosoftDataSqlClientAsyncTestsParameterizedQueryFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
-            
+
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlAsync_WithParameterizedQuery", true)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -179,9 +179,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTests : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientAsyncTests : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientAsyncTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientAsyncTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync/{tableName}")
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     public abstract class MsSqlAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
+        where TFixture : RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
@@ -178,10 +178,19 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTests : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientAsyncTestsFramework : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
     {
-        public MicrosoftDataSqlClientAsyncTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientAsyncTestsFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlAsync")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftDataSqlClientAsyncTestsCore : MsSqlAsyncTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    {
+        public MicrosoftDataSqlClientAsyncTestsCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlAsync/{tableName}")
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -128,18 +128,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientStoredProcedureTests : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests(MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientStoredProcedureTests(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", true)
         {
         }
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns(MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", false)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     public abstract class MsSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture:RemoteApplicationFixture, IMsSqlClientFixture
+        where TFixture : RemoteApplicationFixture, IMsSqlClientFixture
     {
         private readonly IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
@@ -111,7 +111,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureTests : MsSqlStoredProcedureTestsBase<MsSqlBasicMvcFixture>
     {
-        public MsSqlStoredProcedureTests(MsSqlBasicMvcFixture fixture, ITestOutputHelper output) 
+        public MsSqlStoredProcedureTests(MsSqlBasicMvcFixture fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MsSqlController/MsSqlParameterizedStoredProcedure", true)
         {
         }
@@ -126,20 +126,37 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientStoredProcedureTestsFramework : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureFramework>
+    {
+        public MicrosoftDataSqlClientStoredProcedureTestsFramework(MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlParameterizedStoredProcedure", true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFramework : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureFramework>
+    {
+        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFramework(MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSqlParameterizedStoredProcedure", false)
+        {
+        }
+    }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
+    public class MicrosoftDataSqlClientStoredProcedureTestsCore : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientStoredProcedureTestsCore(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", true)
         {
         }
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
+    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore : MsSqlStoredProcedureTestsBase<MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSigns(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore(MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure/{procedureName}/{paramsWithAtSign}", false)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOdbcDriverTests : MsSqlStoredProcedureUsingOdbcDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests(OdbcBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, true)
+        public MsSqlStoredProcedureUsingOdbcDriverTests(OdbcBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, true)
         {
         }
     }
@@ -116,7 +116,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns : MsSqlStoredProcedureUsingOdbcDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns(OdbcBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, false)
+        public MsSqlStoredProcedureUsingOdbcDriverTests_ParamsWithoutAtSigns(OdbcBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, false)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
@@ -103,7 +103,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOleDbDriverTests : MsSqlStoredProcedureUsingOleDbDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOleDbDriverTests(OleDbBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, true)
+        public MsSqlStoredProcedureUsingOleDbDriverTests(OleDbBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, true)
         {
         }
     }
@@ -111,7 +111,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns : MsSqlStoredProcedureUsingOleDbDriverTestsBase
     {
-        public MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns(OleDbBasicMvcFixture fixture, ITestOutputHelper output)  : base(fixture, output, false)
+        public MsSqlStoredProcedureUsingOleDbDriverTests_ParamsWithoutAtSigns(OleDbBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture, output, false)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -180,9 +180,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientTests : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientTests : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql/{tableName}")
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -16,12 +16,12 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     public abstract class MsSqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
+        where TFixture : RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
 
-        public MsSqlTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName) :  base(fixture)
+        public MsSqlTestsBase(TFixture fixture, ITestOutputHelper output, string expectedTransactionName) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -179,10 +179,19 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftDataSqlClientTests : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientTestsFramework : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
     {
-        public MicrosoftDataSqlClientTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientTestsFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSql")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftDataSqlClientTestsCore : MsSqlTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    {
+        public MicrosoftDataSqlClientTestsCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql/{tableName}")
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
@@ -164,18 +164,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientQueryParameterCaptureTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", true)
         {
         }
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixture>
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns(RemoteServiceFixtures.MicrosoftDataSqlClientFixture fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", false)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlWithParameterizedQueryTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
     public abstract class MsSqlQueryParameterCaptureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture:RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
+        where TFixture : RemoteApplicationFixture, RemoteServiceFixtures.IMsSqlClientFixture
     {
         private readonly RemoteServiceFixtures.IMsSqlClientFixture _fixture;
         private readonly string _expectedTransactionName;
@@ -163,19 +163,37 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
-    [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientQueryParameterCaptureTestsFramework : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientQueryParameterCaptureTestsFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSql_WithParameterizedQuery", true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFramework : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework>
+    {
+        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFramework(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureFramework fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClientController/MsSql_WithParameterizedQuery", false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MicrosoftDataSqlClientQueryParameterCaptureTestsCore : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    {
+        public MicrosoftDataSqlClientQueryParameterCaptureTestsCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", true)
         {
         }
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
+    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore : MsSqlQueryParameterCaptureTestsBase<RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSigns(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
+        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore(RemoteServiceFixtures.MicrosoftDataSqlClientFixtureCore fixture, ITestOutputHelper output)
             : base(fixture, output, "WebTransaction/MVC/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery/{tableName}/{paramsWithAtSign}", false)
         {
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixtureCore.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixtureCore.cs
@@ -1,0 +1,150 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+using System.Data.SqlClient;
+using System.Net;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.IntegrationTests.Shared;
+using Xunit;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
+{
+    public class MicrosoftDataSqlClientFixtureCore : RemoteApplicationFixture, IMsSqlClientFixture
+    {
+        private const string ApplicationDirectoryName = @"BasicMvcCoreApplication";
+        private const string ExecutableName = "BasicMvcCoreApplication.exe";
+
+        private const string CreatePersonTableMsSql = "CREATE TABLE {0} (FirstName varchar(20) NOT NULL, LastName varchar(20) NOT NULL, Email varchar(50) NOT NULL)";
+        private const string DropPersonTableMsSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP TABLE {0}";
+        private const string DropProcedureSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP PROCEDURE {0}";
+
+        public string TableName { get; }
+        public string ProcedureName { get; }
+
+        public MicrosoftDataSqlClientFixtureCore() : base(new RemoteService(ApplicationDirectoryName, ExecutableName, ApplicationType.Unbounded, createsPidFile: true, isCoreApp: true, publishApp: true))
+        {
+            TableName = GenerateTableName();
+            ProcedureName = GenerateProcedureName();
+            CreateTable();
+        }
+
+        public void GetMsSql()
+        {
+            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSql?tableName={TableName}";
+
+            using (var webClient = new WebClient())
+            {
+                var responseBody = webClient.DownloadString(address);
+                Assert.NotNull(responseBody);
+            }
+        }
+
+        public void GetMsSqlAsync()
+        {
+            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlAsync?tableName={TableName}";
+
+            using (var webClient = new WebClient())
+            {
+                var responseBody = webClient.DownloadString(address);
+                Assert.NotNull(responseBody);
+            }
+        }
+
+        public void GetMsSql_WithParameterizedQuery(bool paramsWithAtSign)
+        {
+            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSql_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
+
+            using (var webClient = new WebClient())
+            {
+                var responseBody = webClient.DownloadString(address);
+                Assert.NotNull(responseBody);
+            }
+        }
+
+        public void GetMsSqlAsync_WithParameterizedQuery(bool paramsWithAtSign)
+        {
+            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlAsync_WithParameterizedQuery?tableName={TableName}&paramsWithAtSign={paramsWithAtSign}";
+
+            using (var webClient = new WebClient())
+            {
+                var responseBody = webClient.DownloadString(address);
+                Assert.NotNull(responseBody);
+            }
+        }
+
+        public void GetMsSqlParameterizedStoredProcedure(bool paramsWithAtSign)
+        {
+            var address = $"http://localhost:{Port}/MicrosoftDataSqlClient/MsSqlParameterizedStoredProcedure?procedureName={ProcedureName}&paramsWithAtSign={paramsWithAtSign}";
+
+            using (var webClient = new WebClient())
+            {
+                var responseBody = webClient.DownloadString(address);
+                Assert.NotNull(responseBody);
+            }
+        }
+
+        private static string GenerateTableName()
+        {
+            var tableId = Guid.NewGuid().ToString("N").ToLower();
+            return $"person{tableId}";
+        }
+        private static string GenerateProcedureName()
+        {
+            var procId = Guid.NewGuid().ToString("N").ToLower();
+            return $"pTestProc{procId}";
+        }
+
+        private void CreateTable()
+        {
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                var createTable = string.Format(CreatePersonTableMsSql, TableName);
+                using (var command = new SqlCommand(createTable, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private void DropTable()
+        {
+            var dropTableSql = string.Format(DropPersonTableMsSql, TableName);
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand(dropTableSql, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private void DropProcedure()
+        {
+            var dropProcedureSql = string.Format(DropProcedureSql, ProcedureName);
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand(dropProcedureSql, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            DropTable();
+            DropProcedure();
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixtureCoreFramework.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MicrosoftDataSqlClientFixtureCoreFramework.cs
@@ -11,11 +11,8 @@ using Xunit;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
 {
-    public class MicrosoftDataSqlClientFixture : RemoteApplicationFixture, IMsSqlClientFixture
+    public class MicrosoftDataSqlClientFixtureFramework : RemoteApplicationFixture, IMsSqlClientFixture
     {
-        private const string ApplicationDirectoryName = @"BasicMvcCoreApplication";
-        private const string ExecutableName = "BasicMvcCoreApplication.exe";
-
         private const string CreatePersonTableMsSql = "CREATE TABLE {0} (FirstName varchar(20) NOT NULL, LastName varchar(20) NOT NULL, Email varchar(50) NOT NULL)";
         private const string DropPersonTableMsSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP TABLE {0}";
         private const string DropProcedureSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP PROCEDURE {0}";
@@ -23,8 +20,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
         public string TableName { get; }
         public string ProcedureName { get; }
 
-        public MicrosoftDataSqlClientFixture() : base(new RemoteService(ApplicationDirectoryName, ExecutableName, ApplicationType.Unbounded, createsPidFile: true, isCoreApp: true, publishApp: true))
+        public MicrosoftDataSqlClientFixtureFramework() : base(new RemoteWebApplication("BasicMvcApplication", ApplicationType.Unbounded))
         {
+            //base(new RemoteService(ApplicationDirectoryName, ExecutableName, ApplicationType.Unbounded, createsPidFile: true, isCoreApp: false, publishApp: true))
             TableName = GenerateTableName();
             ProcedureName = GenerateProcedureName();
             CreateTable();


### PR DESCRIPTION
## Description

Our existing Microsoft.Data.SqlClient instrumentation only had test coverage for .NET Core. This allowed a bug to slip under the radar where not all forms of `ExecuteReader` and `ExecuteReaderAsync` were properly profiled in .NET Framework. The existing instrumentation points worked fine for .NET Core, but the Microsoft Implementation for .NET Framework and .NET Core differ. A  new internal form of `ExecuteReaderAsync`, and a new form of `ExecuteReader` are now included in the instrumentation XML for Microsoft.Data.SqlClient. The newly added integration tests will break if the new instrumentation entries are removed, so there is high confidence that this resolves the issues with missing instrumentation reported by customers.

Closes #620.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
