### PR TITLE
Update NLog to improve local log decoration coverage

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+* Update NLog to improve local log decoration coverage. [#1393](https://github.com/newrelic/newrelic-dotnet-agent/pull/1393)
+
 ## [10.7.0]
 
 ### New Features

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogLogging.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogLogging.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -8,13 +8,17 @@ using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
-using NLog;
 
 namespace NewRelic.Providers.Wrapper.NLogLogging
 {
     public class NLogWrapper : IWrapper
     {
         private static Action<object, string> _setFormattedMessage;
+        private static Func<object, object> _getLevel;
+        private static Func<object, string> _getFormattedMessage;
+        private static Func<object, DateTime> _getTimestamp;
+        private static Func<object, Exception> _getLogException;
+        private static Func<object, IDictionary<object, object>> _getPropertiesDictionary;
 
         public bool IsTransactionRequired => false;
 
@@ -28,8 +32,8 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
-            var logEvent = instrumentedMethodCall.MethodCall.MethodArguments[2] as LogEventInfo;
-            var logEventType = typeof(LogEventInfo);
+            var logEvent = instrumentedMethodCall.MethodCall.MethodArguments[2];
+            var logEventType = logEvent.GetType();
 
             if (!LogProviders.RegisteredLogProvider[(int)LogProvider.NLog])
             {
@@ -42,37 +46,70 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
             return Delegates.NoOp;
         }
 
-        private void RecordLogMessage(LogEventInfo logEvent, Type logEventType, IAgent agent)
+        private void RecordLogMessage(object logEvent, Type logEventType, IAgent agent)
         {
-            Func<object, object> getLevelFunc = le => ((LogEventInfo)le).Level;
+            var getLevelFunc = _getLevel ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(logEventType, "Level");
 
-            Func<object, string> getRenderedMessageFunc = le => ((LogEventInfo)le).FormattedMessage;
+            var getRenderedMessageFunc = GetFormattedMessageFunc(logEventType); ;
 
-            Func<object, DateTime> getTimestampFunc = le => ((LogEventInfo)le).TimeStamp;
+            var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEventType, "TimeStamp");
 
-            Func<object, Exception> getLogExceptionFunc = le => ((LogEventInfo)le).Exception;
+            var getLogExceptionFunc = _getLogException ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<Exception>(logEventType, "Exception");
 
             // This will either add the log message to the transaction or directly to the aggregator
             var xapi = agent.GetExperimentalApi();
             xapi.RecordLogMessage(WrapperName, logEvent, getTimestampFunc, getLevelFunc, getRenderedMessageFunc, getLogExceptionFunc, GetContextData, agent.TraceMetadata.SpanId, agent.TraceMetadata.TraceId);
         }
 
-        private void DecorateLogMessage(LogEventInfo logEvent, Type logEventType, IAgent agent)
+        private void DecorateLogMessage(object logEvent, Type logEventType, IAgent agent)
         {
-            if (!agent.Configuration.LogDecoratorEnabled || string.IsNullOrWhiteSpace(logEvent?.FormattedMessage))
+            if (!agent.Configuration.LogDecoratorEnabled)
             {
                 return;
             }
 
-            var setFormattedMessage = _setFormattedMessage ??= VisibilityBypasser.Instance.GenerateFieldWriteAccessor<string>(logEventType, "_formattedMessage");
+            var getFormattedMessageFunc = GetFormattedMessageFunc(logEventType);
+            var formattedMessage = getFormattedMessageFunc(logEvent);
+            if (string.IsNullOrWhiteSpace(formattedMessage))
+            {
+                return;
+            }
+
+            // NLog version strings are not setup to allow using min/max version in instrumentation - they only report major version.
+            // This will use the 4.5+ field name and if that is not found, use the pre4.5 field name.
+            // Follow up calls will not throw and just work.
+            Action<object, string> setFormattedMessage;
+            if (_setFormattedMessage == null)
+            {
+                try
+                {
+                    setFormattedMessage = _setFormattedMessage ??= VisibilityBypasser.Instance.GenerateFieldWriteAccessor<string>(logEventType, "_formattedMessage");
+                }
+                catch
+                {
+                    setFormattedMessage = _setFormattedMessage ??= VisibilityBypasser.Instance.GenerateFieldWriteAccessor<string>(logEventType, "formattedMessage");
+                }
+            }
+            else
+            {
+                setFormattedMessage = _setFormattedMessage;
+            }
+
             var formattedMetadata = LoggingHelpers.GetFormattedLinkingMetadata(agent);
-            setFormattedMessage(logEvent, logEvent.FormattedMessage + " " + formattedMetadata);
+            setFormattedMessage(logEvent, formattedMessage + " " + formattedMetadata);
+        }
+
+        private Func<object, string> GetFormattedMessageFunc(Type logEventType)
+        {
+            return _getFormattedMessage ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<string>(logEventType, "FormattedMessage");
         }
 
         private Dictionary<string, object> GetContextData(object logEvent)
         {
             var contextData = new Dictionary<string, object>();
-            foreach (var property in ((LogEventInfo)logEvent).Properties)
+            var getPropertiesDictionary = _getPropertiesDictionary ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<IDictionary<object, object>>(logEvent.GetType(), "Properties");
+            var properties = getPropertiesDictionary(logEvent);
+            foreach (var property in properties)
             {
                 contextData[property.Key.ToString()] = property.Value;
             }


### PR DESCRIPTION
## Description

Changes how the NLog instrumentation updates the log message for local log decoration.

* Instead of examining and using LogEventInfo.Message, the new instrumentation uses LogEventInfo.FormattedMessage and its backing field, (v4.5+ _formattedMessage)|(Pre v4.5 formattedMessage).  This property has additional logic that Message does not and appears to be the source for the actual log message we see.  Calling FormattedMessage causes NLog to build the message and store it in the backing field.  
* Using the visibility bypasser, we get the setter for the backing field and use it to set the field to itself with our decoration token.  The Action is stored staticly, same as with other bypasser setups.
* Since we can only get the major assembly version from NLog assembly we cannot use minVersion or maxVersion.  The cleanest solution was to check for _formattedMessage first since it is the going forward name and if that fails, use formattedMessage.  This is done using reflection, but is will only happen once per run so the impact is minimal.

Caveats:
This does not 100% cover all the log lines.  It does cover the vast majority of them.  


# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
