### PR TITLE
fix: renamed classes that could cause Unity DI registration by convention to fail

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 * Reduce redundant collector request data payload logging in the agent log at DEBUG level. [#1449](https://github.com/newrelic/newrelic-dotnet-agent/pull/1449)
+* Fixes [#654](https://github.com/newrelic/newrelic-dotnet-agent/issues/654) so that Unity DI registration by convention succeeds when scanning NewRelic assemblies. [1476](https://github.com/newrelic/newrelic-dotnet-agent/pull/1476)
 
 ### Other
 * Renamed `NewRelic.Providers.Wrapper.Asp35` to `NewRelic.Providers.Wrapper.AspNet` since this wrapper instruments multiple versions of ASP.NET. Updated installers to remove old `Asp35` artifacts. [#1448](https://github.com/newrelic/newrelic-dotnet-agent/pull/1448)

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValue.cs
@@ -18,9 +18,9 @@ namespace NewRelic.Agent.Core.Attributes
     }
 
     [DebuggerDisplay("{_value ?? _lazyValue}")]
-    public class AttributeValue : IAttributeValue
+    public class AttributeValueCore : IAttributeValue
     {
-        public AttributeValue(AttributeDefinition attribDef)
+        public AttributeValueCore(AttributeDefinition attribDef)
         {
             AttributeDefinition = attribDef;
         }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValueCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValueCollection.cs
@@ -296,17 +296,17 @@ namespace NewRelic.Agent.Core.Attributes
         }
     }
 
-    public class AttributeValueCollection : AttributeValueCollectionBase<AttributeValue>
+    public class AttributeValueCollectionCore : AttributeValueCollectionBase<AttributeValueCore>
     {
-        public AttributeValueCollection(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes) : base(fromCollection, targetModelTypes)
+        public AttributeValueCollectionCore(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes) : base(fromCollection, targetModelTypes)
         {
         }
 
-        public AttributeValueCollection(params AttributeDestinations[] targetModelTypes) : base(targetModelTypes)
+        public AttributeValueCollectionCore(params AttributeDestinations[] targetModelTypes) : base(targetModelTypes)
         {
         }
 
-        public AttributeValueCollection(string transactionGuid, params AttributeDestinations[] targetModelTypes) : base(transactionGuid, targetModelTypes)
+        public AttributeValueCollectionCore(string transactionGuid, params AttributeDestinations[] targetModelTypes) : base(transactionGuid, targetModelTypes)
         {
         }
 
@@ -317,41 +317,41 @@ namespace NewRelic.Agent.Core.Attributes
             { AttributeClassification.UserAttributes, new object() }
         };
 
-        private Dictionary<Guid, AttributeValue> _intrinsicAttributes;
-        private Dictionary<Guid, AttributeValue> _agentAttributes;
-        private Dictionary<Guid, AttributeValue> _userAttributes;
+        private Dictionary<Guid, AttributeValueCore> _intrinsicAttributes;
+        private Dictionary<Guid, AttributeValueCore> _agentAttributes;
+        private Dictionary<Guid, AttributeValueCore> _userAttributes;
 
-        private Dictionary<Guid, AttributeValue> GetAttribValuesInternal(AttributeClassification classification, bool withCreate)
+        private Dictionary<Guid, AttributeValueCore> GetAttribValuesInternal(AttributeClassification classification, bool withCreate)
         {
             switch (classification)
             {
                 case AttributeClassification.Intrinsics:
                     return withCreate
-                        ? _intrinsicAttributes ??= new Dictionary<Guid, AttributeValue>()
+                        ? _intrinsicAttributes ??= new Dictionary<Guid, AttributeValueCore>()
                         : _intrinsicAttributes;
 
                 case AttributeClassification.AgentAttributes:
                     return withCreate
-                        ? _agentAttributes ??= new Dictionary<Guid, AttributeValue>()
+                        ? _agentAttributes ??= new Dictionary<Guid, AttributeValueCore>()
                         : _agentAttributes;
 
                 case AttributeClassification.UserAttributes:
                     return withCreate
-                        ? _userAttributes ??= new Dictionary<Guid, AttributeValue>()
+                        ? _userAttributes ??= new Dictionary<Guid, AttributeValueCore>()
                         : _userAttributes;
             }
 
             return null;
         }
 
-        protected override IEnumerable<AttributeValue> GetAttribValuesImpl(AttributeClassification classification)
+        protected override IEnumerable<AttributeValueCore> GetAttribValuesImpl(AttributeClassification classification)
         {
             var dic = GetAttribValuesInternal(classification, false);
 
-            return dic?.Values ?? Enumerable.Empty<AttributeValue>();
+            return dic?.Values ?? Enumerable.Empty<AttributeValueCore>();
         }
 
-        protected override void RemoveItemsImpl(IEnumerable<AttributeValue> itemsToRemove)
+        protected override void RemoveItemsImpl(IEnumerable<AttributeValueCore> itemsToRemove)
         {
             foreach (var lockObjKvp in _lockObjects)
             {
@@ -394,7 +394,7 @@ namespace NewRelic.Agent.Core.Attributes
 
         protected override bool SetValueImpl(IAttributeValue attribVal)
         {
-            if (attribVal is AttributeValue attribValTyped)
+            if (attribVal is AttributeValueCore attribValTyped)
             {
                 return SetValueImplInternal(attribValTyped);
             }
@@ -419,7 +419,7 @@ namespace NewRelic.Agent.Core.Attributes
                 return false;
             }
 
-            var attribVal = new AttributeValue(attribDef)
+            var attribVal = new AttributeValueCore(attribDef)
             {
                 Value = value
             };
@@ -434,7 +434,7 @@ namespace NewRelic.Agent.Core.Attributes
                 return false;
             }
 
-            var attribVal = new AttributeValue(attribDef)
+            var attribVal = new AttributeValueCore(attribDef)
             {
                 LazyValue = lazyValue
             };
@@ -442,7 +442,7 @@ namespace NewRelic.Agent.Core.Attributes
             return SetValueImplInternal(attribVal);
         }
 
-        private bool SetValueImplInternal(AttributeValue attribVal)
+        private bool SetValueImplInternal(AttributeValueCore attribVal)
         {
             if (IsImmutable)
             {

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
@@ -111,7 +111,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             var queueTime = transaction.TransactionMetadata.QueueTime ?? _zeroTimespan;
             var applicationTime = transaction.GetDurationUntilNow();
 
-            var attributes = new AttributeValueCollection(AttributeDestinations.JavaScriptAgent);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.JavaScriptAgent);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, transaction.TransactionMetadata);
 
             // for now, treat tripId as an agent attribute when passing to browser.  Eventually this will be an intrinsic but need changes to browser code first.
@@ -128,7 +128,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             return new BrowserMonitoringConfigurationData(licenseKey, beacon, errorBeacon, browserMonitoringKey, applicationId, obfuscatedTransactionName, queueTime, applicationTime, jsAgentPayloadFile, obfuscatedFormattedAttributes, sslForHttp);
         }
 
-        private string GetObfuscatedFormattedAttributes(AttributeValueCollection attribValues, string licenseKey)
+        private string GetObfuscatedFormattedAttributes(AttributeValueCollectionCore attribValues, string licenseKey)
         {
             if (attribValues == null)
             {

--- a/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/ITransactionAttributeMetadata.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.Core.Transactions
     public interface ITransactionAttributeMetadata
     {
 
-        AttributeValueCollection UserAndRequestAttributes { get; }
+        AttributeValueCollectionCore UserAndRequestAttributes { get; }
 
         IReadOnlyTransactionErrorState ReadOnlyTransactionErrorState { get; }
 

--- a/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/TransactionMetadata.cs
@@ -90,8 +90,8 @@ namespace NewRelic.Agent.Core.Transactions
         private volatile string _originalUri;
         private volatile string _referrerUri;
 
-        private readonly AttributeValueCollection _transactionAttributes;
-        public AttributeValueCollection UserAndRequestAttributes => _transactionAttributes;
+        private readonly AttributeValueCollectionCore _transactionAttributes;
+        public AttributeValueCollectionCore UserAndRequestAttributes => _transactionAttributes;
 
         private readonly ConcurrentHashSet<string> _allCrossApplicationPathHashes = new ConcurrentHashSet<string>();
         private volatile bool _hasResponseCatHeaders;
@@ -101,7 +101,7 @@ namespace NewRelic.Agent.Core.Transactions
         public TransactionMetadata(string transactionGuid)
         {
             _transactionGuid = transactionGuid;
-            _transactionAttributes = new AttributeValueCollection(transactionGuid, AttributeValueCollection.AllTargetModelTypes);
+            _transactionAttributes = new AttributeValueCollectionCore(transactionGuid, AttributeValueCollectionCore.AllTargetModelTypes);
         }
 
         public IImmutableTransactionMetadata ConvertToImmutableMetadata()

--- a/src/Agent/NewRelic/Agent/Core/Transformers/CustomErrorDataTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/CustomErrorDataTransformer.cs
@@ -50,7 +50,7 @@ namespace NewRelic.Agent.Core.Transformers
                 return;
             }
 
-            var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace);
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace);
 
             if (errorData.CustomAttributes != null && _configurationService.Configuration.CaptureCustomParameters)
             {
@@ -66,8 +66,8 @@ namespace NewRelic.Agent.Core.Transformers
             _attribDefs.TransactionNameForError.TrySetValue(attribValues, errorData.Path);
 
             //We have to do the filtering here b/c these methods further update
-            var errorTrace = _errorTraceMaker.GetErrorTrace(new AttributeValueCollection(attribValues, AttributeDestinations.ErrorTrace), errorData);
-            var errorEvent = _errorEventMaker.GetErrorEvent(errorData, new AttributeValueCollection(attribValues, AttributeDestinations.ErrorEvent), priority);
+            var errorTrace = _errorTraceMaker.GetErrorTrace(new AttributeValueCollectionCore(attribValues, AttributeDestinations.ErrorTrace), errorData);
+            var errorEvent = _errorEventMaker.GetErrorEvent(errorData, new AttributeValueCollectionCore(attribValues, AttributeDestinations.ErrorEvent), priority);
 
             _errorTraceAggregator.Collect(errorTrace);
             _errorEventAggregator.Collect(errorEvent);

--- a/src/Agent/NewRelic/Agent/Core/Transformers/CustomEventTransformer.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/CustomEventTransformer.cs
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.Transformers
                 return;
             }
 
-            var attribValues = new AttributeValueCollection(AttributeDestinations.CustomEvent);
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.CustomEvent);
 
             _attribDefs.CustomEventType.TrySetValue(attribValues, eventType);
             _attribDefs.Timestamp.TrySetDefault(attribValues);

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
         public IAttributeValueCollection GetAttributes(ImmutableTransaction immutableTransaction, TransactionMetricName transactionMetricName, TimeSpan? apdexT, TimeSpan totalTime, TransactionMetricStatsCollection txStats)
         {
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             SetUserAndAgentAttributes(attribVals, immutableTransaction.TransactionMetadata);
             SetIntrinsicAttributes(attribVals, immutableTransaction, transactionMetricName, apdexT, totalTime, txStats);

--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTraceMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionTraceMaker.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
             if (!segmentTrees.Any())
                 throw new ArgumentException("There must be at least one segment to create a trace");
 
-            var filteredAttributes = new AttributeValueCollection(attribValues, AttributeDestinations.TransactionTrace);
+            var filteredAttributes = new AttributeValueCollectionCore(attribValues, AttributeDestinations.TransactionTrace);
 
             // See spec for details on these fields: https://source.datanerd.us/agents/agent-specs/blob/master/Transaction-Trace-LEGACY.md
             var startTime = immutableTransaction.StartTime;

--- a/src/Agent/NewRelic/Agent/Core/WireModels/ErrorEventWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/ErrorEventWireModel.cs
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.Core.WireModels
         protected EventWireModel(AttributeDestinations targetObject, IAttributeValueCollection attribValues, bool isSynthetics, float priority)
         {
             _targetObject = targetObject;
-            AttributeValues = new AttributeValueCollection(attribValues, _targetObject);
+            AttributeValues = new AttributeValueCollectionCore(attribValues, _targetObject);
             Priority = priority;
             IsSynthetics = isSynthetics;
 

--- a/src/Agent/NewRelic/Agent/Core/WireModels/ErrorTraceWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/ErrorTraceWireModel.cs
@@ -81,7 +81,7 @@ namespace NewRelic.Agent.Core.WireModels
 
             public ErrorTraceAttributesWireModel(IAttributeValueCollection attribValues, IList<string> stackTrace = null)
             {
-                var filteredAttribValues = new AttributeValueCollection(attribValues, AttributeDestinations.ErrorTrace);
+                var filteredAttribValues = new AttributeValueCollectionCore(attribValues, AttributeDestinations.ErrorTrace);
 
                 filteredAttribValues.MakeImmutable();
 

--- a/src/Agent/NewRelic/Agent/Core/WireModels/TransactionTraceWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/TransactionTraceWireModel.cs
@@ -106,7 +106,7 @@ namespace NewRelic.Agent.Core.WireModels
 
             public TransactionTraceAttributes(IAttributeValueCollection attribValues)
             {
-                var filteredAttribs = new AttributeValueCollection(attribValues, AttributeDestinations.TransactionTrace);
+                var filteredAttribs = new AttributeValueCollectionCore(attribValues, AttributeDestinations.TransactionTrace);
 
                 filteredAttribs.MakeImmutable();
 

--- a/tests/Agent/UnitTests/CompositeTests/AttributeServiceTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AttributeServiceTests.cs
@@ -22,7 +22,7 @@ namespace CompositeTests
         {
             _compositeTestAgent = new CompositeTestAgent();
            
-            _attribValues = new AttributeValueCollection(AttributeDestinations.TransactionEvent);
+            _attribValues = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent);
         }
 
         [TearDown]

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/CustomEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/CustomEventAggregatorTests.cs
@@ -63,7 +63,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         private IAttributeValueCollection GetCustomEventAttribs()
         {
-            var result = new AttributeValueCollection(AttributeDestinations.CustomEvent);
+            var result = new AttributeValueCollectionCore(AttributeDestinations.CustomEvent);
             _attribDefs.CustomEventType.TrySetValue(result, "event_type");
             _attribDefs.Timestamp.TrySetDefault(result);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/ErrorEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/ErrorEventAggregatorTests.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.Core.Aggregators
         private readonly static Dictionary<string, object> _emptyAttributes = new Dictionary<string, object>();
         private readonly static Dictionary<string, object> _intrinsicAttributes = new Dictionary<string, object> { { TimeStampKey, DateTime.UtcNow.ToUnixTimeMilliseconds() } };
 
-        private readonly static AttributeValueCollection _attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+        private readonly static AttributeValueCollectionCore _attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
 
         [SetUp]
         public void SetUp()

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/TransactionEventAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/TransactionEventAggregatorTests.cs
@@ -35,7 +35,7 @@ namespace NewRelic.Agent.Core.Aggregators
         private static readonly TimeSpan ConfiguredHarvestCycle = TimeSpan.FromSeconds(5);
 
         private const string TimeStampKey = "timestamp";
-        private readonly static AttributeValueCollection _attribValues = new AttributeValueCollection(AttributeDestinations.TransactionEvent);
+        private readonly static AttributeValueCollectionCore _attribValues = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent);
 
         private const int MaxSamplesStored = 10000;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeCollectionTests.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         [SetUp]
         public void SetUp()
         {
-            _attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            _attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
             _attribDefSvc = new AttributeDefinitionService((f) => new AttributeDefinitions(f));
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
@@ -269,7 +269,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         [Test]
         public void LazyValueTest_TransactionEvents()
         {
-            var attribValues = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribValues = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             LazyValueTest_SetAttribValues(attribValues);
 
             var wireModel = new TransactionEventWireModel(attribValues, false, .5f);
@@ -280,7 +280,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         [Test]
         public void LazyValueTest_ErrorEvents()
         {
-            var attribValues = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribValues = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             LazyValueTest_SetAttribValues(attribValues);
 
             var wireModel = new ErrorEventWireModel(attribValues, false, .5f);
@@ -304,7 +304,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         [Test]
         public void LazyValueTest_TransactionTrace()
         {
-            var attribValues = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribValues = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             LazyValueTest_SetAttribValues(attribValues);
 
             var wireModel = new TransactionTraceData.TransactionTraceAttributes(attribValues);
@@ -315,7 +315,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         [Test]
         public void LazyValueTest_ErrorTrace()
         {
-            var attribValues = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribValues = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             LazyValueTest_SetAttribValues(attribValues);
 
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeFilterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeFilterTests.cs
@@ -381,7 +381,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         public void when(TestCase testCase)
         {
             // Arrange
-            var unfilteredAttribs = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var unfilteredAttribs = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var attributeFilterSettings = testCase.Configuration.ToAttributeFilterSettings();
             var testCaseDestinations = testCase.AttributeDestinations.ToAttributeDestinations();
@@ -405,9 +405,9 @@ namespace NewRelic.Agent.Core.Attributes.Tests
 
             attrib.TrySetValue(unfilteredAttribs, "foo");
 
-            foreach(var testDestination in AttributeValueCollection.AllTargetModelTypes)
+            foreach(var testDestination in AttributeValueCollectionCore.AllTargetModelTypes)
             {
-                var filteredAttribs = new AttributeValueCollection(unfilteredAttribs, testDestination);
+                var filteredAttribs = new AttributeValueCollectionCore(unfilteredAttribs, testDestination);
 
                 var countMatchAttribValues = filteredAttribs.GetAttributeValues(AttributeClassification.UserAttributes)
                         .Count(x => x.AttributeDefinition.Name == testCase.AttributeKey);

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeTests.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
                 .CreateCustomAttribute("test", AttributeDestinations.All)
                 .Build(filter);
 
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             attribDef.TrySetValue(attribVals, attributeValue);
 
@@ -86,7 +86,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
                 .CreateCustomAttribute("test", AttributeDestinations.All)
                 .Build(filter);
 
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var trySetResult = attribDef.TrySetValue(attribVals, null);
 
@@ -109,7 +109,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
                 .CreateCustomAttribute("test", AttributeDestinations.All)
                 .Build(filter);
 
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var trySetResult = attribDef.TrySetValue(attribVals, string.Empty);
 
@@ -131,7 +131,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
                 .CreateCustomAttribute("test", AttributeDestinations.All)
                 .Build(filter);
 
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var trySetResult = attribDef.TrySetValue(attribVals, " ");
 
@@ -149,7 +149,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         public void Attributes_key_size()
         {
             var filter = new AttributeFilter(new AttributeFilter.Settings());
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var testKeys = new string[]
                 {
@@ -188,7 +188,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         public void Attributes_value_size_errors()
         {
             var filter = new AttributeFilter(new AttributeFilter.Settings());
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var attributes = new Dictionary<string, string>
             {
@@ -227,7 +227,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         public void Attributes_value_size_other_strings()
         {
             var filter = new AttributeFilter(new AttributeFilter.Settings());
-            var attribVals = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attribVals = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
 
             var attributes = new Dictionary<string, string>
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/CustomEvents/CustomEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CustomEvents/CustomEventWireModelTests.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.CustomEvents.Tests
                     new Dictionary<string, object>()
                 };
 
-                var attribVals = new AttributeValueCollection(AttributeDestinations.CustomEvent);
+                var attribVals = new AttributeValueCollectionCore(AttributeDestinations.CustomEvent);
 
                 _attribDefs.Timestamp.TrySetValue(attribVals, timestampVal);
                 _attribDefs.CustomEventType.TrySetValue(attribVals, typeVal);

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -333,7 +333,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             var spanEvents = _spanEventMaker.GetSpanEvents(immutableTransaction, TransactionName, transactionAttributes).ToList();
             var spanEvent = spanEvents[1];
             var rootSpanEvent = spanEvents[0];
-            var errorEventAttributes = new AttributeValueCollection(transactionAttributes, AttributeDestinations.ErrorEvent);
+            var errorEventAttributes = new AttributeValueCollectionCore(transactionAttributes, AttributeDestinations.ErrorEvent);
 
             // ASSERT
             NrAssert.Multiple(
@@ -364,7 +364,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             var spanEvents = _spanEventMaker.GetSpanEvents(immutableTransaction, TransactionName, transactionAttributes).ToList();
             var spanEvent = spanEvents[1];
             var rootSpanEvent = spanEvents[0];
-            var errorEventAttributes = new AttributeValueCollection(transactionAttributes, AttributeDestinations.ErrorEvent);
+            var errorEventAttributes = new AttributeValueCollectionCore(transactionAttributes, AttributeDestinations.ErrorEvent);
 
             // ASSERT
             NrAssert.Multiple(

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/ImmutableTransactionBuilder.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.Core.Transactions
 
         public int? HttpResponseStatusCode { get; }
 
-        public AttributeValueCollection UserAndRequestAttributes { get; }
+        public AttributeValueCollectionCore UserAndRequestAttributes { get; }
 
         public IEnumerable<string> CrossApplicationAlternatePathHashes { get; }
 
@@ -59,7 +59,7 @@ namespace NewRelic.Agent.Core.Transactions
             string originalUri,
             string referrerUri,
             TimeSpan? queueTime,
-            AttributeValueCollection userAndRequestAttributes,
+            AttributeValueCollectionCore userAndRequestAttributes,
             ITransactionErrorState transactionErrorState,
             int? httpResponseStatusCode,
             int? httpResponseSubStatusCode,
@@ -247,7 +247,7 @@ namespace NewRelic.Agent.Core.Transactions
                 originalUri: "originalUri",
                 referrerUri: "referrerUri",
                 queueTime: new TimeSpan(1),
-                userAndRequestAttributes: new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes),
+                userAndRequestAttributes: new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes),
                 transactionErrorState: _transactionErrorState,
                 httpResponseStatusCode: 200,
                 httpResponseSubStatusCode: 201,

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/CustomErrorDataTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/CustomErrorDataTransformerTests.cs
@@ -77,7 +77,7 @@ namespace NewRelic.Agent.Core.Transformers
         public void Transform_FiltersAttributesBeforeSendingThemToErrorTraceMaker()
         {
             // ARRANGE
-            var attribValues = new AttributeValueCollection(AttributeDestinations.TransactionEvent, AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace, AttributeDestinations.JavaScriptAgent); ;
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent, AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace, AttributeDestinations.JavaScriptAgent); ;
 
             _attribDefs.GetCustomAttributeForCustomEvent("CustomEventAttrib").TrySetValue(attribValues, "CustomEventValue");        //CustomEvent
             _attribDefs.GetCustomAttributeForError("ErrorEventAttrib").TrySetValue(attribValues, "ErrorEventValue");                //Error Event and Trace

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -220,7 +220,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         public void GetErrorEvent_NoTransaction_WithException_ContainsCorrectAttributes()
         {
             // Arrange
-            var customAttributes = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            var customAttributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
 
             _attribDefs.GetCustomAttributeForError("custom attribute name").TrySetValue(customAttributes, "custom attribute value");
             var errorData = _errorService.FromException(new NullReferenceException("NRE message"));
@@ -251,7 +251,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private IAttributeValueCollection GetIntrinsicAttributes()
         {
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
 
             _attribDefs.DatabaseCallCount.TrySetValue(attributes, 10);
             _attribDefs.DatabaseDuration.TrySetValue(attributes, (float)TimeSpan.FromSeconds(10).TotalSeconds);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorTraceMakerTests.cs
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         public void GetErrorTrace_ReturnsErrorTrace_IfStatusCodeIs404()
         {
             var transaction = BuildTestTransaction(statusCode: 404, uri: "http://www.newrelic.com/test?param=value");
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
 
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);
@@ -62,7 +62,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         {
             var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorDataIn });
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
 
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);
@@ -82,7 +82,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var errorData1 = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
             var errorData2 = _errorService.FromMessage("My message2", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorData1, errorData2 });
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
 
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);
@@ -101,7 +101,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         {
             var errorDataIn = _errorService.FromMessage("My message", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(statusCode: 404, uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorDataIn });
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
 
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);
@@ -122,7 +122,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var errorData = _errorService.FromMessage("This message should be stripped.", (Dictionary<string, object>)null, false);
             var transaction = BuildTestTransaction(uri: "http://www.newrelic.com/test?param=value", transactionExceptionDatas: new[] { errorData });
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var transactionMetricName = new TransactionMetricName("WebTransaction", "Name");
 
             var errorTrace = _errorTraceMaker.GetErrorTrace(transaction, attributes, transactionMetricName);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -1388,11 +1388,11 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             
             // ACT
-            var builderAttributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var builderAttributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(builderAttributes, transaction.TransactionMetadata);
 
 
-            var attributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, immutableTransaction.TransactionMetadata);
 
             // ACQUIRE
@@ -1449,7 +1449,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
 
             // ACT
-            var attributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, immutableTransaction.TransactionMetadata);
 
             // ASSERT
@@ -1475,10 +1475,10 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var immutableTransaction = transaction.ConvertToImmutableTransaction();
 
             // ACT
-            var builderAttributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var builderAttributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(builderAttributes, transaction.TransactionMetadata);
 
-            var attributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, immutableTransaction.TransactionMetadata);
 
             // ACQUIRE
@@ -1522,10 +1522,10 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var immutableTransaction = transaction.ConvertToImmutableTransaction();
 
             // ACT
-            var builderAttributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var builderAttributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(builderAttributes, transaction.TransactionMetadata);
 
-            var attributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, immutableTransaction.TransactionMetadata);
 
             AssertAttributeShouldBeAvailableFor(builderAttributes, "http.statusCode", AttributeDestinations.TransactionEvent, AttributeDestinations.ErrorTrace, AttributeDestinations.TransactionTrace, AttributeDestinations.ErrorEvent, AttributeDestinations.SpanEvent);
@@ -1591,7 +1591,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var immutableTransaction = transaction.ConvertToImmutableTransaction();
 
             // ACT
-            var attributes = new AttributeValueCollection(AttributeValueCollection.AllTargetModelTypes);
+            var attributes = new AttributeValueCollectionCore(AttributeValueCollectionCore.AllTargetModelTypes);
             _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, immutableTransaction.TransactionMetadata);
 
             // ACQUIRE
@@ -1728,7 +1728,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var notAvailableFor = new List<AttributeDestinations>();
             foreach(var destination in destinations)
             {
-                var filteredAttribs = new AttributeValueCollection(attribValues, destination);
+                var filteredAttribs = new AttributeValueCollectionCore(attribValues, destination);
                 var values = filteredAttribs.ToDictionary();
 
                 if(!values.ContainsKey(attribName))

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
@@ -55,7 +55,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(startTime: DateTime.Now.AddSeconds(-50));
             var segments = new[] { BuildDataStoreSegmentNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction();
             var segments = new[] { BuildDataStoreSegmentNodeWithInstanceData() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -102,7 +102,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(startTime: expectedStartTime);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -116,7 +116,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(duration: expectedDuration);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -131,7 +131,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(duration: expectedDuration, responseTime: expectedResponseTime);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -148,7 +148,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(uri: inputUrl);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -164,7 +164,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(guid: expectedGuid);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
 
@@ -177,7 +177,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction();
             var segments = Enumerable.Empty<ImmutableSegmentTreeNode>();
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             Assert.Throws<ArgumentException>(() => _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes));
         }
@@ -190,7 +190,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(duration: expectedEndTimeDifference);
             var segments = new[] { BuildNode() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
             var root = trace.TransactionTraceData.RootSegment;
@@ -227,7 +227,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction(startTime: transactionStartTime);
             var segments = new[] { BuildNode(transaction, startTime: segmentStartTime, duration: segmentDuration, name: expectedName, parameters: expectedParameters, methodCallData: methodCallData) };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, segments, transactionMetricName, attributes);
             var realSegments = trace.TransactionTraceData.RootSegment.Children.First().Children;
@@ -257,7 +257,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction();
             var topLevelSegments = new[] { node1.Build(), node2.Build() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, topLevelSegments, transactionMetricName, attributes);
 
@@ -289,7 +289,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = BuildTestTransaction();
             var topLevelSegments = new[] { node1.Build(), node2.Build() };
             var transactionMetricName = new TransactionMetricName("WebTransaction", "TrxName");
-            var attributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
 
             var trace = _transactionTraceMaker.GetTransactionTrace(transaction, topLevelSegments, transactionMetricName, attributes);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTransformerTests.cs
@@ -1040,7 +1040,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         public void TransformSendsCorrectParametersToTraceMaker()
         {
             // ARRANGE
-            var expectedAttributes = new AttributeValueCollection(AttributeDestinations.TransactionTrace);
+            var expectedAttributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace);
             var expectedSegmentTreeNodes = new List<ImmutableSegmentTreeNode> { BuildNode() };
             var expectedTransactionMetricName = new TransactionMetricName("WebTransaction", "TransactionName");
 
@@ -1090,7 +1090,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         public void TransformSendsCorrectParametersToEventMaker()
         {
             // ARRANGE
-            var expectedAttributes = new AttributeValueCollection(AttributeDestinations.TransactionEvent);
+            var expectedAttributes = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent);
             Mock.Arrange(() => _transactionAttributeMaker.GetAttributes(Arg.IsAny<ImmutableTransaction>(), Arg.IsAny<TransactionMetricName>(), Arg.IsAny<TimeSpan?>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TransactionMetricStatsCollection>()))
                 .Returns(expectedAttributes);
 
@@ -1288,7 +1288,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         public void TransformSendsCorrectParametersToErrorTraceMaker()
         {
             // ARRANGE
-            var expectedAttributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var expectedAttributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var expectedTransactionMetricName = new TransactionMetricName("WebTransaction", "TransactionName");
 
             Mock.Arrange(() => _transactionAttributeMaker.GetAttributes(Arg.IsAny<ImmutableTransaction>(), Arg.IsAny<TransactionMetricName>(), Arg.IsAny<TimeSpan?>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TransactionMetricStatsCollection>()))
@@ -1488,7 +1488,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private static ErrorTraceWireModel GetError()
         {
-            var attributes = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+            var attributes = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
             var stackTrace = new List<string>();
             var errorTraceAttributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attributes, stackTrace);
             return new ErrorTraceWireModel(DateTime.Now, "path", "message", "exceptionClassName", errorTraceAttributes, "guid");

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/ErrorEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/ErrorEventWireModelTests.cs
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.Core.WireModels
         [Test]
         public void All_attribute_value_types_in_an_event_do_serialize_correctly()
         {
-            var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
 
 
             // ARRANGE
@@ -103,7 +103,7 @@ namespace NewRelic.Agent.Core.WireModels
         public void Is_synthetics_set_correctly()
         {
             // Arrange
-            var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
             var isSyntheticsEvent = true;
 
             // Act
@@ -119,7 +119,7 @@ namespace NewRelic.Agent.Core.WireModels
         {
             var priority = 0.5f;
 
-            var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+            var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
             _attribDefs.TimestampForError.TrySetValue(attribValues, DateTime.UtcNow);
 
             var wireModel = new ErrorEventWireModel(attribValues, false, priority);

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/ErrorTraceWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/ErrorTraceWireModelTests.cs
@@ -115,7 +115,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_default_fixture_values_are_used_then_serializes_correctly()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -141,7 +141,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void eror_trace_attributes_when_default_fixture_values_are_used_then_serializes_correctly()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
 
@@ -160,7 +160,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void eror_trace_attributes_when_default_fixture_values_are_used_then_serializes_correctly_with_legacy_serializer()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
 
@@ -179,7 +179,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_timestamp_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -190,7 +190,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_path_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -201,7 +201,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_message_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -212,7 +212,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_exceptionClassName_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -223,7 +223,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_parameters_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -234,7 +234,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_construtor_used_guid_property_is_set()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues,_stackTrace);
                 var errorTraceData = new ErrorTraceWireModel(_timestamp, _path, _message, _exceptionClassName, attributes, _guid);
@@ -246,7 +246,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             public void when_agentAttributes_are_supplied_then_they_show_up_in_json()
             {
                 // ARRANGE
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
                 _attribDefs.OriginalUrl.TrySetValue(attribValues, "www.test.com");
 
                 // ACT
@@ -262,7 +262,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             public void when_intrinsicAttributes_are_supplied_then_they_show_up_in_json()
             {
                 // ARRANGE
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
                 _attribDefs.Guid.TrySetValue(attribValues, "GuidTestValue");
 
                 // ACT
@@ -278,7 +278,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             public void when_userAttributes_are_supplied_then_they_show_up_in_json()
             {
                 // ARRANGE
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
                 _attribDefs.GetCustomAttributeForError("Foo").TrySetValue(attribValues, "Bar");
 
                 // ACT
@@ -293,7 +293,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
             [Test]
             public void when_attributes_are_empty_then_it_does_not_show_up()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorTrace);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace);
 
                 // ACT
                 var attributes = new ErrorTraceWireModel.ErrorTraceAttributesWireModel(attribValues, _stackTrace);
@@ -312,7 +312,7 @@ namespace NewRelic.Agent.Core.Errors.UnitTest
                 // ACT
                 Assert.DoesNotThrow(
                     () =>
-                        new ErrorTraceWireModel.ErrorTraceAttributesWireModel(new AttributeValueCollection(AttributeDestinations.ErrorTrace), null));
+                        new ErrorTraceWireModel.ErrorTraceAttributesWireModel(new AttributeValueCollectionCore(AttributeDestinations.ErrorTrace), null));
             }
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/TransactionEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/TransactionEventWireModelTests.cs
@@ -56,7 +56,7 @@ namespace NewRelic.Agent.Core.WireModels.UnitTest
             [Test]
             public void all_fields_serializes_correctly()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.TransactionEvent);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent);
 
                 // ARRANGE
                 var userAttributes = new Dictionary<string, object>
@@ -113,7 +113,7 @@ namespace NewRelic.Agent.Core.WireModels.UnitTest
             public void only_required_fields_serialize_correctly()
             {
                 // Arrange
-                var attribValues = new AttributeValueCollection(AttributeDestinations.ErrorEvent);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.ErrorEvent);
 
                 var isSytheticsEvent = false;
 
@@ -137,7 +137,7 @@ namespace NewRelic.Agent.Core.WireModels.UnitTest
             [Test]
             public void Verify_setting_priority()
             {
-                var attribValues = new AttributeValueCollection(AttributeDestinations.TransactionEvent);
+                var attribValues = new AttributeValueCollectionCore(AttributeDestinations.TransactionEvent);
 
                 _attribDefs.Timestamp.TrySetValue(attribValues, DateTime.UtcNow);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/TransactionTraceWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/TransactionTraceWireModelTests.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.Core.WireModels
             var timestamp = new DateTime(2018, 1, 1, 1, 0, 0, DateTimeKind.Utc);
             var transactionTraceSegment = new TransactionTraceSegment(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Segment Name", new Dictionary<string, object>(), new List<TransactionTraceSegment>(), "Segment Class Name", "Segment Method Name");
 
-            var transactionTrace = new TransactionTraceData(timestamp, transactionTraceSegment, new AttributeValueCollection(AttributeDestinations.TransactionTrace));
+            var transactionTrace = new TransactionTraceData(timestamp, transactionTraceSegment, new AttributeValueCollectionCore(AttributeDestinations.TransactionTrace));
             var transactionSample = new TransactionTraceWireModel(timestamp, TimeSpan.FromSeconds(1), "Transaction Name", "Transaction URI", transactionTrace, "Transaction GUID", null, null, false);
 
             // Act

--- a/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/AttributeComparer.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/AttributeComparer.cs
@@ -151,7 +151,7 @@ namespace NewRelic.Agent.TestUtilities
 
         public static Dictionary<string, object> ToDictionary(this IAttributeValueCollection attribValueCollection, AttributeDestinations targetObject, params AttributeClassification[] classifications)
         {
-            var filteredAttribValues = new AttributeValueCollection(attribValueCollection, targetObject);
+            var filteredAttribValues = new AttributeValueCollectionCore(attribValueCollection, targetObject);
             return ToDictionary(filteredAttribValues, classifications);
         }
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Certain "registration by convention" configurations of the Unity DI framework would fail, complaining about duplicate class names in NewRelic assemblies. 

The fix was to rename one of the two `AttributeValue` implementations to avoid the conflict. So I renamed `NewRelic.Agent.Core.Attributes.AttributeValue` to `NewRelic.Agent.Core.Attributes.AttributeValueCore` and (for consistency, even though it wasn't causing an issue), I renamed `NewRelic.Agent.Core.Attributes.AttributeValueCollection` to `NewRelic.Agent.Core.Attributes.AttributeValueCollectionCore`. 

I tested the fix using Unity and the previous issue was resolved. Also tested with AutoFac and Scrutor, but was never able to repro the original issue prior to the fix. 

#654 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)
- [ ] [Agent Changelog](/src/Agent/CHANGELOG.md) or [Lambda Agent changelog](/src/AwsLambda/CHANGELOG.md) updated 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
- [ ] Review Changelog
