### PR TITLE
Add warning when grpc_proxy is detected

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -394,7 +394,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
             if (!string.IsNullOrWhiteSpace(grpcProxyValue) && string.IsNullOrWhiteSpace(httpsProxyValue))
             {
-                LogMessage(LogLevel.Warn, "The 'grpc_proxy' environment variable is deprecated/no longer supported. Please use 'https_proxy' instead.");
+                LogMessage(LogLevel.Warn, "The 'grpc_proxy' environment variable is deprecated. Please use 'https_proxy' instead.");
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -394,7 +394,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
             if (!string.IsNullOrWhiteSpace(grpcProxyValue) && string.IsNullOrWhiteSpace(httpsProxyValue))
             {
-                LogMessage(LogLevel.Warn, "The 'grpc_proxy' environment variable was detected and the 'https_proxy' environment variable was not detected. The 'grpc_proxy' environment variable is not supported by all gRPC libraries. If a proxy is needed consider using the 'https_proxy' environment variable.");
+                LogMessage(LogLevel.Warn, "The 'grpc_proxy' environment variable is deprecated/no longer supported. Please use 'https_proxy' instead.");
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -15,6 +15,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.SystemInterfaces;
 
 namespace NewRelic.Agent.Core.DataTransport
 {
@@ -133,6 +134,7 @@ namespace NewRelic.Agent.Core.DataTransport
         private readonly IDelayer _delayer;
         protected readonly IAgentHealthReporter _agentHealthReporter;
         private readonly IAgentTimerService _agentTimerService;
+        private readonly IEnvironment _environment;
 
         private readonly IConfigurationService _configSvc;
         protected IConfiguration _configuration => _configSvc?.Configuration;
@@ -256,12 +258,13 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private PartitionedBlockingCollection<TRequest> _collection;
 
-        protected DataStreamingService(IGrpcWrapper<TRequestBatch, TResponse> grpcWrapper, IDelayer delayer, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IAgentTimerService agentTimerService)
+        protected DataStreamingService(IGrpcWrapper<TRequestBatch, TResponse> grpcWrapper, IDelayer delayer, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IAgentTimerService agentTimerService, IEnvironment environment)
         {
             _grpcWrapper = grpcWrapper;
             _delayer = delayer;
             _configSvc = configSvc;
             _agentTimerService = agentTimerService;
+            _environment = environment;
 
             _cancellationTokenSource = new CancellationTokenSource();
             _agentHealthReporter = agentHealthReporter;
@@ -325,6 +328,8 @@ namespace NewRelic.Agent.Core.DataTransport
                 EndpointTestFlakyCode = EndpointTestFlakyCodeConfigValue;
                 EndpointTestDelayMs = EndpointTestDelayMsConfigValue;
 
+                CheckForLegacyProxyAndDisplayWarning();
+
                 return true;
             }
 
@@ -380,6 +385,17 @@ namespace NewRelic.Agent.Core.DataTransport
             }
 
             return false;
+        }
+
+        private void CheckForLegacyProxyAndDisplayWarning()
+        {
+            var grpcProxyValue = _environment.GetEnvironmentVariable("grpc_proxy");
+            var httpsProxyValue = _environment.GetEnvironmentVariable("https_proxy");
+
+            if (!string.IsNullOrWhiteSpace(grpcProxyValue) && string.IsNullOrWhiteSpace(httpsProxyValue))
+            {
+                LogMessage(LogLevel.Warn, "The 'grpc_proxy' environment variable was detected and the 'https_proxy' environment variable was not detected. The 'grpc_proxy' environment variable is not supported by all gRPC libraries. If a proxy is needed consider using the 'https_proxy' environment variable.");
+            }
         }
 
         private void Restart(PartitionedBlockingCollection<TRequest> collection)

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/SpanStreamingService.cs
@@ -7,13 +7,14 @@ using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.Segments;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Core.Logging;
+using NewRelic.SystemInterfaces;
 
 namespace NewRelic.Agent.Core.DataTransport
 {
     public class SpanStreamingService : DataStreamingService<Span, SpanBatch, RecordStatus>
     {
-        public SpanStreamingService(IGrpcWrapper<SpanBatch, RecordStatus> grpcWrapper, IDelayer delayer, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IAgentTimerService agentTimerService)
-            : base(grpcWrapper, delayer, configSvc, agentHealthReporter, agentTimerService)
+        public SpanStreamingService(IGrpcWrapper<SpanBatch, RecordStatus> grpcWrapper, IDelayer delayer, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IAgentTimerService agentTimerService, IEnvironment environment)
+            : base(grpcWrapper, delayer, configSvc, agentHealthReporter, agentTimerService, environment)
         {
         }
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

gRPC-dotnet does not support proxy configuration using the `grpc_proxy` environment variable that gRPC.Core supports. Both gRPC libraries support the `https_proxy` environment variable. In this PR we add a warning to the agent log file when Infinite Tracing is enabled and the `grpc_proxy` environment variable is detected (and the `https_proxy` is not detected). This log message can be used to help with troubleshooting Infinite Tracing connection issues when a proxy is involved.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- ~~[ ] Performance testing completed with satisfactory results (if required)~~ Not required for a one-time warning
- ~~[ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~~ Relevant changelog entries already exist.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
