### PR TITLE
Adds tests for Serilog 1.5.14 and updates MVS with Serilog

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -82,10 +82,8 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.66" Condition="'$(TargetFramework)' == 'net6.0'" />
   
     <!-- Serilog .NET framework references -->
-    <PackageReference Include="Serilog" Version="2.0.0" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="2.0.0" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="2.1.0" Condition="'$(TargetFramework)' == 'net462'" />
-
+    <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />
+    
     <PackageReference Include="Serilog" Version="2.5.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'net471'" />
@@ -102,11 +100,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
 
-    <PackageReference Include="Serilog" Version="2.8.0" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Serilog" Version="2.10.0" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'net5.0'" />
 
-    <PackageReference Include="Serilog" Version="2.10.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Serilog" Version="2.12.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
@@ -10,7 +10,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 {
     class SerilogLoggingAdapter : ILoggingAdapter
     {
-        private static Logger _log;
+        private static ILogger _log;
 
         public SerilogLoggingAdapter()
         {
@@ -86,8 +86,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             _log = loggerConfig.CreateLogger();
         }
 
+        // net462 is using Serilgo 1.5.14 - a very old, but supported version of Serilog. This does not have a Console sink that supports Json.
         public void ConfigureJsonLayoutAppenderForDecoration()
         {
+#if !NET462
             var loggerConfig = new LoggerConfiguration();
 
             loggerConfig
@@ -95,6 +97,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                 .WriteTo.Console(new JsonFormatter());
 
             _log = loggerConfig.CreateLogger();
+#endif
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
@@ -86,7 +86,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             _log = loggerConfig.CreateLogger();
         }
 
-        // net462 is using Serilgo 1.5.14 - a very old, but supported version of Serilog. This does not have a Console sink that supports Json.
+        // net462 is using Serilog 1.5.14 - a very old, but supported version of Serilog. This does not have a Console sink that supports JSON.
         public void ConfigureJsonLayoutAppenderForDecoration()
         {
 #if !NET462

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
@@ -169,3 +169,9 @@
     nuget-packages:
        - { package-name: NLog, versions: [4.1.2, 4.3.11, 4.5.9, 4.5.11, 4.7.15, 5.0.4] }
     local-assemblies:
+
+  - name: serilog
+    xml-file: ${{ MVS_XML_PATH }}/SerilogLogging/Instrumentation.xml
+    nuget-packages:
+       - { package-name: Serilog, versions: [1.5.14, 2.0.0, 2.5.0, 2.7.1, 2.8.0, 2.9.0, 2.10.0, 2.11.0, 2.12.0] }
+    local-assemblies:


### PR DESCRIPTION
## Description

- Updates Serilog integration tests to test version 1.5.14 with net462 since we do have instrumentation for that version.
- Version 1.5.14 Console sink does not accept formatters so no Json testing with that version (we didn't test local json decorating in net462 originally)
- In SerilogLoggingAdapter changed the Logger type to ILogger to support 1.5.14 since that version has the Logger type in a different namespace.  ILogger is in the same location with mostly the same interface so works without any other changes.
- Updates MVS with Serilog covering the major versions

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
