### PR TITLE
chore: remove [Unreleased] section from changelog

### DIFF
--- a/src/Agent/CHANGELOG.md
+++ b/src/Agent/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### New Features
-
-### Fixes
-
 ## [10.9.0] - 2023-03-28
 
 ### New Errors inbox features


### PR DESCRIPTION
Remove `[Unreleased]` section from changelog.md since it's no longer needed with Release Please automation