### PR TITLE
Update and Fixed Incorrect Regular Expression in RestSharp 

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net462;net471;net48;net481</TargetFrameworks>
@@ -16,22 +16,22 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
     
     <!-- log4net .NET framework references -->
-    <PackageReference Include="log4net" Version="1.2.10" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="log4net" Version="2.0.5" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="log4net.Ext.Json" Version="1.2.15.14586" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="log4net" Version="2.0.15" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- log4net .NET core references -->
     <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.9.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="log4net" Version="2.0.12" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="log4net" Version="2.0.13" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!--System.Data.SqlClient (.NET Core/5+ only) -->
@@ -245,15 +245,15 @@
 
   <!-- RestSharp -->
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="RestSharp" Version="106.0.0" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net481'" />
     <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net5.0'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="RestSharp" Version="106.12.0" Condition="'$(TargetFramework)' == 'net7.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

## Description

RestSharp < 106.11.8-alpha.0.13 uses a regular expression which is vulnerable to Regular Expression Denial of Service (ReDoS) when converting strings into DateTimes. If a server responds with a malicious string, the client using RestSharp will be stuck processing it for an exceedingly long time. Thus the remote server can trigger Denial of Service. Affected of this `newrelic-dotnet-agent` are vulnerable to Regular Expression Denial of Service (ReDoS) when converting strings into `DateTime`. Denial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process. The Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your server down.

It most cases, it doesn't take very long for a regex engine to find a match:
```js
$ time node -e '/A(B|C+)+D/.test("ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD")' 0.04s user 0.01s system 95% cpu 0.052 total
$ time node -e '/A(B|C+)+D/.test("ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX")' 1.79s user 0.02s system 99% cpu 1.812 total
```

CVE-2021-27293
[CWE-185](https://cwe.mitre.org/data/definitions/185.html)
[CWE-697](https://cwe.mitre.org/data/definitions/697.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`



# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
