### PR TITLE
Set URI after datastore segment creation

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Aggregators;
 using NewRelic.Agent.Core.Attributes;
@@ -20,7 +21,7 @@ using static NewRelic.Agent.Core.WireModels.MetricWireModel;
 
 namespace NewRelic.Agent.Core.Segments
 {
-    public class DatastoreSegmentData : AbstractSegmentData
+    public class DatastoreSegmentData : AbstractSegmentData, IDatastoreSegmentData
     {
         private readonly static ConnectionInfo EmptyConnectionInfo = new ConnectionInfo(null, null, null);
 
@@ -222,6 +223,11 @@ namespace NewRelic.Agent.Core.Segments
             AttribDefs.PeerAddress.TrySetValue(attribVals, $"{Host}:{PortPathOrId}");
             AttribDefs.PeerHostname.TrySetValue(attribVals, Host);
             AttribDefs.SpanKind.TrySetDefault(attribVals);
+        }
+
+        public void SetConnectionInfo(ConnectionInfo connInfo)
+        {
+            _connectionInfo = connInfo;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -4,6 +4,7 @@
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Core.Api;
+using NewRelic.Agent.Core.Database;
 using NewRelic.Agent.Core.Segments;
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
@@ -26,6 +27,7 @@ namespace NewRelic.Agent.Core.Transactions
         private object _wrapperToken;
 
         private static readonly IExternalSegmentData _noOpExternalSegmentData = new ExternalSegmentData(new Uri("https://www.newrelic.com/"), string.Empty);
+        private static readonly IDatastoreSegmentData _noOpDatastoreSegmentData = new DatastoreSegmentData(new DatabaseService(), new ParsedSqlStatement(DatastoreVendor.Other, string.Empty, string.Empty));
 
         public void End(bool captureResponseTime = true)
         {
@@ -260,6 +262,11 @@ namespace NewRelic.Agent.Core.Transactions
             return _noOpExternalSegmentData;
         }
 
+        public IDatastoreSegmentData CreateDatastoreSegmentData(ParsedSqlStatement sqlStatement, ConnectionInfo connectionInfo, string commandText, IDictionary<string, IConvertible> queryParameters)
+        {
+            return _noOpDatastoreSegmentData;
+        }
+
         public ITransaction AddCustomAttribute(string key, object value)
         {
             return this;
@@ -290,5 +297,6 @@ namespace NewRelic.Agent.Core.Transactions
         {
             return;
         }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -306,7 +306,7 @@ namespace NewRelic.Agent.Core.Transactions
             return segment;
         }
 
-        public AbstractSegmentData CreateDatastoreSegmentData(ParsedSqlStatement parsedSqlStatement, ConnectionInfo connectionInfo, string commandText, IDictionary<string, IConvertible> queryParameters = null)
+        public IDatastoreSegmentData CreateDatastoreSegmentData(ParsedSqlStatement parsedSqlStatement, ConnectionInfo connectionInfo, string commandText, IDictionary<string, IConvertible> queryParameters = null)
         {
             if (!Agent.Configuration.DatastoreTracerQueryParametersEnabled)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IDatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IDatastoreSegmentData.cs
@@ -1,0 +1,17 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.Extensions.Parsing;
+
+namespace NewRelic.Agent.Api.Experimental
+{
+    /// <summary>
+    /// This interface contains methods we may eventually move out of the experimental namespace once they have been sufficiently vetted.
+    /// Methods on this interface are subject to refactoring or removal in future versions of the API.
+    /// </summary>
+    public interface IDatastoreSegmentData : ISegmentData
+    {
+        void SetConnectionInfo(ConnectionInfo connectionInfo);
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
@@ -4,6 +4,8 @@
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace NewRelic.Agent.Api.Experimental
 {
@@ -40,6 +42,17 @@ namespace NewRelic.Agent.Api.Experimental
         /// <param name="method">The method of the request, such as an HTTP verb (e.g. GET or POST).</param>
         /// <returns>An object that can be used to manage all of the data we support for external requests.</returns>
         IExternalSegmentData CreateExternalSegmentData(Uri destinationUri, string method);
+
+        /// <summary>
+        /// Creates an object that holds the data that represents a datastore request. This data can be added to a
+        /// segment so that a segment can represent a datastore request.
+        /// </summary>
+        /// <param name="sqlStatement">An object containing information about the request being made.</param>
+        /// <param name="connectionInfo">An object containing information about the service the request is being made to.</param>
+        /// <param name="commandText">An string with the raw datastore statement text. Can be an empty string.</param>
+        /// <param name="queryParameters">A dictionary of query parameter names and values. Can be null.</param>
+        /// <returns>An object that can be used to manage all of the data we support for datastore requests.</returns>
+        IDatastoreSegmentData CreateDatastoreSegmentData(ParsedSqlStatement sqlStatement, ConnectionInfo connectionInfo, string commandText, IDictionary<string, IConvertible> queryParameters);
 
         DateTime StartTime { get; }
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/ITransactionExperimental.cs
@@ -5,7 +5,6 @@ using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace NewRelic.Agent.Api.Experimental
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,6 +25,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         }
 
         protected readonly ConsoleDynamicMethodFixture _fixture;
+        protected readonly string _host = ElasticSearchConfiguration.ElasticServer.Remove(0, "http://".Length);
 
         protected ElasticsearchAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture)
         {
@@ -70,11 +72,15 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
             var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/Elasticsearch"));
 
+            var operationDatastoreAgentAttributes = operationDatastoreSpans.FirstOrDefault().AgentAttributes;
+
+            var uri = operationDatastoreAgentAttributes.Where(x => x.Key == "peer.address").FirstOrDefault().Value;
 
             NrAssert.Multiple
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Equal(1, operationDatastoreSpans.Count())
+                () => Assert.Equal(1, operationDatastoreSpans.Count()),
+                () => Assert.Equal(_host, uri)
             );
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchAsyncTests.cs
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         }
 
         protected readonly ConsoleDynamicMethodFixture _fixture;
-        protected readonly string _host = ElasticSearchConfiguration.ElasticServer.Remove(0, "http://".Length);
+        protected readonly string _host = GetHostFromElasticServer(ElasticSearchConfiguration.ElasticServer);
 
         protected ElasticsearchAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture)
         {
@@ -40,6 +40,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             _fixture.AddCommand($"ElasticsearchExerciser IndexAsync");
 
             _fixture.AddCommand($"ElasticsearchExerciser SearchAsync");
+
+            // Don't like having to do this but it makes the async tests pass reliably
+            _fixture.AddCommand("RootCommands DelaySeconds 5");
 
             _fixture.Actions
             (
@@ -82,6 +85,21 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
                 () => Assert.Equal(1, operationDatastoreSpans.Count()),
                 () => Assert.Equal(_host, uri)
             );
+        }
+        private static string GetHostFromElasticServer(string elasticServer)
+        {
+            if (elasticServer.StartsWith("https://"))
+            {
+                return elasticServer.Remove(0, "https://".Length);
+            }
+            else if (elasticServer.StartsWith("http://"))
+            {
+                return elasticServer.Remove(0, "http://".Length);
+            }
+            else
+            {
+                return string.Empty;
+            }
         }
 
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchSyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchSyncTests.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
         protected readonly ConsoleDynamicMethodFixture _fixture;
 
-        protected readonly string _host = ElasticSearchConfiguration.ElasticServer.Remove(0, "http://".Length);
+        protected readonly string _host = GetHostFromElasticServer(ElasticSearchConfiguration.ElasticServer);
 
 
         protected ElasticsearchSyncTestsBase(TFixture fixture, ITestOutputHelper output, string clientType) : base(fixture)
@@ -84,6 +84,22 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
                 () => Assert.Equal(1, operationDatastoreSpans.Count()),
                 () => Assert.Equal(_host, uri)
             ); ;
+        }
+
+        private static string GetHostFromElasticServer(string elasticServer)
+        {
+            if (elasticServer.StartsWith("https://"))
+            {
+                return elasticServer.Remove(0, "https://".Length);
+            }
+            else if (elasticServer.StartsWith("http://"))
+            {
+                return elasticServer.Remove(0, "http://".Length);
+            }
+            else
+            {
+                return string.Empty;
+            }
         }
 
     }


### PR DESCRIPTION
## Description

* Adds the necessary interface and methods to support being able to update the ConnectionInfo (which contains the URI) of a `DatastoreSegment` after initial creation.
* Updates integration tests for Elasticsearch to check for the `peer.address` attribute in the datastore segment span, which is what the URI is used to populate
* Comment cleanup in the wrapper

