### PR TITLE
Add Browser Agent injection unit test for .NET special characters

### DIFF
--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -1,6 +1,8 @@
-// Copyright 2020 New Relic, Inc. All rights reserved.
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Xml.Linq;
+using System;
 using NUnit.Framework;
 
 namespace NewRelic.Agent.Core.BrowserMonitoring
@@ -239,6 +241,34 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             var data = "<html><head /><body>im some body text</body></html>";
             var expected = "<html><head />EXPECTED_RUM_LOADER_LOCATION<body>im some body text</body></html>";
             var writer = new BrowserMonitoringWriter(() => "EXPECTED_RUM_LOADER_LOCATION");
+            var result = writer.WriteScriptHeaders(data);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void cross_agent_browser_monitor_injection_from_insane_text()
+        {
+            var angelicText = @"
+                // c# special - verbatim
+                @if(1)@""c:\\documents\x0041\\\files\\\\u0066.txt""@\""{{This}} is the last \u0063hance\x0021\""
+                // c# special - interpolation
+                $""Hello, {DateTime.Now:F3,-7}!""$"" \""\{X}, {Y}\\""\\ is {Math.Sqrt(X * X + Y * Y)}""$$""""""{{{X}}, {{Y}}} is {{Math.Sqrt(X * X + Y * Y)}}""""""
+                // combo
+                @$""@${var}$@{{var}}\{var\}\{\""var""{\}\}\\{\\{{var\}}\\}${}$${}${{}}""$@""@${var}$@{{var}}\{var\}\{\""var""{\}\}\\{\\{{var\}}\\}${}$${}${{}}""
+                // some bad chars
+                ÁáĆćǴ ǵíĹĺŃńŔŕŚ śÝý€ƒ   ©®™œ£¶•
+
+                ¿¡\0\x0\u0000
+                // .net regex && substitutions
+                $1$2$9$13${name}${c}${re}$$$&$`$'$+$_\p{Sc}*(\s?\d+[.,]?\d*)\p{Sc}*\$&\
+                // .net escape chars
+                .$^{[(|)*+?\\a\b\t\r\v\f\n\e\040\x9f\cC\cD\*\G(.+)[\t\u007c](.+)\r?\n\$\\$\\\$\$$\$$$\@\\@\\\@\@@\@@@
+                ";
+
+
+            var data = "<html><head /><body>im some body text</body></html>";
+            var expected = $"<html><head />{angelicText}<body>im some body text</body></html>";
+            var writer = new BrowserMonitoringWriter(() => angelicText);
             var result = writer.WriteScriptHeaders(data);
             Assert.AreEqual(expected, result);
         }


### PR DESCRIPTION
## Description

Adds a unit test to the Browser Agent Injection test suite that should catch any future regressions in the module. This includes `$1`, `$&`, and a bunch of other expressions with special meaning in C#.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
