### PR TITLE
fix: IsOsPlatform() fails on older .NET Framework Versions

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -46,6 +46,7 @@ namespace NewRelic.Agent.Core
 
                 AddVariable("OS", () => System.Environment.OSVersion?.VersionString);
 
+#if NETSTANDARD2_0
                 // report linux distro name and version when appropriate
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
@@ -53,7 +54,6 @@ namespace NewRelic.Agent.Core
                     AddVariable("Linux Distro Version", () => RuntimeEnvironmentInfo.OperatingSystemVersion);
                 }
 
-#if NETSTANDARD2_0
                 // This API is only supported on .net FX 4.7 + so limiting it
                 // to .net core since that is the one affected. 
                 AddVariable(".NET Version", () => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.ToString());

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/Environment.cs
@@ -17,7 +17,6 @@ using NewRelic.Core.Logging;
 using NewRelic.SystemInterfaces;
 using Newtonsoft.Json;
 using NewRelic.Agent.Configuration;
-using System.Runtime.InteropServices;
 
 namespace NewRelic.Agent.Core
 {
@@ -48,7 +47,9 @@ namespace NewRelic.Agent.Core
 
 #if NETSTANDARD2_0
                 // report linux distro name and version when appropriate
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                // This API is only supported on .net FX 4.7 + so limiting it
+                // to .net core since that is the one affected. 
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
                 {
                     AddVariable("Linux Distro Name", () => RuntimeEnvironmentInfo.OperatingSystem);
                     AddVariable("Linux Distro Version", () => RuntimeEnvironmentInfo.OperatingSystemVersion);

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace NewRelic.Agent.Core
 {
@@ -75,20 +74,22 @@ namespace NewRelic.Agent.Core
 
         private static string GetFreeBSDVersion()
         {
+#if NETSTANDARD2_0
             // This is same as sysctl kern.version
             // FreeBSD 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC
             // What we want is major release as minor releases should be compatible.
-            String version = RuntimeInformation.OSDescription;
+            String version = System.Runtime.InteropServices.RuntimeInformation.OSDescription;
             try
             {
                 // second token up to first dot
-                return RuntimeInformation.OSDescription.Split()[1].Split('.')[0];
+                return System.Runtime.InteropServices.RuntimeInformation.OSDescription.Split()[1].Split('.')[0];
             }
             catch (Exception ex)
             {
                 log4net.ILog logger = log4net.LogManager.GetLogger(typeof(RuntimeEnvironmentInfo));
                 logger.Debug($"Unable to report Operating System: Unexpected exception in GetFreeBSDVersion: {ex}");
             }
+#endif
             return string.Empty;
         }
 
@@ -185,24 +186,28 @@ namespace NewRelic.Agent.Core
 
         private static Platform DetermineOSPlatform()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#if NETSTANDARD2_0
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 return Platform.Windows;
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
             {
                 return Platform.Linux;
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
             {
                 return Platform.Darwin;
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")))
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Create("FREEBSD")))
             {
                 return Platform.FreeBSD;
             }
 
             return Platform.Unknown;
+#else
+            return Platform.Windows;
+#endif
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 
 namespace NewRelic.Agent.Core
 {
-#if NETSTANDARD2_0
     // Originally sourced from .NET SDK (https://github.com/dotnet/sdk)
     // https://github.com/dotnet/sdk/blob/3595e2a/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
     // Copyright (c) .NET Foundation and contributors. All rights reserved.
@@ -206,5 +205,4 @@ namespace NewRelic.Agent.Core
             return Platform.Unknown;
         }
     }
-#endif
 }

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace NewRelic.Agent.Core
 {
+#if NETSTANDARD2_0
     // Originally sourced from .NET SDK (https://github.com/dotnet/sdk)
     // https://github.com/dotnet/sdk/blob/3595e2a/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs
     // Copyright (c) .NET Foundation and contributors. All rights reserved.
@@ -205,4 +206,5 @@ namespace NewRelic.Agent.Core
             return Platform.Unknown;
         }
     }
+#endif
 }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Moved all calls to `RuntimeInformation.IsOsPlatform()` within a `#if NETSTANDARD2_0` block.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
