### PR TITLE
Add arm64 profiler to nuget package

### DIFF
--- a/build/ArtifactBuilder/AgentComponents.cs
+++ b/build/ArtifactBuilder/AgentComponents.cs
@@ -227,7 +227,11 @@ namespace ArtifactBuilder
 
         private void CheckForRequiredProperties()
         {
-            var requiredProperties = new Dictionary<string, string> { { nameof(WindowsProfiler), WindowsProfiler } };
+            var requiredProperties = new Dictionary<string, string>();
+            if (Platform != "arm64") 
+            { 
+                requiredProperties.Add(nameof(WindowsProfiler), WindowsProfiler);
+            }
             var missingPropertyNames = new List<string>();
 
             foreach (var requiredProperty in requiredProperties)

--- a/build/ArtifactBuilder/ArtifactBuilder.csproj
+++ b/build/ArtifactBuilder/ArtifactBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -24,10 +24,12 @@ namespace ArtifactBuilder.Artifacts
             var frameworkAgentComponents = AgentComponents.GetAgentComponents(AgentType.Framework, Configuration, "x64", RepoRootDirectory, HomeRootDirectory);
             var frameworkAgentX86Components = AgentComponents.GetAgentComponents(AgentType.Framework, Configuration, "x86", RepoRootDirectory, HomeRootDirectory);
             var coreAgentComponents = AgentComponents.GetAgentComponents(AgentType.Core, Configuration, "x64", RepoRootDirectory, HomeRootDirectory);
+            var coreAgentArm64Components = AgentComponents.GetAgentComponents(AgentType.Core, Configuration, "arm64", RepoRootDirectory, HomeRootDirectory);
             var coreAgentX86Components = AgentComponents.GetAgentComponents(AgentType.Core, Configuration, "x86", RepoRootDirectory, HomeRootDirectory);
             frameworkAgentComponents.ValidateComponents();
             frameworkAgentX86Components.ValidateComponents();
             coreAgentComponents.ValidateComponents();
+            coreAgentArm64Components.ValidateComponents();
             coreAgentX86Components.ValidateComponents();
 
             var package = new NugetPackage(StagingDirectory, OutputDirectory);
@@ -45,7 +47,9 @@ namespace ArtifactBuilder.Artifacts
             coreAgentComponents.CopyComponents($@"{package.GetContentFilesDirectory("any", "netstandard2.0")}\newrelic");
             FileHelpers.CopyFile(coreAgentX86Components.WindowsProfiler, $@"{package.GetContentFilesDirectory("any", "netstandard2.0")}\newrelic\x86");
             package.CopyToContentFiles(coreAgentComponents.LinuxProfiler, @"any\netstandard2.0\newrelic");
+            package.CopyToContentFiles(coreAgentArm64Components.LinuxProfiler, @"any\netstandard2.0\newrelic\linux-arm64");
             package.CopyToContentFiles(coreAgentComponents.GRPCExtensionsLibLinux, @"any\netstandard2.0\newrelic");
+            package.CopyToContentFiles(coreAgentArm64Components.GRPCExtensionsLibLinux, @"any\netstandard2.0\newrelic");
             Directory.CreateDirectory($@"{StagingDirectory}\contentFiles\any\netstandard2.0\newrelic\logs");
             System.IO.File.Create($@"{StagingDirectory}\contentFiles\any\netstandard2.0\newrelic\logs\placeholder").Dispose();
 

--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -149,9 +149,14 @@ namespace ArtifactBuilder
                 };
             }
 
-            AgentInfoJson = Platform == "arm64" ? null : $@"{SourcePath}\..\src\Agent\Miscellaneous\{Platform}\agentinfo.json";
+            var configurationComponents = new List<string> { NewRelicXsd };
+            if (Platform != "arm64")
+            {
+                AgentInfoJson = $@"{SourcePath}\..\src\Agent\Miscellaneous\{Platform}\agentinfo.json";
+                configurationComponents.Add(AgentInfoJson);
+            }
 
-            SetConfigurationComponents(NewRelicXsd, AgentInfoJson);
+            SetConfigurationComponents(configurationComponents.ToArray());
         }
     }
 }


### PR DESCRIPTION
## Description

Adds the linux-arm64 profiler and grpc libraries to the Agent Nuget package. This will allow customers to deploy to ARM using only the nuget package.

The AgentComponents class likely needs to be refactored to be specific to Linux/Windows targets in the future, but I worked around that for now.