### PR TITLE
Update Restsharp to most recent version in tests

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -257,10 +257,17 @@
 
   <!-- RestSharp -->
   <ItemGroup>
+    <!-- This version is used to test against our minimum supported version called out in docs, and
+    to test a version older than 106.7.0 which uses different instrumentation code. -->
     <PackageReference Include="RestSharp" Version="105.2.3" Condition="'$(TargetFramework)' == 'net462'" />
+    <!-- This version is used to test against versions greater than 106.7.0 and less than 107.0.0 to
+    test against the restsharp instrumentation for those versions. -->
     <PackageReference Include="RestSharp" Version="106.15.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <!-- Beginning with version 107.0.0 we rely on httpclient instrumentation to capture the appropriate
+    data from RestSharp usage. -->
     <PackageReference Include="RestSharp" Version="107.3.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RestSharp" Version="108.0.3" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
+    <PackageReference Include="RestSharp" Version="109.0.1" Condition="'$(TargetFramework)' == 'net481'" />
     
     <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
@@ -179,7 +179,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
             {
                 var options = new RestClientOptions($"http://{myHost}:{myPort}")
                 {
+#if NET481
+                    MaxTimeout = 1
+#else
                     Timeout = 1
+#endif
                 };
                 var client = new RestClient(options);
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates Restsharp version `108.0.3` to `109.0.1` in the integration tests. Also replaces the restsharp usage of `Timeout` with `MaxTimeout` because it was deprecated (in `108.0.0`) and removed (in `109.0.0`).

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
