### PR TITLE
Fix NuGet package missing content issues

### DIFF
--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -26,7 +26,7 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="**/newrelic/**/*" target="." />
+    <file src="**\newrelic\**\*" target="." />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
   </files>

--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -26,6 +26,8 @@
     </contentFiles>
   </metadata>
   <files>
+    <file src="**/newrelic/**/*" target="." />
+    <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
   </files>
 </package>

--- a/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
+++ b/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
@@ -17,6 +17,10 @@
     <tags>New Relic</tags>
   </metadata>
   <files>
+    <file src="lib\**" target="lib" />
+    <file src="tools\**" target="tools" />
+    <file src="LICENSE.txt" target="." />
+    <file src="THIRD_PARTY_NOTICES.txt" target="." />
     <file src="..\..\icon.png" target="images\" />
   </files>
 </package>

--- a/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
+++ b/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
@@ -26,6 +26,9 @@
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
   </metadata>
   <files>
+    <file src="content\**" target="content" />
+    <file src="lib\**" target="lib" />
+    <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
   </files>
 </package>

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
+* Resolves [#1346](https://github.com/newrelic/newrelic-dotnet-agent/issues/1346) where some NuGet packages were incomplete for the 10.5.0 release. Impacted packages have been delisted from NuGet. ([#1347](https://github.com/newrelic/newrelic-dotnet-agent/pull/1347))
 
 ## [10.5.0]
 


### PR DESCRIPTION
## Description

Fixes #1346 

PR #1321 broke the following NuGet packages that we deployed in release 10.5.0:
NewRelic.Agent
NewRelic.Agent.Api
NewRelicWindowsAzure

These packages' `.nuspec` files previously did not have a `<files>...</files>` section.  When we added one to include the new icon file, we did not realize that if you have a files section, it disables automatic inclusion of content - everything you want to be in the package has to be in the `<files>...</files>` section.  This PR corrects that.

The team swarmed on these changes, including building the packages locally and comparing their content to the previous good release (10.4.0) so the PR review process is primary going to be testing the built artifacts from this PR's CI to make sure they do what we want them to do (since we currently don't have automatic testing of these artifacts).

# Author Checklist
- [ ] ~Unit tests, Integration tests, and Unbounded tests completed~
- [ ] ~Performance testing completed with satisfactory results (if required)~
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
