### PR TITLE
ci: update top-level permissions and remove deprecated action

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -12,26 +12,20 @@ on:
   schedule:
     - cron:  '0 9 * * *'
 
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  
 env:
   scripts_path: ${{ github.workspace }}\build\scripts
   tools_path: ${{ github.workspace }}\build\Tools
   DOTNET_NOLOGO: true
 
 jobs:
-
-  cancel-previous-workflow-runs:
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') )
-    name: Cancel Previous Runs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - uses: rokroskar/workflow-run-cleanup-action@c631227427d0452af4994af0940d7655ebc50c7c # master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-windows-profiler:
     needs: cancel-previous-workflow-runs
@@ -135,7 +129,10 @@ jobs:
     needs: cancel-previous-workflow-runs
     name: Build Linux ARM64 Profiler
     runs-on: ubuntu-22.04
-    
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      packages: write  # for uraimo/run-on-arch-action to cache docker images    
+
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
     
@@ -583,6 +580,9 @@ jobs:
     name: Run IntegrationTests linux-arm64
     runs-on: ubuntu-22.04
     if: false
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      packages: write  # for uraimo/run-on-arch-action to cache docker images
 
     env:
       test_path: ${{ github.workspace }}/tests/Agent/IntegrationTests/IntegrationTests/TestResults

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -28,7 +28,6 @@ env:
 jobs:
 
   build-windows-profiler:
-    needs: cancel-previous-workflow-runs
     name: Build Windows Profiler
     runs-on: windows-2019
 
@@ -77,7 +76,6 @@ jobs:
           if-no-files-found: error
 
   build-linux-x64-profiler:
-    needs: cancel-previous-workflow-runs
     name: Build Linux x64 Profiler
     runs-on: ubuntu-22.04
 
@@ -126,7 +124,6 @@ jobs:
           if-no-files-found: error
 
   build-linux-arm64-profiler:
-    needs: cancel-previous-workflow-runs
     name: Build Linux ARM64 Profiler
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -972,6 +972,8 @@ jobs:
           if-no-files-found: error
   
   run-multiverse_testing_suite:
+    permissions: 
+      contents: write
     name: Build and Publish Multiverse Testing Suite
     needs: build-test-fullagent-msi
     if: ${{ github.event.release }}

--- a/.github/workflows/awslambda_release.yml
+++ b/.github/workflows/awslambda_release.yml
@@ -21,7 +21,6 @@ env:
 jobs:
 
   build-test-lambda:
-    needs: [ cancel-previous-workflow-runs ]
     name: Build and Test FullAgent and MSIInstaller
     runs-on: windows-2019
 

--- a/.github/workflows/awslambda_release.yml
+++ b/.github/workflows/awslambda_release.yml
@@ -5,26 +5,20 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  
 env:
   scripts_path: ${{ github.workspace }}\build\scripts
   tools_path: ${{ github.workspace }}\build\Tools
   DOTNET_NOLOGO: true
 
 jobs:
-
-  cancel-previous-workflow-runs:
-    if:  github.event_name == 'workflow_dispatch' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/AwsLambdaOpenTracer_v') )
-    name: Cancel Previous Runs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - uses: rokroskar/workflow-run-cleanup-action@c631227427d0452af4994af0940d7655ebc50c7c # master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-test-lambda:
     needs: [ cancel-previous-workflow-runs ]

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -34,6 +34,9 @@ on:
         required: true
         default: 'true'
 
+permissions:
+  contents: read
+  
 env:
   DOTNET_NOLOGO: true
 

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,9 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -27,6 +27,9 @@ on:
         description: 'Run tests in parallel within each namespace'
         required: false
 
+permissions:
+  contents: read
+  
 env:
   DOTNET_NOLOGO: true
 

--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   set-community-label:
     name: Set Community Label

--- a/.github/workflows/siteextension_release.yml
+++ b/.github/workflows/siteextension_release.yml
@@ -13,24 +13,12 @@ env:
 permissions:
   contents: read
 
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-
-  cancel-previous-workflow-runs:
-    permissions:
-      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
-      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
-    if:  github.event_name == 'workflow_dispatch' || ( github.event_name == 'release' && startsWith(github.ref, 'refs/tags/AzureSiteExtension_v') )
-    name: Cancel Previous Runs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - uses: rokroskar/workflow-run-cleanup-action@c631227427d0452af4994af0940d7655ebc50c7c # master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-artifactbuilder:
     if: ${{ github.event.release }}


### PR DESCRIPTION
* Updates several workflows to apply top-level permissions and per-action permissions, as recommended by Step Security. (Not sure how I missed this the other day...)
* Removes usage of the deprecated `rokroskar/workflow-run-cleanup-action`, instead making use of the built-in `concurrency:` element.