### PR TITLE
test: Update code coverage exclusion list

### DIFF
--- a/tests/UnitTests.runsettings
+++ b/tests/UnitTests.runsettings
@@ -20,7 +20,7 @@
                     <!-- See https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
                      and https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#excluding-from-coverage -->
                     <Exclude>[NewRelic.OpenTracing.AmazonLambda*]*</Exclude>
-                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs</ExcludeByFile>
+                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/NewRelic.Agent.Core/AgentManager.cs</ExcludeByFile>
                     <ExcludeByAttribute>NrExcludeFromCodeCoverage,Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                 </Configuration>
             </DataCollector>

--- a/tests/UnitTests.runsettings
+++ b/tests/UnitTests.runsettings
@@ -20,8 +20,7 @@
                     <!-- See https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
                      and https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#excluding-from-coverage -->
                     <Exclude>[NewRelic.OpenTracing.AmazonLambda*]*</Exclude>
-                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/Agent/Core/Config/Configuration.cs</ExcludeByFile>
-                    <ExcludeByFile>**/NewRelic.Agent.Core.Extension/Extension.cs</ExcludeByFile>
+                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs</ExcludeByFile>
                     <ExcludeByAttribute>NrExcludeFromCodeCoverage,Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                 </Configuration>
             </DataCollector>

--- a/tests/UnitTests.runsettings
+++ b/tests/UnitTests.runsettings
@@ -20,7 +20,8 @@
                     <!-- See https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
                      and https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#excluding-from-coverage -->
                     <Exclude>[NewRelic.OpenTracing.AmazonLambda*]*</Exclude>
-                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs</ExcludeByFile>
+                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/Agent/Core/Config/Configuration.cs</ExcludeByFile>
+                    <ExcludeByFile>**/NewRelic.Agent.Core.Extension/Extension.cs</ExcludeByFile>
                     <ExcludeByAttribute>NrExcludeFromCodeCoverage,Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                 </Configuration>
             </DataCollector>


### PR DESCRIPTION
Updated exclusion list for unit test code coverage. Also verified that all files marked in the Code Coverage Analysis spreadsheet as "exclude" are, indeed, excluded. 

We gained a whopping [0.6% increase in code coverage](https://app.codecov.io/github/newrelic/newrelic-dotnet-agent/commit/d230125bfc11ffbdb13b9a96188822b6795cdeb6/tree/src/NewRelic.Core) as a result!