### PR TITLE
Elasticsearch integration tests framework

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -69,15 +69,8 @@ namespace NewRelic.Agent.Core
         {
             get
             {
-                try
-                {
-                    return Singleton.ExistingInstance;
-                }
-                catch (NullReferenceException)
-                {
-                    // The singleton pointer may be null if we instrument a method that's invoked in the agent constructor.
-                    return DisabledAgentManager;
-                }
+                // The singleton pointer may be null if we instrument a method that's invoked in the agent constructor.
+                return Singleton?.ExistingInstance ?? DisabledAgentManager;
             }
         }
 

--- a/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
@@ -1,0 +1,75 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace NewRelic.Agent.IntegrationTests.Shared
+{
+    public class ElasticSearchConfiguration
+    {
+        private static string _elasticServer;
+        private static string _elasticUserName;
+        private static string _elasticPassword;
+
+        public static string ElasticServer
+        {
+            get
+            {
+                if (_elasticServer == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticServer = testConfiguration["Server"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+
+                return _elasticServer;
+            }
+        }
+
+        public static string ElasticUserName {
+            get
+            {
+                if (_elasticUserName == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticUserName = testConfiguration["UserName"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticUserName;
+            }
+        }
+        public static string ElasticPassword {
+            get
+            {
+                if (_elasticPassword == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticPassword = testConfiguration["Password"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticPassword;
+            }
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -111,7 +111,43 @@
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" Condition="'$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.61" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.90" Condition="'$(TargetFramework)' == 'net7.0'" />
-  
+
+    <!-- Elasticsearch NEST framework references -->
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <!-- Elasticsearch NEST .NET/Core references -->
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
+
+    <!-- Elasticsearch.Net framework references -->
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <!-- Elasticsearch.Net .NET/Core references -->
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
+
+    <!-- Elasticsearch.Net framework references -->
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <!-- Elasticsearch.Net .NET/Core references -->
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net7.0'" />
+
     <!-- Serilog .NET framework references -->
     <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />
     

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Threading.Tasks;
-using Azure;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Transport;
+using NewRelic.Agent.IntegrationTests.Shared;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -14,52 +14,63 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         public override void Connect()
         {
-            var settings = new ElasticsearchClientSettings(Address);
+            var settings = new ElasticsearchClientSettings(Address)
+                    .Authentication(new BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
+                    ElasticSearchConfiguration.ElasticPassword)).
+                    DefaultIndex(IndexName);
 
             _client = new ElasticsearchClient(settings);
 
-            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            // TODO: This isn't necessary but will log the response, which can help troubleshoot if
+            // you're having connection errors
+            _client.Ping();
         }
 
         public override void Index()
         {
-            var record = new FakeRecord("foo", "bar", "baz", 00000);
-            var response = _client.Index(record, "indexName");
+            var record = FlightRecord.GetSample();
+            var response = _client.Index(record, IndexName);
+
+            // TODO: Validate that it worked
         }
 
         public override async Task<bool> IndexAsync()
         {
-            var record = new FakeRecord("foo", "bar", "home", 12345);
+            var record = FlightRecord.GetSample();
 
-            var response = await _client.IndexAsync(record, "indexName");
+            var response = await _client.IndexAsync(record, IndexName);
+
+            // TODO: Validate that it worked
 
             return response.IsSuccess();
         }
 
         public override void Search()
         {
-            var response = _client.Search<FakeRecord>(s => s
-                .Index("indexName")
+            var response = _client.Search<FlightRecord>(s => s
+                .Index(IndexName)
                 .From(0)
                 .Size(10)
                 .Query(q => q
-                    .Term(t => t.LastName, "Bar")
+                    .Term(t => t.Departure, FlightRecord.GetSample().Departure)
                 )
             );
 
-            //response.Total
+            // TODO: Validate that it worked
         }
 
         public override async Task<long> SearchAsync()
         {
-            var response = await _client.SearchAsync<FakeRecord>(s => s
-                .Index("indexName")
+            var response = await _client.SearchAsync<FlightRecord>(s => s
+                .Index(IndexName)
                 .From(0)
                 .Size(10)
                 .Query(q => q
-                    .Term(t => t.LastName, "Bar")
+                    .Term(t => t.Departure, FlightRecord.GetSample().Departure)
                 )
             );
+
+            // TODO: Validate that it worked
 
             return response.Total;
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using Azure;
+using Elastic.Clients.Elasticsearch;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
+{
+    internal class ElasticsearchElasticClient : ElasticsearchTestClient
+    {
+        private ElasticsearchClient _client;
+
+        public override void Connect()
+        {
+            var settings = new ElasticsearchClientSettings(Address);
+
+            _client = new ElasticsearchClient(settings);
+
+            var record = new FakeRecord("foo", "bar", "baz", 00000);
+        }
+
+        public override void Index()
+        {
+            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            var response = _client.Index(record, "indexName");
+        }
+
+        public override async Task<bool> IndexAsync()
+        {
+            var record = new FakeRecord("foo", "bar", "home", 12345);
+
+            var response = await _client.IndexAsync(record, "indexName");
+
+            return response.IsSuccess();
+        }
+
+        public override void Search()
+        {
+            var response = _client.Search<FakeRecord>(s => s
+                .Index("indexName")
+                .From(0)
+                .Size(10)
+                .Query(q => q
+                    .Term(t => t.LastName, "Bar")
+                )
+            );
+
+            //response.Total
+        }
+
+        public override async Task<long> SearchAsync()
+        {
+            var response = await _client.SearchAsync<FakeRecord>(s => s
+                .Index("indexName")
+                .From(0)
+                .Size(10)
+                .Query(q => q
+                    .Term(t => t.LastName, "Bar")
+                )
+            );
+
+            return response.Total;
+        }
+
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Runtime.CompilerServices;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 
@@ -21,6 +22,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         private const string ASYNC_MODE = "async";
 
         [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        /// <summary>
+        /// Sets the library to use for further actions
+        /// </summary>
+        /// <param name="client">ElasticsearchNet, NEST, or ElasticClients</param>
         public void SetClient(string clientType)
         {
             if (Enum.TryParse(clientType, out ClientType client))
@@ -48,6 +54,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         [LibraryMethod]
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        /// <summary>
+        /// Performs an Elasticsearch Search operation
+        /// </summary>
+        /// <param name="syncMode">sync or async</param>
         public void Search(string syncMode)
         {
             if (syncMode == ASYNC_MODE)
@@ -62,6 +73,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         [LibraryMethod]
         [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        /// <summary>
+        /// Performs an Elasticsearch Index operation
+        /// </summary>
+        /// <param name="syncMode">sync or async</param>
         public void Index(string syncMode)
         {
             if (syncMode == ASYNC_MODE)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using Nest;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 
@@ -39,6 +38,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                         _client = new ElasticsearchElasticClient();
                         break;
                 }
+                _client.Connect();
             }
             else
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Nest;
+using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
+using NewRelic.Api.Agent;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
+{
+    [Library]
+    public class ElasticsearchExerciser
+    {
+        private enum ClientType
+        {
+            ElasticsearchNet,
+            NEST,
+            ElasticClients
+        }
+        private ClientType _clientType;
+        private ElasticsearchTestClient _client;
+        private const string ASYNC_MODE = "async";
+
+        [LibraryMethod]
+        public void SetClient(string clientType)
+        {
+            if (Enum.TryParse(clientType, out ClientType client))
+            {
+                _clientType = client;
+                switch (_clientType)
+                {
+                    case ClientType.NEST:
+                        _client = new ElasticsearchNestClient();
+                        break;
+                    case ClientType.ElasticsearchNet:
+                        _client = new ElasticsearchNetClient();
+                        break;
+                    case ClientType.ElasticClients:
+                        _client = new ElasticsearchElasticClient();
+                        break;
+                }
+            }
+            else
+            {
+                // oops!
+            }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        public void Search(string syncMode)
+        {
+            if (syncMode == ASYNC_MODE)
+            {
+                _client.SearchAsync();
+            }
+            else
+            {
+                _client.Search();
+            }
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        public void Index(string syncMode)
+        {
+            if (syncMode == ASYNC_MODE)
+            {
+                _client.IndexAsync();
+            }
+            else
+            {
+                _client.Index();
+            }
+        }
+
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -1,0 +1,66 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nest;
+using NewRelic.IntegrationTests.Models;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
+{
+    internal class ElasticsearchNestClient : ElasticsearchTestClient
+    {
+        private ElasticClient _client;
+
+        public override void Connect()
+        {
+            var settings = new ConnectionSettings(Address).DefaultIndex("people");
+
+            _client = new ElasticClient(settings);
+        }
+
+        public override void Index()
+        {
+            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            var response = _client.IndexDocument(record);
+
+        }
+
+        public override async Task<bool> IndexAsync()
+        {
+            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            var response = await _client.IndexDocumentAsync(record);
+            return response.IsValid;
+        }
+
+        public override void Search()
+        {
+            var searchResponse = _client.Search<FakeRecord>(s => s
+                .From(0)
+                .Size(10)
+                .Query(q => q
+                    .Match(m => m
+                    .Field(f => f.LastName)
+                    .Query("whatever")
+                    )
+                   )
+                );
+        }
+
+        public override async Task<long> SearchAsync()
+        {
+            var response = await _client.SearchAsync<FakeRecord>(s => s
+                .From(0)
+                .Size(10)
+                .Query(q => q
+                    .Match(m => m
+                    .Field(f => f.LastName)
+                    .Query("something")
+                    )
+                   )
+                );
+
+            return response.Total;
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Linq;
+using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nest;
-using NewRelic.IntegrationTests.Models;
+using NewRelic.Agent.IntegrationTests.Shared;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -12,53 +13,73 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
     {
         private ElasticClient _client;
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
-            var settings = new ConnectionSettings(Address).DefaultIndex("people");
+            var settings = new ConnectionSettings(Address).
+                BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
+                ElasticSearchConfiguration.ElasticPassword).
+                DefaultIndex(IndexName);
 
             _client = new ElasticClient(settings);
+
+            // TODO: This isn't necessary but will log the response, which can help troubleshoot if
+            // you're having connection errors
+            _client.Ping();
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Index()
         {
-            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            var record = FlightRecord.GetSample();
             var response = _client.IndexDocument(record);
 
+            // TODO: Validate that it worked
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override async Task<bool> IndexAsync()
         {
-            var record = new FakeRecord("foo", "bar", "baz", 00000);
+            var record = FlightRecord.GetSample();
             var response = await _client.IndexDocumentAsync(record);
+
+            // TODO: Validate that it worked
+
             return response.IsValid;
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Search()
         {
-            var searchResponse = _client.Search<FakeRecord>(s => s
+            var searchResponse = _client.Search<FlightRecord>(s => s
                 .From(0)
                 .Size(10)
                 .Query(q => q
                     .Match(m => m
-                    .Field(f => f.LastName)
-                    .Query("whatever")
+                    .Field(f => f.Departure)
+                    .Query(FlightRecord.GetSample().Departure)
                     )
                    )
                 );
+
+            // TODO: Validate that it worked
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override async Task<long> SearchAsync()
         {
-            var response = await _client.SearchAsync<FakeRecord>(s => s
+            var response = await _client.SearchAsync<FlightRecord>(s => s
                 .From(0)
                 .Size(10)
                 .Query(q => q
                     .Match(m => m
-                    .Field(f => f.LastName)
-                    .Query("something")
+                    .Field(f => f.Departure)
+                    .Query(FlightRecord.GetSample().Departure)
                     )
                    )
                 );
+
+            // TODO: Validate that it worked
 
             return response.Total;
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using NewRelic.IntegrationTests.Models;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
+{
+    internal class ElasticsearchNetClient : ElasticsearchTestClient
+    {
+        private ElasticLowLevelClient _client;
+
+        public override void Connect()
+        {
+            var settings = new ConnectionConfiguration(Address)
+                .RequestTimeout(TimeSpan.FromMinutes(2));
+
+            _client = new ElasticLowLevelClient(settings);
+        }
+
+        public override void Index()
+        {
+            var record = new FakeRecord("foo", "bar", "home", 12345);
+            var indexResponse = _client.Index<BytesResponse>("people", "1", PostData.Serializable(record));
+            byte[] responseBytes = indexResponse.Body;
+
+        }
+
+        public override async Task<bool> IndexAsync()
+        {
+            var record = new FakeRecord("foo", "bar", "home", 12345);
+
+            var response = await _client.IndexAsync<StringResponse>("people", "1", PostData.Serializable(record));
+            return response.Success;
+        }
+
+        public override void Search()
+        {
+            var searchResponse = _client.Search<StringResponse>("people", PostData.Serializable(new
+            {
+                from = 0,
+                size = 10,
+                query = new
+                {
+                    match = new
+                    {
+                        LastName = new
+                        {
+                            query = "Bar"
+                        }
+                    }
+                }
+            }));
+
+            var successful = searchResponse.Success;
+            var responseJson = searchResponse.Body;
+        }
+
+        public override async Task<long> SearchAsync()
+        {
+            var response = await _client.SearchAsync<StringResponse>("people", PostData.Serializable(new
+            {
+                from = 0,
+                size = 10,
+                query = new
+                {
+                    match = new
+                    {
+                        LastName = new
+                        {
+                            query = "Bar"
+                        }
+                    }
+                }
+            }));
+            // Gotta parse the JSON :(
+            var json = response.Body;
+            return 0;
+        }
+
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
+using NewRelic.Agent.IntegrationTests.Shared;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
     internal abstract class ElasticsearchTestClient
     {
-        protected const int Port = 9200;
-        protected Uri Address = new Uri($"http://localhost:{Port}");
+        protected const string IndexName = "flights";   // Must be lowercase!
+        protected Uri Address = new Uri(ElasticSearchConfiguration.ElasticServer);
 
         public ElasticsearchTestClient() { }
 
@@ -25,20 +26,37 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         public abstract Task<long> SearchAsync();
     }
 
-    public class FakeRecord
+    public class FlightRecord
     {
-        public FakeRecord(string first, string last, string location, int zip)
+        private static FlightRecord[] Samples =
         {
-            Id = 0;
-            FirstName = first;
-            LastName = last;
-            Location = location;
-            ZipCode = zip;
+            new FlightRecord(1,  "PDX", "09:00", "DEN", "1:30"),
+            new FlightRecord(2,  "ORD", "07:10", "LGA", "10:29"),
+            new FlightRecord(3,  "ATL", "14:35", "IAD", "16:24"),
+            new FlightRecord(4,  "YUL", "15:00", "EWR", "16:38"),
+            new FlightRecord(5,  "BOS", "21:25", "ORD", "23:22"),
+            new FlightRecord(6,  "IAD", "17:50", "GUA", "20:24"),
+            new FlightRecord(7,  "ORD", "05:00", "DEN", "08:30"),
+            new FlightRecord(8,  "IAD", "18:55", "ACC", "09:05"),
+            new FlightRecord(9,  "MIA", "11:05", "EWR", "14:13"),
+            new FlightRecord(10, "AMS", "12:00", "IAD", "14:15"),
+        };
+        public static FlightRecord GetSample(int which = 0) => Samples[which % Samples.Length];
+
+        public static List<FlightRecord> GetSamples(int num) => Samples.Take(num % Samples.Length).ToList();
+
+        protected FlightRecord(int id, string origin, string departure, string dest, string arrival) 
+        {
+            Id = id.ToString();
+            Origin = origin;
+            Departure = departure;
+            Dest = dest;
+            Arrival = arrival;
         }
-        public int Id { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Location { get; set; }
-        public int ZipCode { get; set; }
+        public string Id { get; set; }
+        public string Origin { get; set; }
+        public string Departure { get; set; }
+        public string Dest { get; set; }
+        public string Arrival { get; set; }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
+{
+    internal abstract class ElasticsearchTestClient
+    {
+        protected const int Port = 9200;
+        protected Uri Address = new Uri($"http://localhost:{Port}");
+
+        public ElasticsearchTestClient() { }
+
+        public abstract void Connect();
+        public abstract void Index();
+
+        public abstract Task<bool> IndexAsync();
+
+        public abstract void Search();
+
+        public abstract Task<long> SearchAsync();
+    }
+
+    public class FakeRecord
+    {
+        public FakeRecord(string first, string last, string location, int zip)
+        {
+            Id = 0;
+            FirstName = first;
+            LastName = last;
+            Location = location;
+            ZipCode = zip;
+        }
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Location { get; set; }
+        public int ZipCode { get; set; }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
@@ -1,0 +1,280 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests;
+using NewRelic.Testing.Assertions;
+using StackExchange.Redis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
+{
+    public abstract class ElasticsearchAsyncTestsBase<TFixture> : ElasticsearchTestsBase<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        const string SYNC_MODE = "async";
+
+        protected ElasticsearchAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture, output, clientType, SYNC_MODE)
+        {
+
+        }
+
+        [Fact]
+        public void IndexAndSearch()
+        {
+            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/Index";
+
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"statement/Elasticsearch/flights/Index", metricScope = expectedTransactionName, callCount = 1 },
+            };
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+
+            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/Elasticsearch"));
+
+
+            NrAssert.Multiple
+            (
+                () => Assertions.MetricsExist(expectedMetrics, metrics),
+                () => Assert.Equal(1, operationDatastoreSpans.Count())
+            );
+        }
+
+    }
+
+    #region NEST
+    [NetFrameworkTest]
+    public class ElasticsearchNestAsyncTestsFWLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchNestAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestAsyncTestsFW48 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchNestAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestAsyncTestsFW471 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchNestAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestAsyncTestsFW462 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchNestAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestAsyncTestsCoreLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchNestAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestAsyncTestsCore60 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchNestAsyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestAsyncTestsCore50 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchNestAsyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestAsyncTestsCore31 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchNestAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    #endregion NEST
+
+    #region ElasticsearchNet
+    [NetFrameworkTest]
+    public class ElasticsearchNetAsyncTestsFWLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchNetAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetAsyncTestsFW48 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchNetAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetAsyncTestsFW471 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchNetAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetAsyncTestsFW462 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchNetAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetAsyncTestsCoreLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchNetAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetAsyncTestsCore60 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchNetAsyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetAsyncTestsCore50 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchNetAsyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetAsyncTestsCore31 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchNetAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+    #endregion ElasticsearchNet
+
+    #region ElasticClients
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientAsyncTestsFWLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchElasticClientAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientAsyncTestsFW48 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchElasticClientAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientAsyncTestsFW471 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchElasticClientAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientAsyncTestsFW462 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchElasticClientAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientAsyncTestsCoreLatest : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchElasticClientAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientAsyncTestsCore60 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchElasticClientAsyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientAsyncTestsCore50 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchElasticClientAsyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientAsyncTestsCore31 : ElasticsearchAsyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchElasticClientAsyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+    #endregion ElasticClients
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchSyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchSyncTests.cs
@@ -1,0 +1,279 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
+{
+    public abstract class ElasticsearchSyncTestsBase<TFixture> : ElasticsearchTestsBase<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        const string SYNC_MODE = "sync";
+
+        protected ElasticsearchSyncTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture, output, clientType, SYNC_MODE)
+        {
+
+        }
+
+        [Fact]
+        public void IndexAndSearch()
+        {
+            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/Index";
+
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/Elasticsearch/flights/Index", metricScope = expectedTransactionName, callCount = 1 },
+            };
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+
+            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/Elasticsearch"));
+
+
+            NrAssert.Multiple
+            (
+                () => Assertions.MetricsExist(expectedMetrics, metrics),
+                () => Assert.Equal(1, operationDatastoreSpans.Count())
+            );
+        }
+
+    }
+
+    #region NEST
+    [NetFrameworkTest]
+    public class ElasticsearchNestSyncTestsFWLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchNestSyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestSyncTestsFW48 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchNestSyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestSyncTestsFW471 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchNestSyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestSyncTestsFW462 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchNestSyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestSyncTestsCoreLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchNestSyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestSyncTestsCore60 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchNestSyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestSyncTestsCore50 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchNestSyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestSyncTestsCore31 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchNestSyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    #endregion NEST
+
+    #region ElasticsearchNet
+    [NetFrameworkTest]
+    public class ElasticsearchNetSyncTestsFWLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchNetSyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetSyncTestsFW48 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchNetSyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetSyncTestsFW471 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchNetSyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNetSyncTestsFW462 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchNetSyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetSyncTestsCoreLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchNetSyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetSyncTestsCore60 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchNetSyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetSyncTestsCore50 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchNetSyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNetSyncTestsCore31 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchNetSyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticsearchNet.ToString())
+        {
+        }
+    }
+    #endregion ElasticsearchNet
+
+    #region ElasticClients
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientSyncTestsFWLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public ElasticsearchElasticClientSyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientSyncTestsFW48 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public ElasticsearchElasticClientSyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientSyncTestsFW471 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public ElasticsearchElasticClientSyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchElasticClientSyncTestsFW462 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchElasticClientSyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientSyncTestsCoreLatest : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchElasticClientSyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientSyncTestsCore60 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchElasticClientSyncTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientSyncTestsCore50 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchElasticClientSyncTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchElasticClientSyncTestsCore31 : ElasticsearchSyncTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchElasticClientSyncTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.ElasticClients.ToString())
+        {
+        }
+    }
+    #endregion ElasticClients
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -33,15 +33,15 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests
 
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
-            _fixture.AddCommand($"StackexchangeExerciser SetClient {clientType}");
+            _fixture.AddCommand($"ElasticsearchExerciser SetClient {clientType}");
 
-            _fixture.AddCommand($"StackexchangeExerciser Index");
+            _fixture.AddCommand($"ElasticsearchExerciser Index");
 
-            _fixture.AddCommand($"StackexchangeExerciser Index async");
+            _fixture.AddCommand($"ElasticsearchExerciser Index async");
 
-            _fixture.AddCommand($"StackexchangeExerciser Search");
+            _fixture.AddCommand($"ElasticsearchExerciser Search");
 
-            _fixture.AddCommand($"StackexchangeExerciser Search async");
+            _fixture.AddCommand($"ElasticsearchExerciser Search async");
 
             _fixture.Actions
             (

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -13,8 +13,6 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests
 {
-
-
     public abstract class ElasticsearchTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
         where TFixture : ConsoleDynamicMethodFixture
     {
@@ -24,24 +22,21 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests
             NEST,
             ElasticClients
         }
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        protected readonly ConsoleDynamicMethodFixture _fixture;
 
-        protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture)
+        protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, string clientType, string syncMode) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
 
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            // TODO: Set high to allow for debugging
+            _fixture.SetTimeout(TimeSpan.FromMinutes(20));
 
             _fixture.AddCommand($"ElasticsearchExerciser SetClient {clientType}");
 
-            _fixture.AddCommand($"ElasticsearchExerciser Index");
+            _fixture.AddCommand($"ElasticsearchExerciser Index {syncMode}");
 
-            _fixture.AddCommand($"ElasticsearchExerciser Index async");
-
-            _fixture.AddCommand($"ElasticsearchExerciser Search");
-
-            _fixture.AddCommand($"ElasticsearchExerciser Search async");
+            _fixture.AddCommand($"ElasticsearchExerciser Search {syncMode}");
 
             _fixture.Actions
             (
@@ -56,109 +51,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests
             _fixture.Initialize();
         }
 
-        [Fact]
-        public void CreateReadAndDeleteDatabaseTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadFeedDatabase", metricScope = expectedTransactionName, callCount = 2 },
-
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 2 },
-
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents();
-
-            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
-
-            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/operation/CosmosDB"));
-
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Equal(6, operationDatastoreSpans.Count())
-            );
-        }
     }
 
-    [NetFrameworkTest]
-    public class MongoDBDriverQueryProviderTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MongoDBDriverQueryProviderTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MongoDBDriverQueryProviderTestsFW48 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public MongoDBDriverQueryProviderTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MongoDBDriverQueryProviderTestsFW471 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public MongoDBDriverQueryProviderTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class ElasticsearchNestTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public ElasticsearchNestTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class ElasticsearchNestTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public ElasticsearchNestTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class ElasticsearchNestTestsCore60 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public ElasticsearchNestTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class ElasticsearchNestTestsCore50 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public ElasticsearchNestTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class ElasticsearchNestTestsCore31 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public ElasticsearchNestTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST.ToString())
-        {
-        }
-    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -1,0 +1,164 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Testing.Assertions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.UnboundedIntegrationTests.ElasticsearchTests
+{
+
+
+    public abstract class ElasticsearchTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        protected enum ClientType
+        {
+            ElasticsearchNet,
+            NEST,
+            ElasticClients
+        }
+        private readonly ConsoleDynamicMethodFixture _fixture;
+
+        protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
+            _fixture.AddCommand($"StackexchangeExerciser SetClient {clientType}");
+
+            _fixture.AddCommand($"StackexchangeExerciser Index");
+
+            _fixture.AddCommand($"StackexchangeExerciser Index async");
+
+            _fixture.AddCommand($"StackexchangeExerciser Search");
+
+            _fixture.AddCommand($"StackexchangeExerciser Search async");
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.ForceTransactionTraces();
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void CreateReadAndDeleteDatabaseTests()
+        {
+            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase";
+
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadFeedDatabase", metricScope = expectedTransactionName, callCount = 2 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 2 },
+
+                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            };
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+
+            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/operation/CosmosDB"));
+
+
+            NrAssert.Multiple
+            (
+                () => Assertions.MetricsExist(expectedMetrics, metrics),
+                () => Assert.Equal(6, operationDatastoreSpans.Count())
+            );
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MongoDBDriverQueryProviderTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public MongoDBDriverQueryProviderTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MongoDBDriverQueryProviderTestsFW48 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public MongoDBDriverQueryProviderTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class MongoDBDriverQueryProviderTestsFW471 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public MongoDBDriverQueryProviderTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class ElasticsearchNestTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public ElasticsearchNestTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public ElasticsearchNestTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestTestsCore60 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public ElasticsearchNestTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestTestsCore50 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public ElasticsearchNestTestsCore50(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class ElasticsearchNestTestsCore31 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public ElasticsearchNestTestsCore31(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, ClientType.NEST.ToString())
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -76,5 +76,9 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Elasticsearch\" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -76,9 +76,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Elasticsearch\" />
-  </ItemGroup>
 
 </Project>

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -133,24 +133,41 @@ services:
         container_name: MySqlServer
 
     elastic:
-        image: elastic/elasticsearch:8.6.2
+        image: elasticsearch:8.6.2
         ports:
-            - "9200:9200"
-            - "9300:9300"
+            - 9200:9200
         environment:
             - discovery.type=single-node
-            - xpack.security.enabled=false
-            - xpack.security.enrollment.enabled=false
+            - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ElasticPassword}
+            - xpack.security.enabled=true
             - xpack.security.http.ssl.enabled=false
-            - xpack.security.transport.ssl.enabled=false
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
         container_name: ElasticServer
 
-    kibana:
-        image: kibana:8.6.2
-        environment:
-            - ELASTICSEARCH_HOSTS=http://elastic:9200
-        ports:
-            - "5601:5601"
+    # have to manually set the password for kibana_user - use curl to hit the correct endpoint
+    kibana_pw_setup:
+        image: curlimages/curl
         depends_on:
             - elastic
+        deploy:
+            restart_policy:
+                condition: on-failure
+        entrypoint: [ "sh", "-c", "sleep 10 && curl --user \"elastic:${ELASTIC_PASSWORD:-ElasticPassword}\" -X POST \"elastic:9200/_security/user/kibana_system/_password?pretty\" -H 'Content-Type: application/json' -d'{  \"password\" : \"${KIBANA_PASSWORD:-KibanaPassword}\"}'" ]
+        container_name: KibanaPWSetup
+
+    kibana:
+        depends_on:
+            kibana_pw_setup:
+                 condition: service_completed_successfully
+        image: kibana:8.6.2
+        ports:
+            - 5601:5601
+        environment:
+            - SERVERNAME=kibana
+            - ELASTICSEARCH_HOSTS=http://elastic:9200
+            - ELASTICSEARCH_USERNAME=kibana_system
+            - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-KibanaPassword}
         container_name: Kibana


### PR DESCRIPTION
This supports unbounded integration tests for NEST, Elasticsearch.net, and Elastic.Clients.Elasticsearch. At the moment the tests are pretty basic, and only the sync tests for NEST are passing.