### PR TITLE
Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 * Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
+* Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1376](https://github.com/newrelic/newrelic-dotnet-agent/pull/1376)
 
 ## [10.6.0]
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -55,7 +55,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
                 if (Log.IsEnabledFor(logLevel))
                 {
-                    Log.LogMessage(logLevel, $"GRPC RpcException encountered while handling gRPC server responses: {rpcEx.Status}");
+                    Log.LogMessage(logLevel, $"ResponseStreamWrapper: consumer {ConsumerID} - GRPC RpcException encountered while handling gRPC server responses: {rpcEx.Status}");
                 }
             }
             catch (Exception ex)
@@ -64,7 +64,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
                 if (Log.IsEnabledFor(logLevel))
                 {
-                    Log.LogMessage(logLevel, $"Unknown exception encountered while handling gRPC server responses: {ex}");
+                    Log.LogMessage(logLevel, $"ResponseStreamWrapper: consumer {ConsumerID} - Unknown exception encountered while handling gRPC server responses: {ex}");
                 }
             }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
@@ -27,10 +27,9 @@ namespace NewRelic.Agent.Core.DataTransport
 
         protected override void HandleServerResponse(RecordStatus responseModel, int consumerId)
         {
-            LogMessage(LogLevel.Finest, consumerId, $"Received gRPC Server response: {responseModel.MessagesSeen}");
+            LogMessage(LogLevel.Finest, consumerId, $"Received gRPC Server response messages: {responseModel.MessagesSeen}");
 
             RecordReceived(responseModel.MessagesSeen);
-
         }
 
         private void RecordReceived(ulong countItems)
@@ -65,5 +64,4 @@ namespace NewRelic.Agent.Core.DataTransport
             return batch;
         }
     }
-
 }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -61,6 +61,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string SetApplicationnameAPICalledDuringCollectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
+        // Infinite trace
+        public const string SpanStreamingSuccessLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Attempting to send (\d+) item\(s\) - Success";
+
         public abstract IEnumerable<string> GetFileLines();
 
         public string GetAccountId(TimeSpan? timeoutOrZero = null)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -110,10 +110,12 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return this;
         }
 
-        public NewRelicConfigModifier EnableInfinteTracing(string traceObserverUrl)
+        public NewRelicConfigModifier EnableInfiniteTracing(string traceObserverUrl, string traceObserverPort)
         {
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath,
                new[] { "configuration", "infiniteTracing", "trace_observer" }, "host", traceObserverUrl);
+            CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath,
+                    new[] { "configuration", "infiniteTracing", "trace_observer" }, "port", traceObserverPort);
             return this;
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NServiceBus.Features;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
+{
+    public abstract class InfiniteTracingFlakyTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        public InfiniteTracingFlakyTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.SetTimeout(System.TimeSpan.FromMinutes(5));
+
+            // Ensure the trace observer will throw an error on every request
+            _fixture.RemoteApplication.SetAdditionalEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY", "100");
+
+            // set the code to be returned when the trace observer throws an error
+            // must be a value from 0 to 16 as per https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+            // use the StatusCode enum from gRPC 
+            _fixture.RemoteApplication.SetAdditionalEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY_CODE",
+                ((int)Grpc.Core.StatusCode.Internal).ToString());
+
+            _fixture.AddCommand("InfiniteTracingTester StartAgent");
+
+            _fixture.AddCommand("RootCommands DelaySeconds 15"); // give the agent time to warm up
+
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
+
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier
+                        .ForceTransactionTraces()
+                        .EnableDistributedTrace()
+                        .EnableInfiniteTracing(_fixture.TestConfiguration.TraceObserverUrl, _fixture.TestConfiguration.TraceObserverPort)
+                        .SetLogLevel("finest");
+                }
+                ,
+                exerciseApplication: () =>
+                {
+                    // wait up to 75 seconds for the harvest cycle to complete and emit the supportability metrics we're expecting
+                    var waitUntil = DateTime.Now.AddSeconds(75);
+                    while (DateTime.Now <= waitUntil
+                           && !(_fixture.AgentLog.GetMetrics().Any(metric => metric.MetricSpec.Name == "Supportability/InfiniteTracing/Span/gRPC/INTERNAL")
+                           && _fixture.AgentLog.GetMetrics().Any(metric => metric.MetricSpec.Name == "Supportability/InfiniteTracing/Span/Response/Error")))
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(5));
+                    }
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [SkipOnAlpineFact("See https://github.com/newrelic/newrelic-dotnet-agent/issues/289")]
+        public void Test()
+        {
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                // can't look for specific counts, as errors will cause the counts to vary
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen" },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent" },
+
+                // these two, however, should reliably appear
+                new Assertions.ExpectedMetric() { metricName = "Supportability/InfiniteTracing/Span/Response/Error"},
+                new Assertions.ExpectedMetric() { metricName = "Supportability/InfiniteTracing/Span/gRPC/INTERNAL"}
+            };
+
+            var actualMetrics = _fixture.AgentLog.GetMetrics();
+            Assertions.MetricsExist(expectedMetrics, actualMetrics);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFlakyFWLatestTests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public InfiniteTracingFlakyFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFlakyFW471Tests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public InfiniteTracingFlakyFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class InfiniteTracingFlakyFW462Tests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public InfiniteTracingFlakyFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingFlakyNetCoreLatestTests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public InfiniteTracingFlakyNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingFlakyNetCore50Tests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public InfiniteTracingFlakyNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class InfiniteTracingFlakyNetCore31Tests : InfiniteTracingFlakyTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public InfiniteTracingFlakyNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <RootNamespace>NewRelic.Agent.IntegrationTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.IntegrationTests</AssemblyName>
@@ -33,6 +33,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Grpc.Core" Version="2.40.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Selenium.Support" Version="4.4.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.4.0" />

--- a/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
@@ -53,6 +53,18 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                 return DefaultSetting.TraceObserverUrl;
             }
         }
+        public string TraceObserverPort
+        {
+            get
+            {
+                if (TestSettingOverrides.TryGetValue(_configurationCategory, out var item) && !string.IsNullOrEmpty(item.TraceObserverPort))
+                {
+                    return item.TraceObserverPort;
+                };
+
+                return DefaultSetting.TraceObserverPort;
+            }
+        }
 
         private IntegrationTestConfiguration(string configurationCategory)
         {
@@ -92,6 +104,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         public string AwsAccountNumber { get; set; }
         public string TraceObserverUrl { get; set; }
         public IDictionary<string, string> CustomSettings { get; set; }
+        public string TraceObserverPort { get; set; } = "443";
     }
 
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/InfiniteTracingTester.cs
@@ -28,14 +28,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
         public static void StartAgent()
         {
             NewRelic.Api.Agent.NewRelic.StartAgent();
-            //Get everything started up and time for initial Sample().
-            Thread.Sleep(TimeSpan.FromSeconds(10));
-        }
-
-        [LibraryMethod]
-        public static void Wait()
-        {
-            Thread.Sleep(TimeSpan.FromSeconds(70));
         }
     }
 }


### PR DESCRIPTION
## Description

* Updates the ResponseStreamWrapper exception message to detect when a stream is automatically cancelled due to inactivity and use a more descriptive lg message.  The updated log message explains that this happened and that a new stream will be created when one is needed.
* Adds the consumer ID to the log messages in more places
* Updates the usage of "gRPC" to match the format.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
