### PR TITLE
Update MsSql System.Data.SqlClient tests for .NET 7

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net462;net471;net48;net481</TargetFrameworks>
@@ -36,7 +36,8 @@
     <!--System.Data.SqlClient (.NET Core/5+ only) -->
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.1" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.4" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.4" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!--Microsoft.Data.SqlClient-->
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" Condition="'$(TargetFramework)' == 'net462'" />

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -197,6 +197,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
+    public class MsSqlAsyncTests_SystemDataSqlClient_Core60 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlAsyncTests_SystemDataSqlClient_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
     public class MsSqlAsyncTests_SystemDataSqlClient_Core50 : MsSqlAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MsSqlAsyncTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
@@ -238,6 +238,32 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core60 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core60 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlQueryParamAsyncTests_SystemDataSqlClient_NoAtSigns_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
     public class MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core50 : MsSqlQueryParamAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MsSqlQueryParamAsyncTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
@@ -200,6 +200,32 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_Core60 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core60 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlQueryParamTests_SystemDataSqlClient_NoAtSigns_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
     public class MsSqlQueryParamTests_SystemDataSqlClient_Core50 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MsSqlQueryParamTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -167,6 +167,32 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
     }
 
     [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_Core60 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core60 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  paramsWithAtSign: false)
+        {
+        }
+    }
+
+    [NetCoreTest]
     public class MsSqlStoredProcedureTests_SystemDataSqlClient_Core50 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MsSqlStoredProcedureTests_SystemDataSqlClient_Core50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -191,6 +191,17 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
+    public class MsSqlTests_SystemDataSqlClient_Core60 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MsSqlTests_SystemDataSqlClient_Core60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataSqlClientExerciser")
+        {
+        }
+    }
+
     [NetCoreTest]
     public class MsSqlTests_SystemDataSqlClient_Core50 : MsSqlTestsBase<ConsoleDynamicMethodFixtureCore50>
     {


### PR DESCRIPTION
Quick follow-on PR to update System.Data.SqlClient tests to account for the merge of the .NET 7 branch.  I should have merged main into my branch before merging my last PR, but it didn't say anything about merge conflicts.  Unfortunately, I don't think the current state of `main` will build without these changes.