### PR TITLE
Update grpc stream cancelled due to in-activity log message

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 * Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
-Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
+* Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
 
 ## [10.6.0]
 

--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 * Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
+Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
 
 ## [10.6.0]
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
@@ -27,7 +27,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
         protected override void HandleServerResponse(RecordStatus responseModel, int consumerId)
         {
-            LogMessage(LogLevel.Finest, consumerId, $"Received gRPC Server response: {responseModel.MessagesSeen}");
+            LogMessage(LogLevel.Finest, consumerId, $"Received gRPC Server response messages: {responseModel.MessagesSeen}");
 
             RecordReceived(responseModel.MessagesSeen);
 
@@ -65,5 +65,4 @@ namespace NewRelic.Agent.Core.DataTransport
             return batch;
         }
     }
-
 }


### PR DESCRIPTION
## Description

* Updates the ResponseStreamWrapper exception message to detect when a stream is automatically cancelled due to inactivity and use a more descriptive lg message.  The updated log message explains that this happened and that a new stream will be created when one is needed.
* Adds the consumer ID to the log messages in more places
* Updates the usage of "gRPC" to match the format.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
