### PR TITLE
fix: Clearing transaction context for held transactions and async WCF client instrumentation timing.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -133,6 +133,11 @@ namespace NewRelic.Agent.Core.Transactions
                 {
                     LogFinest("Response time captured.");
                 }
+
+                // Once the response time is captured, the only work remaining for the transaction can be
+                // async work that is holding onto the transaction. We need to remove the transaction
+                // from the transaction context so that it will not be reused.
+                Agent._transactionService.RemoveOutstandingInternalTransactions(true, true);
             }
 
             var remainingUnitsOfWork = NoticeUnitOfWorkEnds();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/ServiceChannelProxyWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/ServiceChannelProxyWrapper.cs
@@ -124,7 +124,7 @@ namespace NewRelic.Providers.Wrapper.Wcf3
                     segment.RemoveSegmentFromCallStack();
                     transaction.Hold();
                     var task = (Task)methodReturnMessage.ReturnValue;
-                    task.ContinueWith(ContinueWork);
+                    task.ContinueWith(ContinueWork, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.HideScheduler);
 
                     void ContinueWork(Task t)
                     {


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

There are 2 changes in this PR to address 2 different but related problems caught by the WCF client integration tests.

1. When asynchronous instrumentation uses the hold-release pattern, the transaction is not removed from the transaction context storage when the response time for that transaction is captured. This can lead to, in some situations, where instrumented code that runs after the "held" but not yet "released" transaction will reuse that transaction instead of creating a new one.
2. The continuation used to end the async segment/span for the WCF client call can sometimes be delayed too long (waiting until the task scheduler finds a convenient time) leading to the external call time being artificially extended and the transaction duration being artificially extended.

To address the first problem, this PR clears out the transaction storage context when the response time for a transaction is captured.

To address the second problem, this PR provides continuation hints so that the task scheduler will attempt to execute our continuation as soon as possible after the WCF client call completes.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
