### PR TITLE
Report Elasticsearch.net operations more accurately

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -636,7 +636,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        namespace: [ CosmosDB, Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, NServiceBus5, Oracle, Postgres, RabbitMq, Redis ]
+        namespace: [ CosmosDB, Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, NServiceBus5, Oracle, Postgres, RabbitMq, Redis, Elasticsearch ]
       fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
     env:

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -636,7 +636,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        namespace: [ CosmosDB, Couchbase, MongoDB, Msmq, MsSql, MySql, NServiceBus, NServiceBus5, Oracle, Postgres, RabbitMq, Redis, Elasticsearch ]
+        namespace: [ CosmosDB, Couchbase, Elasticsearch, MongoDB, Msmq, MsSql, MySql, NServiceBus, NServiceBus5, Oracle, Postgres, RabbitMq, Redis ]
       fail-fast: false # we don't want one test failure in one namespace to kill the other runs
 
     env:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
-            namespaces="[ 'CosmosDB', 'Couchbase', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis', 'Elasticsearch' ]"
+            namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
           else
             # Just use the supplied list of namespaces
             namespaces="[ ${{ github.event.inputs.unbounded-test-namespaces }} ]"

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
-            namespaces="[ 'CosmosDB', 'Couchbase', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
+            namespaces="[ 'CosmosDB', 'Couchbase', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis', 'Elasticsearch' ]"
           else
             # Just use the supplied list of namespaces
             namespaces="[ ${{ github.event.inputs.unbounded-test-namespaces }} ]"

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Elasticsearch.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Elasticsearch.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />
     <ProjectReference Include="..\..\..\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
@@ -9,6 +9,9 @@ using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
 using System.Collections.Concurrent;
+using NewRelic.SystemExtensions;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace NewRelic.Providers.Wrapper.Elasticsearch
 {
@@ -45,6 +48,7 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
             }
 
             var path = (string)instrumentedMethodCall.MethodCall.MethodArguments[1];
+            var request = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
             var postData = instrumentedMethodCall.MethodCall.MethodArguments[2];
             var requestParams = instrumentedMethodCall.MethodCall.MethodArguments[indexOfRequestParams];
 
@@ -53,7 +57,7 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
             var splitPath = path.Trim('/').Split('/');
             var model = splitPath[0]; // For SQL datastores, "model" is the table name. For Elastic it's the index name, which is always the first component of the request path.
 
-            var operation = (requestParams == null) ? GetOperationFromPath(splitPath) : GetOperationFromRequestParams(requestParams);
+            var operation = (requestParams == null) ? GetOperationFromPath(request, splitPath) : GetOperationFromRequestParams(requestParams);
 
             var transactionExperimental = transaction.GetExperimentalApi();
             var datastoreSegmentData = transactionExperimental.CreateDatastoreSegmentData(new ParsedSqlStatement(DatastoreVendor.Elasticsearch, model, operation), new ConnectionInfo(string.Empty, string.Empty, string.Empty), string.Empty, null);
@@ -124,18 +128,98 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
             return uri;
         }
 
-        private string GetOperationFromPath(string[] splitPath)
+        private void ParsePath(string[] splitPath, out string api, out string subApi)
         {
-            switch (splitPath[1])
+            // Some examples of different structures:
+            // GET /my-index/_count?q=user:foo => API = "_count"
+            // GET /my-index/_search => API = "_search"
+            // PUT /my-index-000001 => API = ""
+            // GET /_search/scroll => API = "_search", subApi = "scroll"
+
+            api = "";
+            subApi = "";
+            bool foundApi = false;
+            foreach (var path in splitPath)
             {
-                case "_doc":
-                case "_create":
-                    return "Index";
-                case "_search":
-                    return "Search";
+                // Sub-api is directly after the API
+                if (foundApi)
+                {
+                    subApi = path.Split('?')[0];
+                    break;
+                }
+                else if (path[0] == '_')
+                {
+                    // The API starts with an underscore and may have parameters
+                    api = path.Split('?')[0];
+                    foundApi = true;
+                }
+            }
+        }
+
+        // Some request types are defined by the HTTP request
+        private static ReadOnlyDictionary<string, string> _requestMap = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+        {
+            { "PUT|_doc", "Index" },
+            { "POST|_doc", "Index" },
+            { "GET|_doc", "Get" },
+            { "HEAD|_doc", "Get" },
+            { "DELETE|_doc", "Delete" },
+        });
+
+        // Some request types use abbreviations
+        private static ReadOnlyDictionary<string, string> _renameMap = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+        {
+            { "_mget", "MultiGet" },
+            { "_termvectors", "TermVectors" },
+            { "_msearch", "MultiSearch" },
+            { "_mtermvectors", "MultiTermVectors" },
+            { "_field_caps", "FieldCapabilities" },
+        });
+
+        // Some request types have a subtype
+        private static ReadOnlyDictionary<string, string> _subTypeMap = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+        {
+            { "_search|template", "SearchTemplate" },
+            { "_msearch|template", "MultiSearchTemplate" },
+            { "_render|template", "RenderSearchTemplate" },
+            { "_search|scroll", "Scroll" },
+        });
+
+        // Some request types depend on the type, subtype, and HTTP request type
+        private static ReadOnlyDictionary<string, string> _fullRequestTypeMap = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+        {
+            { "DELETE|_search|scroll", "ClearScroll" },
+        });
+
+        private string GetOperationFromPath(string request, string[] splitPath)
+        {
+            ParsePath(splitPath, out string api, out string subApi);
+
+            string operation;
+            string apiWithSub = api + "|" + subApi;
+            string apiWithRequest = request + "|" + api;
+            string fullApi = apiWithRequest + "|" + subApi;
+
+            // Check from most-specific to least-specific special cases. Most will fall through to the default handler.
+            if (_fullRequestTypeMap.TryGetValue(fullApi, out operation))
+            {
+                return operation;
+            }
+            if (_subTypeMap.TryGetValue(apiWithSub, out operation))
+            {
+                return operation;
+            }
+            if (_requestMap.TryGetValue(apiWithRequest, out operation))
+            {
+                return operation;
+            }
+            if (_renameMap.TryGetValue(api, out operation))
+            {
+                return operation;
             }
 
-            return "Query";
+            // Many request types are named exactly for their API call, like _search, _create, _search_shards
+            return api.CapitalizeEachWord('_');
 		}
 
         private static void SetUriOnDatastoreSegment(ISegment segment, Uri uri)

--- a/src/NewRelic.Core/NewRelic.SystemExtensions/StringExtensions.cs
+++ b/src/NewRelic.Core/NewRelic.SystemExtensions/StringExtensions.cs
@@ -148,5 +148,29 @@ namespace NewRelic.SystemExtensions
 
             return source + trailing;
         }
+
+        public static string CapitalizeWord(this string word)
+        {
+            if (string.IsNullOrEmpty(word))
+            {
+                return word;
+            }
+            string result = char.ToUpper(word[0]).ToString();
+            if (word.Length > 1)
+            {
+                result += word.Substring(1);
+            }
+            return result;
+        }
+
+        public static string CapitalizeEachWord(this string source, char separator = ' ', bool removeSeparator = true)
+        {
+            var words = source.Split(separator);
+            for (int idx = 0; idx < words.Length; idx++)
+            {
+                words[idx] = CapitalizeWord(words[idx]);
+            }
+            return removeSeparator ? string.Join("", words) : string.Join(separator.ToString(), words);
+        }
     }
 }

--- a/tests/NewRelic.Core.Tests/NewRelic.SystemExtensions/StringExtensions.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.SystemExtensions/StringExtensions.cs
@@ -135,5 +135,37 @@ namespace NewRelic.SystemExtensions.UnitTests
 
             Assert.AreEqual(expectedResult, actualResult);
         }
+
+        [TestCase("foo", "Foo")]
+        [TestCase("Bar", "Bar")]
+        [TestCase("Foo", "Foo")]
+        [TestCase("BAR", "BAR")]
+        [TestCase("the quick brown fox", "The quick brown fox")]
+        [TestCase("2251", "2251")]
+        [TestCase(" ", " ")]
+        public void CapitalizeWord(string word, string expectedResult)
+        {
+            var actualResult = word.CapitalizeWord();
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [TestCase("the quick brown fox", ' ', false, "The Quick Brown Fox")]
+        [TestCase("the quick brown fox", ' ', true, "TheQuickBrownFox")]
+        [TestCase("the_quick_brown_fox", '_', false, "The_Quick_Brown_Fox")]
+        [TestCase("the_quick_brown_fox", '_', true, "TheQuickBrownFox")]
+        [TestCase("_foo", '_', true, "Foo")]
+        [TestCase("_foo", '_', false, "_Foo")]
+        [TestCase("bar_", '_', true, "Bar")]
+        [TestCase("bar_", '_', false, "Bar_")]
+        [TestCase("_foo_bar_", '_', true, "FooBar")]
+        [TestCase("_foo_bar_", '_', false, "_Foo_Bar_")]
+
+        public void CapitalizeEachWord(string sentence, char separator, bool removeSeparator, string expectedResult)
+        {
+            var actualResult = sentence.CapitalizeEachWord(separator, removeSeparator);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
     }
 }


### PR DESCRIPTION
Elasticsearch.net does not report the request parameters in a nice object like the other libraries, so we need to parse the path to find the actual operation performed. This should be accurate for all Index, Document, and Search requests. Other APIs may not match up exactly because there are a lot of special cases (abbreviations, etc.), but it should be pretty close.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
