### PR TITLE
Add utility script for generating ConsoleMF test classes

### DIFF
--- a/tests/Agent/IntegrationTests/generateTestSubclasses.ps1
+++ b/tests/Agent/IntegrationTests/generateTestSubclasses.ps1
@@ -17,7 +17,7 @@ $TestName = $BaseClassName.Substring(0, $BaseClassName.IndexOf("Base"))
 
 $NetFrameworkVersions = "FWLatest","FW471","FW462"
 
-$NetCoreVersions = "CoreLatest","Core60","Core50","Core31" 
+$NetCoreVersions = "CoreLatest","Core50","Core31" 
 
 foreach ($NetFrameworkVersion in $NetFrameworkVersions)
 {

--- a/tests/Agent/IntegrationTests/generateTestSubclasses.ps1
+++ b/tests/Agent/IntegrationTests/generateTestSubclasses.ps1
@@ -1,0 +1,48 @@
+############################################################
+# Copyright 2022 New Relic Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+############################################################
+
+Param(
+    [string]$BaseClassName = ""
+)
+
+if ($BaseClassName -eq "")
+{
+    Write-Host "Must specify a base class name.  Example:  -BaseClassName RabbitMqTestsBase"
+    exit
+}
+
+$TestName = $BaseClassName.Substring(0, $BaseClassName.IndexOf("Base"))
+
+$NetFrameworkVersions = "FWLatest","FW471","FW462"
+
+$NetCoreVersions = "CoreLatest","Core60","Core50","Core31" 
+
+foreach ($NetFrameworkVersion in $NetFrameworkVersions)
+{
+    $SubClassName = $TestName + $NetFrameworkVersion
+    Write-Host "[NetFrameworkTest]"
+    Write-Host ("public class {0}: {1}<ConsoleDynamicMethodFixture{2}>" -f $SubClassName, $BaseClassName, $NetFrameworkVersion)
+    Write-Host "{"
+    Write-Host ("    public {0} (ConsoleDynamicMethodFixture{1} fixture, ITestOutputHelper output)" -f $SubClassName, $NetFrameworkVersion)
+    Write-Host "        : base(fixture, output)"
+    Write-Host "    {"
+    Write-Host "    }"
+    Write-Host "}"
+    Write-Host ""
+}
+
+foreach ($NetCoreVersion in $NetCoreVersions)
+{
+    $SubClassName = $TestName + $NetCoreVersion
+    Write-Host "[NetCoreTest]"
+    Write-Host ("public class {0}: {1}<ConsoleDynamicMethodFixture{2}>" -f $SubClassName, $BaseClassName, $NetCoreVersion)
+    Write-Host "{"
+    Write-Host ("    public {0} (ConsoleDynamicMethodFixture{1} fixture, ITestOutputHelper output)" -f $SubClassName, $NetCoreVersion)
+    Write-Host "        : base(fixture, output)"
+    Write-Host "    {"
+    Write-Host "    }"
+    Write-Host "}"
+    Write-Host ""
+}


### PR DESCRIPTION
## Description

I figure people might be tired of creating all the test subclasses for ConsoleMF tests, so I made a script to do it for us.  I've placed it in `tests/Agent/IntegrationTests` and you can run it like (using RabbitMqTests as an example):

`./generateTestSubclasses.ps1 -BaseClassName RabbitMqTestsBase`

and you'll get output you can copy/paste into the test file.

Of course, this would be much cooler if we made it a Visual Studio extension so it could just happen in VS without having to open up a Powershell console, run a command with the correct input parameter, copy/paste text, etc.  But I figured I could get this done in a few minutes, I don't know how hard writing a VS extension is.  Going for "good enough" first.

