### PR TITLE
Reduce build warnings in the unbounded integration tests solution

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
@@ -74,12 +74,14 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             startInfo.EnvironmentVariables.Remove("COR_ENABLE_PROFILING");
             startInfo.EnvironmentVariables.Remove("COR_PROFILER");
             startInfo.EnvironmentVariables.Remove("COR_PROFILER_PATH");
-            startInfo.EnvironmentVariables.Remove("NEWRELIC_HOME");
             startInfo.EnvironmentVariables.Remove("NEWRELIC_INSTALL_PATH");
-            startInfo.EnvironmentVariables.Remove("NEWRELIC_PROFILER_LOG_DIRECTORY");
             startInfo.EnvironmentVariables.Remove("NEWRELIC_LICENSEKEY");
             startInfo.EnvironmentVariables.Remove("NEW_RELIC_LICENSE_KEY");
             startInfo.EnvironmentVariables.Remove("NEW_RELIC_HOST");
+            startInfo.EnvironmentVariables.Remove("NEWRELIC_HOME");
+            startInfo.EnvironmentVariables.Remove("NEWRELIC_PROFILER_LOG_DIRECTORY");
+            startInfo.EnvironmentVariables.Remove("NEWRELIC_LOG_DIRECTORY");
+            startInfo.EnvironmentVariables.Remove("NEWRELIC_LOG_LEVEL");
 
             // configure env vars as needed for testing environment overrides
             foreach (var envVar in environmentVariables)

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -94,29 +94,14 @@
     <PackageReference Include="Microsoft.Web.Infrastructure">
       <Version>1.0.0.0</Version>
     </PackageReference>
-    <PackageReference Include="MySql.Data">
-      <Version>8.0.25</Version>
-    </PackageReference>
-    <PackageReference Include="MySqlConnector">
-      <Version>1.0.1</Version>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Npgsql">
-      <Version>4.0.5</Version>
     </PackageReference>
     <PackageReference Include="Oracle.ManagedDataAccess">
       <Version>12.1.2400</Version>
     </PackageReference>
     <PackageReference Include="ServiceStack.Text">
       <Version>4.0.40</Version>
-    </PackageReference>
-    <PackageReference Include="StackExchange.Redis">
-      <Version>1.0.488</Version>
-    </PackageReference>
-    <PackageReference Include="StackExchange.Redis.StrongName">
-      <Version>1.0.488</Version>
     </PackageReference>
     <PackageReference Include="System.Buffers">
       <Version>4.4.0</Version>

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -88,9 +88,6 @@
     <PackageReference Include="Microsoft.AspNet.WebPages">
       <Version>3.2.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.SqlClient">
-      <Version>3.1.1</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Web.Infrastructure">
       <Version>1.0.0.0</Version>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
@@ -1,8 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;


### PR DESCRIPTION
## Description

This reduces the number of build warnings seen when building the unbounded integration tests solution by removing unnecessary package references from the BasicMvcApplication project.

This PR also fixes a problem I saw where some HostedWebCore-based tests were failing on my local machine because:

1. I had the `NEWRELIC_LOG_LEVEL` env var set globally on my machine with a value of `info`
2. The test harness wasn't removing that env var before starting the test app
3. None of the test assertions could pass because the agent log data they depend on are logged at `debug` level

I made the list of env vars removed before launching a HostedWebCore test app (i.e. `RemoteWebApplication`) look more like the list of env vars removed before launching a console test app (`RemoteService`).

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
