### PR TITLE
Update RecordLogMessage() API to take getter function for context data

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -446,11 +446,11 @@ namespace NewRelic.Agent.Core
                 {
                     logEventWireModel = new LogEventWireModel(timestamp, logMessage, normalizedLevel,
                         StackTraces.ScrubAndTruncate(logException, LogExceptionStackLimit), logException.Message, logException.GetType().ToString(),
-                        spanId, traceId, filterLogContextData(logContextData));
+                        spanId, traceId, FilterLogContextData(logContextData));
                 }
                 else
                 {
-                    logEventWireModel = new LogEventWireModel(timestamp, logMessage, normalizedLevel, spanId, traceId, filterLogContextData(logContextData));
+                    logEventWireModel = new LogEventWireModel(timestamp, logMessage, normalizedLevel, spanId, traceId, FilterLogContextData(logContextData));
                 }
 
                 var transaction = _transactionService.GetCurrentInternalTransaction();
@@ -553,7 +553,7 @@ namespace NewRelic.Agent.Core
             _transactionService.RemoveOutstandingInternalTransactions(removeAsync, removePrimary);
         }
 
-        private Dictionary<string, object> filterLogContextData(Dictionary<string, object> unfilteredContextData)
+        private Dictionary<string, object> FilterLogContextData(Dictionary<string, object> unfilteredContextData)
         {
             if (unfilteredContextData == null)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 
 namespace NewRelic.Agent.Api.Experimental
 {
@@ -29,6 +30,6 @@ namespace NewRelic.Agent.Api.Experimental
         /// <param name="getLogException">A Func<object,Exception> that knows how to get the log exception from the logEvent</param>
         /// <param name="spanId">The span ID of the segment the log message occured within.</param>
         /// <param name="traceId">The trace ID of the transaction the log message occured within.</param>
-        void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, Func<object, Exception> getLogException, string spanId, string traceId);
+        void RecordLogMessage(string frameworkName, object logEvent, Func<object,DateTime> getTimestamp, Func<object,object> getLogLevel, Func<object,string> getLogMessage, Func<object, Exception> getLogException, Func<object, Dictionary<string, object>> getContextData, string spanId, string traceId);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
@@ -57,9 +58,12 @@ namespace NewRelic.Providers.Wrapper.Logging
 
             var getLogExceptionFunc = _getLogException ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<Exception>(logEventType, "ExceptionObject");
 
+            // Placeholder until context data (custom attribute) instrumentation is implemented
+            Func <object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
+
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, getContextDataFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, Type logEventType, IAgent agent)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -50,9 +50,12 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 
                 Func<object, Exception> getLogExceptionFunc = mc => ((MethodCall)mc).MethodArguments[3] as Exception; // using "as" since we want a null if missing
 
+                // Placeholder until context data (custom attribute) instrumentation is implemented
+                Func<object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
+
                 var xapi = agent.GetExperimentalApi();
 
-                xapi.RecordLogMessage(WrapperName, methodCall, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+                xapi.RecordLogMessage(WrapperName, methodCall, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, getContextDataFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
@@ -54,9 +55,12 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
 
             var getLogExceptionFunc = _getLogException ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<Exception>(logEventType, "Exception");
 
+            // Placeholder until context data (custom attribute) instrumentation is implemented
+            Func<object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
+
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, getContextDataFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, Type logEventType, IAgent agent)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
@@ -38,8 +39,11 @@ namespace NewRelic.Providers.Wrapper.SerilogLogging
 
             Func<object, string> getMessageFunc = l => logEvent.RenderMessage();
 
+            // Placeholder until context data (custom attribute) instrumentation is implemented
+            Func<object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
+
             var xapi = _agent.GetExperimentalApi();
-            xapi.RecordLogMessage("serilog", logEvent, getDateTimeFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, _agent.TraceMetadata.SpanId, _agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage("serilog", logEvent, getDateTimeFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, _agent.TraceMetadata.SpanId, _agent.TraceMetadata.TraceId);
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1303,13 +1303,14 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => null;
 
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1330,18 +1331,20 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1355,6 +1358,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);
             Assert.AreEqual(traceId, logEvent.TraceId);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.IsNotNull(logEvent.Priority);
         }
 
@@ -1369,18 +1373,20 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var level = "DEBUG";
             string message = null;
             var exception = NotNewRelic.ExceptionBuilder.BuildException("exception message");
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => exception;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1394,6 +1400,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);
             Assert.AreEqual(traceId, logEvent.TraceId);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.IsNotNull(logEvent.Priority);
         }
 
@@ -1412,13 +1419,14 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => null;
 
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1439,11 +1447,13 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1454,7 +1464,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var harvestedLogEvents = transaction.HarvestLogEvents();
             var logEvent = harvestedLogEvents.FirstOrDefault();
@@ -1465,6 +1475,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);
             Assert.AreEqual(traceId, logEvent.TraceId);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.AreEqual(priority, logEvent.Priority);
         }
 
@@ -1479,11 +1490,13 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var level = "DEBUG";
             string message = null;
             var exception = NotNewRelic.ExceptionBuilder.BuildException("exception message");
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => exception;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1494,7 +1507,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var harvestedLogEvents = transaction.HarvestLogEvents();
             var logEvent = harvestedLogEvents.FirstOrDefault();
@@ -1505,6 +1518,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);
             Assert.AreEqual(traceId, logEvent.TraceId);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.AreEqual(priority, logEvent.Priority);
         }
 
@@ -1523,6 +1537,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => null;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1533,7 +1548,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var harvestedLogEvents = transaction.HarvestLogEvents();
             var logEvent = harvestedLogEvents.FirstOrDefault();
@@ -1551,11 +1566,13 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var timestampUnix = timestamp.ToUnixTimeMilliseconds();
             var level = "DEBUG";
             var message = "message";
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1567,7 +1584,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             transaction.HarvestLogEvents();
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
             var logEvents = privateAccessor.GetField("_logEvents") as ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>;
@@ -1580,6 +1597,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(message, logEvent.Message);
             Assert.AreEqual(spanId, logEvent.SpanId);
             Assert.AreEqual(traceId, logEvent.TraceId);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.AreEqual(priority, logEvent.Priority);
         }
 
@@ -1595,18 +1613,20 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var message = "message";
             var exception = NotNewRelic.ExceptionBuilder.BuildException("exception message");
             var fixedStackTrace = string.Join(" \n", StackTraces.ScrubAndTruncate(exception.StackTrace, 300));
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => exception;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
             var loggingFramework = "testFramework";
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             // Access the private collection of events to get the number of add attempts.
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
@@ -1623,6 +1643,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(fixedStackTrace, logEvent.ErrorStack);
             Assert.AreEqual(exception.Message, logEvent.ErrorMessage);
             Assert.AreEqual(exception.GetType().ToString(), logEvent.ErrorClass);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.IsNotNull(logEvent.Priority);
         }
 
@@ -1638,11 +1659,13 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var message = "message";
             var exception = NotNewRelic.ExceptionBuilder.BuildException("exception message");
             var fixedStackTrace = string.Join(" \n", StackTraces.ScrubAndTruncate(exception.StackTrace, 300));
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => exception;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1653,7 +1676,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var priority = transaction.Priority;
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var harvestedLogEvents = transaction.HarvestLogEvents();
             var logEvent = harvestedLogEvents.FirstOrDefault();
@@ -1667,6 +1690,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(fixedStackTrace, logEvent.ErrorStack);
             Assert.AreEqual(exception.Message, logEvent.ErrorMessage);
             Assert.AreEqual(exception.GetType().ToString(), logEvent.ErrorClass);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.AreEqual(priority, logEvent.Priority);
         }
 
@@ -1682,11 +1706,13 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             var message = "message";
             var exception = NotNewRelic.ExceptionBuilder.BuildException("exception message");
             var fixedStackTrace = string.Join(" \n", StackTraces.ScrubAndTruncate(exception.StackTrace, 300));
+            var contextData = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
 
             Func<object, string> getLevelFunc = (l) => level;
             Func<object, DateTime> getTimestampFunc = (l) => timestamp;
             Func<object, string> getMessageFunc = (l) => message;
             Func<object, Exception> getLogExceptionFunc = (l) => exception;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (l) => contextData;
 
             var spanId = "spanid";
             var traceId = "traceid";
@@ -1698,7 +1724,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             transaction.HarvestLogEvents();
 
             var xapi = _agent as IAgentExperimental;
-            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, spanId, traceId);
+            xapi.RecordLogMessage(loggingFramework, new object(), getTimestampFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, spanId, traceId);
 
             var privateAccessor = new PrivateAccessor(_logEventAggregator);
             var logEvents = privateAccessor.GetField("_logEvents") as ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>;
@@ -1714,6 +1740,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
             Assert.AreEqual(fixedStackTrace, logEvent.ErrorStack);
             Assert.AreEqual(exception.Message, logEvent.ErrorMessage);
             Assert.AreEqual(exception.GetType().ToString(), logEvent.ErrorClass);
+            Assert.AreEqual(contextData, logEvent.ContextData);
             Assert.AreEqual(priority, logEvent.Priority);
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -1763,10 +1763,12 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
         [TestCase(true, "", "", "key1,key2")]
         [TestCase(true, "key1", "", "key1")]
+        [TestCase(true, "key1,key2", "key2", "key1")]
         [TestCase(true, "", "key1", "key2")]
         [TestCase(true, "", "key1,key2", "")]
         [TestCase(true, "key3", "", "")]
         [TestCase(false, "", "", "")]
+        [TestCase(false, "key1,key2", "key2", "")]
         public void RecordLogMessage_ContextDataConfiguration(bool contextDataEnabled, string includeList, string excludeList, string expectedAttributeNames)
         {
             Mock.Arrange(() => _configurationService.Configuration.LogEventCollectorEnabled)


### PR DESCRIPTION
## Description

Implements https://issues.newrelic.com/browse/NEWRELIC-4758.  Includes unit tests to test context data filtration based on include and exclude lists in config (caveat: wildcard filtering support not implemented yet, will be implemented in a follow-on PR).

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
