### PR TITLE
Fix a race condition when using SetApplicationName

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: 
     - main
-    - '**-feature-branch'
+    - 'feature/**'
   release:
     types: [ published ]
   workflow_dispatch:

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Features
 
 ### Fixes
+* Fix a race condition when using SetApplicationName [#1361](https://github.com/newrelic/newrelic-dotnet-agent/pull/1361)
 
 ## [10.6.0]
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -57,6 +57,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string TransactionEndedByGCFinalizerLogLineRegEx = DebugLogLinePrefixRegex + @"Transaction was garbage collected without ever ending(.*)";
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 
+        // SetApplicationName related messages
+        public const string SetApplicationnameAPICalledDuringCollectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
+        public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
+
         public abstract IEnumerable<string> GetFileLines();
 
         public string GetAccountId(TimeSpan? timeoutOrZero = null)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -329,5 +329,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             return this;
         }
+
+        public NewRelicConfigModifier SetSendDataOnExit(bool enabled = true)
+        {
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "service" }, "sendDataOnExit", enabled.ToString().ToLower());
+            return this;
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.DataTransmission
+{
+    public abstract class ConnectSetApplicationNameTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        public ConnectSetApplicationNameTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"ApiCalls TestSetApplicationName NewIntegrationTestName");
+
+            // Needed to ensure that the scheduled reconnect, with a 15 second delay, can happen
+            _fixture.AddCommand($"RootCommands DelaySeconds 30");
+
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                    configModifier
+                    .SetLogLevel("debug");
+
+                    // if sendDataOnExit is true, this test will fail due to it blocking on connect.
+                    configModifier.SetSendDataOnExit(false);
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SetApplicationnameAPICalledDuringCollectMethodLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AttemptReconnectLogLineRegex, TimeSpan.FromMinutes(1));
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Tests()
+        {
+            var connectResponseDatas = _fixture.AgentLog.GetConnectResponseDatas() .ToList();
+            Assert.Equal(2, connectResponseDatas.Count);
+
+            var reconnectLine = _fixture.AgentLog.TryGetLogLines(AgentLogBase.AttemptReconnectLogLineRegex);
+            Assert.True(reconnectLine.Any());
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ConnectSetApplicationNameFWLatestTests : ConnectSetApplicationNameTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ConnectSetApplicationNameFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ConnectSetApplicationNameFW462Tests : ConnectSetApplicationNameTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ConnectSetApplicationNameFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ConnectSetApplicationNameCoreLatestTests : ConnectSetApplicationNameTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ConnectSetApplicationNameCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ConnectSetApplicationNameCore60Tests : ConnectSetApplicationNameTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ConnectSetApplicationNameCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
@@ -48,5 +48,11 @@ namespace MultiFunctionApplicationHelpers.Libraries
                 ConsoleMFLogger.Info($"key: {item.Key}, value:{item.Value}");
             }
         }
+
+        [LibraryMethod]
+        public static void TestSetApplicationName(string applicationName)
+        {
+            NewRelic.Api.Agent.NewRelic.SetApplicationName(applicationName);
+        }
     }
 }


### PR DESCRIPTION
## Description

Now, there is a bool that can be set if a runtime update has occurred, meaning the names have changed.  If this occurs during a Connect, a restart is scheduled.  I used ScheduleRestart so that we will follow the backoff pattern and hopefully not spam connect attempts of there is an issue.  This also lets the connect process complete before we start another.  I didn't think we needed a flag for "connecting" since all the work is done in the Connect method.

The code isn't really unit testable.  I tried to see if I could capture some part of the reconnect happening, but the methods just aren't available.

Adds a new integration test that ensures they process is working.  I only added for the oldest (net462, net6) and latest supported frameworks since framework version shouldn't affect anything.  

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
