### PR TITLE
Remove unneeded package references from test app

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Web.config
@@ -22,9 +22,6 @@
   <system.web>
     <compilation debug="true" targetFramework="4.6.2"/>
     <httpRuntime targetFramework="4.6.1"/>
-    <httpModules>
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"/>
-    </httpModules>
   </system.web>
   <system.webServer>
     <handlers>
@@ -33,12 +30,6 @@
       <remove name="TRACEVerbHandler"/>
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
-    <modules>
-      <remove name="TelemetryCorrelationHttpModule"/>
-      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler"/>
-      <remove name="ApplicationInsightsWebTracking"/>
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler"/>
-    </modules>
     <validation validateIntegratedModeConfiguration="false"/>
   </system.webServer>
   <runtime>

--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Web.config
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/Web.config
@@ -44,10 +44,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1"/>
       </dependentAssembly>
@@ -58,10 +54,6 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
         <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>

--- a/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/WebApiAsyncApplication/WebApiAsyncApplication.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -64,36 +64,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Antlr">
-      <Version>3.5.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="bootstrap">
-      <Version>3.3.7</Version>
-    </PackageReference>
-    <PackageReference Include="jQuery">
-      <Version>3.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept">
-      <Version>2.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer">
-      <Version>2.5.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel">
-      <Version>2.5.1</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.4</Version>
     </PackageReference>
@@ -127,9 +97,6 @@
     <PackageReference Include="Microsoft.AspNet.WebPages">
       <Version>3.2.4</Version>
     </PackageReference>
-    <PackageReference Include="Modernizr">
-      <Version>2.8.3</Version>
-    </PackageReference>
     <PackageReference Include="NewRelic.Agent.Api">
       <Version>8.41.1</Version>
     </PackageReference>
@@ -138,9 +105,6 @@
     </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource">
       <Version>4.4.1</Version>
-    </PackageReference>
-    <PackageReference Include="WebGrease">
-      <Version>1.6.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

This PR removes unneeded package references from the `WebApiAsyncApplication` test app used in our integration tests.  These references are left over from when the app was initially created from a template, but the test app code doesn't use them.

This was brought to our attention by this community-submitted PR that wanted to upgrade one of the package references to patch a CVE: https://github.com/newrelic/newrelic-dotnet-agent/pull/1327  However, it's better long term to just not have the references at all.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
