### PR TITLE
ci: fix errors in stale_pr and stale_issue workflows

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -10,7 +10,6 @@ jobs:
   stale:
     permissions:
       issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
     - name: Harden Runner

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -23,5 +23,7 @@ jobs:
         stale-issue-message: 'This Issue has been marked stale after 90 days with no activity. It will be closed in 30 days if there is no activity.'
         days-before-stale: 90
         days-before-close: 30
+        days-before-pr-stale: -1 # disable pr checking
+        days-before-pr-close: -1 # disable pr checking
         stale-issue-label: 'stale'
         exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review,roadmap'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -9,7 +9,6 @@ permissions:
 jobs:
   stale:
     permissions:
-      issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
@@ -23,5 +22,7 @@ jobs:
         stale-pr-message: 'This PR has been marked stale after 30 days with no activity. It will be closed in 5 days if there is no activity.'
         days-before-stale: 30
         days-before-close: 5
+        days-before-issue-stale: -1 # disable issue checking
+        days-before-issue-close: -1 # disable issue checking
         stale-pr-label: 'stale'
         exempt-pr-labels: 'on hold,in review'


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

After bumping the `actions/stale` action by several major versions, issues were being marked as stand and getting closed when running the `stale_pr.yml` workflow. This was due to a missing configuration that effectively disables checking for stale issues. 

Updated both `stale_pr.yml` and `stale_issue.yml` to address this problem.