### PR TITLE
Added error handling for MEL.ILogger related to context data

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * Fix a race condition when using SetApplicationName [#1361](https://github.com/newrelic/newrelic-dotnet-agent/pull/1361)
+* Resolves [#1374](https://github.com/newrelic/newrelic-dotnet-agent/issues/1374) related to enabling Context Data for some loggers [#1381](https://github.com/newrelic/newrelic-dotnet-agent/pull/1381)
 
 ### Other
 * Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -65,7 +65,9 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
         private static Dictionary<string, object> GetContextData(MEL.ILogger logger, IAgent agent)
         {
             if (_contextDataNotSupported) // short circuit if we previously got an exception trying to access context data
+            {
                 return null;
+            }
 
             try
             {
@@ -109,7 +111,7 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
             }
             catch (Exception e)
             {
-                agent.Logger.Log(Level.Debug, $"Unexpected exception while attempting to get context data. Context data is not supported for this logging framework. Exception: {e}");
+                agent.Logger.Log(Level.Warn, $"Unexpected exception while attempting to get context data. Context data is not supported for this logging framework. Exception: {e}");
                 _contextDataNotSupported = true;
                 return null;
             }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -61,6 +61,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string SetApplicationnameAPICalledDuringCollectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
+        // ContextData related messages
+        public const string ContextDataNotSupportedLogLineRegex = DebugLogLinePrefixRegex + @".* Context data is not supported for this logging framework.";
+
         public abstract IEnumerable<string> GetFileLines();
 
         public string GetAccountId(TimeSpan? timeoutOrZero = null)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -62,7 +62,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
         // ContextData related messages
-        public const string ContextDataNotSupportedLogLineRegex = DebugLogLinePrefixRegex + @".* Context data is not supported for this logging framework.";
+        public const string ContextDataNotSupportedLogLineRegex = WarnLogLinePrefixRegex + @".* Context data is not supported for this logging framework.";
 
         public abstract IEnumerable<string> GetFileLines();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
@@ -9,7 +9,8 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         Serilog,
         MicrosoftLogging,
         SerilogWeb,
-        NLog
+        NLog,
+        DummyMEL
     }
 
     public class LogUtils
@@ -27,6 +28,8 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                     return "serilog";
                 case LoggingFramework.NLog:
                     return "nlog";
+                case LoggingFramework.DummyMEL:
+                    return "DummyMEL";
                 default:
                     return "unknown";
             }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
@@ -49,6 +49,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                             return level;
                     }
                 case LoggingFramework.MicrosoftLogging:
+                case LoggingFramework.DummyMEL:
                     switch (level)
                     {
                         case "DEBUG":

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
@@ -1,0 +1,127 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
+{
+    public abstract class ContextDataNotSupportedTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+        private LoggingFramework _loggingFramework;
+        private bool _contextDataEnabled;
+
+        private const string InfoMessage = "HelloWorld";
+
+        // There are several entries in this dictionary to allow for different methods of adding the values in the test adapter
+        // If you need more entries for your framework, add them
+        private Dictionary<string, string> _expectedAttributes = new Dictionary<string, string>()
+        {
+            { "mycontext1", "foo" },
+            { "mycontext2", "bar" },
+            { "mycontext3", "test" },
+            { "mycontext4", "value" },
+        };
+
+
+        public ContextDataNotSupportedTestsBase(TFixture fixture, ITestOutputHelper output, bool contextDataEnabled, LoggingFramework loggingFramework) : base(fixture)
+        {
+            _fixture = fixture;
+            _loggingFramework = loggingFramework;
+            _contextDataEnabled = contextDataEnabled;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester Configure");
+
+            string context = string.Join(",", _expectedAttributes.Select(x => x.Key + "=" + x.Value).ToArray());
+
+            // should generate an exception message in the log since the dummy ILogger doesn't have the right properties
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessage {InfoMessage} INFO {context}");
+            // do it again - this time, context data should be marked as unsupported and not generate an exception in the log
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessage {InfoMessage} INFO {context}");
+
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                    configModifier
+                    .EnableLogMetrics(true)
+                    .EnableLogForwarding(true)
+                    .EnableContextData(_contextDataEnabled)
+                    .EnableDistributedTrace()
+                    .SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(2));
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var match = _fixture.AgentLog.TryGetLogLines(AgentLogBase.ContextDataNotSupportedLogLineRegex);
+            Assert.Single(match);
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ContextDataNotSupportedFWLatestTests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ContextDataNotSupportedFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.DummyMEL)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ContextDataNotSupportedNetCoreLatestTests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ContextDataNotSupportedNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.DummyMEL)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ContextDataNotSupportedNetCore60Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ContextDataNotSupportedNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.DummyMEL)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ContextDataNotSupportedNetCore50Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ContextDataNotSupportedNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.DummyMEL)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ContextDataNotSupportedNetCore31Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ContextDataNotSupportedNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, true, LoggingFramework.DummyMEL)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
@@ -17,7 +17,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     {
         private readonly TFixture _fixture;
         private LoggingFramework _loggingFramework;
-        private bool _contextDataEnabled;
 
         private const string InfoMessage = "HelloWorld";
 
@@ -32,11 +31,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
         };
 
 
-        public ContextDataNotSupportedTestsBase(TFixture fixture, ITestOutputHelper output, bool contextDataEnabled, LoggingFramework loggingFramework) : base(fixture)
+        public ContextDataNotSupportedTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework) : base(fixture)
         {
             _fixture = fixture;
             _loggingFramework = loggingFramework;
-            _contextDataEnabled = contextDataEnabled;
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
@@ -57,10 +55,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                     configModifier
-                    .EnableLogMetrics(true)
-                    .EnableLogForwarding(true)
-                    .EnableContextData(_contextDataEnabled)
-                    .EnableDistributedTrace()
+                    .EnableContextData()
                     .SetLogLevel("finest");
                 },
                 exerciseApplication: () =>
@@ -75,8 +70,22 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
         [Fact]
         public void Test()
         {
+            // verify the "not supported" warning was logged
             var match = _fixture.AgentLog.TryGetLogLines(AgentLogBase.ContextDataNotSupportedLogLineRegex);
             Assert.Single(match);
+
+            // verify the log data was forwarded, but *without* the attributes
+            var expectedLogLines = new[]
+            {
+                new Assertions.ExpectedLogLine
+                {
+                    Level = LogUtils.GetLevelName(_loggingFramework, "INFO"),
+                    LogMessage = InfoMessage
+                }
+            };
+
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
+            Assertions.LogLinesExist(expectedLogLines, logLines, ignoreAttributeCount: true);
         }
     }
 
@@ -84,7 +93,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     public class ContextDataNotSupportedFWLatestTests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public ContextDataNotSupportedFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LoggingFramework.DummyMEL)
+            : base(fixture, output, LoggingFramework.DummyMEL)
         {
         }
     }
@@ -93,7 +102,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     public class ContextDataNotSupportedNetCoreLatestTests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public ContextDataNotSupportedNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LoggingFramework.DummyMEL)
+            : base(fixture, output, LoggingFramework.DummyMEL)
         {
         }
     }
@@ -102,7 +111,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     public class ContextDataNotSupportedNetCore60Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public ContextDataNotSupportedNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LoggingFramework.DummyMEL)
+            : base(fixture, output, LoggingFramework.DummyMEL)
         {
         }
     }
@@ -111,7 +120,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     public class ContextDataNotSupportedNetCore50Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public ContextDataNotSupportedNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LoggingFramework.DummyMEL)
+            : base(fixture, output, LoggingFramework.DummyMEL)
         {
         }
     }
@@ -120,7 +129,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     public class ContextDataNotSupportedNetCore31Tests : ContextDataNotSupportedTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public ContextDataNotSupportedNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LoggingFramework.DummyMEL)
+            : base(fixture, output, LoggingFramework.DummyMEL)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/DummyMELAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/DummyMELAdapter.cs
@@ -1,0 +1,124 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+#if NETCOREAPP2_1_OR_GREATER || NET48_OR_GREATER
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
+{
+    /// <summary>
+    /// A "dummy" logging adapter that registers a "dummy" MEL.ILogger implementation that doesn't also implement IExternalScopeProvider.
+    /// Used for testing error handling around context data retrieval in MicrosoftLoggingWrapper
+    /// </summary>
+    public class DummyMELAdapter : ILoggingAdapter
+    {
+        private static ILogger _logger;
+
+        public DummyMELAdapter()
+        {
+        }
+
+        public void Debug(string message) => _logger.LogDebug(message);
+
+        public void Info(string message) => _logger.LogInformation(message);
+
+        public void Info(string message, Dictionary<string, object> context)
+        {
+            using (_logger.BeginScope(context))
+            {
+                _logger.LogInformation(message);
+            }
+        }
+
+        public void Warn(string message) => _logger.LogWarning(message);
+
+        public void Error(Exception exception) => _logger.LogError(exception, exception.Message);
+
+        public void ErrorNoMessage(Exception exception) => _logger.LogError(exception, string.Empty);
+
+        public void Fatal(string message) => _logger?.LogCritical(message);
+
+        public void NoMessage()
+        {
+            _logger.LogTrace(string.Empty);
+        }
+
+        public void Configure() => CreateMelLogger();
+
+        public void ConfigureWithInfoLevelEnabled() => CreateMelLogger();
+
+        public void ConfigurePatternLayoutAppenderForDecoration() => CreateMelLogger();
+
+        public void ConfigureJsonLayoutAppenderForDecoration() => CreateMelLogger();
+
+        private void CreateMelLogger()
+        {
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Trace);
+
+                builder.AddDummyILogger();
+            });
+
+            _logger = loggerFactory.CreateLogger<LoggingTester>();
+        }
+    }
+
+    // a bare-bones implementation of MEL.ILogger
+    public class DummyILogger : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => default!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+        }
+    }
+
+    /// <summary>
+    /// And an ILoggerProvider for DummyILogger
+    /// </summary>
+    [ProviderAlias("DummyILogger")]
+    public class DummyILoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentDictionary<string, DummyILogger> _loggers =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public void Dispose()
+        {
+            _loggers.Clear();
+        }
+
+        public ILogger CreateLogger(string categoryName) => _loggers.GetOrAdd(categoryName, name => new DummyILogger());
+    }
+
+    public static class DummyILoggerExtensions
+    {
+        /// <summary>
+        /// Extension method for registering the DummyILoggerProvider
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static ILoggingBuilder AddDummyILogger(
+            this ILoggingBuilder builder)
+        {
+            builder.AddConfiguration();
+
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<ILoggerProvider, DummyILoggerProvider>());
+
+            return builder;
+        }
+    }
+}
+
+#endif

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -36,6 +36,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                     _log = new MicrosoftLoggingLoggingAdapter();
 #endif
                     break;
+                case "DUMMYMEL":
+#if NETCOREAPP2_1_OR_GREATER || NET48_OR_GREATER
+                    _log = new DummyMELAdapter();
+#endif
+                    break;
                 case "NLOG":
                     _log = new NLogLoggingAdapter();
                     break;


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

* Added error handling in `MicrosoftLoggingWrapper.GetContextData()` for cases where a logger implements `MEL.ILogger` but doesn't also expose an `IExternalScopeProvider` property named `ScopeProvider`. If that happens, we log a message and disable further attempts at collecting context data.
* Added integration tests and a dummy implementation of `MEL.ILogger` to verify the fix is working as expected.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)
- [x] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
