### PR TITLE
test: eliminate use of arbitrary delays in ConsoleMF integration tests, part 1

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 
         // SetApplicationName related messages
-        public const string SetApplicationnameAPICalledDuringCollectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
+        public const string SetApplicationnameAPICalledDuringConnectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
         // Infinite trace

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -62,6 +62,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
         // Infinite trace
+        public const string SpanStreamingServiceConnectedLogLineRegex = InfoLogLinePrefixRegex + @"SpanStreamingService: gRPC channel to endpoint (.*) connected.(.*)";
         public const string SpanStreamingSuccessfullySentLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Attempting to send (\d+) item\(s\) - Success";
         public const string SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Received gRPC Server response messages: (\d+)";
         public const string SpanStreamingResponseGrpcError = FinestLogLinePrefixRegex + @"ResponseStreamWrapper: consumer \d+ - gRPC RpcException encountered while handling gRPC server responses: (.*)";

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -58,12 +58,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsAInfoLogMessage INFO");
 
-            // This is necessary to allow the logging data endpoint to be called before the application is shut down
-            _fixture.AddCommand($"RootCommands DelaySeconds 5");
-
-
-
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -71,6 +66,10 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
                     configModifier.EnableLogForwarding()
                     .SetLogLevel("debug");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(10));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -44,26 +44,26 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
     
     public abstract class DataUsageSupportabilityMetricsTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         public DataUsageSupportabilityMetricsTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
-            Fixture = fixture;
-            Fixture.TestLogger = output;
-            Fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
             // Logging commands
-            Fixture.AddCommand($"LoggingTester SetFramework log4net");
-            Fixture.AddCommand($"LoggingTester Configure");
+            _fixture.AddCommand($"LoggingTester SetFramework log4net");
+            _fixture.AddCommand($"LoggingTester ConfigureWithInfoLevelEnabled");
 
-            Fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsADebugLogMessage DEBUG");
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsAInfoLogMessage INFO");
 
-            // This is necessary to cause one harvest cycle to happen and cause the logging data endpoint to be called
-            Fixture.AddCommand($"RootCommands DelaySeconds 60");
+            // This is necessary to allow the logging data endpoint to be called before the application is shut down
+            _fixture.AddCommand($"RootCommands DelaySeconds 5");
 
 
 
-            Fixture.Actions
+            _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
         [InlineData("Supportability/DotNET/Collector/log_event_data/Output/Bytes")]
         public void ExpectedDataUsageMetric(string expectedMetricName)
         {
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var dataUsageMetric = metrics.FirstOrDefault(x => x.MetricSpec.Name == expectedMetricName);
             Assert.NotNull(dataUsageMetric);

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -69,7 +69,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(10));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(30));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
@@ -6,7 +6,6 @@ using MultiFunctionApplicationHelpers;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
@@ -33,17 +32,16 @@ namespace NewRelic.Agent.IntegrationTests.Api
 
     public abstract class CustomSpanNameApiTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         public CustomSpanNameApiTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
-            Fixture = fixture;
-            Fixture.TestLogger = output;
+            _fixture = fixture;
+            _fixture.TestLogger = output;
 
-            Fixture.AddCommand($"AttributeInstrumentation TransactionWithCustomSpanName CustomSpanName");
-            Fixture.AddCommand("RootCommands DelaySeconds 5");
+            _fixture.AddCommand($"AttributeInstrumentation TransactionWithCustomSpanName CustomSpanName");
 
-            Fixture.Actions
+            _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
@@ -53,14 +51,14 @@ namespace NewRelic.Agent.IntegrationTests.Api
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Fact]
         public void SupportabilityMetricExists()
         {
             var expectedMetric = new Assertions.ExpectedMetric { metricName = $"Supportability/ApiInvocation/SpanSetName", callCount = 1 };
-            Assertions.MetricExists(expectedMetric, Fixture.AgentLog.GetMetrics());
+            Assertions.MetricExists(expectedMetric, _fixture.AgentLog.GetMetrics());
         }
 
         [Fact]
@@ -72,7 +70,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
                 new Assertions.ExpectedMetric { metricName = $"DotNet/CustomSpanName", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Internal.AttributeInstrumentation/TransactionWithCustomSpanName", callCount = 1 }
             };
 
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             Assertions.MetricsExist(expectedMetrics, metrics);
         }
@@ -80,7 +78,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
         [Fact]
         public void TransactionTraceContainsSegmentWithCustomSpanName()
         {
-            var transactionTrace = Fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
+            var transactionTrace = _fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
             Assert.NotNull(transactionTrace);
 
             transactionTrace.TraceData.ContainsSegment("CustomSpanName");
@@ -89,7 +87,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
         [Fact]
         public void SpanEventDataHasCustomSpanName()
         {
-            var spanEvents = Fixture.AgentLog.GetSpanEvents();
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
             Assert.Contains(spanEvents, x => (string)x.IntrinsicAttributes["name"] == "CustomSpanName");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
@@ -3,8 +3,6 @@
 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
@@ -26,14 +24,13 @@ namespace NewRelic.Agent.IntegrationTests.AppDomainCaching
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"RootCommands InstrumentedMethodToStartAgent");
-            _fixture.AddCommand($"RootCommands DelaySeconds 10");
 
             if(_appDomainCachingDisabled)
             {
                 _fixture.SetAdditionalEnvironmentVariable("NEW_RELIC_DISABLE_APPDOMAIN_CACHING", _appDomainCachingDisabled ? "true" : "false");
             }
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -42,6 +39,10 @@ namespace NewRelic.Agent.IntegrationTests.AppDomainCaching
                     configModifier
                     .EnableDistributedTrace()
                     .SetLogLevel("debug");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForConnect(TimeSpan.FromSeconds(30));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
@@ -66,7 +66,6 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
             _fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
 
             _fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
-            //_fixture.AddCommand("RootCommands DelaySeconds 5");
 
             _fixture.AddActions
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
@@ -3,13 +3,12 @@
 
 
 using MultiFunctionApplicationHelpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
 
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
@@ -53,7 +52,7 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
     {
         private const string LibraryClassName = "MultiFunctionApplicationHelpers.NetStandardLibraries.Internal.AttributeInstrumentation";
 
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         private readonly bool ForceNewTransaction;
 
@@ -61,35 +60,41 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
         {
             ForceNewTransaction = forceNewTransaction;
 
-            Fixture = fixture;
-            Fixture.TestLogger = output;
+            _fixture = fixture;
+            _fixture.TestLogger = output;
 
-            Fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
+            _fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
 
-            Fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
-            Fixture.AddCommand("RootCommands DelaySeconds 5");
+            _fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
+            //_fixture.AddCommand("RootCommands DelaySeconds 5");
 
-            Fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
+                    configModifier.ForceTransactionTraces()
+                    .SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(10));
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Fact]
         public void Test()
         {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>();
-
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"OtherTransaction/all", callCount = ForceNewTransaction ? 2 : 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"OtherTransaction/Custom/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 });
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"OtherTransaction/all", callCount = ForceNewTransaction ? 2 : 1 },
+                new Assertions.ExpectedMetric { metricName = $"OtherTransaction/Custom/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 }
+            };
 
             if (ForceNewTransaction)
             {
@@ -97,7 +102,7 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
             }
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/SpanOrTransactionBasedOnConfig", callCount = 1 });
 
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             Assertions.MetricsExist(expectedMetrics, metrics);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
@@ -23,9 +23,6 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
 
             _fixture.AddCommand($"ApiCalls TestSetApplicationName NewIntegrationTestName");
 
-            // Needed to ensure that the scheduled reconnect, with a 15 second delay, can happen
-            _fixture.AddCommand($"RootCommands DelaySeconds 30");
-
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -39,8 +36,10 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SetApplicationnameAPICalledDuringCollectMethodLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SetApplicationnameAPICalledDuringConnectMethodLogLineRegex, TimeSpan.FromMinutes(1));
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.AttemptReconnectLogLineRegex, TimeSpan.FromMinutes(1));
+                    // There should be two connected log lines, one for the initial connect and the other after the reconnect
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1), 2);
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
@@ -31,16 +31,6 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
 
             _fixture.AddCommand("InfiniteTracingTester StartAgent");
 
-            // Give the agent time to warm up... If we send a span too soon, it will be sent via DT (span_event_data) instead of 8T (gRPC)
-            _fixture.AddCommand("RootCommands DelaySeconds 15");
-
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -56,6 +46,16 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
                 ,
                 exerciseApplication: () =>
                 {
+                    // Wait for 8T to connect
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanStreamingServiceConnectedLogLineRegex, TimeSpan.FromSeconds(15));
+                    // Now send the command to make the 8T Span
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    // Now wait to see that the 8T spans were sent successfully
                     _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullySentLogLineRegex, TimeSpan.FromSeconds(45), 12);
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.SpanStreamingResponseGrpcError, TimeSpan.FromSeconds(45));
                 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -43,6 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
                     // Now send the command to make the 8T Span
                     _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
                     // Now wait to see that the 8T spans were sent successfully
+                    _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullySentLogLineRegex, TimeSpan.FromMinutes(1), ExpectedSentCount);
                     _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex, TimeSpan.FromMinutes(1), ExpectedSentCount);
                 }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -184,6 +184,16 @@ namespace MultiFunctionApplicationHelpers
             return this;
         }
 
+        public void SendCommand(string cmd)
+        {
+            if (!RemoteApplication.IsRunning)
+            {
+                throw new Exception($"Remote Process has exited, Cannot execute command: {cmd}");
+            }
+
+            RemoteApplication.WriteToStandardInput(cmd);
+        }
+
         public ConsoleDynamicMethodFixture(string applicationDirectoryName, string executableName, string targetFramework, bool isCoreApp, TimeSpan timeout)
             : base(new RemoteConsoleApplication(applicationDirectoryName, executableName, targetFramework, ApplicationType.Shared, isCoreApp, isCoreApp)
                   .SetTimeout(timeout)
@@ -193,12 +203,7 @@ namespace MultiFunctionApplicationHelpers
             {
                 foreach (var cmd in _commands)
                 {
-                    if (!RemoteApplication.IsRunning)
-                    {
-                        throw new Exception($"Remote Process has exited, Cannot execute command: {cmd}");
-                    }
-
-                    RemoteApplication.WriteToStandardInput(cmd);
+                    SendCommand(cmd);
                 }
             });
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
@@ -2,20 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using MultiFunctionApplicationHelpers;
-using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 using NServiceBus;
-using NsbTests;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 #if !NET462
@@ -112,35 +104,33 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void PublishEventInTransaction()
+        public async void PublishEventInTransaction()
         {
-            PublishEvent();
+            await PublishEvent();
         }
 
         [LibraryMethod]
-        public void PublishEvent()
+        public async Task PublishEvent()
         {
             var @event = new Event();
             ConsoleMFLogger.Info($"Sending NServiceBus Event with Id: {@event.Id}");
-            _endpoint.Publish(@event).Wait();
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            await _endpoint.Publish(@event);
         }
 
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void SendCommandInTransaction()
+        public async void SendCommandInTransaction()
         {
-            SendCommand();
+            await SendCommand();
         }
 
         [LibraryMethod]
-        public void SendCommand()
+        public async Task SendCommand()
         {
             var command = new Command();
             ConsoleMFLogger.Info($"Sending NServiceBus Command with Id: {command.Id}");
-            _endpoint.SendLocal(command).Wait();
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            await _endpoint.SendLocal(command);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
@@ -104,7 +104,7 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async void PublishEventInTransaction()
+        public async Task PublishEventInTransaction()
         {
             await PublishEvent();
         }
@@ -120,7 +120,7 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async void SendCommandInTransaction()
+        public async Task SendCommandInTransaction()
         {
             await SendCommand();
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver PublishEventInTransaction");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver PublishEventInTransaction");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 


### PR DESCRIPTION
## Description

In order to help reduce the overall execution time of our CI, as well as be more deterministic, this PR eliminates the use of `RootCommands DelaySeconds` from a bunch of ConsoleMF-based integration tests.  The primary way this has been accomplished is to have the test harness wait for certain agent log lines to appear instead of just sleeping for an arbitrary amount of time.

A few other things:
* The NServiceBus exerciser has been updated to do a more proper async-await pattern that returns a `Task` to the ConsoleMF app that waits on it, rather than doing its own waiting.
* In order to eliminate the need for a 15-second sleep in the 8T tests, which was to allow the SpanStreamingService to connect to the trace observer before exercising the app to generate spans, a new pattern of usage for ConsoleMF is introduced where test application commands can be sent *after* waiting for the appearance of a given agent log line.

The only remaining uses of DelaySeconds are found in the application logging instrumentation tests, where they are being used to work around some un-awaited async calls.  Those tests are complex enough that I plan to tackle solving them in a separate PR.

All of these affected tests are passing for me reliably locally after these changes; we'll see how they go in CI.
