### PR TITLE
test: Update ConfigurationLoaderTests to run even when NEWRELIC_HOME is set

### DIFF
--- a/tests/Agent/UnitTests/Core.UnitTest/Config/ConfigurationLoaderTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Config/ConfigurationLoaderTests.cs
@@ -103,8 +103,12 @@ namespace NewRelic.Agent.Core.Config
         [Test]
         public void GetAgentConfigFileName_ThrowsExceptionWhenNoneFound()
         {
-            var actualException = Assert.Catch<Exception>(() => ConfigurationLoader.GetAgentConfigFileName(), "Expected an exception to be thrown");
-            StringAssert.Contains("Could not find newrelic.config", actualException.Message);
+            using (var staticMocks = new ConfigurationLoaderStaticMocks())
+            {
+                ReplaceNewRelicHomeWithNullIfNecessary(staticMocks);
+                var actualException = Assert.Catch<Exception>(() => ConfigurationLoader.GetAgentConfigFileName(), "Expected an exception to be thrown");
+                StringAssert.Contains("Could not find newrelic.config", actualException.Message);
+            }
         }
 
         [Test]
@@ -170,6 +174,7 @@ namespace NewRelic.Agent.Core.Config
         {
             using (var staticMocks = new ConfigurationLoaderStaticMocks())
             {
+                ReplaceNewRelicHomeWithNullIfNecessary(staticMocks);
                 staticMocks.UseAppDomainAppVirtualPathFunc(() => "testVirtualPath");
 
                 var actualException = Assert.Catch<Exception>(() => ConfigurationLoader.GetAgentConfigFileName(), "Expected an exception to be thrown");
@@ -226,6 +231,7 @@ namespace NewRelic.Agent.Core.Config
         {
             using (var staticMocks = new ConfigurationLoaderStaticMocks())
             {
+                ReplaceNewRelicHomeWithNullIfNecessary(staticMocks);
                 staticMocks.UsePathGetDirectoryNameFunc(_ => null);
 
                 var actualException = Assert.Catch<Exception>(() => ConfigurationLoader.GetAgentConfigFileName(), "Expected an exception to be thrown");
@@ -553,6 +559,14 @@ namespace NewRelic.Agent.Core.Config
 	</threadProfiling>
 </configuration>
 ";
+        }
+
+        private static void ReplaceNewRelicHomeWithNullIfNecessary(ConfigurationLoaderStaticMocks mocks)
+        {
+            if (!string.IsNullOrEmpty(AgentInstallConfiguration.NewRelicHome))
+            {
+                mocks.UseGetNewRelicHome(() => null);
+            }
         }
 
         private class ConfigurationLoaderStaticMocks : IDisposable


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

If you try to run the ConfigurationLoader unit tests locally and you have the NEWRELIC_HOME environment variable set to a valid location, the tests will fail. This PR updates the tests so that the NEWRELIC_HOME environment variable will be overridden to the value that the tests expect (when necessary).

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
