### PR TITLE
Dotty improvements

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check for updates to core technology packages
         run: dotnet run --project ${{ env.scan-tool-path }} ${{ env.nugets }}
         env:
-            webhook: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
+            DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
             nugets:
                  "system.data.sqlclient
                  microsoft.data.sqlclient

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Add agent via nuget and then build the tool
+        run: |
+          cd ${{ env.scan-tool-path }}
+          dotnet add nugetSlackNotifications.csproj package NewRelic.Agent
+          dotnet build
+
       - name: Check for updates to core technology packages
         run: |
           if [ ${{ github.event.inputs.daysToSearch }} != "" ]; then
@@ -40,11 +46,19 @@ jobs:
           if [ "${{ github.event.inputs.testMode }}" == "true" ]; then
             export DOTTY_TEST_MODE="True"
           fi
-          dotnet run --project ${{ env.scan-tool-path }} ${{ env.nugets }}
+          cd ${{ env.scan-tool-path }}/bin/Debug/net6.0
+          dotnet ./nugetSlackNotifications.dll ${{ env.nugets }}
         shell: bash
 
         env:
             DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
+            CORECLR_ENABLE_PROFILING: 1
+            CORECLR_NEWRELIC_HOME: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic
+            CORECLR_PROFILER: {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+            CORECLR_PROFILER_PATH: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic/libNewRelicProfiler.so
+            NEW_RELIC_APP_NAME: Dotty
+            NEW_RELIC_HOST: staging-collector.newrelic.com
+            NEW_RELIC_LICENSE_KEY: ${{ secrets.STAGING_LICENSE_KEY }}
             nugets:
                  "system.data.sqlclient
                  microsoft.data.sqlclient

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -10,7 +10,7 @@ on:
         default: "1"
         type: string
       testMode:
-        description: "If set to true, no notification message will be sent to the team channel."
+        description: "If checked, no notification message will be sent to the team channel."
         type: boolean
         default: false
 
@@ -37,7 +37,7 @@ jobs:
           if [ ${{ github.event.inputs.daysToSearch }} != "" ]; then
             export DOTTY_DAYS_TO_SEARCH=${{ github.event.inputs.daysToSearch }}
           fi
-          if [ ${{ github.event.inputs.testMode }} == "True" ]; then
+          if [ "${{ github.event.inputs.testMode }}" == "true" ]; then
             export DOTTY_TEST_MODE="True"
           fi
           dotnet run --project ${{ env.scan-tool-path }} ${{ env.nugets }}

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -54,7 +54,7 @@ jobs:
             DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
             CORECLR_ENABLE_PROFILING: 1
             CORECLR_NEWRELIC_HOME: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic
-            CORECLR_PROFILER: {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+            CORECLR_PROFILER: "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
             CORECLR_PROFILER_PATH: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic/libNewRelicProfiler.so
             NEW_RELIC_APP_NAME: Dotty
             NEW_RELIC_HOST: staging-collector.newrelic.com

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -4,6 +4,15 @@ on:
   schedule:
    - cron:  '0 10 * * *'
   workflow_dispatch:
+    inputs:
+      daysToSearch:
+        description: "Days of NuGet history to search for package updates"
+        default: "1"
+        type: string
+      testMode:
+        description: "If set to true, no notification message will be sent to the team channel."
+        type: boolean
+        default: false
 
 env:
   DOTNET_NOLOGO: true
@@ -24,7 +33,16 @@ jobs:
           fetch-depth: 0
 
       - name: Check for updates to core technology packages
-        run: dotnet run --project ${{ env.scan-tool-path }} ${{ env.nugets }}
+        run: |
+          if [ ${{ github.event.inputs.daysToSearch }} != "" ]; then
+            export DOTTY_DAYS_TO_SEARCH=${{ github.event.inputs.daysToSearch }}
+          fi
+          if [ ${{ github.event.inputs.testMode }} == "True" ]; then
+            export DOTTY_TEST_MODE="True"
+          fi
+          dotnet run --project ${{ env.scan-tool-path }} ${{ env.nugets }}
+        shell: bash
+
         env:
             DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
             nugets:

--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -108,10 +108,10 @@ namespace nugetSlackNotifications
                     Encoding.UTF8,
                     "application/json");
 
-                var webhookResult = await _client.PostAsync(Environment.GetEnvironmentVariable(webhook), jsonContent);
+                var webhookResult = await _client.PostAsync(webhook, jsonContent);
                 if (webhookResult.StatusCode == HttpStatusCode.OK)
                 {
-                    Log.Information("Webhook invoke successfully");
+                    Log.Information("Webhook invoked successfully");
                 }
                 else
                 {
@@ -120,7 +120,7 @@ namespace nugetSlackNotifications
             }
             else
             {
-                Log.Information($"Channel will not be alerted: # of new versions={_newVersions.Count}, webhook available={webhook != null}, test mode = {_testMode}");
+                Log.Information($"Channel will not be alerted: # of new versions={_newVersions.Count}, webhook available={webhook != null}, test mode={_testMode}");
             }
         }
     }

--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NewRelic.Api.Agent;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -31,6 +32,7 @@ namespace nugetSlackNotifications
 
         }
 
+        [Transaction]
         static async Task CheckPackage(string packageName)
         {
             var response = await _client.GetStringAsync($"https://api.nuget.org/v3/registration5-gz-semver2/{packageName}/index.json");
@@ -79,6 +81,7 @@ namespace nugetSlackNotifications
             }
         }
 
+        [Transaction]
         static async Task AlertOnNewVersions()
         {
             var webhook = Environment.GetEnvironmentVariable("DOTTY_WEBHOOK");

--- a/.github/workflows/scripts/nugetSlackNotifications/newrelic.config
+++ b/.github/workflows/scripts/nugetSlackNotifications/newrelic.config
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!-- Copyright (c) 2008-2020 New Relic, Inc.  All rights reserved. -->
+<!-- For more information see: https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ -->
+<configuration xmlns="urn:newrelic-config" agentEnabled="true">
+	<service licenseKey="REPLACE_WITH_LICENSE_KEY" sendDataOnExit="true" sendDataOnExitThreshold="1" />
+	<application>
+		<name>My Application</name>
+	</application>
+	<log level="info" />
+	<allowAllHeaders enabled="true" />
+	<attributes enabled="true">
+		<exclude>request.headers.cookie</exclude>
+		<exclude>request.headers.authorization</exclude>
+		<exclude>request.headers.proxy-authorization</exclude>
+		<exclude>request.headers.x-*</exclude>
+
+		<include>request.headers.*</include>
+	</attributes>
+	<transactionTracer enabled="true"
+		transactionThreshold="apdex_f"
+		stackTraceThreshold="500"
+		recordSql="obfuscated"
+		explainEnabled="false"
+		explainThreshold="500" />
+	<distributedTracing enabled="true" />
+	<errorCollector enabled="true">
+		<ignoreClasses>
+			<errorClass>System.IO.FileNotFoundException</errorClass>
+			<errorClass>System.Threading.ThreadAbortException</errorClass>
+		</ignoreClasses>
+		<ignoreStatusCodes>
+			<code>401</code>
+			<code>404</code>
+		</ignoreStatusCodes>
+	</errorCollector>
+	<browserMonitoring autoInstrument="true" />
+	<threadProfiling>
+		<ignoreMethod>System.Threading.WaitHandle:InternalWaitOne</ignoreMethod>
+		<ignoreMethod>System.Threading.WaitHandle:WaitAny</ignoreMethod>
+	</threadProfiling>
+</configuration>

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent.Api" Version="10.3.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -7,4 +7,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="newrelic.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Description

Improvements to our tool that checks for new releases of our core instrumented libraries:

1. Add console logging so you can see what the tool is doing.
2. Changed the name of the env var for the Slack webhook from "webhook" to "DOTTY_WEBHOOK".
3. Added env var "DOTTY_DAYS_TO_SEARCH" to allow setting the number of days of NuGet history to search for package updates.  Defaults to the previously hardcoded value of 1.
4. Added env var "DOTTY_TEST_MODE" to allow running the tool without sending the Slack notification.
5. Modified the action workflow to allow setting these env vars when run manually.
6. Added monitoring the tool with the .NET agent:
   1. Added a newrelic.config with the necessary sendDataOnExit config that gets copied to the output dir.
   2. Modified the action workflow to install the (latest) .NET agent via nuget
   3. Added the necessary profiling env vars

