### PR TITLE
Add integration test coverage for RestSharp v107+

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net462;net471;net48;net481</TargetFrameworks>
@@ -246,9 +246,10 @@
   <!-- RestSharp -->
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="RestSharp" Version="106.0.0" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RestSharp" Version="107.1.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RestSharp" Version="106.15.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="RestSharp" Version="107.3.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="RestSharp" Version="108.0.3" Condition="'$(TargetFramework)' == 'net481'" />
+    
     <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net5.0'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -248,7 +248,7 @@
     <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="RestSharp" Version="106.0.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RestSharp" Version="106.15.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RestSharp" Version="107.1.0" Condition="'$(TargetFramework)' == 'net481'" />
     <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net5.0'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
@@ -45,7 +45,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
                 if (method == "GET")
                 {
                     var bird = response.Data;
-                    System.IO.File.AppendAllText(@"C:\IntegrationTestWorkingDirectory\RestAPIController.log", $"SyncClient method={method}, generic={generic} got Bird {bird.CommonName} ({bird.BandingCode})" + Environment.NewLine);
+                    ConsoleMFLogger.Info($"SyncClient method={method}, generic={generic} got Bird {bird.CommonName} ({bird.BandingCode})");
                 }
 
                 if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
@@ -44,7 +44,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
                 if (method == "GET")
                 {
                     var bird = response.Data;
-                    System.IO.File.AppendAllText(@"C:\IntegrationTestWorkingDirectory\RestAPIController.log", $"SyncClient method={method}, generic={generic} got Bird {bird.CommonName} ({bird.BandingCode})" + Environment.NewLine);
+                    ConsoleMFLogger.Info($"SyncClient method={method}, generic={generic} got Bird {bird.CommonName} ({bird.BandingCode})");
                 }
 
                 if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
@@ -37,7 +37,8 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
             var requests = GetRequests(endpoint, id);
             if (generic)
             {
-                var response = client.Execute<Bird>(requests[method]);
+                // This may cause hangs...
+                var response = client.ExecuteAsync<Bird>(requests[method]).GetAwaiter().GetResult();
                 if (method == "GET")
                 {
                     var bird = response.Data;
@@ -51,7 +52,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
             }
             else
             {
-                var response = client.Execute(requests[method]);
+                var response = client.ExecuteAsync(requests[method]).GetAwaiter().GetResult();
                 if ((response.StatusCode != System.Net.HttpStatusCode.OK) && (response.StatusCode != System.Net.HttpStatusCode.NoContent))
                 {
                     return $"Unexpected HTTP status code {response.StatusCode}";
@@ -74,7 +75,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
             var id = 1;
 
             var requests = GetRequests(endpoint, id);
-            IRestResponse response;
+            RestResponse response;
             if (generic)
             {
                 if (cancelable)
@@ -122,7 +123,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
             var id = 1;
 
             var requests = GetRequests(endpoint, id);
-            IRestResponse response;
+            RestResponse response;
             if (generic)
             {
                 if (cancelable)
@@ -173,9 +174,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
 
             try
             {
-                var client = new RestClient($"http://{myHost}:{myPort}");
-                client.Timeout = 1;
-                var response = await client.ExecuteTaskAsync(new RestRequest(endpoint + "Get/" + id));
+                var options = new RestClientOptions($"http://{myHost}:{myPort}")
+                {
+                    Timeout = 1
+                };
+                var client = new RestClient(options);
+
+                var response = await client.ExecuteAsync(new RestRequest(endpoint + "Get/" + id));
             }
             catch (Exception)
             {
@@ -187,34 +192,34 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
 
 #region Helpers
 
-        private Dictionary<string, IRestRequest> GetRequests(string endpoint, int id)
+        private Dictionary<string, RestRequest> GetRequests(string endpoint, int id)
         {
-            var requests = new Dictionary<string, IRestRequest>();
+            var requests = new Dictionary<string, RestRequest>();
             requests.Add("GET", new RestRequest(endpoint + "Get/" + id));
-            requests.Add("PUT", new RestRequest(endpoint + "Put/" + id, Method.PUT).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
-            requests.Add("DELETE", new RestRequest(endpoint + "Delete/" + id, Method.DELETE));
-            requests.Add("POST", new RestRequest(endpoint + "Post/", Method.POST).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
+            requests.Add("PUT", new RestRequest(endpoint + "Put/" + id, Method.Put).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
+            requests.Add("DELETE", new RestRequest(endpoint + "Delete/" + id, Method.Delete));
+            requests.Add("POST", new RestRequest(endpoint + "Post/", Method.Post).AddJsonBody(new { CommonName = "Painted Bunting", BandingCode = "PABU" }));
             return requests;
         }
 
-        private Task<IRestResponse<T>> ExecuteAsyncGeneric<T>(RestClient client, IRestRequest request, CancellationTokenSource cancellationTokenSource = null)
+        private Task<RestResponse<T>> ExecuteAsyncGeneric<T>(RestClient client, RestRequest request, CancellationTokenSource cancellationTokenSource = null)
         {
             if (cancellationTokenSource == null)
             {
-                return client.ExecuteTaskAsync<T>(request);
+                return client.ExecuteAsync<T>(request);
             }
 
-            return client.ExecuteTaskAsync<T>(request, cancellationTokenSource.Token);
+            return client.ExecuteAsync<T>(request, cancellationTokenSource.Token);
         }
 
-        private Task<IRestResponse> ExecuteAsync(RestClient client, IRestRequest request, CancellationTokenSource cancellationTokenSource = null)
+        private Task<RestResponse> ExecuteAsync(RestClient client, RestRequest request, CancellationTokenSource cancellationTokenSource = null)
         {
             if (cancellationTokenSource == null)
             {
-                return client.ExecuteTaskAsync(request);
+                return client.ExecuteAsync(request);
             }
 
-            return client.ExecuteTaskAsync(request, cancellationTokenSource.Token);
+            return client.ExecuteAsync(request, cancellationTokenSource.Token);
         }
 
 #endregion


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

This PR adds integration test coverage for the latest released 107 and 108 versions of RestSharp. As we only have 4 targets to test RestSharp in .NET Framework, I chose to keep coverage for the latest released versions of 105, 106, 107, and 108. This will allow us to confidently tell customers who experience issues that if they upgrade to the latest version of whatever major release they are using, things will work.

Interestingly, the assertions in the RestSharp tests can't tell a difference between external segments generated by RestSharp, HttpWebRequest, or HttpClient instrumentation. This probably means we did a good job of normalizing external segment generation across different instrumentation points.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
