### PR TITLE
NLog instrumentation adds context data to log event data

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
@@ -109,7 +109,16 @@ namespace NewRelic.Agent.Core.JsonConverters
                     foreach (var item in logEvent.ContextData)
                     {
                         jsonWriter.WritePropertyName(Context + "." + item.Key);
-                        jsonWriter.WriteValue(item.Value);
+                        string contextValueJson;
+                        try
+                        {
+                            contextValueJson = JsonConvert.SerializeObject(item.Value);
+                        }
+                        catch
+                        {
+                            contextValueJson = item.Value.GetType().ToString();
+                        }
+                        jsonWriter.WriteRawValue(contextValueJson);
                     }
 
                     jsonWriter.WriteEndObject();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -104,7 +104,8 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
                 else
                 {
                     // This probably isn't a good idea, should just have an "ignore" fallback
-                    contextData[property.Key.ToString()] = property.Value;
+                    var insertKey = property.Key.ToString();
+                    contextData[insertKey] = property.Value;
                 }
             }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -93,20 +93,7 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
             var properties = getPropertiesDictionary(logEvent);
             foreach (var property in properties)
             {
-                if (property.Key is string keyName)
-                {
-                    contextData[keyName] = property.Value;
-                }
-                else if (property.Key is int keyNum)
-                {
-                    contextData[keyNum.ToString()] = property.Value;
-                }
-                else
-                {
-                    // This probably isn't a good idea, should just have an "ignore" fallback
-                    var insertKey = property.Key.ToString();
-                    contextData[insertKey] = property.Value;
-                }
+                contextData[property.Key.ToString()] = property.Value;
             }
 
             return contextData;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -18,6 +18,7 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
         private static Func<object, DateTime> _getTimestamp;
         private static Func<object, string> _messageGetter;
         private static Func<object, Exception> _getLogException;
+        private static Func<object, IDictionary<object, object>> _getPropertiesDictionary;
 
         public bool IsTransactionRequired => false;
 
@@ -55,12 +56,9 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
 
             var getLogExceptionFunc = _getLogException ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<Exception>(logEventType, "Exception");
 
-            // Placeholder until context data (custom attribute) instrumentation is implemented
-            Func<object, Dictionary<string, object>> getContextDataFunc = (logEvent) => null;
-
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
-            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, getContextDataFunc, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
+            xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, GetContextData, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
         private void DecorateLogMessage(object logEvent, Type logEventType, IAgent agent)
@@ -84,6 +82,33 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
             // this cannot be made a static since it is unique to each logEvent
             var messageSetter = VisibilityBypasser.Instance.GeneratePropertySetter<string>(logEvent, "Message");
             messageSetter(originalMessage + " " + formattedMetadata);
+        }
+
+        private Dictionary<string, object> GetContextData(object logEvent)
+        {
+            var contextData = new Dictionary<string, object>();
+
+            var getPropertiesDictionary = _getPropertiesDictionary ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<IDictionary<object, object>>(logEvent.GetType(), "Properties");
+
+            var properties = getPropertiesDictionary(logEvent);
+            foreach (var property in properties)
+            {
+                if (property.Key is string keyName)
+                {
+                    contextData[keyName] = property.Value;
+                }
+                else if (property.Key is int keyNum)
+                {
+                    contextData[keyNum.ToString()] = property.Value;
+                }
+                else
+                {
+                    // This probably isn't a good idea, should just have an "ignore" fallback
+                    contextData[property.Key.ToString()] = property.Value;
+                }
+            }
+
+            return contextData;
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
@@ -242,4 +242,142 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
 
     #endregion
 
+    #region NLog
+
+    #region ContextData Enabled
+
+    [NetFrameworkTest]
+    public class NLogContextDataEnabledFWLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public NLogContextDataEnabledFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogContextDataEnabledFW471Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public NLogContextDataEnabledFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogContextDataEnabledFW462Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public NLogContextDataEnabledFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataEnabledNetCoreLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public NLogContextDataEnabledNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataEnabledNetCore60Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public NLogContextDataEnabledNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataEnabledNetCore50Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public NLogContextDataEnabledNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataEnabledNetCore31Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public NLogContextDataEnabledNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    #endregion
+
+    #region ContextData Disabled
+
+    [NetFrameworkTest]
+    public class NLogContextDataDisabledFWLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public NLogContextDataDisabledFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogContextDataDisabledFW471Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public NLogContextDataDisabledFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class NLogContextDataDisabledFW462Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public NLogContextDataDisabledFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataDisabledNetCoreLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public NLogContextDataDisabledNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataDisabledNetCore60Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public NLogContextDataDisabledNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataDisabledNetCore50Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public NLogContextDataDisabledNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.NLog)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class NLogContextDataDisabledNetCore31Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public NLogContextDataDisabledNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, false, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    #endregion
+
+
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
@@ -27,6 +27,16 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             _log.Info(message);
         }
 
+        public void Info(string message, Dictionary<string, object> context)
+        {
+            LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, null, message);
+            foreach (var kvp in context)
+            {
+                logEvent.Properties[kvp.Key] = kvp.Value;
+            }
+            _log.Log(logEvent);
+        }
+
         public void Warn(string message)
         {
             _log.Warn(message);
@@ -97,9 +107,5 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             return logFactory.GetLogger("NLogLoggingTest");
         }
 
-        public void Info(string message, Dictionary<string, object> context)
-        {
-            throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
## Description

1. Update the NLog instrumentation wrapper to access a log event's `IDictionary<object,object> Properties` and add those values to the log event data being recorded in the agent.
2. Add subclasses of `ContextDataTestsBase` (integration tests) for NLog
3. Update `LogEventWireModelCollectionJsonConverter` to handle non-primitive value objects.   Even though we're not testing this in integration tests, I did ad-hoc testing of this use case, and this change is necessary to avoid errors being logged in the agent and log data being lost if the customer's use case looks like this:

```
class Person
{
    public int Id { get; set; }
    public string Name { get; set; }
}

var message = $"Log message with string key and object value";
LogEventInfo logEvent = new LogEventInfo(LogLevel.Info, null, message);
logEvent.Properties["person"] = new Person { Id = 1, Name = "Alice" };
logger.Log(logEvent);
```

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
