### PR TITLE
ci: apply harden-runner egress policy config

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       # intentionally disabled for this job
-      # - name: Harden Runner
-      #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-      #   with:
-      #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: Harden Runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -92,6 +92,7 @@ jobs:
       #<other env vars here>
 
     steps:
+      # intentionally disabled for this job
       # - name: Harden Runner
       #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       #   with:
@@ -143,7 +144,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            ghcr.io:443
+            github.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
+            ppa.launchpadcontent.net:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -591,8 +604,8 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          egress-policy: audit
+            
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
@@ -796,8 +809,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            ghcr.io:443
+            github.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
+            pkg-containers.githubusercontent.com:443
+            ppa.launchpadcontent.net:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
@@ -863,7 +887,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            deb.debian.org:80
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -84,11 +84,11 @@ jobs:
       #<other env vars here>
 
     steps:
-      # intentionally disabled for this job
-      - name: Harden Runner
-        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      # intentionally disabled for this job, when enabled it causes a failure in the Build Linux Profiler step
+      # - name: Harden Runner
+      #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+      #   with:
+      #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -806,19 +806,42 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             auth.docker.io:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            ghcr.io:443
+            centos.hivelocity.net:80
+            centos.mirror.constant.com:80
+            centos.mirror.ndchost.com:80
+            centos.mirror.shastacoe.net:80
+            coresite.mm.fcix.net:80
+            distro.ibiblio.org:80
+            forksystems.mm.fcix.net:80
             github.com:443
-            motd.ubuntu.com:443
-            packages.microsoft.com:443
-            pkg-containers.githubusercontent.com:443
-            ppa.launchpadcontent.net:443
+            la.mirrors.clouvider.net:80
+            linux-mirrors.fnal.gov:80
+            linux.cc.lehigh.edu:80
+            mirror.clarkson.edu:80
+            mirror.cs.vt.edu:80
+            mirror.math.princeton.edu:80
+            mirror.mia11.us.leaseweb.net:80
+            mirror.rackspace.com:80
+            mirror.sfo12.us.leaseweb.net:80
+            mirror.stjschools.org:80
+            mirror.vacares.com:80
+            mirror.wdc2.us.leaseweb.net:80
+            mirrorlist.centos.org:80
+            mirrors.greenmountainaccess.net:80
+            mirrors.iu13.net:80
+            mirrors.ocf.berkeley.edu:80
+            mirrors.seas.harvard.edu:80
+            mirrors.sonic.net:80
+            mirrors.vcea.wsu.edu:80
+            mirrors.xtom.com:80
+            or-mirror.iwebfusion.net:80
             production.cloudflare.docker.com:443
             registry-1.docker.io:443
+
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:

--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -15,15 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign to One Project
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: Harden Runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
-    - name: Assign NEW issues and NEW pull requests to Dotnet Engineering Board
+      - name: Assign NEW issues and NEW pull requests to Dotnet Engineering Board
 
-      uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1 # 1.3.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/newrelic/projects/20'
-        column_name: 'Triage'
+        uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1 # 1.3.1
+        if: github.event.action == 'opened'
+        with:
+          project: 'https://github.com/orgs/newrelic/projects/20'
+          column_name: 'Triage'

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: Download Deploy Artifacts
         uses: dawidd6/action-download-artifact@7132ab516fba5f602fafae6fdd4822afa10db76f # v2.26.1
@@ -247,7 +250,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: >
+            api.fastly.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            deb.debian.org:80
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
+            nr-downloads-main.s3.amazonaws.com:443
+            packages.microsoft.com:443
+            ppa.launchpadcontent.net:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
 
       - name: Install dos2unix
         run: |

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -9,10 +9,11 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+    # intentionally disabled, as the links in our markdown docs grow, we would constantly need to update the allowed endpoints for this step.
+    # - name: Harden Runner
+    #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+    #   with:
+    #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -2,6 +2,12 @@ name: Check Markdown links
 
 on: push
 
+
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -15,16 +15,16 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    # intentionally disabled, as the links in our markdown docs grow, we would constantly need to update the allowed endpoints for this step.
-    # - name: Harden Runner
-    #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
-    #   with:
-    #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: Harden Runner
+        uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
+        with:
+          egress-policy: audit # Leave it audit mode
 
-    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
-    - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
-      with:
-        #use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        config-file: '.github/workflows/markdowncheck.config.json'
-        #max-depth: 2
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+      
+      - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
+        with:
+          #use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/markdowncheck.config.json'
+          #max-depth: 2

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -33,15 +33,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.nuget.org:443
-            collector-1.staging-collectors.newrelic.com:443
-            dc.services.visualstudio.com:443
-            github.com:443
-            newrelic.com:0
-            staging-collector.newrelic.com:443
+          egress-policy: audit # Leave it audit mode
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -33,7 +33,15 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.nuget.org:443
+            collector-1.staging-collectors.newrelic.com:443
+            dc.services.visualstudio.com:443
+            github.com:443
+            newrelic.com:0
+            staging-collector.newrelic.com:443
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - uses: google-github-actions/release-please-action@ee9822ec2c397e8a364d634464339ac43a06e042 # v3.7.6
         with:

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - name: Test Default Branch
         id: default-branch

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,12 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -11,6 +11,12 @@ env:
   DOTNET_NOLOGO: true
   NR_DEV_BUILD_HOME: false
 
+
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,18 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            bestpractices.coreinfrastructure.org:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            index.docker.io:443
+            mcr.microsoft.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            sigstore-tuf-root.storage.googleapis.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -12,7 +12,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            registry.npmjs.org:443
 
       - name: Check if organization member
         id: is_organization_member

--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -11,6 +11,8 @@ jobs:
   set-community-label:
     name: Set Community Label
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
@@ -34,6 +36,4 @@ jobs:
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master
         with:
           add-labels: "community"
-          permissions:
-            issues: write
             

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -16,7 +16,10 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
 
     - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -16,7 +16,10 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
 
     - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:


### PR DESCRIPTION
Applies the recommended configuration for the `harden-runner` action to most of our workflows. Note that some workflows haven't been executed yet, so there is no recommended configuration available at this time.