### PR TITLE
Update Custom Event sample size default value.

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 * Custom Event Limit Increase
-  * This version increases the default limit of custom events from X events per minute to Y events per minute. In the scenario that custom events were being limited, this change will allow more custom events to be sent to New Relic. There is also a new configurable maximum limit of 100,000 events per minute. To change the limits, see the documentation for [max_samples_stored](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#custom_events). To learn more about the change and how to determine if custom events are being dropped, see our Explorers Hub [post](https://discuss.newrelic.com/t/send-more-custom-events-with-the-latest-apm-agents/190497). [#1284](https://github.com/newrelic/newrelic-dotnet-agent/pull/1284)
+  * This version increases the default limit of custom events from 10,000 events per minute to 30,000 events per minute. In the scenario that custom events were being limited, this change will allow more custom events to be sent to New Relic. There is also a new configurable maximum limit of 100,000 events per minute. To change the limits, see the documentation for [max_samples_stored](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#custom_events). To learn more about the change and how to determine if custom events are being dropped, see our Explorers Hub [post](https://discuss.newrelic.com/t/send-more-custom-events-with-the-latest-apm-agents/190497). [#1284](https://github.com/newrelic/newrelic-dotnet-agent/pull/1284)
 
 ### Fixes
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### New Features
+* Custom Event Limit Increase
+  * This version increases the default limit of custom events from X events per minute to Y events per minute. In the scenario that custom events were being limited, this change will allow more custom events to be sent to New Relic. There is also a new configurable maximum limit of 100,000 events per minute. To change the limits, see the documentation for [max_samples_stored](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#custom_events). To learn more about the change and how to determine if custom events are being dropped, see our Explorers Hub [post](https://discuss.newrelic.com/t/send-more-custom-events-with-the-latest-apm-agents/190497). [#1284](https://github.com/newrelic/newrelic-dotnet-agent/pull/1284)
 
 ### Fixes
 

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -2466,7 +2466,7 @@ namespace NewRelic.Agent.Core.Config
         {
             this.attributesField = new configurationCustomEventsAttributes();
             this.enabledField = true;
-            this.maximumSamplesStoredField = 10000;
+            this.maximumSamplesStoredField = 30000;
         }
         
         public configurationCustomEventsAttributes attributes
@@ -2496,7 +2496,7 @@ namespace NewRelic.Agent.Core.Config
         }
         
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        [System.ComponentModel.DefaultValueAttribute(10000)]
+        [System.ComponentModel.DefaultValueAttribute(30000)]
         public int maximumSamplesStored
         {
             get

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -736,7 +736,7 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="maximumSamplesStored" type="xs:int" default="10000">
+                        <xs:attribute name="maximumSamplesStored" type="xs:int" default="30000">
                             <xs:annotation>
                                 <xs:documentation>
                                     The maximum number of samples to store in memory at a time.	Default is 10000.

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -3021,7 +3021,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [TestCase(null, 20, 30, ExpectedResult = 30)]
         [TestCase(null, null, 30, ExpectedResult = 30)]
         [TestCase(null, 20, null, ExpectedResult = 20)]
-        [TestCase(null, null, null, ExpectedResult = 10000)]
+        [TestCase(null, null, null, ExpectedResult = 30000)]
         public int CustomEventsMaxSamplesStoredOverriddenByEnvironment(string environmentSetting, int? localSetting, int? serverSetting)
         {
             Mock.Arrange(() => _environment.GetEnvironmentVariable("MAX_EVENT_SAMPLES_STORED")).Returns(environmentSetting);

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2992,7 +2992,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [Test]
         public void CustomEventsMaxSamplesStoredPassesThroughToLocalConfig()
         {
-            Assert.That(_defaultConfig.CustomEventsMaximumSamplesStored, Is.EqualTo(10000));
+            Assert.That(_defaultConfig.CustomEventsMaximumSamplesStored, Is.EqualTo(30000));
 
             _localConfig.customEvents.maximumSamplesStored = 10001;
             Assert.That(_defaultConfig.CustomEventsMaximumSamplesStored, Is.EqualTo(10001));


### PR DESCRIPTION
## Description

Update Custom Event sample size default value from 10,000 to 30,000.

