### PR TITLE
System.Data.SqlClient (.NET Core/5+) tests

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -35,14 +35,6 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.6.1" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.4" Condition="'$(TargetFramework)' == 'net6.0'" />
 
-    <!--System.Data.Odbc/Oledb (.NET Core/5+ only) -->
-    <PackageReference Include="System.Data.Odbc" Version="4.6.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="System.Data.Odbc" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="System.Data.Odbc" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="System.Data.Oledb" Version="4.6.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="System.Data.Oledb" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="System.Data.Oledb" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-
     <!--Microsoft.Data.SqlClient-->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.5" Condition="'$(TargetFramework)' == 'net471'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 
     <!--System.Data.SqlClient (.NET Core/5+ only) -->
-    <PackageReference Include="System.Data.SqlClient" Version="4.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.1" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.4" Condition="'$(TargetFramework)' == 'net6.0'" />
 
     <!--System.Data.Odbc/Oledb (.NET Core/5+ only) -->

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -30,6 +30,18 @@
     <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 
+    <!--System.Data.SqlClient (.NET Core/5+ only) -->
+    <PackageReference Include="System.Data.SqlClient" Version="4.1.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.4" Condition="'$(TargetFramework)' == 'net6.0'" />
+
+    <!--System.Data.Odbc/Oledb (.NET Core/5+ only) -->
+    <PackageReference Include="System.Data.Odbc" Version="4.6.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="System.Data.Odbc" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Data.Odbc" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="System.Data.Oledb" Version="4.6.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="System.Data.Oledb" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Data.Oledb" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 
     <!--Microsoft.Data.SqlClient-->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" Condition="'$(TargetFramework)' == 'net462'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
@@ -234,57 +234,60 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
             }
         }
 
-        [LibraryMethod]
-        [Transaction]
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
-        {
-            EnsureProcedure(procedureName, DbParameterData.OdbcMsSqlParameters);
 
-            var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
+        #region Currently (as of 2022-10-20) unsupported ODBC/OleDB operations
+        //[LibraryMethod]
+        //[Transaction]
+        //[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        //public int MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
+        //{
+        //    EnsureProcedure(procedureName, DbParameterData.OdbcMsSqlParameters);
 
-            using (var connection = new OdbcConnection(MsSqlOdbcConfiguration.MsSqlOdbcConnectionString))
-            using (var command = new OdbcCommand($"{{call {procedureName}({parameterPlaceholder})}}", connection))
-            {
-                connection.Open();
-                command.CommandType = CommandType.StoredProcedure;
-                foreach (var parameter in DbParameterData.OdbcMsSqlParameters)
-                {
-                    var paramName = paramsWithAtSign
-                        ? parameter.ParameterName
-                        : parameter.ParameterName.TrimStart('@');
+        //    var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
 
-                    command.Parameters.Add(new OdbcParameter(paramName, parameter.Value)); ;
-                }
+        //    using (var connection = new OdbcConnection(MsSqlOdbcConfiguration.MsSqlOdbcConnectionString))
+        //    using (var command = new OdbcCommand($"{{call {procedureName}({parameterPlaceholder})}}", connection))
+        //    {
+        //        connection.Open();
+        //        command.CommandType = CommandType.StoredProcedure;
+        //        foreach (var parameter in DbParameterData.OdbcMsSqlParameters)
+        //        {
+        //            var paramName = paramsWithAtSign
+        //                ? parameter.ParameterName
+        //                : parameter.ParameterName.TrimStart('@');
 
-                return command.ExecuteNonQuery();
-            }
-        }
+        //            command.Parameters.Add(new OdbcParameter(paramName, parameter.Value)); ;
+        //        }
 
-        [LibraryMethod]
-        [Transaction]
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedureUsingOleDbDriver(string procedureName, bool paramsWithAtSign)
-        {
-            EnsureProcedure(procedureName, DbParameterData.OleDbMsSqlParameters);
+        //        return command.ExecuteNonQuery();
+        //    }
+        //}
 
-            using (var connection = new OleDbConnection(MsSqlOleDbConfiguration.MsSqlOleDbConnectionString))
-            using (var command = new OleDbCommand(procedureName, connection))
-            {
-                connection.Open();
-                command.CommandType = CommandType.StoredProcedure;
-                foreach (var parameter in DbParameterData.OleDbMsSqlParameters)
-                {
-                    var paramName = paramsWithAtSign
-                        ? parameter.ParameterName
-                        : parameter.ParameterName.TrimStart('@');
+        //[LibraryMethod]
+        //[Transaction]
+        //[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        //public int MsSqlParameterizedStoredProcedureUsingOleDbDriver(string procedureName, bool paramsWithAtSign)
+        //{
+        //    EnsureProcedure(procedureName, DbParameterData.OleDbMsSqlParameters);
 
-                    command.Parameters.Add(new OleDbParameter(paramName, parameter.Value));
-                }
+        //    using (var connection = new OleDbConnection(MsSqlOleDbConfiguration.MsSqlOleDbConnectionString))
+        //    using (var command = new OleDbCommand(procedureName, connection))
+        //    {
+        //        connection.Open();
+        //        command.CommandType = CommandType.StoredProcedure;
+        //        foreach (var parameter in DbParameterData.OleDbMsSqlParameters)
+        //        {
+        //            var paramName = paramsWithAtSign
+        //                ? parameter.ParameterName
+        //                : parameter.ParameterName.TrimStart('@');
 
-                return command.ExecuteNonQuery();
-            }
-        }
+        //            command.Parameters.Add(new OleDbParameter(paramName, parameter.Value));
+        //        }
+
+        //        return command.ExecuteNonQuery();
+        //    }
+        //}
+        #endregion
 
         [LibraryMethod]
         public void CreateTable(string tableName)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
@@ -1,0 +1,356 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#if NETCOREAPP3_1_OR_GREATER
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Data.SqlClient;
+using System.Data;
+using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+using System.Threading;
+using System.Data.OleDb;
+using System.Data.Odbc;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
+{
+    [Library]
+    public class SystemDataSqlClientExerciser
+    {
+        private const string InsertPersonMsSql = "INSERT INTO {0} (FirstName, LastName, Email) VALUES('Testy', 'McTesterson', 'testy@mctesterson.com')";
+        private const string DeletePersonMsSql = "DELETE FROM {0} WHERE Email = 'testy@mctesterson.com'";
+        private const string CountPersonMsSql = "SELECT COUNT(*) FROM {0} WITH(nolock)";
+        private static readonly string CreateProcedureStatement = @"CREATE OR ALTER PROCEDURE [dbo].[{0}] {1} AS RETURN 0";
+        private const string CreatePersonTableMsSql = "CREATE TABLE {0} (FirstName varchar(20) NOT NULL, LastName varchar(20) NOT NULL, Email varchar(50) NOT NULL)";
+        private const string DropPersonTableMsSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP TABLE {0}";
+        private const string DropProcedureSql = "IF (OBJECT_ID('{0}') IS NOT NULL) DROP PROCEDURE {0}";
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string MsSql(string tableName)
+        {
+            var teamMembers = new List<string>();
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
+                {
+
+                    using (var reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            if (reader.NextResult())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            }
+                        }
+                    }
+                }
+
+                var insertSql = string.Format(InsertPersonMsSql, tableName);
+                var countSql = string.Format(CountPersonMsSql, tableName);
+                var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                using (var command = new SqlCommand(insertSql, connection))
+                {
+                    var insertCount = command.ExecuteNonQuery();
+                }
+
+                using (var command = new SqlCommand(countSql, connection))
+                {
+                    var teamMemberCount = command.ExecuteScalar();
+                }
+
+                using (var command = new SqlCommand(deleteSql, connection))
+                {
+                    var deleteCount = command.ExecuteNonQuery();
+                }
+            }
+
+            return string.Join(",", teamMembers);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> MsSqlAsync(string tableName)
+        {
+            var teamMembers = new List<string>();
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
+                {
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            if (await reader.NextResultAsync())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            }
+                        }
+                    }
+                }
+
+                var insertSql = string.Format(InsertPersonMsSql, tableName);
+                var countSql = string.Format(CountPersonMsSql, tableName);
+                var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                using (var command = new SqlCommand(insertSql, connection))
+                {
+                    var insertCount = await command.ExecuteNonQueryAsync();
+                }
+
+                using (var command = new SqlCommand(countSql, connection))
+                {
+                    var teamMemberCount = await command.ExecuteScalarAsync();
+                }
+
+                using (var command = new SqlCommand(deleteSql, connection))
+                {
+                    var deleteCount = await command.ExecuteNonQueryAsync();
+                }
+            }
+
+            return string.Join(",", teamMembers);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string MsSqlWithParameterizedQuery(bool paramsWithAtSign)
+        {
+            var teamMembers = new List<string>();
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
+                {
+                    command.Parameters.Add(new SqlParameter(paramsWithAtSign ? "@FN" : "FN", "O'Keefe"));
+                    using (var reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            if (reader.NextResult())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            }
+                        }
+                    }
+                }
+
+            }
+
+            return string.Join(",", teamMembers);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> MsSqlAsync_WithParameterizedQuery(string tableName, bool paramsWithAtSign)
+        {
+            var teamMembers = new List<string>();
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
+                {
+                    command.Parameters.Add(new SqlParameter(paramsWithAtSign ? "@FN" : "FN", "O'Keefe"));
+                    using (var reader = await command.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            if (await reader.NextResultAsync())
+                            {
+                                teamMembers.Add(reader.GetString(reader.GetOrdinal("FirstName")));
+                            }
+                        }
+                    }
+                }
+
+                var insertSql = string.Format(InsertPersonMsSql, tableName);
+                var countSql = string.Format(CountPersonMsSql, tableName);
+                var deleteSql = string.Format(DeletePersonMsSql, tableName);
+
+                using (var command = new SqlCommand(insertSql, connection))
+                {
+                    var insertCount = await command.ExecuteNonQueryAsync();
+                }
+
+                using (var command = new SqlCommand(countSql, connection))
+                {
+                    var teamMemberCount = await command.ExecuteScalarAsync();
+                }
+
+                using (var command = new SqlCommand(deleteSql, connection))
+                {
+                    var deleteCount = await command.ExecuteNonQueryAsync();
+                }
+            }
+
+            return string.Join(",", teamMembers);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
+        {
+            EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var command = new SqlCommand(procedureName, connection))
+            {
+                connection.Open();
+                command.CommandType = CommandType.StoredProcedure;
+                foreach (var parameter in DbParameterData.MsSqlParameters)
+                {
+                    var paramName = paramsWithAtSign
+                        ? parameter.ParameterName
+                        : parameter.ParameterName.TrimStart('@');
+
+                    command.Parameters.Add(new SqlParameter(paramName, parameter.Value));
+                }
+
+                return command.ExecuteNonQuery();
+            }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public int MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
+        {
+            EnsureProcedure(procedureName, DbParameterData.OdbcMsSqlParameters);
+
+            var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
+
+            using (var connection = new OdbcConnection(MsSqlOdbcConfiguration.MsSqlOdbcConnectionString))
+            using (var command = new OdbcCommand($"{{call {procedureName}({parameterPlaceholder})}}", connection))
+            {
+                connection.Open();
+                command.CommandType = CommandType.StoredProcedure;
+                foreach (var parameter in DbParameterData.OdbcMsSqlParameters)
+                {
+                    var paramName = paramsWithAtSign
+                        ? parameter.ParameterName
+                        : parameter.ParameterName.TrimStart('@');
+
+                    command.Parameters.Add(new OdbcParameter(paramName, parameter.Value)); ;
+                }
+
+                return command.ExecuteNonQuery();
+            }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public int MsSqlParameterizedStoredProcedureUsingOleDbDriver(string procedureName, bool paramsWithAtSign)
+        {
+            EnsureProcedure(procedureName, DbParameterData.OleDbMsSqlParameters);
+
+            using (var connection = new OleDbConnection(MsSqlOleDbConfiguration.MsSqlOleDbConnectionString))
+            using (var command = new OleDbCommand(procedureName, connection))
+            {
+                connection.Open();
+                command.CommandType = CommandType.StoredProcedure;
+                foreach (var parameter in DbParameterData.OleDbMsSqlParameters)
+                {
+                    var paramName = paramsWithAtSign
+                        ? parameter.ParameterName
+                        : parameter.ParameterName.TrimStart('@');
+
+                    command.Parameters.Add(new OleDbParameter(paramName, parameter.Value));
+                }
+
+                return command.ExecuteNonQuery();
+            }
+        }
+
+        [LibraryMethod]
+        public void CreateTable(string tableName)
+        {
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                var createTable = string.Format(CreatePersonTableMsSql, tableName);
+                using (var command = new SqlCommand(createTable, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [LibraryMethod]
+        public void DropTable(string tableName)
+        {
+            var dropTableSql = string.Format(DropPersonTableMsSql, tableName);
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand(dropTableSql, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [LibraryMethod]
+        public void DropProcedure(string procedureName)
+        {
+            var dropProcedureSql = string.Format(DropProcedureSql, procedureName);
+
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            {
+                connection.Open();
+
+                using (var command = new SqlCommand(dropProcedureSql, connection))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [LibraryMethod]
+        public void Wait(int millisecondsTimeOut)
+        {
+            Thread.Sleep(millisecondsTimeOut);
+        }
+
+        private void EnsureProcedure(string procedureName, DbParameter[] dbParameters)
+        {
+            var parameters = string.Join(", ", dbParameters.Select(x => $"{x.ParameterName} {x.DbTypeName}"));
+            var statement = string.Format(CreateProcedureStatement, procedureName, parameters);
+            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var command = new SqlCommand(statement, connection))
+            {
+                connection.Open();
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+}
+
+#endif

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -173,9 +173,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class SystemDataAsyncTestsFWLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlAsyncTests_SystemData_FWLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public SystemDataAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -185,9 +185,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientAsyncTestsCoreLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlAsyncTests_SystemDataSqlClient_CoreLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public SystemDataSqlClientAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_SystemDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -197,9 +197,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientAsyncTestsCore50 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    public class MsSqlAsyncTests_SystemDataSqlClient_Core50 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
-        public SystemDataSqlClientAsyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -209,9 +209,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientAsyncTestsCore31 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlAsyncTests_SystemDataSqlClient_Core31 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public SystemDataSqlClientAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_SystemDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -221,9 +221,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsFWLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlAsyncTests_MicrosoftDataSqlClient_FWLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -233,9 +233,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsFW462 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlAsyncTests_MicrosoftDataSqlClient_FW462 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -246,9 +246,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsCoreLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlAsyncTests_MicrosoftDataSqlClient_CoreLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -258,9 +258,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsCore31 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlAsyncTests_MicrosoftDataSqlClient_Core31 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlAsyncTests_MicrosoftDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -184,6 +184,42 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    [NetCoreTest]
+    public class SystemDataSqlClientAsyncTestsCoreLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public SystemDataSqlClientAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SystemDataSqlClientAsyncTestsCore50 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public SystemDataSqlClientAsyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SystemDataSqlClientAsyncTestsCore31 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public SystemDataSqlClientAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
     [NetFrameworkTest]
     public class MicrosoftDataSqlClientAsyncTestsFWLatest : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlAsyncTestsParameterizedQueryBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    public abstract class MsSqlQueryParamAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
         where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly ConsoleDynamicMethodFixture _fixture;
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         private readonly string _tableName;
         private readonly bool _paramsWithAtSign;
 
-        public MsSqlAsyncTestsParameterizedQueryBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
+        public MsSqlQueryParamAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -179,10 +179,12 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+
+    #region System.Data (.NET Framework only)
     [NetFrameworkTest]
-    public class MsSqlAsyncTestsParameterizedQuery : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamAsyncTests_SystemData_FWLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlAsyncTestsParameterizedQuery(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -193,9 +195,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlAsyncTestsParameterizedQuery_ParamsWithoutAtSign : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamAsyncTests_SystemData_NoAtSigns_FWLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlAsyncTestsParameterizedQuery_ParamsWithoutAtSign(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -204,13 +206,97 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
         }
     }
+    #endregion
 
-    #region Microsoft.Data.SqlClient Tests
+
+    #region System.Data.SqlClient (.NET Core/5+ only)
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_CoreLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core50 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core50 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core31 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core31 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+    #endregion
+
+
+    #region Microsoft.Data.SqlClient (FW and Core/5+)
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryFW : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_FWLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -222,9 +308,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFW : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -235,9 +321,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryFW462 : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_FW462 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -249,9 +335,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFW462 : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -262,9 +348,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_CoreLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -275,9 +361,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -288,9 +374,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore31 : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_Core31 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQueryCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -301,9 +387,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore31 : MsSqlAsyncTestsParameterizedQueryBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_Core31 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientAsyncTestsParameterizedQuery_ParamsWithoutAtSignCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamAsyncTests_MicrosoftDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 {
-    public abstract class MsSqlQueryParameterCaptureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    public abstract class MsSqlQueryParamTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
         where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly ConsoleDynamicMethodFixture _fixture;
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         private readonly string _tableName;
         private readonly bool _paramsWithAtSigns;
 
-        public MsSqlQueryParameterCaptureTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
+        public MsSqlQueryParamTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -144,10 +144,11 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    #region System.Data (.NET Framework only)
     [NetFrameworkTest]
-    public class MsSqlQueryParameterCaptureTests : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamTests_SystemData_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlQueryParameterCaptureTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -158,9 +159,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlQueryParameterCaptureTests_ParamsWithoutAtSigns : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlQueryParameterCaptureTests_ParamsWithoutAtSigns(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -169,11 +170,96 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
         }
     }
+    #endregion
+
+    #region System.Data.SqlClient (.NET Core/5+ only)
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_Core50 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core50 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_Core31 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core31 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+
+    #endregion
+
+    #region Microsoft.Data.SqlClient (FW and Core/5+)
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTestsFW : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -185,9 +271,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFW : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -199,9 +285,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTestsFW462 : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -213,9 +299,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFW462 : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
 
             : base(
                   fixture: fixture,
@@ -227,9 +313,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTestsCore : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -240,9 +326,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -253,9 +339,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTestsCore31 : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_Core31 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -266,9 +352,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore31 : MsSqlQueryParameterCaptureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_Core31 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientQueryParameterCaptureTests_ParamsWithoutAtSignsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -277,4 +363,5 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
         }
     }
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -110,10 +110,11 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    #region System.Data (.NET Framework only)
     [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlStoredProcedureTests_SystemData_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlStoredProcedureTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -124,9 +125,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests_ParamsWithoutAtSigns : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlStoredProcedureTests_SystemData_NoAtSigns_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlStoredProcedureTests_ParamsWithoutAtSigns(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -135,11 +136,97 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
         }
     }
+    #endregion
+
+    #region System.Data.SqlClient (.NET Core/5+ only)
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_Core50 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core50 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_Core31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    #endregion
+
+
+    #region Microsoft.Data.SqlClient (FW and Core/5+)
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientStoredProcedureTestsFW : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientStoredProcedureTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -150,9 +237,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFW : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -163,9 +250,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientStoredProcedureTestsFW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientStoredProcedureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -176,9 +263,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -189,9 +276,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTestsCore : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientStoredProcedureTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -202,9 +289,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -215,9 +302,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTestsCore31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_Core31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientStoredProcedureTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -228,9 +315,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_Core31 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientStoredProcedureTests_ParamsWithoutAtSignsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -239,4 +326,5 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
         }
     }
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -111,6 +111,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    // Only tests for System.Data in .NET Framework for ODBC, since the OdbcCommandWrapper is .NET Framework only,
+    // and the instrumentation.xml only matches System.Data as of 2022-10-20
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOdbcDriverTests : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
@@ -107,6 +107,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    // Only tests for System.Data in .NET Framework for OleDb, since the OleDbCommandWrapper is .NET Framework only,
+    // and the instrumentation.xml only matches System.Data as of 2022-10-20
     [NetFrameworkTest]
     public class MsSqlStoredProcedureUsingOleDbDriverTests : MsSqlStoredProcedureUsingOleDbDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using MultiFunctionApplicationHelpers;
@@ -184,6 +183,30 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     public class SystemDataSqlClientTestsCoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SystemDataSqlClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SystemDataSqlClientTestsCore50 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public SystemDataSqlClientTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class SystemDataSqlClientTestsCore31 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public SystemDataSqlClientTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -168,9 +168,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class SystemDataTestsFWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlTests_SystemData_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public SystemDataTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -180,9 +180,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientTestsCoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlTests_SystemDataSqlClient_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public SystemDataSqlClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlTests_SystemDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -192,9 +192,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientTestsCore50 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore50>
+    public class MsSqlTests_SystemDataSqlClient_Core50 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
-        public SystemDataSqlClientTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+        public MsSqlTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -204,9 +204,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class SystemDataSqlClientTestsCore31 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlTests_SystemDataSqlClient_Core31 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public SystemDataSqlClientTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlTests_SystemDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -216,9 +216,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientTestsFWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlTests_MicrosoftDataSqlClient_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MicrosoftDataSqlClientTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -228,9 +228,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetFrameworkTest]
-    public class MicrosoftDataSqlClientTestsFW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
+    public class MsSqlTests_MicrosoftDataSqlClient_FW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
-        public MicrosoftDataSqlClientTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        public MsSqlTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -240,9 +240,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientTestsCoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class MsSqlTests_MicrosoftDataSqlClient_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public MicrosoftDataSqlClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public MsSqlTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
@@ -252,9 +252,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
-    public class MicrosoftDataSqlClientTestsCore31 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore31>
+    public class MsSqlTests_MicrosoftDataSqlClient_Core31 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
-        public MicrosoftDataSqlClientTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+        public MsSqlTests_MicrosoftDataSqlClient_Core31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -180,6 +180,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    [NetCoreTest]
+    public class SystemDataSqlClientTestsCoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public SystemDataSqlClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
     [NetFrameworkTest]
     public class MicrosoftDataSqlClientTestsFWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {


### PR DESCRIPTION
## Description

Add integration tests for `System.Data.SqlClient` in .NET Core/5+.
Testing driver package versions 4.4.0 through 4.8.4.  4.4.0 is the oldest version where our explain plan feature works.

I also renamed other tests that already existed to help normalize the test class names according to the following pattern:
TestFileName_ExerciserName_{Options}_TargetFrameworkMoniker

I added some comments to explain why we don't have ODBC or OleDb tests for System.Data.SqlClient (our instrumentation currently doesn't support .NET Core).

