### PR TITLE
Update error group callback api implementation

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/NewRelic.cs
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.cs
@@ -828,16 +828,19 @@ namespace NewRelic.Api.Agent
             return Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
-        /// <summary>
-        /// DOCS GO HERE
+        /// <summary> Sets the method that will be invoked to define the error group that an exception
+        /// should belong to.
+        ///
+        /// The callback takes an Exception and returns the name of the error group to use. Return values
+        /// that are null, empty, or whitespace will not associate the Exception to an error group.
         /// </summary>
-        /// <param name="callback"></param>
+        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public static void ErrorFingerprintingCallback(Func<Exception, string> callback)
+        public static void SetErrorGroupCallback(Func<Exception, string> callback)
         {
             try
             {
-                System.Diagnostics.Trace.WriteLine("NewRelic.ErrorFingerprintingCallback()");
+                System.Diagnostics.Trace.WriteLine("NewRelic.SetErrorGroupCallback()");
             }
             catch
             {

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
@@ -637,7 +637,7 @@ namespace NewRelic.Agent.Core
             const string apiName = nameof(SetErrorGroupCallback);
             void work()
             {
-                InternalApi.ErrorFingerprintingCallback(callback);
+                InternalApi.SetErrorGroupCallback(callback);
             }
             TryInvoke(work, apiName, ApiMethod.SetErrorGroupCallback);
         }

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
@@ -625,9 +625,16 @@ namespace NewRelic.Agent.Core
             return InternalApi.GetResponseMetadata() ?? new Dictionary<string, string>();
         }
 
-        public static void ErrorFingerprintingCallback(Func<Exception, string> callback)
+        /// <summary> Sets the method that will be invoked to define the error group that an exception
+        /// should belong to.
+        ///
+        /// The callback takes an Exception and returns the name of the error group to use. Return values
+        /// that are null, empty, or whitespace will not associate the Exception to an error group.
+        /// </summary>
+        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
+        public static void SetErrorGroupCallback(Func<Exception, string> callback)
         {
-            const string apiName = nameof(ErrorFingerprintingCallback);
+            const string apiName = nameof(SetErrorGroupCallback);
             void work()
             {
                 InternalApi.ErrorFingerprintingCallback(callback);

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
@@ -755,13 +755,19 @@ namespace NewRelic.Agent.Core.Api
             return _agent.CurrentTransaction.GetResponseMetadata();
         }
 
-        /// <summary>
-        /// DOCS GO HERE
+        /// <summary> Sets the method that will be invoked to define the error group that an exception
+        /// should belong to.
+        ///
+        /// The callback takes an Exception and returns the name of the error group to use. Return values
+        /// that are null, empty, or whitespace will not associate the Exception to an error group.
         /// </summary>
-        /// <param name="callback"></param>
-        public void ErrorFingerprintingCallback(Func<Exception, string> callback)
+        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
+        public void SetErrorGroupCallback(Func<Exception, string> callback)
         {
-            ((Agent)_agent).ErrorFingerprintingCallback = callback;
+            using (new IgnoreWork())
+            {
+                EventBus<ErrorGroupCallbackUpdateEvent>.Publish(new ErrorGroupCallbackUpdateEvent(callback));
+            }
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
@@ -43,6 +43,7 @@ namespace NewRelic.Agent.Core.Configuration
             _subscriptions.Add<ConfigurationDeserializedEvent>(OnConfigurationDeserialized);
             _subscriptions.Add<ServerConfigurationUpdatedEvent>(OnServerConfigurationUpdated);
             _subscriptions.Add<AppNameUpdateEvent>(OnAppNameUpdate);
+            _subscriptions.Add<ErrorGroupCallbackUpdateEvent>(OnErrorGroupCallbackUpdate);
             _subscriptions.Add<GetCurrentConfigurationRequest, IConfiguration>(OnGetCurrentConfiguration);
             _subscriptions.Add<SecurityPoliciesConfigurationUpdatedEvent>(OnSecurityPoliciesUpdated);
         }
@@ -91,7 +92,16 @@ namespace NewRelic.Agent.Core.Configuration
             if (_runTimeConfiguration.ApplicationNames.SequenceEqual(appNameUpdateEvent.AppNames))
                 return;
 
-            _runTimeConfiguration = new RunTimeConfiguration(appNameUpdateEvent.AppNames);
+            _runTimeConfiguration = new RunTimeConfiguration(appNameUpdateEvent.AppNames, _runTimeConfiguration.ErrorGroupCallback);
+            UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
+        }
+
+        private void OnErrorGroupCallbackUpdate(ErrorGroupCallbackUpdateEvent errorGroupCallbackUpdateEvent)
+        {
+            if (_runTimeConfiguration.ErrorGroupCallback == errorGroupCallbackUpdateEvent.ErrorGroupCallback)
+                return;
+
+            _runTimeConfiguration = new RunTimeConfiguration(_runTimeConfiguration.ApplicationNames, errorGroupCallbackUpdateEvent.ErrorGroupCallback);
             UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1201,6 +1201,8 @@ namespace NewRelic.Agent.Core.Configuration
         public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; private set; }
         public IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings { get; private set; }
 
+        public Func<Exception, string> ErrorGroupCallback => _runTimeConfiguration.ErrorGroupCallback;
+
         #endregion
 
         public Dictionary<string, string> RequestHeadersMap => _serverConfiguration.RequestHeadersMap;

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -307,6 +307,10 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("error_collector.ignore_messages")]
         public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings => _configuration.IgnoreErrorMessagesForAgentSettings;
 
+        // Serializing this Func doesn't provide us with more information than the supportability metrics
+        [JsonIgnore()]
+        public Func<Exception, string> ErrorGroupCallback => _configuration.ErrorGroupCallback;
+
         [JsonProperty("agent.request_headers_map")]
         public Dictionary<string, string> RequestHeadersMap => _configuration.RequestHeadersMap;
                 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/RunTimeConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/RunTimeConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,14 +11,18 @@ namespace NewRelic.Agent.Core.Configuration
     {
         public IEnumerable<string> ApplicationNames;
 
+        public Func<Exception, string> ErrorGroupCallback;
+
         public RunTimeConfiguration()
         {
             ApplicationNames = Enumerable.Empty<string>();
+            ErrorGroupCallback = null;
         }
 
-        public RunTimeConfiguration(IEnumerable<string> applicationNames)
+        public RunTimeConfiguration(IEnumerable<string> applicationNames, Func<Exception, string> errorGroupCallback)
         {
             ApplicationNames = applicationNames.ToList();
+            ErrorGroupCallback = errorGroupCallback;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Events/ErrorGroupCallbackUpdateEvent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Events/ErrorGroupCallbackUpdateEvent.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+
+namespace NewRelic.Agent.Core.Events
+{
+    public class ErrorGroupCallbackUpdateEvent
+    {
+        public readonly Func<Exception, string> ErrorGroupCallback;
+
+        public ErrorGroupCallbackUpdateEvent(Func<Exception, string> errorGroupCallback)
+        {
+            ErrorGroupCallback = errorGroupCallback;
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/IAgentApi.cs
@@ -266,11 +266,14 @@ namespace NewRelic.Agent.Api
         /// <returns> A list of key-value pairs representing the request metadata. </returns>
         IEnumerable<KeyValuePair<string, string>> GetResponseMetadata();
 
-        /// <summary>
-        /// DOCS GO HERE
+        /// <summary> Sets the method that will be invoked to define the error group that an exception
+        /// should belong to.
+        ///
+        /// The callback takes an Exception and returns the name of the error group to use. Return values
+        /// that are null, empty, or whitespace will not associate the Exception to an error group.
         /// </summary>
-        /// <param name="callback"></param>
-        void ErrorFingerprintingCallback(Func<Exception, string> callback);
+        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
+        void SetErrorGroupCallback(Func<Exception, string> callback);
     }
 }
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
@@ -324,7 +324,7 @@ namespace NewRelic.Agent.Api
         /// that are null, empty, or whitespace will not associate the Exception to an error group.
         /// </summary>
         /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
-        public static void ErrorFingerprintingCallback(Func<Exception, string> callback)
+        public static void SetErrorGroupCallback(Func<Exception, string> callback)
         {
             _agentApiImplementation?.SetErrorGroupCallback(callback);
         }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/InternalApi.cs
@@ -317,13 +317,16 @@ namespace NewRelic.Agent.Api
             return _agentApiImplementation?.GetResponseMetadata() ?? Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
-        /// <summary>
-        /// DOCS GO HERE
+        /// <summary> Sets the method that will be invoked to define the error group that an exception
+        /// should belong to.
+        ///
+        /// The callback takes an Exception and returns the name of the error group to use. Return values
+        /// that are null, empty, or whitespace will not associate the Exception to an error group.
         /// </summary>
-        /// <param name="callback"></param>
+        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
         public static void ErrorFingerprintingCallback(Func<Exception, string> callback)
         {
-            _agentApiImplementation?.ErrorFingerprintingCallback(callback);
+            _agentApiImplementation?.SetErrorGroupCallback(callback);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -99,6 +99,7 @@ namespace NewRelic.Agent.Configuration
         IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration { get; }
         IEnumerable<string> IgnoreErrorClassesForAgentSettings { get; }
         IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings { get; }
+        Func<Exception, string> ErrorGroupCallback { get; }
         Dictionary<string, string> RequestHeadersMap { get; }
         string EncodingKey { get; }
         string EntityGuid { get; }

--- a/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AgentApiTests.cs
@@ -1743,6 +1743,23 @@ namespace CompositeTests
 
         #endregion
 
+        #region SetErrorGroupCallback
+
+        [Test]
+        public void Test_SetErrorGroupCallback()
+        {
+            Func<Exception, string> myCallback = ex => "my error group";
+
+            AgentApi.SetErrorGroupCallback(myCallback);
+
+            _compositeTestAgent.PushConfiguration();
+            var errorGroupCallback = _compositeTestAgent.CurrentConfiguration.ErrorGroupCallback;
+
+            Assert.AreSame(myCallback, errorGroupCallback);
+        }
+
+        #endregion
+
         #region GetRequestMetadata
 
         [Test]

--- a/tests/Agent/UnitTests/CompositeTests/ApiSupportabilityMetricTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/ApiSupportabilityMetricTests.cs
@@ -112,6 +112,14 @@ namespace CompositeTests
         }
 
         [Test]
+        public void SetErrorGroupCallback()
+        {
+            AgentApi.SetErrorGroupCallback(null);
+
+            HarvestAndValidateMetric("SetErrorGroupCallback");
+        }
+
+        [Test]
         public void SetTransactionName()
         {
             CallAgentApiMethodRequiringTransaction(() => AgentApi.SetTransactionName("custom", "transactionName"), "SetTransactionName");

--- a/tests/Agent/UnitTests/Core.UnitTest/Api/AgentApiImplementationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Api/AgentApiImplementationTests.cs
@@ -1,9 +1,13 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Testing.Assertions;
 using NUnit.Framework;
 using Telerik.JustMock;
 
@@ -15,6 +19,7 @@ namespace NewRelic.Agent.Core.Api
         private IConfiguration _configuration;
         private IAgent _wrapperApi;
         private IAgentApi _agentApi;
+        private List<ErrorGroupCallbackUpdateEvent> _errorGroupCallbackUpdateEvents;
 
         [SetUp]
         public void Setup()
@@ -25,7 +30,16 @@ namespace NewRelic.Agent.Core.Api
 
             _wrapperApi = Mock.Create<IAgent>();
 
+            _errorGroupCallbackUpdateEvents = new List<ErrorGroupCallbackUpdateEvent>();
+            EventBus<ErrorGroupCallbackUpdateEvent>.Subscribe(OnRaisedErrorGroupCallbackUpdateEvent);
+
             _agentApi = new AgentApiImplementation(null, null, null, null, null, null, null, configurationService, _wrapperApi, null, null, null);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            EventBus<ErrorGroupCallbackUpdateEvent>.Unsubscribe(OnRaisedErrorGroupCallbackUpdateEvent);
         }
 
 
@@ -99,6 +113,24 @@ namespace NewRelic.Agent.Core.Api
 
             //Assert
             Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void SetErrorGroupCallbackShouldRaiseEvent()
+        {
+            Func<Exception, string> myCallback = ex => "mygroup";
+
+            _agentApi.SetErrorGroupCallback(myCallback);
+
+            NrAssert.Multiple(
+                () => Assert.AreEqual(1, _errorGroupCallbackUpdateEvents.Count, "Expected only one update event to be triggered."),
+                () => Assert.AreSame(myCallback, _errorGroupCallbackUpdateEvents[0].ErrorGroupCallback, "Expected the callback in the event to match the callback passed to the API.")
+                );
+        }
+
+        private void OnRaisedErrorGroupCallbackUpdateEvent(ErrorGroupCallbackUpdateEvent updateEvent)
+        {
+            _errorGroupCallbackUpdateEvents.Add(updateEvent);
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -204,6 +204,8 @@ namespace NewRelic.Agent.Core.DataTransport
             { "eight", new[] { "eight1", "eight2" } },
         };
 
+        public Func<Exception, string> ErrorGroupCallback => ex => "my error group";
+
         public Dictionary<string, string> RequestHeadersMap => new Dictionary<string, string>
         {
             { "one", "1" },


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the code referenced in #1400 
- Renames the API for ErrorFingerprintingCallback to SetErrorGroupCallback.
- Updates the API SetErrorGroupCallback implementation to behave similarly to the SetApplicationName API method
- Adds a documentation summary to the SetErrorGroupCallback method

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- ~~[ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~~ Will be updated in a separate PR 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
