### PR TITLE
Reduce agent request payload logging

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -73,7 +73,6 @@ namespace NewRelic.Agent.Core.DataTransport
             {
                 var uri = GetUri(method, connectionInfo);
 
-                Log.DebugFormat("Request({0}): About to Invoke \"{1}\" with : {2}", requestGuid, method, serializedData);
                 AuditLog(Direction.Sent, Source.InstrumentedApp, uri.ToString());
                 AuditLog(Direction.Sent, Source.InstrumentedApp, serializedData);
 
@@ -245,7 +244,7 @@ namespace NewRelic.Agent.Core.DataTransport
             }
 
             // P17: Not supposed to read/use the exception message in the connect response body. We are still going to log it, carefully, since it is very useful for support.
-            Log.ErrorFormat("Request({0}): Received HTTP status code {1} with message {2}", requestGuid, statusCode.ToString(), responseText);
+            Log.ErrorFormat("Request({0}): Received HTTP status code {1} with message {2}. Request content was: {3}", requestGuid, statusCode.ToString(), responseText, serializedData);
 
             throw new HttpException(statusCode, responseText);
         }


### PR DESCRIPTION
## Description

About year ago, we modified the agent to log (at debug level) both that it was "About to invoke" a request to the collector with a payload of data, and that it had successfully "Invoked" that same call.  This was to help with some integration test instability caused when the same request had to be sent multiple times due to collector errors.  The payload of data being sent was included in both "About to invoke" and "Invoked" log messages, in case there was an error response from the collector and the payload contents would be useful in diagnosing the error.  (The payload needs to be logged in the "Invoked" messages for the integration tests to work.)

However, this significantly increased the volume of data in agent logs at the debug level under normal circumstances. This PR removes the "about to invoke" log message in favor of logging the payload in any error handling log messages.

Note: will do the changelog once the PR number is known.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] ~Performance testing completed with satisfactory results (if required)~
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
