### PR TITLE
chore: Obfuscate license keys in logs.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -4,6 +4,7 @@
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.Exceptions;
+using NewRelic.Core;
 using NewRelic.Core.Logging;
 using System;
 using System.Collections.Generic;
@@ -44,6 +45,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public const int ProtocolVersion = 17;
         private const int CompressMinimumByteLength = 20;
         private const string EmptyResponseBody = "{}";
+        private const string LicenseKeyParameterName = "license_key";
 
         private bool _diagnoseConnectionError = true;
         private readonly IConfiguration _configuration;
@@ -156,7 +158,7 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private static void AuditLog(Direction direction, Source source, string uri)
         {
-            var message = string.Format(AuditLogFormat, direction, source, uri);
+            var message = string.Format(AuditLogFormat, direction, source, Strings.ObfuscateLicenseKeyInAuditLog(uri, LicenseKeyParameterName));
             Logging.AuditLog.Log(message);
         }
 
@@ -164,7 +166,7 @@ namespace NewRelic.Agent.Core.DataTransport
         {
             var uri = new StringBuilder("/agent_listener/invoke_raw_method?method=")
                 .Append(method)
-                .Append("&license_key=")
+                .Append($"&{LicenseKeyParameterName}=")
                 .Append(_configuration.AgentLicenseKey)
                 .Append("&marshal_format=json")
                 .Append("&protocol_version=")
@@ -290,5 +292,6 @@ namespace NewRelic.Agent.Core.DataTransport
                 Log.Error(message);
             }
         }
+
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
@@ -95,6 +95,16 @@ namespace NewRelic.Agent.Core.Utils
             return Strings.SafeFileName(inputName);
         }
 
+        [TestCase("[{\"high_security\":false}]", ExpectedResult = "[{\"high_security\":false}]")]
+        [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde&marshal_format=json&protocol_version=17",
+            ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabc********************************&marshal_format=json&protocol_version=17")]
+        [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=shortLicenseKey&marshal_format=json&protocol_version=17",
+            ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=***************&marshal_format=json&protocol_version=17")]
+        public string ObfuscateLicenseKeyForAuditLog(string inputText)
+        {
+            return Strings.ObfuscateLicenseKeyInAuditLog(inputText, "license_key");
+        }
+
         private static IEnumerable<object[]> ConvertBytesToStringTestData()
         {
             var encodings = new Encoding[] { Encoding.Unicode, Encoding.UTF8, Encoding.ASCII };


### PR DESCRIPTION
## Description

There were a couple of cases where the agent would log your entire New Relic license key value to a local log file:

- When audit logging is enabled
- When Infinite Tracing is enabled, and the agent's log level is set to FINEST

This PR fixes this by only logging the first 8 characters of the key for troubleshooting purposes, and replacing the rest with asterisks.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
