### PR TITLE
Update and Fixed Signature validation bypass in ServiceStack 

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/ServiceStackApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ServiceStack">
-      <Version>5.5.0</Version>
+      <Version>5.9.2</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Client">
       <Version>5.5.0</Version>


### PR DESCRIPTION

## Description
ServiceStack before 5.9.2 mishandles JWT signature verification unless an application has a custom ValidateToken function that establishes a valid minimum length for a signature.


CVE-2020-28042
[CWE-347](https://cwe.mitre.org/data/definitions/347.html)

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
- [x] Review Changelog
