### PR TITLE
Enabled authentication for ElasticSearch and Kibana

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
@@ -1,3 +1,6 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 using System;
 
 namespace NewRelic.Agent.IntegrationTests.Shared

--- a/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace NewRelic.Agent.IntegrationTests.Shared
+{
+    public class ElasticSearchConfiguration
+    {
+        private static string _elasticServer;
+        private static string _elasticUserName;
+        private static string _elasticPassword;
+
+        public static string ElasticServer
+        {
+            get
+            {
+                if (_elasticServer == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticServer = testConfiguration["Server"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+
+                return _elasticServer;
+            }
+        }
+
+        public static string ElasticUserName {
+            get
+            {
+                if (_elasticUserName == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticUserName = testConfiguration["UserName"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticUserName;
+            }
+        }
+        public static string ElasticPassword {
+            get
+            {
+                if (_elasticPassword == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticPassword = testConfiguration["Password"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticPassword;
+            }
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -133,24 +133,43 @@ services:
         container_name: MySqlServer
 
     elastic:
-        image: elastic/elasticsearch:8.6.2
+        image: elasticsearch:8.6.2
         ports:
-            - "9200:9200"
-            - "9300:9300"
+            - 9200:9200
         environment:
             - discovery.type=single-node
-            - xpack.security.enabled=false
-            - xpack.security.enrollment.enabled=false
+            - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ElasticPassword}
+            - xpack.security.enabled=true
             - xpack.security.http.ssl.enabled=false
-            - xpack.security.transport.ssl.enabled=false
+        mem_limit: 2g
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
         container_name: ElasticServer
 
-    kibana:
-        image: kibana:8.6.2
-        environment:
-            - ELASTICSEARCH_HOSTS=http://elastic:9200
-        ports:
-            - "5601:5601"
+    # have to manually set the password for kibana_user - use curl to hit the correct endpoint
+    kibana_pw_setup:
+        image: curlimages/curl
         depends_on:
             - elastic
+        deploy:
+            restart_policy:
+                condition: on-failure
+        entrypoint: [ "sh", "-c", "sleep 10 && curl --user \"elastic:${ELASTIC_PASSWORD:-ElasticPassword}\" -X POST \"elastic:9200/_security/user/kibana_system/_password?pretty\" -H 'Content-Type: application/json' -d'{  \"password\" : \"${KIBANA_PASSWORD:-KibanaPassword}\"}'" ]
+        container_name: KibanaPWSetup
+
+    kibana:
+        depends_on:
+            kibana_pw_setup:
+                 condition: service_completed_successfully
+        image: kibana:8.6.2
+        ports:
+            - 5601:5601
+        environment:
+            - SERVERNAME=kibana
+            - ELASTICSEARCH_HOSTS=http://elastic:9200
+            - ELASTICSEARCH_USERNAME=kibana_system
+            - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-KibanaPassword}
+        mem_limit: 2g
         container_name: Kibana

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -141,7 +141,6 @@ services:
             - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ElasticPassword}
             - xpack.security.enabled=true
             - xpack.security.http.ssl.enabled=false
-        mem_limit: 2g
         ulimits:
             memlock:
                 soft: -1
@@ -171,5 +170,4 @@ services:
             - ELASTICSEARCH_HOSTS=http://elastic:9200
             - ELASTICSEARCH_USERNAME=kibana_system
             - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-KibanaPassword}
-        mem_limit: 2g
         container_name: Kibana


### PR DESCRIPTION
* Modified docker-compose to configure ElasticSearch and Kibana to require authentication. 
* Added a configuration helper class to get to the secrets for ElasticSearch from integration tests (Note that the helper class is presently untested, but should work correctly once the appropriate local secrets are in place.)