### PR TITLE
ci: change egress-policy to audit for all harden-runner usages

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -88,7 +88,7 @@ jobs:
       # - name: Harden Runner
       #   uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       #   with:
-      #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      #     egress-policy: audit 
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -138,19 +138,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            auth.docker.io:443
-            azure.archive.ubuntu.com:80
-            esm.ubuntu.com:443
-            ghcr.io:443
-            github.com:443
-            motd.ubuntu.com:443
-            packages.microsoft.com:443
-            pkg-containers.githubusercontent.com:443
-            ppa.launchpadcontent.net:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
+          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -807,40 +795,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            auth.docker.io:443
-            centos.hivelocity.net:80
-            centos.mirror.constant.com:80
-            centos.mirror.ndchost.com:80
-            centos.mirror.shastacoe.net:80
-            coresite.mm.fcix.net:80
-            distro.ibiblio.org:80
-            forksystems.mm.fcix.net:80
-            github.com:443
-            la.mirrors.clouvider.net:80
-            linux-mirrors.fnal.gov:80
-            linux.cc.lehigh.edu:80
-            mirror.clarkson.edu:80
-            mirror.cs.vt.edu:80
-            mirror.math.princeton.edu:80
-            mirror.mia11.us.leaseweb.net:80
-            mirror.rackspace.com:80
-            mirror.sfo12.us.leaseweb.net:80
-            mirror.stjschools.org:80
-            mirror.vacares.com:80
-            mirror.wdc2.us.leaseweb.net:80
-            mirrorlist.centos.org:80
-            mirrors.greenmountainaccess.net:80
-            mirrors.iu13.net:80
-            mirrors.ocf.berkeley.edu:80
-            mirrors.seas.harvard.edu:80
-            mirrors.sonic.net:80
-            mirrors.vcea.wsu.edu:80
-            mirrors.xtom.com:80
-            or-mirror.iwebfusion.net:80
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
+          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -908,13 +863,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            auth.docker.io:443
-            deb.debian.org:80
-            github.com:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
+          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -19,9 +19,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - name: Assign NEW issues and NEW pull requests to Dotnet Engineering Board
 

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Run a one-line script
         run: echo Hello, world!

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -50,9 +50,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - name: Download Deploy Artifacts
         uses: dawidd6/action-download-artifact@7132ab516fba5f602fafae6fdd4822afa10db76f # v2.26.1
@@ -250,19 +248,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.fastly.com:443
-            auth.docker.io:443
-            azure.archive.ubuntu.com:80
-            deb.debian.org:80
-            esm.ubuntu.com:443
-            motd.ubuntu.com:443
-            nr-downloads-main.s3.amazonaws.com:443
-            packages.microsoft.com:443
-            ppa.launchpadcontent.net:443
-            production.cloudflare.docker.com:443
-            registry-1.docker.io:443
+          egress-policy: audit
 
       - name: Install dos2unix
         run: |

--- a/.github/workflows/deploy_awslambda.yml
+++ b/.github/workflows/deploy_awslambda.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Download Deploy Artifacts
         uses: dawidd6/action-download-artifact@7132ab516fba5f602fafae6fdd4822afa10db76f # v2.26.1

--- a/.github/workflows/deploy_siteextension.yml
+++ b/.github/workflows/deploy_siteextension.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Download Deploy Artifacts
         uses: dawidd6/action-download-artifact@7132ab516fba5f602fafae6fdd4822afa10db76f # v2.26.1

--- a/.github/workflows/get_release_checksums.yml
+++ b/.github/workflows/get_release_checksums.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Download Deploy Artifacts
         uses: dawidd6/action-download-artifact@7132ab516fba5f602fafae6fdd4822afa10db76f # v2.26.1

--- a/.github/workflows/multiverse_run.yml
+++ b/.github/workflows/multiverse_run.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -104,7 +104,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - name: Setup .NET Core 3.1.100
         uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,9 +17,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - uses: google-github-actions/release-please-action@f7edb9e61420a022c0f1123edaf342d7e127df92 # v3.7.7
         with:

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -26,9 +26,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
+          egress-policy: audit
 
       - name: Test Default Branch
         id: default-branch

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: audit 
 
       - id: configure_integration_tests_matrix
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,17 +35,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            api.osv.dev:443
-            bestpractices.coreinfrastructure.org:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            index.docker.io:443
-            mcr.microsoft.com:443
-            oss-fuzz-build-logs.storage.googleapis.com:443
-            sigstore-tuf-root.storage.googleapis.com:443
+          egress-policy: audit
 
       - name: "Checkout code"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/set_community_label.yml
+++ b/.github/workflows/set_community_label.yml
@@ -18,10 +18,7 @@ jobs:
         uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
         with:
           disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            registry.npmjs.org:443
+          egress-policy: audit
 
       - name: Check if organization member
         id: is_organization_member

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -16,9 +16,7 @@ jobs:
       uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       with:
         disable-sudo: true
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
+        egress-policy: audit
 
     - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -16,9 +16,7 @@ jobs:
       uses: step-security/harden-runner@03bee3930647ebbf994244c21ddbc0d4933aab4f # v2.3.0
       with:
         disable-sudo: true
-        egress-policy: block
-        allowed-endpoints: >
-          api.github.com:443
+        egress-policy: audit
 
     - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
       with:


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Using `egress-policy: block` in the `harden-runner` action has proven unreliable (the recommended allow-list is incomplete for some jobs), so I'm reverting all usages to `egress-policy: audit` - that will allow all outbound traffic but will also generate artifacts that will let us see the egress traffic from a workflow, in case there is ever a question or issue.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
