### PR TITLE
fix: Add missing instrumentation to MSI installer

### DIFF
--- a/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
+++ b/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
@@ -38,7 +38,7 @@ namespace ArtifactBuilder.Artifacts
                 return;
             }
 
-            //ValidateWxsDefinitionFileForInstaller();
+            ValidateWxsDefinitionFileForInstaller();
 
             var fileSearchPattern = $@"NewRelicAgent_{Platform}_*.msi";
             var msiPath = Directory.GetFiles(MsiDirectory, fileSearchPattern).FirstOrDefault();
@@ -162,7 +162,7 @@ namespace ArtifactBuilder.Artifacts
                     throw new PackagingException($"Product.wxs file {file.Id} did not have KeyPath set to yes, but was {file.KeyPath}.");
                 }
 
-                var expectedSourcePath = isCore ? $@"$(var.SolutionDir)newrelichome_$(var.Platform)_coreclr\extensions\{file.Name}" : $@"$(var.SolutionDir)newrelichome_$(var.Platform)\extensions\{file.Name}";
+                var expectedSourcePath = isCore ? $@"$(var.HomeFolderPath)_coreclr\extensions\{file.Name}" : $@"$(var.HomeFolderPath)\extensions\{file.Name}";
                 if (file.Source != expectedSourcePath)
                 {
                     throw new PackagingException($"Product.wxs file {file.Id} did not have the expected source path of {expectedSourcePath}, but was {file.Source}");

--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -439,6 +439,9 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="CouchbaseWrapperComponent" Guid="{21A0A03D-4799-4D8B-B6DB-553DD66C7020}">
         <File Id="CouchbaseWrapperFile" Name="NewRelic.Providers.Wrapper.Couchbase.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Couchbase.dll"/>
       </Component>
+      <Component Id="CosmosDbWrapperComponent" Guid="{C72D656C-B55D-4690-9BD7-9343096D4553}">
+        <File Id="CosmosDbWrapperFile" Name="NewRelic.Providers.Wrapper.CosmosDb.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.CosmosDb.dll"/>
+      </Component>
 
       <Component Id="OwinWrapperComponent" Guid="{FC044DC6-52D8-42C6-A9FE-CB9425EF5811}">
         <File Id="OwinWrapperFile" Name="NewRelic.Providers.Wrapper.Owin.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Owin.dll"/>
@@ -495,6 +498,9 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreRabbitMqWrapperComponent" Guid="{758394DD-AB71-4E58-8E18-BF1135F8B2C2}">
         <File Id="CoreRabbitMqWrapperFile" Name="NewRelic.Providers.Wrapper.RabbitMq.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.RabbitMq.dll"/>
+      </Component>
+      <Component Id="CoreCosmosDbWrapperComponent" Guid="{3855755F-2A69-43EC-AE31-8D778E4B41E2}">
+        <File Id="CoreCosmosDbWrapperFile" Name="NewRelic.Providers.Wrapper.CosmosDb.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.CosmosDb.dll"/>
       </Component>
       <Component Id="CoreLog4NetLoggingWrapperComponent" Guid="{882392E9-9403-41EC-9321-9C6E53781744}">
         <File Id="CoreLog4NetLoggingWrapperFile" Name="NewRelic.Providers.Wrapper.Log4NetLogging.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Log4NetLogging.dll"/>
@@ -592,6 +598,9 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="CouchbaseInstrumentationComponent" Guid="{03FA7D3A-3368-45B1-92B8-19DA97A659B8}">
         <File Id="CouchbaseInstrumentationFile" Name="NewRelic.Providers.Wrapper.Couchbase.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Couchbase.Instrumentation.xml"/>
       </Component>
+      <Component Id="CosmosDbInstrumentationComponent" Guid="{56DEAF3E-5F51-4C47-82E5-1C2D0FF4E7DD}">
+        <File Id="CosmosDbInstrumentationFile" Name="NewRelic.Providers.Wrapper.CosmosDb.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.CosmosDb.Instrumentation.xml"/>
+      </Component>
       <Component Id="MiscInstrumentationComponent" Guid="{EE12546C-A328-49A7-84BE-B9A556ADA0A8}">
         <File Id="MiscInstrumentationFile" Name="NewRelic.Providers.Wrapper.Misc.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Misc.Instrumentation.xml"/>
       </Component>
@@ -633,6 +642,9 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreRabbitMqInstrumentationComponent" Guid="{1CDC18CC-992A-4386-BC4D-DE87A85D9568}">
         <File Id="CoreRabbitMqInstrumentationFile" Name="NewRelic.Providers.Wrapper.RabbitMq.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.RabbitMq.Instrumentation.xml"/>
+      </Component>
+      <Component Id="CoreCosmosDbInstrumentationComponent" Guid="{1B6D4139-9217-4A03-94D0-D6E3AFFE0A8E}">
+        <File Id="CoreCosmosDbInstrumentationFile" Name="NewRelic.Providers.Wrapper.CosmosDb.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.CosmosDb.Instrumentation.xml"/>
       </Component>
       <Component Id="CoreLog4NetLoggingInstrumentationComponent" Guid="{A40554DF-870C-477C-8910-1113A221820C}">
         <File Id="CoreLog4NetLoggingInstrumentationFile" Name="NewRelic.Providers.Wrapper.Log4NetLogging.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Log4NetLogging.Instrumentation.xml"/>


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The MSI installer was not configured to install the CosmosDb instrumentation files. This PR adds the missing files to the MSI installer, and restores the tests that attempt to detect if instrumentation is missing from the MSI installer configuration files.

The ArtifactBuilder was run locally to validate that the configuration tests are working. These tests detected that the MSI installer did not include the CosmosDb instrumentation.

# Author Checklist
- ~~[ ] Unit tests, Integration tests, and Unbounded tests completed~~
- ~~[ ] Performance testing completed with satisfactory results (if required)~~

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
