### PR TITLE
Rename error_group to error.group.name

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -588,7 +588,7 @@ namespace NewRelic.Agent.Core.Attributes
 
         private AttributeDefinition<string, string> _errorGroup;
         public AttributeDefinition<string, string> ErrorGroup => _errorGroup ?? (_errorGroup =
-            AttributeDefinitionBuilder.CreateString("error_group", AttributeClassification.AgentAttributes)
+            AttributeDefinitionBuilder.CreateString("error.group.name", AttributeClassification.AgentAttributes)
                 .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace)
                 .WithConvert(IgnoreEmptyAndWhitespaceErrorGroupValues)
                 .Build(_attribFilter));

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -38,6 +38,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private IAttributeDefinitionService _attribDefSvc;
         private IAttributeDefinitions _attribDefs => _attribDefSvc?.AttributeDefs;
         private Func<Exception, string> _errorGroupCallback;
+        private const string _expectedErrorGroupAttributeName = "error.group.name";
 
         [SetUp]
         public void SetUp()
@@ -261,7 +262,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var errorEvent = _errorEventMaker.GetErrorEvent(errorData, new AttributeValueCollection(AttributeDestinations.ErrorEvent), 0.5f);
 
             var agentAttributes = errorEvent.AgentAttributes();
-            var errorGroupAttribute = agentAttributes["error_group"];
+            var errorGroupAttribute = agentAttributes[_expectedErrorGroupAttributeName];
 
             Assert.AreEqual("test group", errorGroupAttribute);
         }
@@ -278,7 +279,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var agentAttributeKeys = errorEvent.AgentAttributes().Keys;
 
-            CollectionAssert.DoesNotContain(agentAttributeKeys, "error_group");
+            CollectionAssert.DoesNotContain(agentAttributeKeys, _expectedErrorGroupAttributeName);
         }
 
         [Test]
@@ -306,7 +307,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var errorEvent = _errorEventMaker.GetErrorEvent(immutableTransaction, attributes);
 
             var agentAttributes = errorEvent.AgentAttributes();
-            var errorGroupAttribute = agentAttributes["error_group"];
+            var errorGroupAttribute = agentAttributes[_expectedErrorGroupAttributeName];
 
             Assert.AreEqual("test group", errorGroupAttribute);
         }
@@ -339,7 +340,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var agentAttributeKeys = errorEvent.AgentAttributes().Keys;
 
-            CollectionAssert.DoesNotContain(agentAttributeKeys, "error_group");
+            CollectionAssert.DoesNotContain(agentAttributeKeys, _expectedErrorGroupAttributeName);
         }
 
         private IAttributeValueCollection GetIntrinsicAttributes()

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
@@ -24,6 +24,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private ErrorService _errorService;
         private AttributeDefinitionService _attribDefSvc;
         private IAttributeDefinitions _attribDefs => _attribDefSvc.AttributeDefs;
+        private const string _expectedErrorGroupAttributeName = "error.group.name";
 
         private const string StripExceptionMessagesMessage = "Message removed by New Relic based on your currently enabled security settings.";
 
@@ -147,7 +148,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);
 
             var agentAttributes = errorTrace.Attributes.AgentAttributes;
-            var errorGroupAttribute = agentAttributes["error_group"];
+            var errorGroupAttribute = agentAttributes[_expectedErrorGroupAttributeName];
 
             Assert.AreEqual("test group", errorGroupAttribute);
         }
@@ -166,7 +167,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var agentAttributes = errorTrace.Attributes.AgentAttributes;
 
-            CollectionAssert.DoesNotContain(agentAttributes.Keys, "error_group");
+            CollectionAssert.DoesNotContain(agentAttributes.Keys, _expectedErrorGroupAttributeName);
         }
 
         [Test]
@@ -178,7 +179,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var errorTrace = _errorTraceMaker.GetErrorTrace(attributes, errorDataIn);
 
             var agentAttributes = errorTrace.Attributes.AgentAttributes;
-            var errorGroupAttribute = agentAttributes["error_group"];
+            var errorGroupAttribute = agentAttributes[_expectedErrorGroupAttributeName];
 
             Assert.AreEqual("test group", errorGroupAttribute);
         }
@@ -195,7 +196,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var agentAttributes = errorTrace.Attributes.AgentAttributes;
 
-            CollectionAssert.DoesNotContain(agentAttributes.Keys, "error_group");
+            CollectionAssert.DoesNotContain(agentAttributes.Keys, _expectedErrorGroupAttributeName);
         }
 
         private ImmutableTransaction BuildTestTransaction(string uri = null, string guid = null, int? statusCode = null, int? subStatusCode = null, IEnumerable<ErrorData> transactionExceptionDatas = null)


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Follow up to https://github.com/newrelic/newrelic-dotnet-agent/pull/1418#issuecomment-1453912439 that renames `error_group` to `error.group.name`.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
