### PR TITLE
Update set_community_label.yml

### DIFF
--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   set-community-label:
@@ -30,3 +30,6 @@ jobs:
         uses: andymckay/labeler@3a4296e9dcdf9576b0456050db78cfd34853f260 # master
         with:
           add-labels: "community"
+          permissions:
+            issues: write
+            

--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 permissions:
-  contents: read
+  issues: write
 
 jobs:
   set-community-label:


### PR DESCRIPTION
Constraint writes permission to issue updates.  Currently, the community label is not working.
