### PR TITLE
Include original message in NLog output when local decoration is enabled

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 
+### Fixes
+* Resolves an issue with local log decoration for NLog where the original log message was not included in the output. [#1249](https://github.com/newrelic/newrelic-dotnet-agent/pull/1249)
+
 ## [10.1.0] - 2022-09-12
 
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -79,7 +79,7 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
 
             // this cannot be made a static since it is unique to each logEvent
             var messageSetter = VisibilityBypasser.Instance.GeneratePropertySetter<string>(logEvent, "Message");
-            messageSetter(messageGetter + " " + formattedMetadata);
+            messageSetter(originalMessage + " " + formattedMetadata);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -60,12 +60,16 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         [Fact]
         public void LogIsDecorated()
         {
+            var testOutput = _fixture.RemoteApplication.CapturedOutput.StandardOutput;
+            // Make sure the original message is there
+            var commandResults = Regex.Split(testOutput, System.Environment.NewLine).Where(l => !l.Contains("EXECUTING"));
+            Assert.Contains(_testMessage, string.Join(System.Environment.NewLine, commandResults));
+
             // Sample decorated data we are looking for:
             // "NR-LINKING|MjczMDcwfEFQTXxBUFBMSUNBVElPTnwxODQyMg|blah.hsd1.ca.comcast.net|45f120972d61834b96fb890d2a8f97e7|840d9a82e8bc18a8|myApplicationName|"
             var regex = new Regex(@"NR-LINKING\|([a-zA-Z0-9]*)\|([a-zA-Z0-9._-]*)\|([a-zA-Z0-9]*)\|([a-zA-Z0-9]*)\|(.+?)\|");
             if (_decorationEnabled)
             {
-                var testOutput = _fixture.RemoteApplication.CapturedOutput.StandardOutput;
                 // Make sure the added metadata is there
                 var match = regex.Match(testOutput);
                 Assert.True(match.Success);
@@ -82,9 +86,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
                 Assert.NotNull(spanId);
                 Assert.Equal(_primaryApplicationName, entityName);
 
-                // Make sure the original message is there too
-                var commandResults = Regex.Split(testOutput, System.Environment.NewLine).Where(l => !l.Contains("EXECUTING"));
-                Assert.Contains(_testMessage, string.Join(System.Environment.NewLine, commandResults));
             }
             else
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
@@ -83,6 +83,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         {
 #if NETCOREAPP2_2_OR_GREATER || NET471_OR_GREATER // Only supported in newer versions of .NET
             SerializedLayout serializedLayout = new SerializedLayout();
+#if NETFRAMEWORK
+            serializedLayout.AddMember("Message");
+#else
+            serializedLayout.AddMember("message");
+#endif
             serializedLayout.AddMember("NR_LINKING");
             serializedLayout.ActivateOptions();
 


### PR DESCRIPTION
## Description

Fixes a bug in NLog instrumentation where the original message was not being included in output if the local decoration option was enabled.

Integration tests are updated to verify the inclusion of the original message in the output for local decoration scenarios.

This PR is in draft until I verify end-to-end functionality.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
