### PR TITLE
Updates attribute limit error log messages with transaction guid

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 * The [NewRelic.Agent NuGet package](https://www.nuget.org/packages/NewRelic.Agent) now includes the Linux Arm64 profiler. This can be found in the `newrelic/linux-arm64` directory. Configure your `CORECLR_PROFILER_PATH` environment variable to use this version of the profiler when deploying to linux ARM64 targets.
-* When finest logs is enabled, the transaction guid will be applied to attribute limit log messages, if present.
+* When finest logs are enabled, the transaction guid will be applied to attribute limit log messages, if present.
 
 ### Fixes
 *

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New Features
 * The [NewRelic.Agent NuGet package](https://www.nuget.org/packages/NewRelic.Agent) now includes the Linux Arm64 profiler. This can be found in the `newrelic/linux-arm64` directory. Configure your `CORECLR_PROFILER_PATH` environment variable to use this version of the profiler when deploying to linux ARM64 targets.
+* When finest logs is enabled, the transaction guid will be applied to attribute limit log messages, if present.
 
 ### Fixes
 *

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -944,7 +944,7 @@ namespace NewRelic.Agent.Core.Transactions
             _configuration = configuration;
             Priority = priority;
             _traceId = configuration.DistributedTracingEnabled ? GuidGenerator.GenerateNewRelicTraceId() : null;
-            TransactionMetadata = new TransactionMetadata();
+            TransactionMetadata = new TransactionMetadata(_guid);
 
             CallStackManager = callStackManager;
             _transactionTracerMaxSegments = configuration.TransactionTracerMaxSegments;

--- a/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
@@ -90,11 +90,19 @@ namespace NewRelic.Agent.Core.Transactions
         private volatile string _originalUri;
         private volatile string _referrerUri;
 
-        private readonly AttributeValueCollection _transactionAttributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+        private readonly AttributeValueCollection _transactionAttributes;
         public AttributeValueCollection UserAndRequestAttributes => _transactionAttributes;
 
         private readonly ConcurrentHashSet<string> _allCrossApplicationPathHashes = new ConcurrentHashSet<string>();
         private volatile bool _hasResponseCatHeaders;
+
+        private readonly string _transactionGuid;
+
+        public TransactionMetadata(string transactionGuid)
+        {
+            _transactionGuid = transactionGuid;
+            _transactionAttributes = new AttributeValueCollection(transactionGuid, AttributeValueCollection.AllTargetModelTypes);
+        }
 
         public IImmutableTransactionMetadata ConvertToImmutableMetadata()
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringPrereqCheckerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringPrereqCheckerTests.cs
@@ -221,7 +221,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         {
             var name = TransactionName.ForWebTransaction("foo", "bar");
             var segments = Enumerable.Empty<Segment>();
-            var metadata = new TransactionMetadata().ConvertToImmutableMetadata();
+            var metadata = new TransactionMetadata("transactionGuid").ConvertToImmutableMetadata();
             var guid = Guid.NewGuid().ToString();
 
             _internalTransaction = Mock.Create<IInternalTransaction>();

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -269,7 +269,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var segments = Enumerable.Empty<Segment>();
 
-            var placeholderMetadataBuilder = new TransactionMetadata();
+            var placeholderMetadataBuilder = new TransactionMetadata(guid);
             var placeholderMetadata = placeholderMetadataBuilder.ConvertToImmutableMetadata();
 
             var attribDefSvc = new AttributeDefinitionService((f) => new AttributeDefinitions(f));

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
@@ -138,7 +138,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private ImmutableTransaction BuildTestTransaction(string uri = null, string guid = null, int? statusCode = null, int? subStatusCode = null, IEnumerable<ErrorData> transactionExceptionDatas = null)
         {
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata(guid);
             if (uri != null)
                 transactionMetadata.SetUri(uri);
             if (statusCode != null)

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
@@ -133,7 +133,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private ImmutableTransaction BuildTestTransaction(string uri = null, string guid = null, int? statusCode = null, int? subStatusCode = null, IEnumerable<ErrorData> transactionExceptionDatas = null, IAttributeDefinitions attribDefs = null)
         {
-            var txMetadata = new TransactionMetadata();
+            var txMetadata = new TransactionMetadata(guid);
             if (uri != null)
                 txMetadata.SetUri(uri);
             if (statusCode != null)

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             segments = segments ?? Enumerable.Empty<Segment>();
 
-            var placeholderMetadataBuilder = new TransactionMetadata();
+            var placeholderMetadataBuilder = new TransactionMetadata(guid);
             var placeholderMetadata = placeholderMetadataBuilder.ConvertToImmutableMetadata();
 
             var immutableTransaction = new ImmutableTransaction(name, segments, placeholderMetadata, DateTime.Now, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), guid, false, false, false, 0.5f, false, string.Empty, null, _attribDefSvc.AttributeDefs);
@@ -101,7 +101,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
         {
             var uri = "sqlTrace/Uri";
 
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata("transactionGuid");
             transactionMetadata.SetUri(uri);
 
             var name = TransactionName.ForWebTransaction("TxsWithSegments", "TxWithSegmentX");

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -1300,7 +1300,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var segments = Enumerable.Empty<Segment>();
 
-            var placeholderMetadataBuilder = new TransactionMetadata();
+            var placeholderMetadataBuilder = new TransactionMetadata(guid);
             var placeholderMetadata = placeholderMetadataBuilder.ConvertToImmutableMetadata();
 
             var immutableTransaction = new ImmutableTransaction(name, segments, placeholderMetadata, DateTime.Now, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), guid, false, false, false, priority, sampled, traceId, BuildMockTracingState(guidInPayload: guidInPayload, parentIdInPayload: parentIdInPayload, hasFatalError), _attribDefs);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
@@ -210,7 +210,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var segments = Enumerable.Empty<Segment>();
 
-            var placeholderMetadataBuilder = new TransactionMetadata();
+            var placeholderMetadataBuilder = new TransactionMetadata(guid);
             var placeholderMetadata = placeholderMetadataBuilder.ConvertToImmutableMetadata();
 
             var immutableTransaction = new ImmutableTransaction(name, segments, placeholderMetadata, DateTime.UtcNow, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), guid, false, false, false, priority, sampled, traceId, BuildMockTracingState(isDTParticipant), _attribDefs);
@@ -226,7 +226,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var segments = Enumerable.Empty<Segment>();
 
-            var placeholderMetadataBuilder = new TransactionMetadata();
+            var placeholderMetadataBuilder = new TransactionMetadata(guid);
             var placeholderMetadata = placeholderMetadataBuilder.ConvertToImmutableMetadata();
 
             var immutableTransaction = new ImmutableTransaction(name, segments, placeholderMetadata, DateTime.UtcNow, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), guid, false, false, false, priority, sampled, traceId, null, _attribDefs);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
@@ -355,7 +355,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private ImmutableTransaction BuildTestTransaction(DateTime? startTime = null, TimeSpan? duration = null, TimeSpan? responseTime = null, string uri = null, string guid = null)
         {
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata(guid);
             if (uri != null)
                 transactionMetadata.SetUri(uri);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/SqlTraceWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/SqlTraceWireModelTests.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.WireModels
         [Test]
         public void multiple_sqlId_does_not_has_9_digits_number()
         {
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata("transactionGuid");
             var name = TransactionName.ForWebTransaction("foo", "bar");
             var metadata = transactionMetadata.ConvertToImmutableMetadata();
             var duration = TimeSpan.FromSeconds(1);

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionMetadataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/Builders/TransactionMetadataTests.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Build_HasEmptyPathHashIfNeverSet()
         {
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata("transactionGuid");
             var immutableMetadata = transactionMetadata.ConvertToImmutableMetadata();
 
             NrAssert.Multiple(
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Getters_HttpResponseStatusCode()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             Assert.IsNull(metadata.HttpResponseStatusCode);
 
             metadata.SetHttpResponseStatusCode(200, null, Mock.Create<IErrorService>());
@@ -54,7 +54,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Getters_QueueTime()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             Assert.IsNull(metadata.QueueTime);
 
             metadata.SetQueueTime(TimeSpan.FromSeconds(20));
@@ -67,7 +67,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Getters_CATContentLength()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             Assert.AreEqual(-1, metadata.GetCrossApplicationReferrerContentLength());
 
             metadata.SetCrossApplicationReferrerContentLength(44444);
@@ -80,7 +80,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Build_HasZeroAlternatePathHashesIfSetOnce()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             metadata.SetCrossApplicationPathHash("pathHash1");
             var immutableMetadata = metadata.ConvertToImmutableMetadata();
 
@@ -93,7 +93,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Build_PutsAllPathHashesIntoAlternatePathHashes_ExceptLatest()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             metadata.SetCrossApplicationPathHash("pathHash1");
             metadata.SetCrossApplicationPathHash("pathHash2");
             metadata.SetCrossApplicationPathHash("pathHash3");
@@ -110,7 +110,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         [Test]
         public void Build_DoesNotKeepDuplicatesOfPathHashes()
         {
-            var metadata = new TransactionMetadata();
+            var metadata = new TransactionMetadata("transactionGuid");
             metadata.SetCrossApplicationPathHash("pathHash1");
             metadata.SetCrossApplicationPathHash("pathHash2");
             metadata.SetCrossApplicationPathHash("pathHash1");
@@ -131,7 +131,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
         {
             var maxPathHashes = PathHashMaker.AlternatePathHashMaxSize;
 
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata("transactionGuid");
             Enumerable.Range(0, maxPathHashes + 2).ForEach(number => transactionMetadata.SetCrossApplicationPathHash($"pathHash{number}"));
             var immutableMetadata = transactionMetadata.ConvertToImmutableMetadata();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/TransactionFinalizerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/TransactionFinalizerTests.cs
@@ -282,7 +282,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
         private ImmutableTransaction BuildTestTransaction(IEnumerable<Segment> segments = null, DateTime? startTime = null)
         {
-            var transactionMetadata = new TransactionMetadata();
+            var transactionMetadata = new TransactionMetadata("transactionGuid");
 
             var name = TransactionName.ForWebTransaction("foo", "bar");
             segments = segments ?? Enumerable.Empty<Segment>();


### PR DESCRIPTION
## Description

When troubleshooting attribute limit errors in busy applications, it is difficult to know which transaction the errors are coming from.  This PR updates those log messages to include the transaction guid at finest like most other log messages,

- Attribute limit error messages include the transaction guid
- Updates AttributeValueCollection.cs with a new constructor that takes and stores the transaction guid.  It leaves the other constructors alone.
- Updates AttributeValueCollection.ValidateCollectionLimits to use a helper method to decide when the new finest logs format should be used
- Updates TransactionMetadata to have an explicit constructor that takes in and stores the transaction guid while also instantiating the AttributeValueCollection using its new constructor.  
- Updates Core/Transactions/Transaction.cs to use the new TransactionMetadata constructor to pass in the guid.
- Updates all the unit tests to use the new TransactionMetadata constructor

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
