### PR TITLE
feat: Move TLS config logging closer to connect. (#1558)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
@@ -74,6 +74,7 @@ namespace NewRelic.Agent.Core.DataTransport
             try
             {
                 ValidateNotBothHsmAndSecurityPolicies(_configuration);
+                LogTlsConfiguration();
 
                 var preconnectResult = SendPreconnectRequest();
                 _connectionInfo = new ConnectionInfo(_configuration, preconnectResult.RedirectHost);
@@ -110,6 +111,11 @@ namespace NewRelic.Agent.Core.DataTransport
                 Log.Error($"Unable to connect to the New Relic service at {_connectionInfo} : {e}");
                 throw;
             }
+        }
+
+        private void LogTlsConfiguration()
+        {
+            Log.Info($"Current TLS Configuration (System.Net.ServicePointManager.SecurityProtocol): {System.Net.ServicePointManager.SecurityProtocol}");
         }
 
         private void GenerateSpanEventsHarvestLimitMetrics(SingleEventHarvestConfig spanEventHarvestConfig)

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -184,12 +184,6 @@ namespace NewRelic.Agent.Core
 
             StartServices();
             LogInitialized();
-            LogTlsConfiguration();
-        }
-
-        private void LogTlsConfiguration()
-        {
-            Log.Info($"TLS Configuration (System.Net.ServicePointManager.SecurityProtocol): {System.Net.ServicePointManager.SecurityProtocol}");
         }
 
         private void LogInitialized()


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Moves logging of TLS configuration from early during initialization to just before the PreConnect call. This should ensure that we log the "current" TLS configuration at the moment we are connecting, which may be different from what we found during startup (i.e., client app can change the configuration at any time). 

Tested by changing the TLS configuration after application startup, then making a change to newRelic.config, which forced a re-connect. Verified that the TLS config logged on re-connect matched the changed value.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
