### PR TITLE
test: reduce logging integration testing time

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -471,8 +471,7 @@ jobs:
       matrix:
         namespace: [ AgentFeatures, AgentLogs, AgentMetrics, Api, AppDomainCaching, AspNetCore, BasicInstrumentation, CatInbound, CatOutbound, CodeLevelMetrics, Configuration, 
           CSP, CustomAttributes, CustomInstrumentation, DataTransmission, DistributedTracing, Errors, HttpClientInstrumentation, InfiniteTracing, Logging.ContextData, 
-          Logging.HsmAndCsp, Logging.LocalDecoration, Logging.LogLevelDetection, Logging.MaxSamplesStored, Logging.MetricsAndForwarding.log4net, 
-          Logging.MetricsAndForwarding.MicrosoftLogging, Logging.MetricsAndForwarding.NLog, Logging.MetricsAndForwarding.Serilog, Logging.ZeroMaxSamplesStored,
+          Logging.HsmAndCsp, Logging.LocalDecoration, Logging.LogLevelDetection, Logging.MaxSamplesStored, Logging.MetricsAndForwarding, Logging.ZeroMaxSamplesStored,
           Owin, ReJit.NetCore, ReJit.NetFramework, RequestHandling, RequestHeadersCapture.AspNet, RequestHeadersCapture.AspNetCore, RequestHeadersCapture.EnvironmentVariables, 
           RequestHeadersCapture.Owin, RequestHeadersCapture.WCF, RestSharp, WCF.Client.IIS.ASPDisabled, WCF.Client.IIS.ASPEnabled, WCF.Client.Self, 
           WCF.Service.IIS.ASPDisabled, WCF.Service.IIS.ASPEnabled, WCF.Service.Self] # maintain alphabetical order, please!

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -54,8 +54,7 @@ jobs:
             # Use the full list of namespaces
             namespaces="[ 'AgentFeatures', 'AgentLogs', 'AgentMetrics', 'Api', 'AppDomainCaching', 'AspNetCore', 'BasicInstrumentation', 'CatInbound', 'CatOutbound', 'CodeLevelMetrics', 'Configuration', \
           'CSP', 'CustomAttributes', 'CustomInstrumentation', 'DataTransmission', 'DistributedTracing', 'Errors', 'HttpClientInstrumentation', 'InfiniteTracing', 'Logging.ContextData', \
-          'Logging.HsmAndCsp', 'Logging.LocalDecoration', 'Logging.LogLevelDetection', 'Logging.MaxSamplesStored', 'Logging.MetricsAndForwarding.log4net', \
-          'Logging.MetricsAndForwarding.MicrosoftLogging', 'Logging.MetricsAndForwarding.NLog', 'Logging.MetricsAndForwarding.Serilog', 'Logging.ZeroMaxSamplesStored', \
+          'Logging.HsmAndCsp', 'Logging.LocalDecoration', 'Logging.LogLevelDetection', 'Logging.MaxSamplesStored', 'Logging.MetricsAndForwarding', 'Logging.ZeroMaxSamplesStored', \
           'Owin', 'ReJit.NetCore', 'ReJit.NetFramework', 'RequestHandling', 'RequestHeadersCapture.AspNet', 'RequestHeadersCapture.AspNetCore', 'RequestHeadersCapture.EnvironmentVariables', \
           'RequestHeadersCapture.Owin', 'RequestHeadersCapture.WCF', 'RestSharp', 'WCF.Client.IIS.ASPDisabled', 'WCF.Client.IIS.ASPEnabled', 'WCF.Client.Self', \
           'WCF.Service.IIS.ASPDisabled', 'WCF.Service.IIS.ASPEnabled', 'WCF.Service.Self' ]"

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string TransactionHasAlreadyCapturedResponseTimeLogLineRegEx = FinestLogLinePrefixRegex + @"Transaction has already captured the response time(.*)";
 
         // SetApplicationName related messages
-        public const string SetApplicationnameAPICalledDuringCollectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
+        public const string SetApplicationnameAPICalledDuringConnectMethodLogLineRegex = WarnLogLinePrefixRegex + "The runtime configuration was updated during connect";
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
         // Infinite trace

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -62,6 +62,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string AttemptReconnectLogLineRegex = InfoLogLinePrefixRegex + "Will attempt to reconnect in \\d{2,3} seconds";
 
         // Infinite trace
+        public const string SpanStreamingServiceConnectedLogLineRegex = InfoLogLinePrefixRegex + @"SpanStreamingService: gRPC channel to endpoint (.*) connected.(.*)";
         public const string SpanStreamingSuccessfullySentLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Attempting to send (\d+) item\(s\) - Success";
         public const string SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Received gRPC Server response messages: (\d+)";
         public const string SpanStreamingResponseGrpcError = FinestLogLinePrefixRegex + @"ResponseStreamWrapper: consumer \d+ - gRPC RpcException encountered while handling gRPC server responses: (.*)";

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -58,12 +58,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsAInfoLogMessage INFO");
 
-            // This is necessary to allow the logging data endpoint to be called before the application is shut down
-            _fixture.AddCommand($"RootCommands DelaySeconds 5");
-
-
-
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -71,6 +66,10 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
                     configModifier.EnableLogForwarding()
                     .SetLogLevel("debug");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(10));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -44,26 +44,26 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
     
     public abstract class DataUsageSupportabilityMetricsTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         public DataUsageSupportabilityMetricsTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
-            Fixture = fixture;
-            Fixture.TestLogger = output;
-            Fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
             // Logging commands
-            Fixture.AddCommand($"LoggingTester SetFramework log4net");
-            Fixture.AddCommand($"LoggingTester Configure");
+            _fixture.AddCommand($"LoggingTester SetFramework log4net");
+            _fixture.AddCommand($"LoggingTester ConfigureWithInfoLevelEnabled");
 
-            Fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsADebugLogMessage DEBUG");
+            _fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsAInfoLogMessage INFO");
 
-            // This is necessary to cause one harvest cycle to happen and cause the logging data endpoint to be called
-            Fixture.AddCommand($"RootCommands DelaySeconds 60");
+            // This is necessary to allow the logging data endpoint to be called before the application is shut down
+            _fixture.AddCommand($"RootCommands DelaySeconds 5");
 
 
 
-            Fixture.Actions
+            _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
         [InlineData("Supportability/DotNET/Collector/log_event_data/Output/Bytes")]
         public void ExpectedDataUsageMetric(string expectedMetricName)
         {
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var dataUsageMetric = metrics.FirstOrDefault(x => x.MetricSpec.Name == expectedMetricName);
             Assert.NotNull(dataUsageMetric);

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -69,7 +69,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(10));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(30));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
@@ -6,7 +6,6 @@ using MultiFunctionApplicationHelpers;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
@@ -33,17 +32,16 @@ namespace NewRelic.Agent.IntegrationTests.Api
 
     public abstract class CustomSpanNameApiTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         public CustomSpanNameApiTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
-            Fixture = fixture;
-            Fixture.TestLogger = output;
+            _fixture = fixture;
+            _fixture.TestLogger = output;
 
-            Fixture.AddCommand($"AttributeInstrumentation TransactionWithCustomSpanName CustomSpanName");
-            Fixture.AddCommand("RootCommands DelaySeconds 5");
+            _fixture.AddCommand($"AttributeInstrumentation TransactionWithCustomSpanName CustomSpanName");
 
-            Fixture.Actions
+            _fixture.Actions
             (
                 setupConfiguration: () =>
                 {
@@ -53,14 +51,14 @@ namespace NewRelic.Agent.IntegrationTests.Api
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Fact]
         public void SupportabilityMetricExists()
         {
             var expectedMetric = new Assertions.ExpectedMetric { metricName = $"Supportability/ApiInvocation/SpanSetName", callCount = 1 };
-            Assertions.MetricExists(expectedMetric, Fixture.AgentLog.GetMetrics());
+            Assertions.MetricExists(expectedMetric, _fixture.AgentLog.GetMetrics());
         }
 
         [Fact]
@@ -72,7 +70,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
                 new Assertions.ExpectedMetric { metricName = $"DotNet/CustomSpanName", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Internal.AttributeInstrumentation/TransactionWithCustomSpanName", callCount = 1 }
             };
 
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             Assertions.MetricsExist(expectedMetrics, metrics);
         }
@@ -80,7 +78,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
         [Fact]
         public void TransactionTraceContainsSegmentWithCustomSpanName()
         {
-            var transactionTrace = Fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
+            var transactionTrace = _fixture.AgentLog.GetTransactionSamples().FirstOrDefault();
             Assert.NotNull(transactionTrace);
 
             transactionTrace.TraceData.ContainsSegment("CustomSpanName");
@@ -89,7 +87,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
         [Fact]
         public void SpanEventDataHasCustomSpanName()
         {
-            var spanEvents = Fixture.AgentLog.GetSpanEvents();
+            var spanEvents = _fixture.AgentLog.GetSpanEvents();
             Assert.Contains(spanEvents, x => (string)x.IntrinsicAttributes["name"] == "CustomSpanName");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
@@ -3,8 +3,6 @@
 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
@@ -26,14 +24,13 @@ namespace NewRelic.Agent.IntegrationTests.AppDomainCaching
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"RootCommands InstrumentedMethodToStartAgent");
-            _fixture.AddCommand($"RootCommands DelaySeconds 10");
 
             if(_appDomainCachingDisabled)
             {
                 _fixture.SetAdditionalEnvironmentVariable("NEW_RELIC_DISABLE_APPDOMAIN_CACHING", _appDomainCachingDisabled ? "true" : "false");
             }
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -42,6 +39,10 @@ namespace NewRelic.Agent.IntegrationTests.AppDomainCaching
                     configModifier
                     .EnableDistributedTrace()
                     .SetLogLevel("debug");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForConnect(TimeSpan.FromSeconds(30));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
@@ -66,7 +66,6 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
             _fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
 
             _fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
-            //_fixture.AddCommand("RootCommands DelaySeconds 5");
 
             _fixture.AddActions
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
@@ -3,13 +3,12 @@
 
 
 using MultiFunctionApplicationHelpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
 
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {
@@ -53,7 +52,7 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
     {
         private const string LibraryClassName = "MultiFunctionApplicationHelpers.NetStandardLibraries.Internal.AttributeInstrumentation";
 
-        protected readonly TFixture Fixture;
+        protected readonly TFixture _fixture;
 
         private readonly bool ForceNewTransaction;
 
@@ -61,35 +60,41 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
         {
             ForceNewTransaction = forceNewTransaction;
 
-            Fixture = fixture;
-            Fixture.TestLogger = output;
+            _fixture = fixture;
+            _fixture.TestLogger = output;
 
-            Fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
+            _fixture.EnvironmentVariables.Add("NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD", ForceNewTransaction ? "true" : "false");
 
-            Fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
-            Fixture.AddCommand("RootCommands DelaySeconds 5");
+            _fixture.AddCommand($"AttributeInstrumentation MakeOtherTransactionWithThreadedCallToInstrumentedMethod");
+            //_fixture.AddCommand("RootCommands DelaySeconds 5");
 
-            Fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
+                    configModifier.ForceTransactionTraces()
+                    .SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(10));
                 }
             );
 
-            Fixture.Initialize();
+            _fixture.Initialize();
         }
 
         [Fact]
         public void Test()
         {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>();
-
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"OtherTransaction/all", callCount = ForceNewTransaction ? 2 : 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"OtherTransaction/Custom/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 });
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 });
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"OtherTransaction/all", callCount = ForceNewTransaction ? 2 : 1 },
+                new Assertions.ExpectedMetric { metricName = $"OtherTransaction/Custom/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/MakeOtherTransactionWithThreadedCallToInstrumentedMethod", callCount = 1 }
+            };
 
             if (ForceNewTransaction)
             {
@@ -97,7 +102,7 @@ namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
             }
             expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{LibraryClassName}/SpanOrTransactionBasedOnConfig", callCount = 1 });
 
-            var metrics = Fixture.AgentLog.GetMetrics().ToList();
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             Assertions.MetricsExist(expectedMetrics, metrics);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
@@ -23,9 +23,6 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
 
             _fixture.AddCommand($"ApiCalls TestSetApplicationName NewIntegrationTestName");
 
-            // Needed to ensure that the scheduled reconnect, with a 15 second delay, can happen
-            _fixture.AddCommand($"RootCommands DelaySeconds 30");
-
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -39,8 +36,10 @@ namespace NewRelic.Agent.IntegrationTests.DataTransmission
                 },
                 exerciseApplication: () =>
                 {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SetApplicationnameAPICalledDuringCollectMethodLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SetApplicationnameAPICalledDuringConnectMethodLogLineRegex, TimeSpan.FromMinutes(1));
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.AttemptReconnectLogLineRegex, TimeSpan.FromMinutes(1));
+                    // There should be two connected log lines, one for the initial connect and the other after the reconnect
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1), 2);
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
@@ -31,16 +31,6 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
 
             _fixture.AddCommand("InfiniteTracingTester StartAgent");
 
-            // Give the agent time to warm up... If we send a span too soon, it will be sent via DT (span_event_data) instead of 8T (gRPC)
-            _fixture.AddCommand("RootCommands DelaySeconds 15");
-
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-            _fixture.AddCommand("InfiniteTracingTester Make8TSpan");
-
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -56,6 +46,16 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
                 ,
                 exerciseApplication: () =>
                 {
+                    // Wait for 8T to connect
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanStreamingServiceConnectedLogLineRegex, TimeSpan.FromSeconds(15));
+                    // Now send the command to make the 8T Span
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
+                    // Now wait to see that the 8T spans were sent successfully
                     _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullySentLogLineRegex, TimeSpan.FromSeconds(45), 12);
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.SpanStreamingResponseGrpcError, TimeSpan.FromSeconds(45));
                 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -43,6 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
                     // Now send the command to make the 8T Span
                     _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
                     // Now wait to see that the 8T spans were sent successfully
+                    _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullySentLogLineRegex, TimeSpan.FromMinutes(1), ExpectedSentCount);
                     _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex, TimeSpan.FromMinutes(1), ExpectedSentCount);
                 }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
                 },
                 exerciseApplication: () =>
                 {
-                    Thread.Sleep(TimeSpan.FromSeconds(2));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(30));
                 }
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/HSMOrCSPDisablesForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/HSMOrCSPDisablesForwardingTests.cs
@@ -37,7 +37,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.HsmAndCsp
 
                     // applicationLogging metrics and forwarding enabled by default
                     configModifier
-                    .EnableDistributedTrace()
                     .SetLogLevel("debug");
 
                     if (typeof(TFixture).ToString().Contains("HSM"))

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -21,20 +22,18 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly TFixture _fixture;
-        private readonly bool _decorationEnabled;
         private readonly bool _isWebLogTest;
         private const string _primaryApplicationName = "Local Decoration Test App Name";
         private const string _secondaryApplicationName = "Some other testing application name";
         private const string _compositeApplicationName = _primaryApplicationName + ", " + _secondaryApplicationName;
         private const string _testMessage = "DecorateMe";
 
-        public LocalDecorationTestsBase(TFixture fixture, ITestOutputHelper output, bool decorationEnabled, LayoutType layoutType,
+        public LocalDecorationTestsBase(TFixture fixture, ITestOutputHelper output, LayoutType layoutType,
             LoggingFramework loggingFramework, bool isWebLogTest = false,  bool logWithParam = false) : base(fixture)
         {
-            _decorationEnabled = decorationEnabled;
             _isWebLogTest = isWebLogTest;
             _fixture = fixture;
-            _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
@@ -50,16 +49,21 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
 
             _fixture.RemoteApplication.AppName = _compositeApplicationName;
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                     configModifier
-                    .EnableLogDecoration(_decorationEnabled)
+                    .EnableLogDecoration(true)
                     .EnableDistributedTrace()
-                    .SetLogLevel("debug");
+                    .SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(30));
                 }
             );
 
@@ -79,45 +83,38 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
             // For web logging tests there will be multiple unexpected log lines. To support this, we prefix all log lines in web tests with a known string.
             var regex = new Regex((_isWebLogTest ? "^ThisIsAWebLog.*" : "") + @"NR-LINKING\|([a-zA-Z0-9]*)\|([a-zA-Z0-9._-]*)\|([a-zA-Z0-9]*)\|([a-zA-Z0-9]*)\|(.+?)\|", RegexOptions.Multiline);
 
-            if (_decorationEnabled)
-            {
-                // Make sure the added metadata is there
-                MatchCollection matches = regex.Matches(testOutput);
-                Assert.True(matches.Count > 0);
+            // Make sure the added metadata is there
+            MatchCollection matches = regex.Matches(testOutput);
+            Assert.True(matches.Count > 0);
 
-                foreach (Match match in matches)
-                {
-                    Assert.True(match.Success);
-                    Assert.NotEmpty(match.Groups);
-                    var entityGuid = match.Groups[1].Value;
-                    var hostname = match.Groups[2].Value;
-                    var traceId = match.Groups[3].Value;
-                    var spanId = match.Groups[4].Value;
-                    var entityName = HttpUtility.UrlDecode(match.Groups[5].Value);
-
-                    Assert.NotNull(entityGuid);
-                    Assert.NotNull(hostname);
-                    Assert.NotNull(traceId);
-                    Assert.NotNull(spanId);
-                    Assert.Equal(_primaryApplicationName, entityName);
-                }
-            }
-            else
+            foreach (Match match in matches)
             {
-                Assert.DoesNotMatch(regex, _fixture.RemoteApplication.CapturedOutput.StandardOutput);
+                Assert.True(match.Success);
+                Assert.NotEmpty(match.Groups);
+                var entityGuid = match.Groups[1].Value;
+                var hostname = match.Groups[2].Value;
+                var traceId = match.Groups[3].Value;
+                var spanId = match.Groups[4].Value;
+                var entityName = HttpUtility.UrlDecode(match.Groups[5].Value);
+
+                Assert.NotNull(entityGuid);
+                Assert.NotNull(hostname);
+                Assert.NotNull(traceId);
+                Assert.NotNull(spanId);
+                Assert.Equal(_primaryApplicationName, entityName);
             }
         }
     }
 
     #region log4net
 
-    #region Json layout, decoration enabled
+    #region Json layout
 
     [NetFrameworkTest]
     public class Log4netJsonLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4netJsonLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
@@ -126,7 +123,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4netJsonLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
@@ -135,7 +132,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4netJsonLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
@@ -144,7 +141,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public Log4netJsonLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
@@ -153,7 +150,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4netJsonLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
@@ -162,78 +159,20 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netJsonLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4netJsonLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Log4net)
         {
         }
     }
 
     #endregion
 
-    #region Json layout, decoration disabled
-
-    [NetFrameworkTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public Log4netJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration enabled
+    #region Pattern layout
 
     [NetFrameworkTest]
     public class Log4netPatternLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public Log4netPatternLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -242,7 +181,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public Log4netPatternLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -251,7 +190,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public Log4netPatternLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -260,7 +199,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public Log4netPatternLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -269,7 +208,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public Log4netPatternLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -278,65 +217,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class Log4netPatternLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public Log4netPatternLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration disabled
-
-    [NetFrameworkTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public Log4netPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Log4net)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Log4net)
         {
         }
     }
@@ -347,12 +228,12 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
 
     #region Serilog
 
-    #region Json layout, decoration enabled
+    #region Json layout
     [NetFrameworkTest]
     public class SerilogJsonLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogJsonLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
@@ -361,7 +242,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogJsonLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogJsonLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
@@ -370,7 +251,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogJsonLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogJsonLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
@@ -379,7 +260,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogJsonLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public SerilogJsonLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
@@ -388,7 +269,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogJsonLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogJsonLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
@@ -397,77 +278,20 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogJsonLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogJsonLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.Serilog)
         {
         }
     }
 
     #endregion
 
-    #region Json layout, decoration disabled
-    [NetFrameworkTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public SerilogJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration enabled
+    #region Pattern layout
 
     [NetFrameworkTest]
     public class SerilogPatternLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public SerilogPatternLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
@@ -476,7 +300,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogPatternLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public SerilogPatternLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
@@ -485,7 +309,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogPatternLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public SerilogPatternLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
@@ -494,7 +318,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogWebPatternLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public SerilogWebPatternLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.SerilogWeb, true)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.SerilogWeb, true)
         {
         }
     }
@@ -503,7 +327,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogPatternLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public SerilogPatternLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
@@ -512,7 +336,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogPatternLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public SerilogPatternLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
@@ -521,84 +345,24 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class SerilogPatternLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public SerilogPatternLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-
-    #endregion
-
-    #region Pattern Layout, decoration disabled
-
-    [NetFrameworkTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class SerilogPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public SerilogPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.Serilog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.Serilog)
         {
         }
     }
 
     #endregion
-
 
     #endregion
 
     #region MicrosoftLogging
 
-    #region Json layout, decoration enabled
+    #region Json layout
 
     [NetCoreTest]
     public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -607,7 +371,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -616,7 +380,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -625,7 +389,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingJsonLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -634,69 +398,20 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingJsonLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public MicrosoftLoggingJsonLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.MicrosoftLogging)
         {
         }
     }
 
     #endregion
 
-    #region Json layout, decoration disabled
-
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MicrosoftLoggingJsonLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MicrosoftLoggingJsonLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration enabled
+    #region Pattern layout
 
     [NetCoreTest]
     public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -705,7 +420,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -714,7 +429,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -723,7 +438,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public MicrosoftLoggingPatternLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -732,56 +447,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class MicrosoftLoggingPatternLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public MicrosoftLoggingPatternLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration disabled
-
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MicrosoftLoggingPatternLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MicrosoftLoggingPatternLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.MicrosoftLogging)
         {
         }
     }
@@ -792,13 +458,13 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
 
     #region NLog
 
-    #region Json layout, decoration enabled
+    #region Json layout
 
     [NetFrameworkTest]
     public class NLogJsonLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public NLogJsonLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -807,7 +473,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public NLogJsonLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -816,7 +482,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutWithParamDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public NLogJsonLayoutWithParamDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -825,7 +491,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutWithParamDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public NLogJsonLayoutWithParamDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -833,7 +499,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public NLogJsonLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -842,7 +508,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public NLogJsonLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -851,7 +517,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public NLogJsonLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -860,7 +526,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogJsonLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog)
         {
         }
     }
@@ -869,7 +535,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutWithParamDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public NLogJsonLayoutWithParamDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -878,78 +544,20 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogJsonLayoutWithParamDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogJsonLayoutWithParamDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Json, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
 
     #endregion
 
-    #region Json layout, decoration disabled
-
-    [NetFrameworkTest]
-    public class NLogJsonLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class NLogJsonLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogJsonLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public NLogJsonLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Json, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration enabled
+    #region Pattern layout
 
     [NetFrameworkTest]
     public class NLogPatternLayoutDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public NLogPatternLayoutDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -958,7 +566,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public NLogPatternLayoutDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -967,7 +575,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutWithParamDecorationEnabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public NLogPatternLayoutWithParamDecorationEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -976,7 +584,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutWithParamDecorationEnabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public NLogPatternLayoutWithParamDecorationEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -985,7 +593,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public NLogPatternLayoutDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -994,7 +602,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationEnabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
     {
         public NLogPatternLayoutDecorationEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -1003,7 +611,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationEnabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
     {
         public NLogPatternLayoutDecorationEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -1012,7 +620,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogPatternLayoutDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog)
         {
         }
     }
@@ -1022,7 +630,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutWithParamDecorationEnabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public NLogPatternLayoutWithParamDecorationEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }
@@ -1031,65 +639,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
     public class NLogPatternLayoutWithParamDecorationEnabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
     {
         public NLogPatternLayoutWithParamDecorationEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, true, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
-        {
-        }
-    }
-
-    #endregion
-
-    #region Pattern layout, decoration disabled
-
-    [NetFrameworkTest]
-    public class NLogPatternLayoutDecorationDisabledTestsFWLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class NLogPatternLayoutDecorationDisabledTestsFW471Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationDisabledTestsNetCoreLatestTests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationDisabledTestsNetCore60Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore60>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationDisabledTestsNetCore50Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore50>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class NLogPatternLayoutDecorationDisabledTestsNetCore31Tests : LocalDecorationTestsBase<ConsoleDynamicMethodFixtureCore31>
-    {
-        public NLogPatternLayoutDecorationDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-            : base(fixture, output, false, LayoutType.Pattern, LoggingFramework.NLog)
+            : base(fixture, output, LayoutType.Pattern, LoggingFramework.NLog, logWithParam: true)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
 
             _fixture.RemoteApplication.AppName = _compositeApplicationName;
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -76,8 +76,8 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
         {
             var testOutput = _fixture.RemoteApplication.CapturedOutput.StandardOutput;
             // Make sure the original message is there
-            var commandResults = Regex.Split(testOutput, System.Environment.NewLine).Where(l => !l.Contains("EXECUTING"));
-            Assert.Contains(_testMessage, string.Join(System.Environment.NewLine, commandResults));
+            var commandResults = Regex.Split(testOutput, Environment.NewLine).Where(l => !l.Contains("EXECUTING"));
+            Assert.Contains(_testMessage, string.Join(Environment.NewLine, commandResults));
 
             // Sample decorated data we are looking for:
             // "NR-LINKING|MjczMDcwfEFQTXxBUFBMSUNBVElPTnwxODQyMg|blah.hsd1.ca.comcast.net|45f120972d61834b96fb890d2a8f97e7|840d9a82e8bc18a8|myApplicationName|"

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -57,7 +57,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
 
                     configModifier
                     .EnableLogDecoration(true)
-                    .EnableDistributedTrace()
                     .SetLogLevel("finest");
                 },
                 exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
@@ -38,7 +38,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LogLevelDetection
 
                     // applicationLogging metrics and forwarding enabled by default
                     configModifier
-                    .EnableDistributedTrace()
                     .SetLogLevel("debug");
                 },
                 exerciseApplication: () =>

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -442,136 +442,121 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     #region log4net
 
-    namespace log4net
+    [NetFrameworkTest]
+    public class Log4NetMetricsAndForwardingTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+        public Log4NetMetricsAndForwardingTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
         {
-            public Log4NetMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
-        {
-            public Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Log4net)
-            {
-            }
         }
     }
 
+    [NetFrameworkTest]
+    public class Log4NetMetricsAndForwardingTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
+    {
+        public Log4NetMetricsAndForwardingTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class Log4NetMetricsAndForwardingTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public Log4NetMetricsAndForwardingTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4NetMetricsAndForwardingTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public Log4NetMetricsAndForwardingTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4NetMetricsAndForwardingTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public Log4NetMetricsAndForwardingTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4NetMetricsAndForwardingTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public Log4NetMetricsAndForwardingTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class Log4NetMetricsAndForwardingTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public Log4NetMetricsAndForwardingTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Log4net)
+        {
+        }
+    }
     #endregion
 
-    #region MicrosoftLogging
+    #region MEL
 
-    namespace MicrosoftLogging
+    [NetCoreTest]
+    public class MELMetricsAndForwardingTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
+        public MELMetricsAndForwardingTestsNetCoreLatestTests(
+            ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.MicrosoftLogging)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
+    [NetCoreTest]
+    public class MELMetricsAndForwardingTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MELMetricsAndForwardingTestsNetCore60Tests(
+            ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.MicrosoftLogging)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
+    [NetCoreTest]
+    public class MELMetricsAndForwardingTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
+    {
+        public MELMetricsAndForwardingTestsNetCore50Tests(
+            ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.MicrosoftLogging)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
+    [NetCoreTest]
+    public class
+        MELMetricsAndForwardingTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
+    {
+        public MELMetricsAndForwardingTestsNetCore31Tests(
+            ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.MicrosoftLogging)
-            {
-            }
         }
+    }
 
-        [NetFrameworkTest]
-        public class
-        MicrosoftLoggingMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-        ConsoleDynamicMethodFixtureFWLatest>
+    [NetFrameworkTest]
+    public class
+    MELMetricsAndForwardingTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public MELMetricsAndForwardingTestsFWLatestTests(
+            ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.MicrosoftLogging)
         {
-            public MicrosoftLoggingMetricsAndForwardingEnabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.MicrosoftLogging)
-            {
-            }
         }
     }
 
@@ -579,102 +564,99 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     #region Serilog
 
-    namespace Serilog
+    [NetFrameworkTest]
+    public class
+        SerilogMetricsAndForwardingTestsFWLatestTests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFWLatest>
     {
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
+        public SerilogMetricsAndForwardingTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
+    [NetFrameworkTest]
+    public class
+        SerilogMetricsAndForwardingTestsFW471Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFW471>
+    {
+        public SerilogMetricsAndForwardingTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
+    [NetFrameworkTest]
+    public class
+        SerilogMetricsAndForwardingTestsFW462Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFW462>
+    {
+        public SerilogMetricsAndForwardingTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
+    [NetCoreTest]
+    public class
+        SerilogMetricsAndForwardingTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public SerilogMetricsAndForwardingTestsNetCoreLatestTests(
+            ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
+    [NetCoreTest]
+    public class
+        SerilogMetricsAndForwardingTestsNetCore60Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore60>
+    {
+        public SerilogMetricsAndForwardingTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
+    [NetCoreTest]
+    public class
+        SerilogMetricsAndForwardingTestsNetCore50Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore50>
+    {
+        public SerilogMetricsAndForwardingTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
+    [NetCoreTest]
+    public class
+        SerilogMetricsAndForwardingTestsNetCore31Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore31>
+    {
+        public SerilogMetricsAndForwardingTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.Serilog)
         {
-            public SerilogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.Serilog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            SerilogWebMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
+    [NetCoreTest]
+    public class
+        SerilogWebMetricsAndForwardingTestsNetCore60Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore60>
+    {
+        public SerilogWebMetricsAndForwardingTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogWeb, canHaveLogsOutsideTransaction: false)
         {
-            public SerilogWebMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.SerilogWeb, canHaveLogsOutsideTransaction: false)
-            {
-            }
         }
     }
 
@@ -682,90 +664,87 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     #region NLog
 
-    namespace NLog
+    [NetFrameworkTest]
+    public class
+        NLogMetricsAndForwardingTestsFWLatestTests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFWLatest>
     {
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
+        public NLogMetricsAndForwardingTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
+    [NetFrameworkTest]
+    public class
+        NLogMetricsAndForwardingTestsFW471Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFW471>
+    {
+        public NLogMetricsAndForwardingTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
+    [NetFrameworkTest]
+    public class
+        NLogMetricsAndForwardingTestsFW462Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureFW462>
+    {
+        public NLogMetricsAndForwardingTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
+    [NetCoreTest]
+    public class
+        NLogMetricsAndForwardingTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public NLogMetricsAndForwardingTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
+    [NetCoreTest]
+    public class
+        NLogMetricsAndForwardingTestsNetCore60Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore60>
+    {
+        public NLogMetricsAndForwardingTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
+    [NetCoreTest]
+    public class
+        NLogMetricsAndForwardingTestsNetCore50Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore50>
+    {
+        public NLogMetricsAndForwardingTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
+    }
 
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
+    [NetCoreTest]
+    public class
+        NLogMetricsAndForwardingTestsNetCore31Tests : MetricsAndForwardingTestsBase<
+            ConsoleDynamicMethodFixtureCore31>
+    {
+        public NLogMetricsAndForwardingTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
+            ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLog)
         {
-            public NLogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, LoggingFramework.NLog)
-            {
-            }
         }
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -65,13 +65,13 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private const string ErrorClassValue = "System.Exception";
 
-        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework, bool canHaveLogsOutsideTransaction = true) : base(fixture)
+        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework) : base(fixture)
         {
             _fixture = fixture;
             _loggingFramework = loggingFramework;
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
-            _canHaveLogsOutsideTransaction = canHaveLogsOutsideTransaction;
+            _canHaveLogsOutsideTransaction = _loggingFramework != LoggingFramework.SerilogWeb;
 
             _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
             _fixture.AddCommand($"LoggingTester Configure");
@@ -655,7 +655,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
     {
         public SerilogWebMetricsAndForwardingTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
             ITestOutputHelper output)
-            : base(fixture, output, LoggingFramework.SerilogWeb, canHaveLogsOutsideTransaction: false)
+            : base(fixture, output, LoggingFramework.SerilogWeb)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -16,8 +16,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly TFixture _fixture;
-        private bool _metricsEnabled;
-        private bool _forwardingEnabled;
         private LoggingFramework _loggingFramework;
         private bool _canHaveLogsOutsideTransaction;
 
@@ -67,11 +65,9 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private const string ErrorClassValue = "System.Exception";
 
-        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, bool metricsEnabled, bool forwardingEnabled, bool canHaveLogsOutsideTransaction, LoggingFramework loggingFramework) : base(fixture)
+        public MetricsAndForwardingTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework, bool canHaveLogsOutsideTransaction = true) : base(fixture)
         {
             _fixture = fixture;
-            _metricsEnabled = metricsEnabled;
-            _forwardingEnabled = forwardingEnabled;
             _loggingFramework = loggingFramework;
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
@@ -132,9 +128,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
                     var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                     configModifier
-                    .EnableLogMetrics(metricsEnabled)
-                    .EnableLogForwarding(forwardingEnabled)
-                    .EnableDistributedTrace()
                     .SetLogLevel("debug");
                 },
                 exerciseApplication: () =>
@@ -179,40 +172,19 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             };
 
             var actualMetrics = _fixture.AgentLog.GetMetrics();
-            if (_metricsEnabled)
-            {
-                Assertions.MetricsExist(loggingMetrics, actualMetrics);
-            }
-            else
-            {
-                Assertions.MetricsDoNotExist(loggingMetrics, actualMetrics);
-            }
+            Assertions.MetricsExist(loggingMetrics, actualMetrics);
         }
 
         private void SupportabilityForwardingConfigurationMetricExists()
         {
             var actualMetrics = _fixture.AgentLog.GetMetrics();
-            if (_forwardingEnabled)
-            {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Forwarding/DotNET/enabled");
-            }
-            else
-            {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Forwarding/DotNET/disabled");
-            }
+            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Forwarding/DotNET/enabled");
         }
 
         private void SupportabilityMetricsConfigurationMetricExists()
         {
             var actualMetrics = _fixture.AgentLog.GetMetrics();
-            if (_metricsEnabled)
-            {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Metrics/DotNET/enabled");
-            }
-            else
-            {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Metrics/DotNET/disabled");
-            }
+            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == "Supportability/Logging/Metrics/DotNET/enabled");
         }
 
         private void SupportabilityLoggingFrameworkMetricExists()
@@ -227,70 +199,49 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             var expectedFrameworkName = LogUtils.GetFrameworkName(_loggingFramework);
             var actualMetrics = _fixture.AgentLog.GetMetrics();
 
-            if (_forwardingEnabled)
-            {
-                Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled");
-            }
-            else
-            {
-                Assert.DoesNotContain(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled");
-            }
+            Assert.Contains(actualMetrics, x => x.MetricSpec.Name == $"Supportability/Logging/Forwarding/DotNET/{expectedFrameworkName}/enabled");
         }
 
         private void CountsAndValuesAreAsExpected()
         {
             var logEventData = _fixture.AgentLog.GetLogEventData().FirstOrDefault();
-            if (_forwardingEnabled)
-            {
-                Assert.NotNull(logEventData);
-                Assert.NotNull(logEventData.Common);
-                Assert.NotNull(logEventData.Common.Attributes);
-                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityGuid));
-                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityName));
-                Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.Hostname));
-            }
-            else
-            {
-                Assert.Null(logEventData);
-            }
+            Assert.NotNull(logEventData);
+            Assert.NotNull(logEventData.Common);
+            Assert.NotNull(logEventData.Common.Attributes);
+            Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityGuid));
+            Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.EntityName));
+            Assert.False(string.IsNullOrWhiteSpace(logEventData.Common.Attributes.Hostname));
 
             var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
-            if (_forwardingEnabled)
-            {
-                Assert.Equal(29, logLines.Length);
+            Assert.Equal(29, logLines.Length);
 
-                foreach (var logLine in logLines)
+            foreach (var logLine in logLines)
+            {
+                if (LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE") == logLine.Level &&
+                    (logLine.ErrorMessage.EndsWith("NoMessage") || logLine.ErrorMessage.StartsWith("Exception of type"))) // SerilogWeb uses MEL (built in) and that handles exception messages differently
                 {
-                    if (LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE") == logLine.Level &&
-                        (logLine.ErrorMessage.EndsWith("NoMessage") || logLine.ErrorMessage.StartsWith("Exception of type"))) // SerilogWeb uses MEL (built in) and that handles exception messages differently
-                    {
-                        Assert.True(string.IsNullOrWhiteSpace(logLine.Message));
-                    }
-                    else
-                    {
-                        Assert.False(string.IsNullOrWhiteSpace(logLine.Message));
-                    }
-
-                    Assert.False(string.IsNullOrWhiteSpace(logLine.Level));
-                    Assert.NotEqual(0, logLine.Timestamp);
-
-                    if (logLine.Level == LogUtils.GetLevelName(_loggingFramework, "ERROR"))
-                    {
-                        Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorStack));
-                        Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorMessage));
-                        Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorClass));
-                    }
+                    Assert.True(string.IsNullOrWhiteSpace(logLine.Message));
                 }
-            }
-            else
-            {
-                Assert.Empty(logLines);
+                else
+                {
+                    Assert.False(string.IsNullOrWhiteSpace(logLine.Message));
+                }
+
+                Assert.False(string.IsNullOrWhiteSpace(logLine.Level));
+                Assert.NotEqual(0, logLine.Timestamp);
+
+                if (logLine.Level == LogUtils.GetLevelName(_loggingFramework, "ERROR"))
+                {
+                    Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorStack));
+                    Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorMessage));
+                    Assert.False(string.IsNullOrWhiteSpace(logLine.ErrorClass));
+                }
             }
         }
 
         private void LoggingWorksWithTraceAttributeOutsideTransaction()
         {
-            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
+            if (_canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -307,113 +258,101 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private void LoggingWorksWithDifferentTraceAttributesInsideTransaction()
         {
-            if (_forwardingEnabled)
+            var expectedLogLines = new Assertions.ExpectedLogLine[]
             {
-                var expectedLogLines = new Assertions.ExpectedLogLine[]
-                {
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = DifferentTraceAttributesInsideTransactionLogMessage, HasTraceId = true, HasSpanId = true, HasException = false }
-                };
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = DifferentTraceAttributesInsideTransactionLogMessage, HasTraceId = true, HasSpanId = true, HasException = false }
+            };
 
-                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
 
-                Assertions.LogLinesExist(expectedLogLines, logLines);
+            Assertions.LogLinesExist(expectedLogLines, logLines);
 
-                var logsOfInterest = logLines.Where(x => !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("DifferentTraceAttributesInsideTransaction")).ToArray();
+            var logsOfInterest = logLines.Where(x => !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("DifferentTraceAttributesInsideTransaction")).ToArray();
 
-                Assert.Equal(2, logsOfInterest.Length);
-                Assert.NotEqual(logsOfInterest[0].Spanid, logsOfInterest[1].Spanid);
-            }
+            Assert.Equal(2, logsOfInterest.Length);
+            Assert.NotEqual(logsOfInterest[0].Spanid, logsOfInterest[1].Spanid);
         }
 
         private void LoggingWorksInsideTransaction()
         {
-            if (_forwardingEnabled)
+            Assertions.ExpectedLogLine inTransactionExpectedLogLine;
+            Assertions.ExpectedLogLine OutsideTransactionExpectedLogLine;
+            if (_canHaveLogsOutsideTransaction)
             {
-                Assertions.ExpectedLogLine inTransactionExpectedLogLine;
-                Assertions.ExpectedLogLine OutsideTransactionExpectedLogLine;
-                if (_canHaveLogsOutsideTransaction)
-                {
-                    inTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : InTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
-                    OutsideTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = false, HasSpanId = false, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : OutsideTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
-                }
-                else
-                {
-                    // Serilog always exists in a transaction
-                    inTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : InTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
-                    OutsideTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : OutsideTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
-                }
-
-                var expectedLogLines = new Assertions.ExpectedLogLine[]
-                {
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = InTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = InTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = InTransactionErrorMessage, ErrorClass = ErrorClassValue },
-
-                    // 2 expected NOMESSAGE log lines since there is no way to tell the inside transaction line from the outside transaction line
-                    // One line needs to have HasTraceId and HasSpanId set to false
-                    inTransactionExpectedLogLine,
-                    OutsideTransactionExpectedLogLine,
-                };
-
-                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
-
-                Assertions.LogLinesExist(expectedLogLines, logLines);
-
-                Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
-                    (!string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("InTransaction"))
-                    || string.IsNullOrWhiteSpace(x.Message)
-                ).Count());
+                inTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : InTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
+                OutsideTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = false, HasSpanId = false, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : OutsideTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
             }
+            else
+            {
+                // Serilog always exists in a transaction
+                inTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : InTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
+                OutsideTransactionExpectedLogLine = new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "NOMESSAGE"), LogMessage = null, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = _loggingFramework == LoggingFramework.SerilogWeb ? SerilogWebErrorNoMessage : OutsideTransactionErrorNoMessage, ErrorClass = ErrorClassValue };
+            }
+
+            var expectedLogLines = new Assertions.ExpectedLogLine[]
+            {
+               new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = InTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+               new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = InTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = InTransactionErrorMessage, ErrorClass = ErrorClassValue },
+
+               // 2 expected NOMESSAGE log lines since there is no way to tell the inside transaction line from the outside transaction line
+               // One line needs to have HasTraceId and HasSpanId set to false
+               inTransactionExpectedLogLine,
+               OutsideTransactionExpectedLogLine,
+       };
+
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+
+            Assertions.LogLinesExist(expectedLogLines, logLines);
+
+            Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
+                (!string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("InTransaction"))
+                || string.IsNullOrWhiteSpace(x.Message)
+            ).Count());
         }
 
         private void AsyncLoggingWorksInsideTransaction()
         {
-            if (_forwardingEnabled)
+            var expectedLogLines = new Assertions.ExpectedLogLine[]
             {
-                var expectedLogLines = new Assertions.ExpectedLogLine[]
-                {
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncInTransactionDebugMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncInTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncInTransactionWarningMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncInTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncInTransactionErrorMessage, ErrorClass = ErrorClassValue },
-                };
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncInTransactionDebugMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncInTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncInTransactionWarningMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncInTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncInTransactionErrorMessage, ErrorClass = ErrorClassValue },
+            };
 
-                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
 
-                Assertions.LogLinesExist(expectedLogLines, logLines);
+            Assertions.LogLinesExist(expectedLogLines, logLines);
 
-                Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
-                    !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncInTransaction")
-                ).Count());
-            }
+            Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
+                !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncInTransaction")
+            ).Count());
         }
 
         private void AsyncNoAwaitLoggingWorksInsideTransaction()
         {
-            if (_forwardingEnabled)
+            // NOTE: since the log is not awaited, the logs intermittently show up in/out of a transaction.
+            // Because of this the spanId/traceId members are not checked by not specifying true/false in the ExpectedLogLines
+            var expectedLogLines = new Assertions.ExpectedLogLine[]
             {
-                // NOTE: since the log is not awaited, the logs intermittently show up in/out of a transaction.
-                // Because of this the spanId/traceId members are not checked by not specifying true/false in the ExpectedLogLines
-                var expectedLogLines = new Assertions.ExpectedLogLine[]
-                {
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitInTransactionDebugMessage, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitInTransactionInfoMessage, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitInTransactionWarningMessage, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitInTransactionErrorMessage, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncNoAwaitInTransactionErrorMessage, ErrorClass = ErrorClassValue },
-                };
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitInTransactionDebugMessage, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitInTransactionInfoMessage, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitInTransactionWarningMessage, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitInTransactionErrorMessage, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncNoAwaitInTransactionErrorMessage, ErrorClass = ErrorClassValue },
+            };
 
-                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
 
-                Assertions.LogLinesExist(expectedLogLines, logLines);
+            Assertions.LogLinesExist(expectedLogLines, logLines);
 
-                Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
-                    !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncNoAwaitInTransaction")
-                ).Count());
-            }
+            Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
+                !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncNoAwaitInTransaction")
+            ).Count());
         }
 
         private void LoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
+            if (_canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -439,7 +378,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private void AsyncLoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
+            if (_canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -461,7 +400,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private void AsyncNoAwaitLoggingWorksOutsideTransaction()
         {
-            if (_forwardingEnabled && _canHaveLogsOutsideTransaction)
+            if (_canHaveLogsOutsideTransaction)
             {
                 var expectedLogLines = new Assertions.ExpectedLogLine[]
                 {
@@ -483,24 +422,21 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
         private void AsyncNoAwaitWithDelayLoggingWorksInsideTransaction()
         {
-            if (_forwardingEnabled)
+            var expectedLogLines = new Assertions.ExpectedLogLine[]
             {
-                var expectedLogLines = new Assertions.ExpectedLogLine[]
-                {
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitWithDelayInTransactionDebugMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitWithDelayInTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitWithDelayInTransactionWarningMessage, HasTraceId = true, HasSpanId = true, HasException = false },
-                    new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, ErrorClass = ErrorClassValue },
-                };
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "DEBUG"), LogMessage = AsyncNoAwaitWithDelayInTransactionDebugMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "INFO"), LogMessage = AsyncNoAwaitWithDelayInTransactionInfoMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "WARN"), LogMessage = AsyncNoAwaitWithDelayInTransactionWarningMessage, HasTraceId = true, HasSpanId = true, HasException = false },
+                new Assertions.ExpectedLogLine { Level = LogUtils.GetLevelName(_loggingFramework, "ERROR"), LogMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, HasTraceId = true, HasSpanId = true, HasException = true, ErrorStack = ErrorStackValue, ErrorMessage = AsyncNoAwaitWithDelayInTransactionErrorMessage, ErrorClass = ErrorClassValue },
+            };
 
-                var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
+            var logLines = _fixture.AgentLog.GetLogEventDataLogLines();
 
-                Assertions.LogLinesExist(expectedLogLines, logLines);
+            Assertions.LogLinesExist(expectedLogLines, logLines);
 
-                Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
-                    !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncNoAwaitWithDelayInTransaction")
-                ).Count());
-            }
+            Assert.Equal(expectedLogLines.Length, logLines.Where(x =>
+                !string.IsNullOrWhiteSpace(x.Message) && x.Message.StartsWith("AsyncNoAwaitWithDelayInTransaction")
+            ).Count());
         }
     }
 
@@ -508,12 +444,11 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     namespace log4net
     {
-        #region Metrics and Forwarding Enabled
         [NetFrameworkTest]
         public class Log4NetMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
         {
             public Log4NetMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -522,7 +457,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
         {
             public Log4NetMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -531,7 +466,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
         {
             public Log4NetMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -540,7 +475,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
         {
             public Log4NetMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -549,7 +484,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
         {
             public Log4NetMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -558,7 +493,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
         {
             public Log4NetMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
@@ -567,210 +502,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         public class Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
         {
             public Log4NetMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Log4net)
+                : base(fixture, output, LoggingFramework.Log4net)
             {
             }
         }
-
-        #endregion
-
-        #region Metrics and Forwarding Disabled
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
-        {
-            public Log4NetMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Enabled, Forwarding Disabled
-        [NetFrameworkTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
-        {
-            public Log4NetMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Disabled, Forwarding Enabled
-        [NetFrameworkTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW471>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureFW462>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore60>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore50>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class Log4netMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<ConsoleDynamicMethodFixtureCore31>
-        {
-            public Log4netMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Log4net)
-            {
-            }
-        }
-
-        #endregion
     }
 
     #endregion
@@ -779,8 +514,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     namespace MicrosoftLogging
     {
-        #region Metrics and Forwarding Enabled
-
         [NetCoreTest]
         public class
             MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
@@ -788,7 +521,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCoreLatestTests(
                 ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
+                : base(fixture, output, LoggingFramework.MicrosoftLogging)
             {
             }
         }
@@ -800,7 +533,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore60Tests(
                 ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
+                : base(fixture, output, LoggingFramework.MicrosoftLogging)
             {
             }
         }
@@ -812,7 +545,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore50Tests(
                 ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
+                : base(fixture, output, LoggingFramework.MicrosoftLogging)
             {
             }
         }
@@ -824,7 +557,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingEnabledTestsNetCore31Tests(
                 ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
+                : base(fixture, output, LoggingFramework.MicrosoftLogging)
             {
             }
         }
@@ -836,204 +569,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public MicrosoftLoggingMetricsAndForwardingEnabledTestsFWLatestTests(
                 ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.MicrosoftLogging)
+                : base(fixture, output, LoggingFramework.MicrosoftLogging)
             {
             }
         }
-
-        #endregion
-
-        #region Metrics and Forwarding Disabled
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            MicrosoftLoggingMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-        ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public MicrosoftLoggingMetricsAndForwardingDisabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Enabled, Forwarding Disabled
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-        ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public MicrosoftLoggingMetricsEnabledAndForwardingDisabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Disabled, Forwarding Enabled
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public MicrosoftLoggingMetricsDisabledAndForwardingEnabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.MicrosoftLogging)
-            {
-            }
-        }
-
-        #endregion
     }
 
     #endregion
@@ -1042,8 +581,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     namespace Serilog
     {
-        #region Metrics and Forwarding Enabled
-
         [NetFrameworkTest]
         public class
             SerilogMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
@@ -1051,7 +588,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1063,7 +600,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1075,7 +612,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1087,7 +624,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsNetCoreLatestTests(
                 ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1099,7 +636,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1111,7 +648,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1123,7 +660,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.Serilog)
+                : base(fixture, output, LoggingFramework.Serilog)
             {
             }
         }
@@ -1135,276 +672,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public SerilogWebMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, false, LoggingFramework.SerilogWeb)
+                : base(fixture, output, LoggingFramework.SerilogWeb, canHaveLogsOutsideTransaction: false)
             {
             }
         }
-
-        #endregion
-
-        #region Metrics and Forwarding Disabled
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public SerilogMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Enabled, Forwarding Disabled
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public SerilogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Disabled, Forwarding Enabled
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore60Tests(
-                ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(
-                ConsoleDynamicMethodFixtureCore50 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            SerilogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public SerilogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(
-                ConsoleDynamicMethodFixtureCore31 fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.Serilog)
-            {
-            }
-        }
-
-        #endregion
     }
 
     #endregion
@@ -1413,8 +684,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
 
     namespace NLog
     {
-        #region Metrics and Forwarding Enabled
-
         [NetFrameworkTest]
         public class
             NLogMetricsAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
@@ -1422,7 +691,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1434,7 +703,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1446,7 +715,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1458,7 +727,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1470,7 +739,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1482,7 +751,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
@@ -1494,276 +763,10 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
         {
             public NLogMetricsAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
                 ITestOutputHelper output)
-                : base(fixture, output, true, true, true, LoggingFramework.NLog)
+                : base(fixture, output, LoggingFramework.NLog)
             {
             }
         }
-
-        #endregion
-
-        #region Metrics and Forwarding Disabled
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public NLogMetricsAndForwardingDisabledTestsFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public NLogMetricsAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public NLogMetricsAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public NLogMetricsAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public NLogMetricsAndForwardingDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public NLogMetricsAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public NLogMetricsAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Enabled, Forwarding Disabled
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public NLogMetricsEnabledAndForwardingDisabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, true, false, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        #endregion
-
-        #region Metrics Disabled, Forwarding Enabled
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsFWLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFWLatest>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsFWLatestTests(
-                ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsFW471Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW471>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsFW471Tests(ConsoleDynamicMethodFixtureFW471 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetFrameworkTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsFW462Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureFW462>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCoreLatest>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCoreLatestTests(
-                ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCore60Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore60>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCore60Tests(ConsoleDynamicMethodFixtureCore60 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore50>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCore50Tests(ConsoleDynamicMethodFixtureCore50 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        [NetCoreTest]
-        public class
-            NLogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests : MetricsAndForwardingTestsBase<
-                ConsoleDynamicMethodFixtureCore31>
-        {
-            public NLogMetricsDisabledAndForwardingEnabledTestsNetCore31Tests(ConsoleDynamicMethodFixtureCore31 fixture,
-                ITestOutputHelper output)
-                : base(fixture, output, false, true, true, LoggingFramework.NLog)
-            {
-            }
-        }
-
-        #endregion
     }
 
     #endregion

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
@@ -37,7 +37,6 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
                     // applicationLogging metrics and forwarding enabled by default
                     configModifier
                     .SetLogForwardingMaxSamplesStored(1) // must be 1 since 0 causes it to return the default
-                    .EnableDistributedTrace()
                     .SetLogLevel("debug");
                 }
             );

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/ConsoleDynamicMethodFixture.cs
@@ -184,6 +184,16 @@ namespace MultiFunctionApplicationHelpers
             return this;
         }
 
+        public void SendCommand(string cmd)
+        {
+            if (!RemoteApplication.IsRunning)
+            {
+                throw new Exception($"Remote Process has exited, Cannot execute command: {cmd}");
+            }
+
+            RemoteApplication.WriteToStandardInput(cmd);
+        }
+
         public ConsoleDynamicMethodFixture(string applicationDirectoryName, string executableName, string targetFramework, bool isCoreApp, TimeSpan timeout)
             : base(new RemoteConsoleApplication(applicationDirectoryName, executableName, targetFramework, ApplicationType.Shared, isCoreApp, isCoreApp)
                   .SetTimeout(timeout)
@@ -193,12 +203,7 @@ namespace MultiFunctionApplicationHelpers
             {
                 foreach (var cmd in _commands)
                 {
-                    if (!RemoteApplication.IsRunning)
-                    {
-                        throw new Exception($"Remote Process has exited, Cannot execute command: {cmd}");
-                    }
-
-                    RemoteApplication.WriteToStandardInput(cmd);
+                    SendCommand(cmd);
                 }
             });
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -157,32 +157,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             await Task.Run(() => CreateSingleLogMessage(message, level));
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        [LibraryMethod]
-        public static async Task CreateSingleLogMessageAsyncNoAwait(string message, string level)
-        {
-            _ = Task.Run(() => CreateSingleLogMessage(message, level));
-        }
-
-        [LibraryMethod]
-        [Transaction]
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-
-        public static async Task CreateSingleLogMessageInTransactionAsyncNoAwait(string message, string level)
-        {
-            _ = Task.Run(() => CreateSingleLogMessage(message, level));
-        }
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
-
-        [LibraryMethod]
-        [Transaction]
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public static async Task CreateSingleLogMessageInTransactionAsyncNoAwaitWithDelay(string message, string level)
-        {
-            _ = Task.Run(() => CreateSingleLogMessage(message, level));
-            await Task.Delay(1000);
-        }
-
         [LibraryMethod]
         [Trace]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
@@ -2,20 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using MultiFunctionApplicationHelpers;
-using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 using NServiceBus;
-using NsbTests;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 #if !NET462
@@ -112,35 +104,33 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void PublishEventInTransaction()
+        public async void PublishEventInTransaction()
         {
-            PublishEvent();
+            await PublishEvent();
         }
 
         [LibraryMethod]
-        public void PublishEvent()
+        public async Task PublishEvent()
         {
             var @event = new Event();
             ConsoleMFLogger.Info($"Sending NServiceBus Event with Id: {@event.Id}");
-            _endpoint.Publish(@event).Wait();
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            await _endpoint.Publish(@event);
         }
 
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void SendCommandInTransaction()
+        public async void SendCommandInTransaction()
         {
-            SendCommand();
+            await SendCommand();
         }
 
         [LibraryMethod]
-        public void SendCommand()
+        public async Task SendCommand()
         {
             var command = new Command();
             ConsoleMFLogger.Info($"Sending NServiceBus Command with Id: {command.Id}");
-            _endpoint.SendLocal(command).Wait();
-            Task.Delay(TimeSpan.FromSeconds(2)).Wait();
+            await _endpoint.SendLocal(command);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
@@ -104,7 +104,7 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async void PublishEventInTransaction()
+        public async Task PublishEventInTransaction()
         {
             await PublishEvent();
         }
@@ -120,7 +120,7 @@ namespace NsbTests
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async void SendCommandInTransaction()
+        public async Task SendCommandInTransaction()
         {
             await SendCommand();
         }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithAsyncEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
             _fixture.AddCommand("NServiceBusDriver PublishEvent");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver PublishEventInTransaction");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver PublishEventInTransaction");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
             _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -26,7 +26,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("RootCommands DelaySeconds 5");
             _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
             _fixture.Actions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -26,15 +26,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
 
             _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
             _fixture.AddCommand("NServiceBusDriver SendCommand");
-            _fixture.AddCommand("NServiceBusDriver StopNServiceBus");
 
-            _fixture.Actions
+            _fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
                 }
             );
 


### PR DESCRIPTION
## Description

Reduce logging (application logging instrumentation) integration test cycle time.  Summary of changes:

- Eliminate use of artificial delays (`RootCommands DelaySeconds`) and instead wait on agent log messages where necessary
- Reduce testing of configuration options.  The feature config option logic for logging metrics and log forwarding is handled in a central agent API method `RecordLogMessage` and is sufficiently unit tested there.  The logic for the local decoration config option is in the individual instrumentation wrappers and so the local decoration tests continue to test the feature being enabled or disabled.
- We don't need to test fire-and-forget async scenarios in the `MetricsAndForwarding` tests in addition to async-wait scenarios.  There is no special logic in the wrappers to handle different async scenarios, and the fire-and-forget pattern posed a challenge to removing artificial delays from the tests.
- Miscellaneous cleanup, e.g. don't explicitly set agent configuration options that are already on by default

FYI, since I started this branch from a previous branch before it was merged, the code diff shows a bunch of previous changes that have already been merged.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
