### PR TITLE
Update MySqlConnector test coverage

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -80,13 +80,13 @@
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySqlConnector" Version="1.3.13" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySqlConnector" Version="2.2.4" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySqlConnector .NET/Core references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="MySqlConnector" Version="1.3.13" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include ="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include ="MySqlConnector" Version="2.2.4" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- StackExchange.Redis framework references -->
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.608" Condition="'$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION
## Description

MySqlConnector recently released version 2.2.4. This PR updates our unbounded integration tests to cover this version.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed


# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
