### PR TITLE
Add read packages permissions to agent deploy job

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -36,6 +36,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   
 env:
   DOTNET_NOLOGO: true


### PR DESCRIPTION
## Description

Attempted to deploy the agent and got an error saying that the `index-download-site` job in the agent deploy workflow needed the `packages:read` permission.  This PR adds that permission.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
