### PR TITLE
Partial fix for Segment out-of-range error

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -59,9 +59,15 @@ namespace NewRelic.Agent.Core.Transactions
                     return Segment.NoOpSegment;
                 }
 
-                if (Segments[currentSegmentIndex.Value] != null)
+                int idx = currentSegmentIndex.Value;
+                if (idx >= Segments.Count)
                 {
-                    return Segments[currentSegmentIndex.Value];
+                    Log.Warn($"Transaction {Guid} is out of sync with the current segment [looking for {idx} out of {Segments.Count}]");
+                    return Segment.NoOpSegment;
+                }
+                if (Segments[idx] != null)
+                {
+                    return Segments[idx];
                 }
 
                 return Segment.NoOpSegment;


### PR DESCRIPTION
Partial fix for issue with Transactions created in an async context. See [#1366](https://github.com/newrelic/newrelic-dotnet-agent/issues/1366)

I believe there is still an general issue with Transactions created in an async context; this is just one of the places where it can happen.

Because this is an async timing issue, I wasn't able to come up with a consistent unit or integration test to capture it, unfortunately.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
