### PR TITLE
Remove uneeded string.IsNullOrWhiteSpace check and add error group integration tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorEventMaker.cs
@@ -94,10 +94,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             using (_agentTimerService.StartNew(SetErrorGroupSupportabilityName))
             {
                 var errorGroup = _configurationService.Configuration.ErrorGroupCallback?.Invoke((IReadOnlyDictionary<string, object>)callbackAttributes);
-                if (!string.IsNullOrWhiteSpace(errorGroup))
-                {
-                    _attribDefs.ErrorGroup.TrySetValue(attribValues, errorGroup);
-                }
+                _attribDefs.ErrorGroup.TrySetValue(attribValues, errorGroup);
             }
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorTraceMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/ErrorTraceMaker.cs
@@ -138,10 +138,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             using (_agentTimerService.StartNew(SetErrorGroupSupportabilityName))
             {
                 var errorGroup = _configurationService.Configuration.ErrorGroupCallback?.Invoke((IReadOnlyDictionary<string, object>)callbackAttributes);
-                if (!string.IsNullOrWhiteSpace(errorGroup))
-                {
-                    _attribDefs.ErrorGroup.TrySetValue(attribValues, errorGroup);
-                }
+                _attribDefs.ErrorGroup.TrySetValue(attribValues, errorGroup);
             }
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
@@ -1,0 +1,178 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Api
+{
+    public abstract class ErrorGroupCallbackTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    {
+        private const string ErrorGroupName = "error.group.name";
+        private string _errorGroupValue;
+        private string _testCommand;
+
+        protected readonly TFixture Fixture;
+
+        public ErrorGroupCallbackTestsBase(TFixture fixture, ITestOutputHelper output, string testCommand, string testParameter) : base(fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestLogger = output;
+            _testCommand = testCommand;
+
+            _errorGroupValue = testParameter;
+            if (string.IsNullOrWhiteSpace(testParameter))
+            {
+                Fixture.AddCommand($"ApiCalls {testCommand}");
+            }
+            else
+            {
+                Fixture.AddCommand($"ApiCalls {testCommand} {testParameter}");
+            }
+
+            Fixture.AddCommand("AttributeInstrumentation MakeWebTransactionWithException");
+
+            Fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(Fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                    configModifier.SetLogLevel("finest");
+                    configModifier.AddExpectedErrorMessages("System.Exception", new List<string> { "Test Message" });
+                }
+            );
+
+            Fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var errorEvents = Fixture.AgentLog.GetErrorEvents();
+            var errorEvent = errorEvents.FirstOrDefault();
+
+            var errorTraces = Fixture.AgentLog.GetErrorTraces();
+            var errorTrace = errorTraces.FirstOrDefault();
+
+            var actualMetrics = Fixture.AgentLog.GetMetrics().ToList();
+
+            var apiMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Supportability/ApiInvocation/SetErrorGroupCallback"}
+            };
+
+            var asserts = new List<Action> { () => Assertions.MetricsExist(apiMetrics, actualMetrics) };
+            if (_testCommand == "TestSetErrorGroupCallbackReturnsString")
+            {
+                StringTests(asserts, errorEvent, errorTrace);
+            }
+            else if (_testCommand == "TestSetErrorGroupCallbackWithKeys")
+            {
+                DictionaryTests(asserts, errorEvent, errorTrace);
+            }
+            else if (_testCommand == "TestNullSetErrorGroupCallback")
+            {
+                NullTests(asserts, errorEvent, errorTrace);
+            }
+            else
+            {
+                Assert.True(false, "Test Command was invalid: " + _testCommand);
+            }
+
+            NrAssert.Multiple(asserts.ToArray());
+        }
+
+        private void StringTests(List<Action> asserts, ErrorEventEvents errorEvent, ErrorTrace errorTrace)
+        {
+            var expectedAgentAttributes = new Dictionary<string, string>
+            {
+                { ErrorGroupName, _errorGroupValue}
+            };
+
+            asserts.Add(() => Assertions.ErrorEventHasAttributes(expectedAgentAttributes, EventAttributeType.Agent, errorEvent));
+            asserts.Add(() => Assertions.ErrorTraceHasAttributes(expectedAgentAttributes, ErrorTraceAttributeType.Agent, errorTrace));
+        }
+
+        private void DictionaryTests(List<Action> asserts, ErrorEventEvents errorEvent, ErrorTrace errorTrace)
+        {
+            var expectedAgentAttributes = new Dictionary<string, string>
+            {
+                { ErrorGroupName, "success"}
+            };
+
+            asserts.Add(() => Assertions.ErrorEventHasAttributes(expectedAgentAttributes, EventAttributeType.Agent, errorEvent));
+            asserts.Add(() => Assertions.ErrorTraceHasAttributes(expectedAgentAttributes, ErrorTraceAttributeType.Agent, errorTrace));
+        }
+
+        private void NullTests(List<Action> asserts, ErrorEventEvents errorEvent, ErrorTrace errorTrace)
+        {
+            var unexpectedAgentAttributes = new List<string> { ErrorGroupName };
+
+            asserts.Add(() => Assertions.ErrorEventDoesNotHaveAttributes(unexpectedAgentAttributes, EventAttributeType.Agent, errorEvent));
+            asserts.Add(() => Assertions.ErrorTraceDoesNotHaveAttributes(unexpectedAgentAttributes, ErrorTraceAttributeType.Agent, errorTrace));
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ErrorGroupCallbackReturnsStringTestsFW : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ErrorGroupCallbackReturnsStringTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestSetErrorGroupCallbackReturnsString", "CustomErrorGroup")
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ErrorGroupCallbackWithKeyTestsFW : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ErrorGroupCallbackWithKeyTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestSetErrorGroupCallbackWithKeys", string.Empty)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ErrorGroupCallbackNullTestsFW : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ErrorGroupCallbackNullTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestNullSetErrorGroupCallback",  string.Empty)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ErrorGroupCallbackReturnsStringTestsCore : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ErrorGroupCallbackReturnsStringTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestSetErrorGroupCallbackReturnsString", "CustomErrorGroup")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ErrorGroupCallbackWithKeyTestsCore : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ErrorGroupCallbackWithKeyTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestSetErrorGroupCallbackWithKeys", string.Empty)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ErrorGroupCallbackNullTestsCore : ErrorGroupCallbackTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ErrorGroupCallbackNullTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, "TestNullSetErrorGroupCallback", string.Empty)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
@@ -4,6 +4,7 @@
 
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -61,6 +62,69 @@ namespace MultiFunctionApplicationHelpers.Libraries
         public static void TestSetTransactionUserId(string userId)
         {
             NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction.SetUserId(userId);
+        }
+
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestSetErrorGroupCallbackReturnsString(string callbackReturn)
+        {
+            NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback((x) => callbackReturn);
+        }
+
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestSetErrorGroupCallbackWithKeys()
+        {
+            // list of keys that are expected as part of agent spec
+            var expectedKeys = new[]
+            {
+                "error.class",
+                "error.message",
+                "stack_trace",
+                "transactionName",
+                "request.uri",
+                "error.expected"
+                // The following attribute keys are expected to be available, but in this specific test, they are not.
+                // "http.statusCode", (no http call in test)
+                // "request.method" (no http call in test)
+                // "transactionUiName" (Not available)
+            };
+
+            NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback((dict) =>
+            {
+                if (dict == null)
+                {
+                    return "IReadOnlyDictionary was null";
+                }
+
+                if (dict.Count < 1)
+                {
+                    return "IReadOnlyDictionary Count was " + dict.Count;
+                }
+
+                var missingKeys = new List<string>();
+                foreach (var key in expectedKeys)
+                {
+                    if (!dict.ContainsKey(key))
+                    {
+                        missingKeys.Add(key);
+                    }
+                }
+
+                if (missingKeys.Count > 0)
+                {
+                    return "IReadOnlyDictionary missing keys: " + string.Join(", ", missingKeys);
+                }
+
+                return "success";
+            });
+        }
+
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestNullSetErrorGroupCallback()
+        {
+            NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback((Func<IReadOnlyDictionary<string, object>, string>)null);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AttributeInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AttributeInstrumentation.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
@@ -132,6 +133,20 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Internal
             Task.Delay(TimeSpan.FromMilliseconds(10)).Wait();
 
             DoSomeWork(spanName);
+        }
+
+        /// <summary>
+        /// Synchronous method creating a Web transaction With Exception (NoticeError)
+        /// </summary>
+        [LibraryMethod]
+        [Transaction(Web = true)]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void MakeWebTransactionWithException()
+        {
+            Task.Delay(TimeSpan.FromMilliseconds(100)).Wait();
+            var exception = new Exception("Test Message");
+            NewRelic.Api.Agent.NewRelic.NoticeError(exception);
+            Task.Delay(TimeSpan.FromMilliseconds(1000)).Wait();
         }
     }
 }


### PR DESCRIPTION
## Description

Adds integration tests for errors inbox error grouping

- Tests that the API call supportability metric is present
- Tests that attribute is not added if callback is null
- Tests that the string is passed back correctly from the callback
- Tests that the spec required attributes are in the dictionary passed to the callback - there are some exceptions called out in the test fixture.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
