### PR TITLE
Run S3 index after deploy

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -126,6 +126,7 @@ jobs:
         shell: pwsh
 
   index-download-site:
+    needs: deploy-downloadsite
     name: Rebuild indexes on the download site
     if: ${{ github.event.inputs.indexdownloadsite == 'true' }}
     uses: ./.github/workflows/build_download_site_index_files.yml


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The s3 index currently runs at the same time/before the download site deploy. This should make the index job wait until deploy has completed

# Reviewer Checklist
- [ ] Perform code review
