### PR TITLE
Fix lambda test assertions

### DIFF
--- a/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/LambdaTracerTests.cs
+++ b/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/LambdaTracerTests.cs
@@ -150,9 +150,9 @@ namespace NewRelic.Tests.AwsLambda.AwsLambdaOpenTracerTests
         {
             var tracer = LambdaTracer.Instance;
             var tags = new Dictionary<string, string>() { { "newrelic", "fred flintstone" } };
-            Assert.That(() => tracer.Extract(BuiltinFormats.TextMap, new TextMapExtractAdapter(tags)), Throws.Exception.TypeOf<ArgumentNullException>());
-            Assert.That(() => tracer.Extract(BuiltinFormats.HttpHeaders, new TextMapExtractAdapter(tags)), Throws.Exception.TypeOf<ArgumentNullException>());
-            Assert.That(() => tracer.Extract(NewRelicFormats.Payload, new PayloadExtractAdapter("I AM BAD")), Throws.Exception.TypeOf<ArgumentNullException>());
+            Assert.That(() => tracer.Extract(BuiltinFormats.TextMap, new TextMapExtractAdapter(tags)), Throws.Exception.TypeOf<ArgumentException>());
+            Assert.That(() => tracer.Extract(BuiltinFormats.HttpHeaders, new TextMapExtractAdapter(tags)), Throws.Exception.TypeOf<ArgumentException>());
+            Assert.That(() => tracer.Extract(NewRelicFormats.Payload, new PayloadExtractAdapter("I AM BAD")), Throws.Exception.TypeOf<ArgumentException>());
         }
 
         [Test]


### PR DESCRIPTION
## Description

Updates lambda test assertions to match new exception type introduced by https://github.com/newrelic/newrelic-dotnet-agent/pull/1287