### PR TITLE
Elasticsearch error reporting

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -30,12 +30,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Index()
+        private void IndexInternal(string indexName, bool validate = true)
         {
             var record = FlightRecord.GetSample();
-            var response = _client.Index(record, IndexName);
+            var response = _client.Index(record, indexName);
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            if (validate)
+            {
+                Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public override void Index()
+        {
+            IndexInternal(IndexName);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -122,6 +131,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var response = await _client.MultiSearchAsync<FlightRecord>();
 
             return response.TotalResponses;
+        }
+
+        public override void GenerateError()
+        {
+            IndexInternal(BadIndexName, false);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -91,5 +91,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public async Task IndexManyAsync() => await _client.IndexManyAsync();
 
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void GenerateError() => _client.GenerateError();
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 using Nest;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
@@ -29,12 +30,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Index()
+        private void IndexInternal(string indexName, bool validate = true)
         {
             var record = FlightRecord.GetSample();
-            var response = _client.IndexDocument(record);
+            var response = _client.Index(record, i => i.Index(indexName));
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            if (validate)
+            {
+                Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public override void Index()
+        {
+            IndexInternal(IndexName);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -152,6 +162,12 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
 
             return response.TotalResponses;
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public override void GenerateError()
+        {
+            IndexInternal(BadIndexName, false);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -27,12 +27,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Index()
+        private void IndexInternal(string indexName, bool validate = true)
         {
             var record = FlightRecord.GetSample();
-            var response = _client.Index<BytesResponse>(IndexName, record.Id.ToString(), PostData.Serializable(record));
+            var response = _client.Index<BytesResponse>(indexName, record.Id.ToString(), PostData.Serializable(record));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            if (validate)
+            {
+                Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public override void Index()
+        {
+            IndexInternal(IndexName);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -188,6 +197,12 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             Assert.True(response.Success, $"Elasticsearch server error: {response}");
 
             return 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public override void GenerateError()
+        {
+            IndexInternal(BadIndexName);
         }
 
     }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -12,6 +12,8 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
     internal abstract class ElasticsearchTestClient
     {
         protected const string IndexName = "flights";   // Must be lowercase!
+        protected const string BadIndexName = "_ILLEGAL";
+
         protected Uri Address = new Uri(ElasticSearchConfiguration.ElasticServer);
 
         public ElasticsearchTestClient() { }
@@ -33,6 +35,8 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         public abstract void MultiSearch();
 
         public abstract Task<long> MultiSearchAsync();
+
+        public abstract void GenerateError();
     }
 
     public class FlightRecord

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -69,6 +69,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
             _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
 
+            _fixture.AddCommand($"ElasticsearchExerciser GenerateError");
+
             _fixture.Actions
             (
                 setupConfiguration: () =>
@@ -128,6 +130,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         public void MultiSearchAsync()
         {
             ValidateOperation("SearchAsync");
+        }
+
+        [Fact]
+        public void Error()
+        {
+            ValidateError("GenerateError");
+        }
+
+        private void ValidateError(string operationName)
+        {
+            var errorTrace =
+                _fixture.AgentLog.TryGetErrorTrace(
+                    $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/{operationName}");
+            Assert.NotNull(errorTrace);
         }
 
 


### PR DESCRIPTION
Elasticsearch's error handling is a bit unusual. As far as I can tell, if the library layer can detect an error before it sends the request to the server, it doesn't throw an exception or set any kind of error object. Though some of the libraries look like they fake an HTTP status code? In any case, this approach should give us enough error info to be useful.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
