### PR TITLE
Stop any harvests while reconnecting

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
@@ -73,9 +73,5 @@ namespace NewRelic.Agent.Core.Aggregators
             _scheduler.StopExecuting(Harvest);
         }
 
-        protected void Stop()
-        {
-            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
-        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
@@ -23,8 +23,14 @@ namespace NewRelic.Agent.Core.Aggregators
             _scheduler = scheduler;
             _processStatic = processStatic;
 
+            _subscriptions.Add<StopHarvestEvent>(OnStopHarvestEvent);
             _subscriptions.Add<AgentConnectedEvent>(OnAgentConnected);
             _subscriptions.Add<PreCleanShutdownEvent>(OnPreCleanShutdown);
+        }
+
+        private void OnStopHarvestEvent(StopHarvestEvent obj)
+        {
+            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
         }
 
         public abstract void Collect(T wireModel);
@@ -65,6 +71,11 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             base.Dispose();
             _scheduler.StopExecuting(Harvest);
+        }
+
+        protected void Stop()
+        {
+            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.Core.Aggregators
         }
 
         protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled && _configuration.LogEventsMaxSamplesStored > 0;
+        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
 
         public override void Dispose()
         {

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.Core.Aggregators
         }
 
         protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
+        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled && _configuration.LogEventsMaxSamplesStored > 0;
 
         public override void Dispose()
         {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
@@ -135,6 +135,8 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private void Reconnect()
         {
+            EventBus<StopHarvestEvent>.Publish(new StopHarvestEvent());
+
             lock (_syncObject)
             {
                 Disconnect();
@@ -207,8 +209,6 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private void OnRestartAgent(RestartAgentEvent eventData)
         {
-            EventBus<StopHarvestEvent>.Publish(new StopHarvestEvent());
-
             Reconnect();
         }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
@@ -207,6 +207,8 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private void OnRestartAgent(RestartAgentEvent eventData)
         {
+            EventBus<StopHarvestEvent>.Publish(new StopHarvestEvent());
+
             Reconnect();
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Events/StopHarvestEvent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Events/StopHarvestEvent.cs
@@ -1,0 +1,9 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Core.Events
+{
+    public class StopHarvestEvent
+    {
+    }
+}

--- a/tests/Agent/UnitTests/CompositeTests/HarvestDisableWhileReconnectingTest.cs
+++ b/tests/Agent/UnitTests/CompositeTests/HarvestDisableWhileReconnectingTest.cs
@@ -1,0 +1,58 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Core.Aggregators;
+using NewRelic.Agent.Core.Configuration;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Testing.Assertions;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using Telerik.JustMock;
+
+namespace CompositeTests
+{
+    [TestFixture]
+    public class HarvestDisableWhileReconnectingTest
+    {
+        private static CompositeTestAgent _compositeTestAgent;
+        private IAgent _agent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _compositeTestAgent = new CompositeTestAgent();
+            _agent = _compositeTestAgent.GetAgent();
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            _compositeTestAgent.Dispose();
+        }
+
+        //This test makes sure that all aggregators stop their Harvest, by executing _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2)), when agent restart event is fired. This makes sure that no data is sent during configuration update period.
+        [Test]
+        public void HarvestIsDisabledWhileReconnectingTest()
+        {
+            var connectionHandler = Mock.Create<IConnectionHandler>();
+
+            _compositeTestAgent.Container.ReplaceRegistration(connectionHandler);
+            _compositeTestAgent.Container.Resolve<IConnectionManager>();
+
+            var numExistingAggregators = 9; //We currently have 9 different aggregators.
+
+            var scheduler = _compositeTestAgent.Container.Resolve<IScheduler>();
+
+            EventBus<RestartAgentEvent>.Publish(new RestartAgentEvent());
+
+            Mock.Assert(() => scheduler.StopExecuting(Arg.IsAny<Action>(), TimeSpan.FromSeconds(2)), Occurs.Exactly(numExistingAggregators));
+
+        }
+    }
+}


### PR DESCRIPTION
## Description
In an edge case where a user sets to disable event collection for specific event types from the New Relic APM UI and the agent is issued a reconnect, the agent still sends up the disabled events during the agent reconnecting period.

During the agent reconnecting window, all of the configuration settings get reset to the default values while waiting for the configuration setting backend negotiation to complete. This causes some events still being collected and sent up during this time period regardless some events collection were explicitly disabled.

This PR proposes a fix where the agent stops any scheduled `Harvest` during the agent's reconnecting process.