### PR TITLE
Add environment variables for SendDataOnExit functionality

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] changes
 
+### New Features
+* Add new environment variables to control SendDataOnExit functionality: `NEW_RELIC_SEND_DATA_ON_EXIT`, `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS`. [#1250](https://github.com/newrelic/newrelic-dotnet-agent/pull/1250)
+
 ### Fixes
 * Resolves an issue where some instrumentation was missing for Microsoft.Data.SqlClient in .NET Framework. [#1248](https://github.com/newrelic/newrelic-dotnet-agent/pull/1248)
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -780,8 +780,8 @@ namespace NewRelic.Agent.Core.Configuration
 
         public virtual string CollectorHost { get { return EnvironmentOverrides(_localConfiguration.service.host, @"NEW_RELIC_HOST"); } }
         public virtual int CollectorPort => EnvironmentOverrides(_localConfiguration.service.port > 0 ? _localConfiguration.service.port : (int?)null, "NEW_RELIC_PORT") ?? DefaultSslPort;
-        public virtual bool CollectorSendDataOnExit { get { return _localConfiguration.service.sendDataOnExit; } }
-        public virtual float CollectorSendDataOnExitThreshold { get { return _localConfiguration.service.sendDataOnExitThreshold; } }
+        public virtual bool CollectorSendDataOnExit { get { return EnvironmentOverrides(_localConfiguration.service.sendDataOnExit, "NEW_RELIC_SEND_DATA_ON_EXIT"); } }
+        public virtual float CollectorSendDataOnExitThreshold { get { return EnvironmentOverrides((uint?)null, "NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS") ?? _localConfiguration.service.sendDataOnExitThreshold; } }
         public virtual bool CollectorSendEnvironmentInfo { get { return _localConfiguration.service.sendEnvironmentInfo; } }
         public virtual bool CollectorSyncStartup { get { return _localConfiguration.service.syncStartup; } }
         public virtual uint CollectorTimeout { get { return (_localConfiguration.service.requestTimeout > 0) ? (uint)_localConfiguration.service.requestTimeout : CollectorSendDataOnExit ? 2000u : 60 * 2 * 1000; } }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -345,6 +345,30 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.InstrumentationLoggingEnabled;
         }
 
+        [TestCase("true", false, ExpectedResult = true)]
+        [TestCase("false", true, ExpectedResult = false)]
+        [TestCase("1", false, ExpectedResult = true)]
+        [TestCase("0", true, ExpectedResult = false)]
+        [TestCase("blarg", true, ExpectedResult = true)]
+        [TestCase(null, true, ExpectedResult = true)]
+        [TestCase(null, false, ExpectedResult = false)]
+        public bool SendDataOnExitIsOverriddenByEnvironment(string environmentSetting, bool localSetting)
+        {
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_SEND_DATA_ON_EXIT")).Returns(environmentSetting);
+            _localConfig.service.sendDataOnExit = localSetting;
+            return _defaultConfig.CollectorSendDataOnExit;
+        }
+
+        [TestCase("100", 500f, ExpectedResult = 100)]
+        [TestCase("blarg", 500f, ExpectedResult = 500f)]
+        [TestCase(null, 500f, ExpectedResult = 500f)]
+        public float SendDataOnExitThresholdIsOverriddenByEnvironment(string environmentSetting, float localSetting)
+        {
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS")).Returns(environmentSetting);
+            _localConfig.service.sendDataOnExitThreshold = localSetting;
+            return _defaultConfig.CollectorSendDataOnExitThreshold;
+        }
+
         [Test]
         public void DiagnosticsCaptureAgentTimingSetFromLocal
         ([Values(true, false, null)] bool? localIsEnabled,


### PR DESCRIPTION
## Description

This PR adds new environment variables to control SendDataOnExit functionality:
- `NEW_RELIC_SEND_DATA_ON_EXIT`: (boolean) enables/disables send data on exit
- `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS`: (uint) sets the minimum number of MS that the application must have been running before data will be sent on exit (when enabled).

Includes unit tests.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
