### PR TITLE
More realistic use of SetErrorGroupCallback

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
     public abstract class ErrorGroupCallbackTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         private const string ErrorGroupName = "error.group.name";
-        private const string ErrorGroupValue = "CustomErrorGroup";
+        private const string ErrorGroupValue = "TestErrors";
 
         protected readonly TFixture Fixture;
 
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
             Fixture = fixture;
             Fixture.TestLogger = output;
 
-            Fixture.AddCommand($"ApiCalls TestSetErrorGroupCallbackReturnsString " + ErrorGroupValue);
+            Fixture.AddCommand($"ApiCalls TestSetErrorGroupCallback");
             Fixture.AddCommand("AttributeInstrumentation MakeWebTransactionWithException");
 
             Fixture.Actions

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
@@ -4,7 +4,6 @@
 
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -66,9 +65,22 @@ namespace MultiFunctionApplicationHelpers.Libraries
 
         [LibraryMethod]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public static void TestSetErrorGroupCallbackReturnsString(string callbackReturn)
+        public static void TestSetErrorGroupCallback()
         {
-            NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback((x) => callbackReturn);
+            NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(ErrorGroupCallback);
+        }
+
+        private static string ErrorGroupCallback(IReadOnlyDictionary<string, object> attributes)
+        {
+            var errorGroupName = "OtherErrors";
+            if (attributes.TryGetValue("error.message", out var errorMessage))
+            {
+                if (errorMessage.ToString() == "Test Message") // See AttributeInstrumentation.MakeWebTransactionWithException
+                {
+                    errorGroupName = "TestErrors";
+                }
+            }
+            return errorGroupName;
         }
     }
 }


### PR DESCRIPTION
## Description

Update the integration tests for SetErrorGroupCallback to be a slightly more realistic example of how the API might be used by a customer.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] ~Performance testing completed with satisfactory results (if required)~
- [ ] ~[Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated~

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
