### PR TITLE
Move supportability metric create for enabled logging framework to location

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -411,6 +411,8 @@ namespace NewRelic.Agent.Core
 
         public void RecordLogMessage(string frameworkName, object logEvent, Func<object, DateTime> getTimestamp, Func<object, object> getLevel, Func<object, string> getLogMessage, Func<object, Exception> getLogException, string spanId, string traceId)
         {
+            _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
+
             var normalizedLevel = string.Empty;
             if (_configurationService.Configuration.LogMetricsCollectorEnabled ||
                 _configurationService.Configuration.LogEventCollectorEnabled)
@@ -427,7 +429,7 @@ namespace NewRelic.Agent.Core
             // IOC container defaults to singleton so this will access the same aggregator
             if (_configurationService.Configuration.LogEventCollectorEnabled)
             {
-                _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
+                _agentHealthReporter.ReportLogForwardingEnabledWithFramework(frameworkName);
 
                 var logMessage = getLogMessage(logEvent);
                 var logException = getLogException(logEvent);

--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -411,8 +411,6 @@ namespace NewRelic.Agent.Core
 
         public void RecordLogMessage(string frameworkName, object logEvent, Func<object, DateTime> getTimestamp, Func<object, object> getLevel, Func<object, string> getLogMessage, Func<object, Exception> getLogException, string spanId, string traceId)
         {
-            _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
-
             var normalizedLevel = string.Empty;
             if (_configurationService.Configuration.LogMetricsCollectorEnabled ||
                 _configurationService.Configuration.LogEventCollectorEnabled)
@@ -429,6 +427,8 @@ namespace NewRelic.Agent.Core
             // IOC container defaults to singleton so this will access the same aggregator
             if (_configurationService.Configuration.LogEventCollectorEnabled)
             {
+                _agentHealthReporter.ReportLogForwardingFramework(frameworkName);
+
                 var logMessage = getLogMessage(logEvent);
                 var logException = getLogException(logEvent);
 

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -531,10 +531,18 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         #region Log Events and Metrics
 
+        // Used to report a logging framework is being instrumented for log forwarding, it does not take into account if forwarding was enabled or not.
         private ConcurrentDictionary<string, bool> _loggingFrameworksReported = new ConcurrentDictionary<string, bool>();
         public void ReportLogForwardingFramework(string logFramework)
         {
             _loggingFrameworksReported.TryAdd(logFramework, false);
+        }
+
+        // Used to report that both log forwarding is enabled and that a logging framework is being instrumented for logforwarding.
+        private ConcurrentDictionary<string, bool> _loggingForwardingEnabledWithFrameworksReported = new ConcurrentDictionary<string, bool>();
+        public void ReportLogForwardingEnabledWithFramework(string logFramework)
+        {
+            _loggingForwardingEnabledWithFrameworksReported.TryAdd(logFramework, false);
         }
 
         public void CollectLoggingMetrics()
@@ -560,6 +568,15 @@ namespace NewRelic.Agent.Core.AgentHealth
                 {
                     ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogFrameworkName(kvp.Key));
                     _loggingFrameworksReported[kvp.Key] = true;
+                }
+            }
+
+            foreach (var kvp in _loggingForwardingEnabledWithFrameworksReported)
+            {
+                if (kvp.Value == false)
+                {
+                    ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogForwardingEnabledWithFrameworkName(kvp.Key));
+                    _loggingForwardingEnabledWithFrameworksReported[kvp.Key] = true;
                 }
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
@@ -145,5 +145,6 @@ namespace NewRelic.Agent.Core.AgentHealth
         void ReportLoggingEventCollected();
         void ReportLoggingEventsSent(int count);
         void ReportLogForwardingFramework(string logFramework);
+        void ReportLogForwardingEnabledWithFramework(string logFramework);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core.Metric/MetricNames.cs
@@ -1084,7 +1084,12 @@ namespace NewRelic.Agent.Core.Metric
             return SupportabilityLogFrameworkPs + loggingFramework + PathSeparator + Enabled;
         }
 
-        
+        private const string SupportabilityLogForwardingEnabledWithFrameworkNamePs = SupportabilityLoggingEventsPs + Forwarding + PathSeparator + DotNet + PathSeparator;
+        public static string GetSupportabilityLogForwardingEnabledWithFrameworkName(string loggingFramework)
+        {
+            return SupportabilityLogForwardingEnabledWithFrameworkNamePs + loggingFramework + PathSeparator + Enabled;
+        }
+
         #endregion
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -219,7 +219,15 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             var expectedFrameworkName = LogUtils.GetFrameworkName(_loggingFramework);
             var actualMetrics = _fixture.AgentLog.GetMetrics();
-            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+
+            if (_forwardingEnabled)
+            {
+                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+            }
+            else
+            {
+                Assert.DoesNotContain(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+            }
         }
 
         private void CountsAndValuesAreAsExpected()

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -154,6 +154,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             SupportabilityForwardingConfigurationMetricExists();
             SupportabilityMetricsConfigurationMetricExists();
             SupportabilityLoggingFrameworkMetricExists();
+            SupportabilityLoggingForwardingEnabledWithFrameworkMetricExists();
             CountsAndValuesAreAsExpected();
             LoggingWorksWithTraceAttributeOutsideTransaction();
             LoggingWorksWithDifferentTraceAttributesInsideTransaction();
@@ -219,14 +220,21 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             var expectedFrameworkName = LogUtils.GetFrameworkName(_loggingFramework);
             var actualMetrics = _fixture.AgentLog.GetMetrics();
+            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+        }
+
+        private void SupportabilityLoggingForwardingEnabledWithFrameworkMetricExists()
+        {
+            var expectedFrameworkName = LogUtils.GetFrameworkName(_loggingFramework);
+            var actualMetrics = _fixture.AgentLog.GetMetrics();
 
             if (_forwardingEnabled)
             {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled");
             }
             else
             {
-                Assert.DoesNotContain(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/DotNET/{expectedFrameworkName}/enabled");
+                Assert.DoesNotContain(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled");
             }
         }
 


### PR DESCRIPTION
## Description

- Adds new `Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled` to occur after log forwarding configuration has been confirmed enabled.  This allows metric to account for both the logging framework being instrumented AND log forwarding being enabled.
- Updates integrations tests to account for the new metric

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
