### PR TITLE
Add custom attribute support for Serilog logging

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
@@ -39,8 +40,33 @@ namespace NewRelic.Providers.Wrapper.SerilogLogging
 
             Func<object, string> getMessageFunc = l => logEvent.RenderMessage();
 
-            // Placeholder until context data (custom attribute) instrumentation is implemented
-            Func<object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
+            Func<object, Dictionary<string, object>> getContextDataFunc = (o) =>
+            {
+                Dictionary<string, object> context = new Dictionary<string, object>();
+                var properties = logEvent.Properties;
+                if ((properties == null) || (properties.Count == 0))
+                {
+                    return context;
+                }
+                foreach (var pair in properties)
+                {
+                    // We can keep simple types as they are, but complex types are stored in nested LogEventPropertyValue objects, which
+                    // are complicated to serialize as JSON. For those, use Render() to at least format them nicely as a string
+                    if (pair.Value is ScalarValue scalar)
+                    {
+                        context[pair.Key] = scalar.Value;
+                    }
+                    else
+                    {
+                        using (StringWriter sw = new StringWriter())
+                        {
+                            pair.Value.Render(sw);
+                            context[pair.Key] = sw.ToString();
+                        }
+                    }
+                }
+                return context;
+            };
 
             var xapi = _agent.GetExperimentalApi();
             xapi.RecordLogMessage("serilog", logEvent, getDateTimeFunc, getLevelFunc, getMessageFunc, getLogExceptionFunc, getContextDataFunc, _agent.TraceMetadata.SpanId, _agent.TraceMetadata.TraceId);


### PR DESCRIPTION
## Description

Add custom attribute support for Serilog logging. Basic object types are left as-is; complex object types are converted to a string.

Because logging integration tests are shared among loggers, that will be done in a separate PR.

Changelog will be updated when all functionality has been merged.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
