### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the users listed below will be requested for
+# review when someone opens a pull request.
+# We could use a team alias, but we currently only have one team 
+# defined named "@newrelic/dotnet" that contains more people than 
+# this subset that we want automatically added as reviewers to PRs
+*       @nr-ahemsath @jaffinito @nrcventura @JcolemanNR @chynesNR @tippmar-nr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # the users listed below will be requested for
 # review when someone opens a pull request.
-# We could use a team alias, but we currently only have one team 
-# defined named "@newrelic/dotnet" that contains more people than 
-# this subset that we want automatically added as reviewers to PRs
-*       @nr-ahemsath @jaffinito @nrcventura @JcolemanNR @chynesNR @tippmar-nr
+*       @newrelic/dotnet-code-reviewers


### PR DESCRIPTION
## Description

Add a CODEOWNERS file to the repo, to auto-assign the team members as reviewers to PRs as they are created.

GitHub docs on code owners: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

# Author Checklist
- [ ] ~Unit tests, Integration tests, and Unbounded tests completed~
- [ ] ~Performance testing completed with satisfactory results (if required)~
- [ ] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
