### PR TITLE
Use configured errorgroupcallback

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -64,7 +64,6 @@ namespace NewRelic.Agent.Core
         private readonly ILogContextDataFilter _logContextDataFilter;
         private Extensions.Logging.ILogger _logger;
         private IStackExchangeRedisCache _stackExchangeRedisCache;
-        private Func<Exception, string> _errorFingerprintingCallback;
 
         public Agent(ITransactionService transactionService, ITransactionTransformer transactionTransformer,
             IThreadPoolStatic threadPoolStatic, ITransactionMetricNameMaker transactionMetricNameMaker, IPathHashMaker pathHashMaker,
@@ -300,19 +299,6 @@ namespace NewRelic.Agent.Core
             }
 
             Log.Error($"An exception occurred in a wrapper: {exception}");
-        }
-
-        //TODO: does this callback really belong on IAgent??
-        public Func<Exception, string> ErrorFingerprintingCallback
-        {
-            get
-            {
-                return _errorFingerprintingCallback ??= x => null;
-            }
-            set
-            {
-                _errorFingerprintingCallback = value;
-            }
         }
 
         #endregion Error handling

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -590,7 +590,18 @@ namespace NewRelic.Agent.Core.Attributes
         public AttributeDefinition<string, string> ErrorGroup => _errorGroup ?? (_errorGroup =
             AttributeDefinitionBuilder.CreateString("error_group", AttributeClassification.AgentAttributes)
                 .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace)
+                .WithConvert(IgnoreEmptyAndWhitespaceErrorGroupValues)
                 .Build(_attribFilter));
+
+        private static string IgnoreEmptyAndWhitespaceErrorGroupValues(string errorGroupValue)
+        {
+            if (!string.IsNullOrWhiteSpace(errorGroupValue))
+            {
+                return errorGroupValue;
+            }
+
+            return null;
+        }
 
         private AttributeDefinition<string, string> _endUserId;
         public AttributeDefinition<string, string> EndUserId => _endUserId ?? (_endUserId =

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorData.cs
@@ -14,11 +14,11 @@ namespace NewRelic.Agent.Core.Errors
         public string Path { get; set; }
         public ReadOnlyDictionary<string, object> CustomAttributes { get; }
         public bool IsExpected { get; }
-        public string GroupFingerprint { get; }
+        public string ErrorGroup { get; }
 
         public const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
-        public ErrorData(string errorMessage, string errorTypeName, string stackTrace, DateTime noticedAt, ReadOnlyDictionary<string, object> customAttributes, bool isExpected, string groupFingerprint)
+        public ErrorData(string errorMessage, string errorTypeName, string stackTrace, DateTime noticedAt, ReadOnlyDictionary<string, object> customAttributes, bool isExpected, string errorGroup)
         {
             NoticedAt = noticedAt;
             StackTrace = stackTrace;
@@ -27,7 +27,7 @@ namespace NewRelic.Agent.Core.Errors
             Path = null;
             CustomAttributes = customAttributes;
             IsExpected = isExpected;
-            GroupFingerprint = groupFingerprint;
+            ErrorGroup = errorGroup;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
@@ -122,7 +122,9 @@ namespace NewRelic.Agent.Core.Errors
         {
             // this does more work than just getting the exception, so we want to do this just once.
             var baseException = exception.GetBaseException();
-            var groupFingerprint = Agent.Instance?.ErrorFingerprintingCallback(exception);
+            // When generating the error group we use the outermost exception so that we can provide as much context as possible
+            // to the callback.
+            var errorGroup = _configurationService.Configuration.ErrorGroupCallback?.Invoke(exception);
             var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : baseException.Message;
             var baseExceptionTypeName = GetFriendlyExceptionTypeName(baseException);
             // We want the message from the base exception since that is the real exception.
@@ -131,7 +133,7 @@ namespace NewRelic.Agent.Core.Errors
             var noticedAt = DateTime.UtcNow;
 
             var isExpected = IsErrorFromExceptionSpecified(exception, _configurationService.Configuration.ExpectedErrorsConfiguration);
-            return new ErrorData(message, baseExceptionTypeName, stackTrace, noticedAt, customAttributes, isExpected, groupFingerprint);
+            return new ErrorData(message, baseExceptionTypeName, stackTrace, noticedAt, customAttributes, isExpected, errorGroup);
         }
 
         private static bool IsErrorFromExceptionSpecified(Exception exception, IDictionary<string, IEnumerable<string>> source)

--- a/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Errors/ErrorService.cs
@@ -79,14 +79,12 @@ namespace NewRelic.Agent.Core.Errors
 
         public ErrorData FromMessage(string errorMessage, IDictionary<string, string> customAttributes, bool isExpected)
         {
-            var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : errorMessage;
-            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes), isExpected, null);
+            return FromMessageInternal(errorMessage, customAttributes, isExpected);
         }
 
         public ErrorData FromMessage(string errorMessage, IDictionary<string, object> customAttributes, bool isExpected)
         {
-            var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : errorMessage;
-            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes), isExpected, null);
+            return FromMessageInternal(errorMessage, customAttributes, isExpected);
         }
 
         public ErrorData FromErrorHttpStatusCode(int statusCode, int? subStatusCode, DateTime noticedAt)
@@ -116,6 +114,12 @@ namespace NewRelic.Agent.Core.Errors
         private string GetFormattedHttpStatusCode(int statusCode, int? subStatusCode)
         {
             return subStatusCode == null ? $"{statusCode}" : $"{statusCode}.{subStatusCode}";
+        }
+
+        private ErrorData FromMessageInternal<T>(string errorMessage, IDictionary<string, T> customAttributes, bool isExpected)
+        {
+            var message = _configurationService.Configuration.StripExceptionMessages ? ErrorData.StripExceptionMessagesMessage : errorMessage;
+            return new ErrorData(message, CustomErrorTypeName, null, DateTime.UtcNow, CaptureAttributes(customAttributes), isExpected, null);
         }
 
         private ErrorData FromExceptionInternal(Exception exception, ReadOnlyDictionary<string, object> customAttributes)

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorEventMaker.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             _attribDefs.ErrorDotMessage.TrySetValue(attribValues, errorData.ErrorMessage);
             _attribDefs.TimestampForError.TrySetValue(attribValues, errorData.NoticedAt);
 
-            SetFingerprint(errorData, attribValues);
+            SetErrorGroup(errorData, attribValues);
             return new ErrorEventWireModel(attribValues, false, priority);
         }
 
@@ -44,13 +44,13 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             var priority = immutableTransaction.Priority;
 
             _attribDefs.GetTypeAttribute(TypeAttributeValue.TransactionError).TrySetDefault(attribValues);
-            SetFingerprint(immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData, attribValues);
+            SetErrorGroup(immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData, attribValues);
             return new ErrorEventWireModel(attribValues, isSynthetics, priority);
         }
 
-        private void SetFingerprint(ErrorData errorData, IAttributeValueCollection attribValues)
+        private void SetErrorGroup(ErrorData errorData, IAttributeValueCollection attribValues)
         {
-            _attribDefs.ErrorGroup.TrySetValue(attribValues, errorData.GroupFingerprint);
+            _attribDefs.ErrorGroup.TrySetValue(attribValues, errorData.ErrorGroup);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorTraceMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorTraceMaker.cs
@@ -105,7 +105,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         private ErrorTraceWireModel.ErrorTraceAttributesWireModel GetErrorTraceAttributes(ErrorData errorData, IAttributeValueCollection attributes, IList<string> stackTrace)
         {
-            _attribDefs.ErrorGroup.TrySetValue(attributes, errorData.GroupFingerprint);
+            _attribDefs.ErrorGroup.TrySetValue(attributes, errorData.ErrorGroup);
             return new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attributes, stackTrace);
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Errors/ErrorServiceTests.cs
@@ -317,6 +317,79 @@ namespace NewRelic.Agent.Core.Errors
 
         }
 
+        [TestCase("test group")]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("     ")]
+        public void FromException_ShouldHaveErrorGroup(string callbackReturnValue)
+        {
+            SetupConfiguration(null, null, null, false, null, null, null, true);
+            SetupErrorGroupCallback(ex => callbackReturnValue);
+
+            var testException = new Exception("Test exception message");
+            var errorData = _errorService.FromException(testException);
+
+            Assert.AreEqual(callbackReturnValue, errorData.ErrorGroup);
+        }
+
+        [Test]
+        public void FromException_ShouldNotHaveErrorGroup()
+        {
+            SetupConfiguration(null, null, null, false, null, null, null, true);
+            SetupErrorGroupCallback(null);
+
+            var testException = new Exception("Test exception message");
+            var errorData = _errorService.FromException(testException);
+
+            Assert.IsNull(errorData.ErrorGroup);
+        }
+
+        [Test]
+        public void FromException_ErrorGroupShouldUseOuterException()
+        {
+            SetupConfiguration(null, null, null, false, null, null, null, true);
+            SetupErrorGroupCallback(TestErrorGroupCallback);
+
+            var innerException = new Exception("Inner exception message");
+            var outerException = new Exception("Outer exception message", innerException);
+
+            var errorData = _errorService.FromException(outerException);
+
+            Assert.AreEqual("outer", errorData.ErrorGroup);
+
+            string TestErrorGroupCallback(Exception ex)
+            {
+                if (ex.InnerException != null)
+                {
+                    return "outer";
+                }
+
+                return "inner";
+            }
+        }
+
+        [Test]
+        public void FromMessage_ShouldNotHaveErrorGroup()
+        {
+            SetupConfiguration(null, null, null, false, null, null, null, true);
+            SetupErrorGroupCallback(ex => "test group");
+
+            var errorData = _errorService.FromMessage("test error message", new Dictionary<string, object>(), false);
+
+            Assert.IsNull(errorData.ErrorGroup);
+        }
+
+        [Test]
+        public void FromErrorHttpStatusCode_ShouldNotHaveErrorGroup()
+        {
+            SetupConfiguration(null, null, null, false, null, null, null, true);
+            SetupErrorGroupCallback(ex => "test group");
+
+            var errorData = _errorService.FromErrorHttpStatusCode(500, null, DateTime.UtcNow);
+
+            Assert.IsNull(errorData.ErrorGroup);
+        }
+
         private void SetupConfiguration(List<string> classesToBeIgnored, IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeIgnored,
             List<float> statusCodesToIgnore, bool stripExceptionMessages, List<string> errorClassesToBeExpected,
             IEnumerable<KeyValuePair<string, IEnumerable<string>>> errorMessagesToBeExpected, string expectedStatusCodes, bool errorCollectorEnabled)
@@ -377,5 +450,9 @@ namespace NewRelic.Agent.Core.Errors
             EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
         }
 
+        private void SetupErrorGroupCallback(Func<Exception, string> callback)
+        {
+            EventBus<ErrorGroupCallbackUpdateEvent>.Publish(new ErrorGroupCallbackUpdateEvent(callback));
+        }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -47,6 +47,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
             Mock.Arrange(() => _configuration.ErrorCollectorCaptureEvents).Returns(true);
+            Mock.Arrange(() => _configuration.ErrorGroupCallback).Returns((Func<Exception, string>)null);
 
             _configurationService = Mock.Create<IConfigurationService>();
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -37,17 +37,19 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private static ITimerFactory _timerFactory;
         private IAttributeDefinitionService _attribDefSvc;
         private IAttributeDefinitions _attribDefs => _attribDefSvc?.AttributeDefs;
+        private Func<Exception, string> _errorGroupCallback;
 
         [SetUp]
         public void SetUp()
         {
+            _errorGroupCallback = null;
             _configuration = Mock.Create<IConfiguration>();
 
             _attribDefSvc = new AttributeDefinitionService((f) => new AttributeDefinitions(f));
 
             Mock.Arrange(() => _configuration.ErrorCollectorEnabled).Returns(true);
             Mock.Arrange(() => _configuration.ErrorCollectorCaptureEvents).Returns(true);
-            Mock.Arrange(() => _configuration.ErrorGroupCallback).Returns((Func<Exception, string>)null);
+            Mock.Arrange(() => _configuration.ErrorGroupCallback).Returns(() => _errorGroupCallback);
 
             _configurationService = Mock.Create<IConfigurationService>();
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
@@ -248,6 +250,96 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
                 () => Assert.Contains("custom attribute name", userAttributes)
             );
+        }
+
+        [Test]
+        public void GetErrorEvent_NoTransaction_WithException_ContainsErrorGroup()
+        {
+            _errorGroupCallback = ex => "test group";
+            var errorData = _errorService.FromException(new Exception("test message"));
+
+            var errorEvent = _errorEventMaker.GetErrorEvent(errorData, new AttributeValueCollection(AttributeDestinations.ErrorEvent), 0.5f);
+
+            var agentAttributes = errorEvent.AgentAttributes();
+            var errorGroupAttribute = agentAttributes["error_group"];
+
+            Assert.AreEqual("test group", errorGroupAttribute);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("     ")]
+        public void GetErrorEvent_NoTransaction_WithException_DoesNotContainErrorGroup(string callbackReturnValue)
+        {
+            _errorGroupCallback = ex => callbackReturnValue;
+            var errorData = _errorService.FromException(new Exception("test message"));
+
+            var errorEvent = _errorEventMaker.GetErrorEvent(errorData, new AttributeValueCollection(AttributeDestinations.ErrorEvent), 0.5f);
+
+            var agentAttributeKeys = errorEvent.AgentAttributes().Keys;
+
+            CollectionAssert.DoesNotContain(agentAttributeKeys, "error_group");
+        }
+
+        [Test]
+        public void GetErrorEvent_InTransaction_WithException_ContainsErrorGroup()
+        {
+            var errorData = new ErrorData("Out of Memory Message", "OutOfMemoryError", null, DateTime.UtcNow, null, false, "test group");
+
+            var transaction = BuildTestTransaction(statusCode: 500,
+                                                            exceptionData: errorData,
+                                                            uri: "http://www.newrelic.com/test?param=value",
+                                                            referrerUri: "http://referrer.uri",
+                                                            includeUserAttributes: true);
+
+            var immutableTransaction = transaction.ConvertToImmutableTransaction();
+
+            var transactionMetricName = _transactionMetricNameMaker.GetTransactionMetricName(immutableTransaction.TransactionName);
+            var txStats = new TransactionMetricStatsCollection(transactionMetricName);
+
+            var attributes = _transactionAttributeMaker.GetAttributes(immutableTransaction, transactionMetricName, TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(15), txStats);
+
+
+            attributes.AddRange(GetIntrinsicAttributes());
+
+            var errorEvent = _errorEventMaker.GetErrorEvent(immutableTransaction, attributes);
+
+            var agentAttributes = errorEvent.AgentAttributes();
+            var errorGroupAttribute = agentAttributes["error_group"];
+
+            Assert.AreEqual("test group", errorGroupAttribute);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("     ")]
+        public void GetErrorEvent_InTransaction_WithException_DoesNotContainErrorGroup(string errorGroupValue)
+        {
+            var errorData = new ErrorData("Out of Memory Message", "OutOfMemoryError", null, DateTime.UtcNow, null, false, errorGroupValue);
+
+            var transaction = BuildTestTransaction(statusCode: 500,
+                                                            exceptionData: errorData,
+                                                            uri: "http://www.newrelic.com/test?param=value",
+                                                            referrerUri: "http://referrer.uri",
+                                                            includeUserAttributes: true);
+
+            var immutableTransaction = transaction.ConvertToImmutableTransaction();
+
+            var transactionMetricName = _transactionMetricNameMaker.GetTransactionMetricName(immutableTransaction.TransactionName);
+            var txStats = new TransactionMetricStatsCollection(transactionMetricName);
+
+            var attributes = _transactionAttributeMaker.GetAttributes(immutableTransaction, transactionMetricName, TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(15), txStats);
+
+
+            attributes.AddRange(GetIntrinsicAttributes());
+
+            var errorEvent = _errorEventMaker.GetErrorEvent(immutableTransaction, attributes);
+
+            var agentAttributeKeys = errorEvent.AgentAttributes().Keys;
+
+            CollectionAssert.DoesNotContain(agentAttributeKeys, "error_group");
         }
 
         private IAttributeValueCollection GetIntrinsicAttributes()


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the error group functionality mentioned in #1401. 
- Renames groupFingerprint to errorGroup
- Update error group attribute to not get generated if the error group is null, empty string, or just whitespace
- Gets the error group callback from configuration instead of the agent class

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- ~~[ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~~ to be updated in a separate PR 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
