### PR TITLE
Updates the LambdaTracer.Extract exception type

### DIFF
--- a/src/AwsLambda/AwsLambdaOpenTracer/LambdaTracer.cs
+++ b/src/AwsLambda/AwsLambdaOpenTracer/LambdaTracer.cs
@@ -111,7 +111,7 @@ namespace NewRelic.OpenTracing.AmazonLambda
             {
                 var message = $"{NEWRELIC_TRACE_HEADER} header value was not accepted.";
                 _logger.Log(message, false, "ERROR");
-                throw new ArgumentNullException(message);
+                throw new ArgumentException(message);
             }
 
             var transportDurationInMillis = (DateTimeOffset.UtcNow - distributedTracePayload.Timestamp).TotalMilliseconds;

--- a/src/AwsLambda/CHANGELOG.md
+++ b/src/AwsLambda/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### New Features
+### Fixes
+* Updates the LambdaTracer.Extract exception type. The previous exception type, ArgumentNullException, was incorrect.  The new type, ArgumentException, is better fit.. [#1287](https://github.com/newrelic/newrelic-dotnet-agent/pull/1287)
 
 ## [1.3.1] - 2022-10-03
 ### Fixes


### PR DESCRIPTION
## Description

The previous exception type, ArgumentNullException, was incorrect.  The new type, ArgumentException, is better fit.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
