### PR TITLE
MVS updates for mongocsharpdriver/mongodb.driver

### DIFF
--- a/tests/Agent/MultiverseTesting/ConsoleScanner/InstrumentationSet.cs
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/InstrumentationSet.cs
@@ -15,5 +15,7 @@ namespace NewRelic.Agent.ConsoleScanner
         public List<NugetSet> NugetPackages { get; set; }
 
         public List<string> LocalAssemblies { get; set; }
+
+        public bool DownloadLatest { get; set; } = true;
     }
 }

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/Program.cs
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/Program.cs
@@ -19,7 +19,7 @@ namespace NewRelic.Agent.ConsoleScanner
     public class Program
     {
         // This list does not include some specific frameworks as explained below
-        // .NET Framework 4.x.x: these could be the only version in older packages and will still work in apps targeting up to 4.8.x.
+        // .NET Framework 3/4.x.x: these could be the only version in older packages and will still work in apps targeting up to 4.8.x.
         // .NET Standard: all versions prior to 2.0 support .NET Framework 4.5+ so we they might be used on their own.
         // Microsoft Store (Windows Store) "netcore" is listed directly in the ShouldScan method since adding it here would block other allowed frameworks.
         /// <summary>
@@ -28,9 +28,7 @@ namespace NewRelic.Agent.ConsoleScanner
         private static List<string> _excludedFrameworks = new List<string> {
             "net1", // .NET Framework 1.x.x
             "net2", // .NET Framework 2.x.x
-            "net3", // .NET Framework 3.x.x
-            "net3", // .NET Framework 3.x.x
-            "netcoreapp1", // .NET Core 1.x.x (this version of .NET was complete different from 2.x.x)
+            "netcoreapp1", // .NET Core 1.x.x (this version of .NET was completely different from 2.x.x)
             "netcore45", // Microsoft Store (Windows Store) - Windows 8.x
             "netcore5", // Microsoft Store (Windows Store)
             "netmf", // .NET MicroFramework
@@ -138,14 +136,14 @@ namespace NewRelic.Agent.ConsoleScanner
             {
                 foreach (var nugetPackage in instrumentationSet.NugetPackages)
                 {
-                    downloadedNugetInfoList.AddRange(GetNugetPackages(nugetPackage.PackageName, nugetPackage.Versions, instrumentationAssemblies));
+                    downloadedNugetInfoList.AddRange(GetNugetPackages(nugetPackage.PackageName, nugetPackage.Versions, instrumentationAssemblies, instrumentationSet.DownloadLatest));
                 }
             }
 
             return downloadedNugetInfoList;
         }
 
-        public static List<DownloadedNugetInfo> GetNugetPackages(string packageName, List<string> versions, List<string> instrumentationAssemblies)
+        public static List<DownloadedNugetInfo> GetNugetPackages(string packageName, List<string> versions, List<string> instrumentationAssemblies, bool downloadLatest)
         {
             var downloadedNugetInfos = new List<DownloadedNugetInfo>();
 
@@ -153,7 +151,15 @@ namespace NewRelic.Agent.ConsoleScanner
             {
                 Directory.CreateDirectory(_nugetDataDirectory);
                 var client = new NugetClient(_nugetDataDirectory);
-                versions.Add(client.GetLatestVersion(packageName)); // add current version to versions list
+                if (downloadLatest)
+                {
+                    versions.Add(client.GetLatestVersion(packageName)); // add current version to versions list
+                }
+                else
+                {
+                    Console.WriteLine($"Not downloading latest version of package {packageName} based on config.");
+                }
+                    
                 foreach (var version in versions.Distinct()) // using Distinct to prevent duplicates
                 {
                     var dllFileLocations = new List<string>();

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/config.yml
@@ -36,12 +36,13 @@
     nuget-packages:
        - { package-name: mongocsharpdriver, versions: [1.5.0, 1.6.0, 1.6.1, 1.7.1, 1.8.3, 1.9.2, 1.10.0, 1.10.1, 1.11.0] }
     local-assemblies:
+    download-latest: false
 
   - name: mongodb26
     xml-file: ${{ MVS_XML_PATH }}/MongoDb26/Instrumentation.xml
     nuget-packages:
-       - { package-name: MongoDB.Driver, versions: [2.0.2, 2.1.1, 2.2.4, 2.3.0, 2.4.4, 2.5.1, 2.6.1, 2.7.3, 2.8.1, 2.9.3, 2.10.4, 2.11.6, 2.12.2, 2.13.3, 2.14.1, 2.15.0] }
-       - { package-name: MongoDB.Driver.Core, versions: [2.0.2, 2.1.1, 2.2.4, 2.3.0, 2.4.4, 2.5.1, 2.6.1, 2.7.3, 2.8.1, 2.9.3, 2.10.4, 2.11.6, 2.12.2, 2.13.3, 2.14.1, 2.15.0] }
+       - { package-name: MongoDB.Driver, versions: [2.0.2, 2.1.1, 2.2.4, 2.3.0, 2.4.4, 2.5.1, 2.6.1, 2.7.3, 2.8.1, 2.9.3, 2.10.4, 2.11.6, 2.12.2, 2.13.3, 2.14.1, 2.15.1, 2.16.1, 2.17.1] }
+       - { package-name: MongoDB.Driver.Core, versions: [2.0.2, 2.1.1, 2.2.4, 2.3.0, 2.4.4, 2.5.1, 2.6.1, 2.7.3, 2.8.1, 2.9.3, 2.10.4, 2.11.6, 2.12.2, 2.13.3, 2.14.1, 2.15.1, 2.16.1, 2.17.1] }
     local-assemblies:
 
   # assembly in inst.xml is System.Messaging.dll, can get newer ones from nuget (?), but typically located in the GAC


### PR DESCRIPTION
## Description

This PR:

1. Reverts a recent change to ignore assemblies starting with `net3`.  This was causing us to lose visibility into the `mongocsharpdriver` package because its assemblies are `net35`.  (Note: I don't know if ignoring `net3` was put in to fix a specific bug or if it just seemed like a good idea at the time; if it was to fix a specific bug we'll need to discuss further.)
2. Adds a new, optional instrumentation set config property called "DownloadLatest" (`download-latest: true/false` in YAML).  This controls whether to download and scan the latest NuGet package for the package name.  The default value is true and preserves the original behavior.  I set it to "false" for `mongocsharpdriver` because we don't care what MongoDB is doing for this package in 2.x+.
3. Updates the latest versions scanned for MongoDB.Driver

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
