### PR TITLE
docs: Remove invalid CSP link

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -141,7 +141,7 @@ The integration tests require round-trip communication with valid New Relic acco
 
   1. Create a `secrets.json` file using the template below or copy the [example](https://github.com/newrelic/newrelic-dotnet-agent/blob/main/tests/Agent/IntegrationTests/UnboundedServices/example-secrets.json).  **Do *not* place the `secrets.json` file within your local repo folder.**
   2. Replace the license key placeholders in the `secrets.json` template with actual license keys.
-      * The `REPLACE_WITH_HIGH_SECURITY_LICENSE_KEY` and `REPLACE_WITH_SECURITY_POLICIES_CONFIGURABLE_LICENSE_KEY` are placeholders for license keys from a [HSM](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode)-enabled account and a [CSP](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/enable-configurable-security-policies)-enabled account, respectively.
+      * The `REPLACE_WITH_HIGH_SECURITY_LICENSE_KEY` and `REPLACE_WITH_SECURITY_POLICIES_CONFIGURABLE_LICENSE_KEY` are placeholders for license keys from a [HSM](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode)-enabled account and a CSP-enabled account, respectively.
       * To find your license keys, visit [this page](https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/new-relic-license-key/).
 
 * Once placeholder values have been replaced with actual values:


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The integration tests doc contained a url that was purposely removed and there is no planned replacement for it. For now we can just remove the link from our doc which should allow our markdown url checker to start passing again.

# Author Checklist
- ~~[ ] Unit tests, Integration tests, and Unbounded tests completed~~
- ~~[ ] Performance testing completed with satisfactory results (if required)~~

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
