### PR TITLE
Updates RestSharp testing to use ConsoleMF app and expands tested versions

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicMvcApplicationTestFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicMvcApplicationTestFixture.cs
@@ -40,16 +40,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             var address = $"http://{DestinationServerName}:{Port}/Default/HttpClientTaskCancelled";
             DownloadStringAndAssertEqual(address, "Worked");
         }
-        public void GetRestSharpSyncClient(string method, bool generic)
-        {
-            var address = $"http://{DestinationServerName}:{Port}/RestSharp/SyncClient?method={method}&generic={generic}";
-            DownloadStringAndAssertEqual(address, "Worked");
-        }
-        public void GetRestSharpAsyncAwaitClient(string method, bool generic, bool cancelable)
-        {
-            var address = $"http://{DestinationServerName}:{Port}/RestSharp/AsyncAwaitClient?method={method}&generic={generic}&cancelable={cancelable}";
-            DownloadStringAndAssertEqual(address, "Worked");
-        }
 
         public HttpResponseHeaders GetRestSharpAsyncAwaitClientWithHeaders(string method, bool generic, bool cancelable)
         {
@@ -74,12 +64,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         }
 
-        public void GetRestSharpTaskResultClient(string method, bool generic, bool cancelable)
-        {
-            var address = $"http://{DestinationServerName}:{Port}/RestSharp/TaskResultClient?method={method}&generic={generic}&cancelable={cancelable}";
-            DownloadStringAndAssertEqual(address, "Worked");
-        }
-
         public HttpResponseHeaders GetRestSharpTaskResultClientWithHeaders(string method, bool generic, bool cancelable)
         {
             var address = $"http://{DestinationServerName}:{Port}/RestSharp/TaskResultClient?method={method}&generic={generic}&cancelable={cancelable}";
@@ -101,12 +85,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
                 return Task.Run(() => httpClient.SendAsync(httpRequestMessage)).Result.Headers;
             }
 
-        }
-
-        public void GetRestSharpClientTaskCancelled()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/RestSharp/RestSharpClientTaskCancelled";
-            DownloadStringAndAssertEqual(address, "Worked");
         }
 
         public void Get404(string Path = "DoesNotExist")

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
@@ -100,6 +100,15 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
     }
 
     [NetFrameworkTest]
+    public class RestSharpInstrumentationAsyncAwaitCATFW48 : RestSharpInstrumentationAsyncAwaitCATBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public RestSharpInstrumentationAsyncAwaitCATFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
     public class RestSharpInstrumentationAsyncAwaitCATFW471 : RestSharpInstrumentationAsyncAwaitCATBase<ConsoleDynamicMethodFixtureFW471>
     {
         public RestSharpInstrumentationAsyncAwaitCATFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -4,24 +4,36 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
+using System;
+using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
-    [NetFrameworkTest]
-    public class RestSharpInstrumentationCAT : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public abstract class RestSharpInstrumentationCATBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
     {
-        private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
+        private readonly TFixture _fixture;
 
-        public RestSharpInstrumentationCAT(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
+        public RestSharpInstrumentationCATBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
-            _fixture.Actions(
+
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} GET false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} PUT false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} POST false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} DELETE false");
+            _fixture.AddCommand($"RestSharpExerciser RestSharpClientTaskCancelled {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand("RestSharpService StopService");
+
+            _fixture.AddActions
+            (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
@@ -30,48 +42,37 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
                     configModifier.SetLogLevel("finest");
                     configModifier.EnableCat();
                     configModifier.ForceTransactionTraces();
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.GetRestSharpSyncClient(method: "GET", generic: false);
-                    _fixture.GetRestSharpSyncClient(method: "PUT", generic: false);
-                    _fixture.GetRestSharpSyncClient(method: "POST", generic: false);
-                    _fixture.GetRestSharpSyncClient(method: "DELETE", generic: false);
-                    _fixture.GetRestSharpClientTaskCancelled();
-
-                    //Adding some time for metrics to be fully generated. 
-                    Thread.Sleep(3000);
                 }
             );
+
             _fixture.Initialize();
         }
 
         [Fact]
         public void Test()
         {
-            var myHostname = _fixture.DestinationServerName; // This is needed because we are making "external" calls to ourself to test RestSharp
             var crossProcessId = _fixture.AgentLog.GetCrossProcessId();
+            var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/SyncClient";
+            var cancelledTrasnsactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/RestSharpClientTaskCancelled";
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 5 },
-                new Assertions.ExpectedMetric { metricName = "External/allWeb", callCount = 5 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = @"WebTransaction/MVC/RestSharpController/SyncClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 2 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", metricScope = cancelledTrasnsactionName, callCount = 1},
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples()
-                .Where(sample => sample.Path == @"WebTransaction/MVC/RestSharpController/SyncClient" || sample.Path == @"WebTransaction/WebAPI/RestAPI/Get" || sample.Path == @"WebTransaction/MVC/RestSharpController/RestSharpClientTaskCancelled")
+                .Where(sample => sample.Path == callerTransactionName || sample.Path == @"WebTransaction/WebAPI/RestAPI/Get" || sample.Path == cancelledTrasnsactionName)
                 .FirstOrDefault();
 
             Assert.NotNull(transactionSample);
@@ -90,6 +91,33 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             var wrapperError = _fixture.AgentLog.TryGetLogLine(agentWrapperErrorRegex);
 
             Assert.Null(wrapperError);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationCATFWLatest : RestSharpInstrumentationCATBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public RestSharpInstrumentationCATFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationCATFW471 : RestSharpInstrumentationCATBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public RestSharpInstrumentationCATFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationCATFW462 : RestSharpInstrumentationCATBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public RestSharpInstrumentationCATFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -104,6 +104,15 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
     }
 
     [NetFrameworkTest]
+    public class RestSharpInstrumentationCATFW48 : RestSharpInstrumentationCATBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public RestSharpInstrumentationCATFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
     public class RestSharpInstrumentationCATFW471 : RestSharpInstrumentationCATBase<ConsoleDynamicMethodFixtureFW471>
     {
         public RestSharpInstrumentationCATFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
@@ -124,6 +124,15 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
     }
 
     [NetFrameworkTest]
+    public class RestSharpInstrumentationDistributedTracingFW48 : RestSharpInstrumentationDistributedTracingBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public RestSharpInstrumentationDistributedTracingFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
     public class RestSharpInstrumentationDistributedTracingFW471 : RestSharpInstrumentationDistributedTracingBase<ConsoleDynamicMethodFixtureFW471>
     {
         public RestSharpInstrumentationDistributedTracingFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
@@ -100,6 +100,15 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
     }
 
     [NetFrameworkTest]
+    public class RestSharpInstrumentationTaskResultCATFW48 : RestSharpInstrumentationTaskResultCATBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public RestSharpInstrumentationTaskResultCATFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
     public class RestSharpInstrumentationTaskResultCATFW471 : RestSharpInstrumentationTaskResultCATBase<ConsoleDynamicMethodFixtureFW471>
     {
         public RestSharpInstrumentationTaskResultCATFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -11,16 +13,26 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {
-    [NetFrameworkTest]
-    public class RestSharpInstrumentationTaskResultCAT : NewRelicIntegrationTest<RemoteServiceFixtures.BasicMvcApplicationTestFixture>
+    public abstract class RestSharpInstrumentationTaskResultCATBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
     {
-        private readonly RemoteServiceFixtures.BasicMvcApplicationTestFixture _fixture;
+        private readonly TFixture _fixture;
 
-        public RestSharpInstrumentationTaskResultCAT(RemoteServiceFixtures.BasicMvcApplicationTestFixture fixture, ITestOutputHelper output) : base(fixture)
+        public RestSharpInstrumentationTaskResultCATBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
-            _fixture.Actions(
+
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} GET true true");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} PUT false false");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} POST false false");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} DELETE true true");
+            _fixture.AddCommand("RestSharpService StopService");
+
+            _fixture.AddActions
+            (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
@@ -28,42 +40,35 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
 
                     configModifier.EnableCat();
                     configModifier.ForceTransactionTraces();
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.GetRestSharpTaskResultClient(method: "GET", generic: true, cancelable: true);
-                    _fixture.GetRestSharpTaskResultClient(method: "PUT", generic: false, cancelable: false);
-                    _fixture.GetRestSharpTaskResultClient(method: "POST", generic: false, cancelable: false);
-                    _fixture.GetRestSharpTaskResultClient(method: "DELETE", generic: true, cancelable: true);
                 }
             );
+
             _fixture.Initialize();
         }
 
         [Fact]
         public void Test()
         {
-            var myHostname = _fixture.DestinationServerName; // This is needed because we are making "external" calls to ourself to test RestSharp
             var crossProcessId = _fixture.AgentLog.GetCrossProcessId();
+            var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/TaskResultClient";
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = "External/allWeb", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/GET", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/{myHostname}/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{myHostname}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var transactionSample = _fixture.AgentLog.GetTransactionSamples()
-                .Where(sample => sample.Path == @"WebTransaction/MVC/RestSharpController/TaskResultClient" || sample.Path == @"WebTransaction/WebAPI/RestAPI/Get")
+                .Where(sample => sample.Path == callerTransactionName || sample.Path == @"WebTransaction/WebAPI/RestAPI/Get")
                 .FirstOrDefault();
 
             Assert.NotNull(transactionSample);
@@ -82,6 +87,33 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             var wrapperError = _fixture.AgentLog.TryGetLogLine(agentWrapperErrorRegex);
 
             Assert.Null(wrapperError);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationTaskResultCATFWLatest : RestSharpInstrumentationTaskResultCATBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public RestSharpInstrumentationTaskResultCATFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationTaskResultCATFW471 : RestSharpInstrumentationTaskResultCATBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public RestSharpInstrumentationTaskResultCATFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RestSharpInstrumentationTaskResultCATFW462 : RestSharpInstrumentationTaskResultCATBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public RestSharpInstrumentationTaskResultCATFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net462;net471;net48;net481</TargetFrameworks>
@@ -247,10 +247,12 @@
     <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="RestSharp" Version="106.0.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net48'" />
-    <!-- Not testing these versions, but it simplfies the classes by not needing if directives -->
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net7.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -242,6 +242,17 @@
     <Reference Include="System.Messaging" Condition="'$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 
+  <!-- RestSharp -->
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="RestSharp" Version="106.0.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net48'" />
+    <!-- Not testing these versions, but it simplfies the classes by not needing if directives -->
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net6.0'" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
     <ProjectReference Include="..\..\..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/Startups.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/Startups.cs
@@ -21,4 +21,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Owin
             appBuilder.UseWebApi(config);
         }
     }
+
+    public class FullRoutesStartup : IStartup
+    {
+        public void Configuration(IAppBuilder appBuilder)
+        {
+            var config = new HttpConfiguration();
+            config.MapHttpAttributeRoutes();
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{action}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+            appBuilder.UseWebApi(config);
+        }
+    }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestAPIController.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestAPIController.cs
@@ -1,0 +1,56 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Web.Http;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
+{
+    public class RestAPIController : ApiController
+    {
+        public class Bird
+        {
+            public string CommonName { get; set; }
+            public string BandingCode { get; set; }
+        }
+
+        [HttpGet]
+        public IEnumerable<Bird> Get()
+        {
+            return new Bird[] { new Bird { CommonName = "American Kestrel", BandingCode = "AMKE" }, new Bird { CommonName = "Snowy Owl", BandingCode = "SNOW" } };
+        }
+
+        [HttpGet]
+        public Bird Get(int id)
+        {
+            // If the ID is 4, this request is coming from the RestSharpClientTaskCancelled parent
+            // endpoint and we need to ensure that the client times out before the request succeeds
+            if (id == 4)
+            {
+                Thread.Sleep(100);
+            }
+
+            return new Bird { CommonName = "Northern Flicker", BandingCode = "NOFL" };
+        }
+
+        [HttpPost]
+        public void Post([FromBody] Bird bird)
+        {
+            // Do nothing
+        }
+
+        [HttpPut]
+        public void Put(int id, [FromBody] Bird bird)
+        {
+            // Do nothing
+        }
+
+        [HttpDelete]
+        public void Delete(int id)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
@@ -1,0 +1,223 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using RestSharp;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+using System.Runtime.CompilerServices;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
+{
+    [Library]
+    public class RestSharpExerciser
+    {
+        private class Bird
+        {
+            public string CommonName { get; set; }
+            public string BandingCode { get; set; }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string SyncClient(int port, string method, bool generic)
+        {
+            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myPort = port;
+            var client = new RestClient($"http://{myHost}:{myPort}");
+
+            var endpoint = "api/RestAPI/";
+            var id = 1;
+
+            var requests = GetRequests(endpoint, id);
+            if (generic)
+            {
+                var response = client.Execute<Bird>(requests[method]);
+                if (method == "GET")
+                {
+                    var bird = response.Data;
+                    System.IO.File.AppendAllText(@"C:\IntegrationTestWorkingDirectory\RestAPIController.log", $"SyncClient method={method}, generic={generic} got Bird {bird.CommonName} ({bird.BandingCode})" + Environment.NewLine);
+                }
+
+                if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))
+                {
+                    return $"Unexpected HTTP status code {response.StatusCode}";
+                }
+            }
+            else
+            {
+                var response = client.Execute(requests[method]);
+                if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))
+                {
+                    return $"Unexpected HTTP status code {response.StatusCode}";
+                }
+            }
+
+            return "Worked";
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> AsyncAwaitClient(int port, string method, bool generic, bool cancelable)
+        {
+            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myPort = port;
+            var client = new RestClient($"http://{myHost}:{myPort}");
+
+            var endpoint = "api/RestAPI/";
+            var id = 1;
+
+            var requests = GetRequests(endpoint, id);
+            IRestResponse response;
+            if (generic)
+            {
+                if (cancelable)
+                {
+                    var cancellationTokenSource = new CancellationTokenSource();
+                    response = await ExecuteAsyncGeneric<Bird>(client, requests[method], cancellationTokenSource);
+                }
+                else
+                {
+                    response = await ExecuteAsyncGeneric<Bird>(client, requests[method]);
+                }
+            }
+            else
+            {
+                if (cancelable)
+                {
+                    var cancellationTokenSource = new CancellationTokenSource();
+                    response = await ExecuteAsync(client, requests[method], cancellationTokenSource);
+                }
+                else
+                {
+                    response = await ExecuteAsync(client, requests[method]);
+                }
+            }
+
+            if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))
+            {
+                return $"Unexpected HTTP status code {response.StatusCode}";
+            }
+
+            return "Worked";
+
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string TaskResultClient(int port, string method, bool generic, bool cancelable)
+        {
+            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myPort = port;
+            var client = new RestClient($"http://{myHost}:{myPort}");
+
+            var endpoint = "api/RestAPI/";
+            var id = 1;
+
+            var requests = GetRequests(endpoint, id);
+            IRestResponse response;
+            if (generic)
+            {
+                if (cancelable)
+                {
+                    var cancellationTokenSource = new CancellationTokenSource();
+                    var task = ExecuteAsyncGeneric<Bird>(client, requests[method], cancellationTokenSource);
+                    response = task.Result;
+                }
+                else
+                {
+                    var task = ExecuteAsyncGeneric<Bird>(client, requests[method]);
+                    response = task.Result;
+                }
+            }
+            else
+            {
+                if (cancelable)
+                {
+                    var cancellationTokenSource = new CancellationTokenSource();
+                    var task = ExecuteAsync(client, requests[method], cancellationTokenSource);
+                    response = task.Result;
+                }
+                else
+                {
+                    var task = ExecuteAsync(client, requests[method]);
+                    response = task.Result;
+                }
+            }
+
+            if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))
+            {
+                return $"Non-200 HTTP status code {response.StatusCode}";
+            }
+
+            return "Worked";
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> RestSharpClientTaskCancelled(int port)
+        {
+            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myPort = port;
+
+            var endpoint = "api/RestAPI/";
+            var id = 4;
+
+            try
+            {
+                var client = new RestClient($"http://{myHost}:{myPort}");
+                client.Timeout = 1;
+                var response = await client.ExecuteTaskAsync(new RestRequest(endpoint + "Get/" + id));
+            }
+            catch (Exception)
+            {
+                //Swallow for test purposes
+            }
+
+            return "Worked";
+        }
+
+#region Helpers
+
+        private Dictionary<string, IRestRequest> GetRequests(string endpoint, int id)
+        {
+            var requests = new Dictionary<string, IRestRequest>();
+            requests.Add("GET", new RestRequest(endpoint + "Get/" + id));
+            requests.Add("PUT", new RestRequest(endpoint + "Put/" + id, Method.PUT).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
+            requests.Add("DELETE", new RestRequest(endpoint + "Delete/" + id, Method.DELETE));
+            requests.Add("POST", new RestRequest(endpoint + "Post/", Method.POST).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
+            return requests;
+        }
+
+        private Task<IRestResponse<T>> ExecuteAsyncGeneric<T>(RestClient client, IRestRequest request, CancellationTokenSource cancellationTokenSource = null)
+        {
+            if (cancellationTokenSource == null)
+            {
+                return client.ExecuteTaskAsync<T>(request);
+            }
+
+            return client.ExecuteTaskAsync<T>(request, cancellationTokenSource.Token);
+        }
+
+        private Task<IRestResponse> ExecuteAsync(RestClient client, IRestRequest request, CancellationTokenSource cancellationTokenSource = null)
+        {
+            if (cancellationTokenSource == null)
+            {
+                return client.ExecuteTaskAsync(request);
+            }
+
+            return client.ExecuteTaskAsync(request, cancellationTokenSource.Token);
+        }
+
+#endregion
+
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpService.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using MultiFunctionApplicationHelpers.NetStandardLibraries.Owin;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using System;
+using System.Net.Http;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
+{
+    [Library]
+    public class RestSharpService
+    {
+        private readonly HttpClient _client = new HttpClient();
+        private OwinService _owinService;
+
+        /// <summary>
+        /// Starts the RestSharp Test Service with a specific port and path
+        /// </summary>
+        /// <param name="port"></param>
+        /// <param name="relativePath"></param>
+        [LibraryMethod]
+        public void StartService(int port)
+        {
+            try
+            {
+                ConsoleMFLogger.Info("Starting RestSharp Test Service.");
+
+                // build owin service
+                _owinService = new OwinServiceBuilder()
+                    .RegisterController(typeof(RestAPIController))
+                    .AddStartup(new FullRoutesStartup())
+                    .Build();
+
+                // Start OWIN host 
+                _owinService.StartService(port);
+            }
+            catch (Exception ex)
+            {
+                ConsoleMFLogger.Error(ex);
+            }
+        }
+
+        /// <summary>
+        /// Stops the RestSharp Test Service
+        /// </summary>
+        [LibraryMethod]
+        public void StopService()
+        {
+            ConsoleMFLogger.Info("Stopping RestSharp Test Service");
+            _owinService.StopService();
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Migrates almost all RestSharp tests to use ConsoleMF app.
- Uses the existing OwinService to build a host service for the controllers and added a new Startup to support the controllers.
- Only DT specfic tests, which are not migrated to ConsoleMF, need the old BasicMvcApplication tests so those are still present
- The unused methods in the BasicMvcApplicationTestApplicationFixture for RestSharp were removed.
- Expands our test coverage to the versions of RestSharp we state that we support
  - 105.2.3
  - 106.0.0
  - 106.6.10
- No changes were made to the instrumentation


# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
