### PR TITLE
chore: Look for specific msi version and file path cleanup.

### DIFF
--- a/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
+++ b/build/ArtifactBuilder/Artifacts/MsiInstaller.cs
@@ -290,7 +290,7 @@ namespace ArtifactBuilder.Artifacts
 
         private bool TryGetMsiPath(out string msiPath)
         {
-            var fileSearchPattern = $@"NewRelicAgent_{Platform}_*.msi";
+            var fileSearchPattern = $@"NewRelicAgent_{Platform}_{_frameworkAgentComponents.Version}.msi";
             msiPath = Directory.GetFiles(MsiDirectory, fileSearchPattern).FirstOrDefault();
 
             if (string.IsNullOrEmpty(msiPath))
@@ -311,7 +311,7 @@ namespace ArtifactBuilder.Artifacts
                 return;
             }
 
-            var installedFilesRoot = unpackedLocation + $@"\New Relic\.NET Agent\";
+            var installedFilesRoot = Path.Join(unpackedLocation, "New Relic", ".NET Agent");
 
             var expectedComponents = GetExpectedComponents(installedFilesRoot);
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the ArtifactBuilder for the Msi installer so that it will grab the correct version of the profiler (the one that matches that locally built agent) so that it compare the correct agent components. This PR also includes another case where we can use Path.Join to build out the file paths.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
