### PR TITLE
Added elastic search and kibana to unbounded services

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -131,4 +131,26 @@ services:
             # the connection string used by those tests
             - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-MysqlPassword}
         container_name: MySqlServer
-        
+
+    elastic:
+        image: elastic/elasticsearch:8.6.2
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        environment:
+            - discovery.type=single-node
+            - xpack.security.enabled=false
+            - xpack.security.enrollment.enabled=false
+            - xpack.security.http.ssl.enabled=false
+            - xpack.security.transport.ssl.enabled=false
+        container_name: ElasticServer
+
+    kibana:
+        image: kibana:8.6.2
+        environment:
+        - ELASTICSEARCH_HOSTS=http://elastic:9200
+        ports:
+        - "5601:5601"
+        depends_on:
+        - elastic
+        container_name: Kibana

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -1,15 +1,15 @@
 version: "3.8"
 services:
 
-    cosmosdb: 
-        build: ./cosmosdb 
+    cosmosdb:
+        build: ./cosmosdb
         ports:
             - "8081:8081"
             - "10251-10254:10251-10254"
         environment:
             - AZURE_COSMOS_EMULATOR_KEY=${AZURE_COSMOS_EMULATOR_KEY:-C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==}
             - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=${AZURE_COSMOS_EMULATOR_PARTITION_COUNT:-25}
-            - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=${AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE:-false} 
+            - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=${AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE:-false}
             - AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE=${AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE:-127.0.0.1}
         container_name: CosmosDbServer
         deploy:
@@ -18,8 +18,8 @@ services:
                     cpus: '2.0'
                     memory: 3g
 
-    rabbitmq: 
-        build: ./rabbitmq 
+    rabbitmq:
+        build: ./rabbitmq
         ports:
             - "5671-5672:5671-5672"
         hostname: my-rabbit
@@ -28,24 +28,24 @@ services:
             - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-RabbitPassword}
         container_name: RabbitmqServer
 
-    mongodb32: 
-        build: ./mongodb32 
+    mongodb32:
+        build: ./mongodb32
         ports:
             - "27017:27017"
-        environment: 
+        environment:
             - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
             - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPassword}
         container_name: MongoDB32Server
 
-    mongodb60: 
-        build: ./mongodb60 
+    mongodb60:
+        build: ./mongodb60
         ports:
             - "27018:27017"
-        environment: 
+        environment:
             - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-MongoUser}
             - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-MongoPassword}
         container_name: MongoDB60Server
-                    
+
     redis:
         build: ./redis
         command: redis-server --requirepass ${REDIS_PASSWORD:-RedisPassword}
@@ -53,7 +53,7 @@ services:
             - "6379:6379"
         container_name: RedisServer
 
-    couchbase: 
+    couchbase:
         build: ./couchbase
         ports:
             - "8092-8094:8092-8094"
@@ -65,7 +65,7 @@ services:
             - COUCHBASE_ADMINISTRATOR_USERNAME=${COUCHBASE_ADMINISTRATOR_USERNAME:-CouchbaseUser}
             - COUCHBASE_ADMINISTRATOR_PASSWORD=${COUCHBASE_ADMINISTRATOR_PASSWORD:-CouchbasePassword}
         container_name: CouchbaseServer
-                        
+
     postgres:
         build: ./postgres
         ports:
@@ -148,9 +148,9 @@ services:
     kibana:
         image: kibana:8.6.2
         environment:
-        - ELASTICSEARCH_HOSTS=http://elastic:9200
+            - ELASTICSEARCH_HOSTS=http://elastic:9200
         ports:
-        - "5601:5601"
+            - "5601:5601"
         depends_on:
-        - elastic
+            - elastic
         container_name: Kibana


### PR DESCRIPTION
Adds elastic search and kibana to the UnboundedServices `docker-compose.yml`. All security and SSL/TLS configurations are disabled in elastic search to work around the auto-generated certificate file issue. Shouldn't be a problem for our environment. 

Tested that a test app can send data to Elastic Search via http://localhost:9200 and that I can view the data using Kibana (http://localhost:5601).