### PR TITLE
Friendlier TLS Configuration Message

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -189,7 +189,7 @@ namespace NewRelic.Agent.Core
 
         private void LogTlsConfiguration()
         {
-            Log.Info($"TLS Configuration (System.Net.ServicePointManager.SecurityProtocol): {System.Net.ServicePointManager.SecurityProtocol}");
+            Log.Info($"TLS Configuration (System.Net.ServicePointManager.SecurityProtocol): {System.Net.ServicePointManager.SecurityProtocol.ToFriendlyString()}");
         }
 
         private void LogInitialized()

--- a/src/Agent/NewRelic/Agent/Core/Utilities/SecurityProtocolTypeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/SecurityProtocolTypeExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net;
+using System.Text;
+
+namespace NewRelic.Agent.Core.Utilities
+{
+    public static class SecurityProtocolTypeExtensions
+    {
+        /// <summary>
+        /// Have to define this enum privately, as all possible values aren't represented in System.Net.SecurityProtocolType,
+        /// depending on which .NET version is targeted. The hex values come from System.Security.Authentication.SslProtocols enum
+        /// and/or System.Net.SecurityProtocolType enum (same values in both places)
+        /// </summary>
+        private enum InternalSecurityProtocolType
+        {
+            Ssl2 = 0x000C,
+            Ssl3 = 0x0030,
+            Tls10 = 0x00C0,
+            Tls11 = 0x0300,
+            Tls12 = 0x0C00,
+            Tls13 = 0x3000
+        }
+
+        /// <summary>
+        /// Convert a SecurityProtocolType enum value to a "friendly" string
+        /// </summary>
+        /// <param name="protocolType"></param>
+        /// <returns></returns>
+        public static string ToFriendlyString(this SecurityProtocolType protocolType)
+        {
+            if (protocolType == 0) 
+            {
+                return "Using System Default Settings";
+            }
+
+            var sb = new StringBuilder();
+            foreach (int flag in Enum.GetValues(typeof(InternalSecurityProtocolType)))
+            {
+                if (((int)protocolType & flag) == flag)
+                {
+                    if (sb.Length > 0)
+                        sb.Append(", ");
+
+                    switch ((InternalSecurityProtocolType)flag)
+                    {
+                        case InternalSecurityProtocolType.Ssl2:
+                            sb.Append("SSL 2");
+                            break;
+                        case InternalSecurityProtocolType.Ssl3:
+                            sb.Append("SSL 3");
+                            break;
+                        case InternalSecurityProtocolType.Tls10:
+                            sb.Append("TLS 1.0");
+                            break;
+                        case InternalSecurityProtocolType.Tls11:
+                            sb.Append("TLS 1.1");
+                            break;
+                        case InternalSecurityProtocolType.Tls12:
+                            sb.Append("TLS 1.2");
+                            break;
+                        case InternalSecurityProtocolType.Tls13:
+                            sb.Append("TLS 1.3");
+                            break;
+                    }
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/SecurityProtocolTypeExtensionsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/SecurityProtocolTypeExtensionsTest.cs
@@ -1,0 +1,27 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net;
+using System.Runtime.Remoting.Messaging;
+using NewRelic.Agent.Core.Utilities;
+using NUnit.Framework;
+
+namespace NewRelic.Agent.Core.Utils
+{
+    [TestFixture]
+    public class SecurityProtocolTypeExtensionsTest
+    {
+        [TestCase(0x0, ExpectedResult = "Using System Default Settings")] // because .SystemDefault enum value doesn't exist for some platforms
+        [TestCase(SecurityProtocolType.Ssl3, ExpectedResult = "SSL 3")]
+        [TestCase(SecurityProtocolType.Tls, ExpectedResult = "TLS 1.0")]
+        [TestCase(SecurityProtocolType.Tls11, ExpectedResult = "TLS 1.1")]
+        [TestCase(SecurityProtocolType.Tls12, ExpectedResult = "TLS 1.2")]
+        [TestCase(SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls, ExpectedResult = "SSL 3, TLS 1.0")]
+        [TestCase(0x3000, ExpectedResult = "TLS 1.3")] // because .Tls13 enum value doesn't exist for some platforms
+        public string ToFriendlyString_Test(SecurityProtocolType securityProtocolType)
+        {
+            return securityProtocolType.ToFriendlyString();
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/SecurityProtocolTypeExtensionsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/SecurityProtocolTypeExtensionsTest.cs
@@ -13,6 +13,7 @@ namespace NewRelic.Agent.Core.Utils
     public class SecurityProtocolTypeExtensionsTest
     {
         [TestCase(0x0, ExpectedResult = "Using System Default Settings")] // because .SystemDefault enum value doesn't exist for some platforms
+        [TestCase(0x000C, ExpectedResult = "SSL 2")] // because .Ssl2 enum value doesn't exist for some platforms
         [TestCase(SecurityProtocolType.Ssl3, ExpectedResult = "SSL 3")]
         [TestCase(SecurityProtocolType.Tls, ExpectedResult = "TLS 1.0")]
         [TestCase(SecurityProtocolType.Tls11, ExpectedResult = "TLS 1.1")]


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

A minor modification to our logging at startup to help ease support questions. Currently, if the machine is configured for TLS 1.0, the log message simply says "Tls". With this change, we get a more verbose message that clearly indicates the TLS version or that the app is using the system default settings: 

```
2023-02-13 20:52:35,993 NewRelic   INFO: [pid: 25852, tid: 1] TLS Configuration (System.Net.ServicePointManager.SecurityProtocol): Using System Default Settings
```

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
