### PR TITLE
chore: Pin Dockerfile dependencies by hash.

### DIFF
--- a/src/Agent/NewRelic/Profiler/linux/Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Dockerfile
@@ -1,6 +1,6 @@
 # Using a multistage build to work around some expired certificates
 # that prevent cloning the CLR repo from the older ubuntu image.
-FROM ubuntu:22.04 AS ClrRepoCloner
+FROM ubuntu@sha256:ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 AS ClrRepoCloner #22.04
 
 RUN apt-get update && apt-get install -y \
   git
@@ -14,7 +14,7 @@ RUN git clone --branch release/3.1 https://github.com/dotnet/coreclr.git
 
 # This builds an Ubuntu image, clones the coreclr github repo and builds it.
 # It then sets up the environment for compiling the New Relic .NET profiler.
-FROM ubuntu:14.04
+FROM ubuntu@sha256:881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d #14.04
 
 RUN apt-get update && apt-get install -y \
   wget \

--- a/src/Agent/NewRelic/Profiler/linux/Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Dockerfile
@@ -1,6 +1,7 @@
 # Using a multistage build to work around some expired certificates
 # that prevent cloning the CLR repo from the older ubuntu image.
-FROM ubuntu@sha256:ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 AS ClrRepoCloner #22.04
+# v22.04
+FROM ubuntu@sha256:ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 AS ClrRepoCloner 
 
 RUN apt-get update && apt-get install -y \
   git
@@ -14,7 +15,8 @@ RUN git clone --branch release/3.1 https://github.com/dotnet/coreclr.git
 
 # This builds an Ubuntu image, clones the coreclr github repo and builds it.
 # It then sets up the environment for compiling the New Relic .NET profiler.
-FROM ubuntu@sha256:881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d #14.04
+# v14.04
+FROM ubuntu@sha256:881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d
 
 RUN apt-get update && apt-get install -y \
   wget \


### PR DESCRIPTION
Addresses a [code scanning alert](https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/203) by updating the Linux profiler Dockerfile to reference source images by hash rather than version tag. 

Tested locally via `docker-compose build build` and was successful.