### PR TITLE
test: Exclude all files in Agent\Extensions\Providers and subfolders

### DIFF
--- a/tests/UnitTests.runsettings
+++ b/tests/UnitTests.runsettings
@@ -20,7 +20,7 @@
                     <!-- See https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
                      and https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#excluding-from-coverage -->
                     <Exclude>[NewRelic.OpenTracing.AmazonLambda*]*</Exclude>
-                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/NewRelic.Agent.Core/AgentManager.cs</ExcludeByFile>
+                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/NewRelic.Agent.Core/AgentManager.cs, **/Agent\Extensions/**/*</ExcludeByFile>
                     <ExcludeByAttribute>NrExcludeFromCodeCoverage,Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                 </Configuration>
             </DataCollector>

--- a/tests/UnitTests.runsettings
+++ b/tests/UnitTests.runsettings
@@ -20,7 +20,7 @@
                     <!-- See https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md#advanced-options-supported-via-runsettings
                      and https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#excluding-from-coverage -->
                     <Exclude>[NewRelic.OpenTracing.AmazonLambda*]*</Exclude>
-                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/NewRelic.Agent.Core/AgentManager.cs, **/Agent\Extensions/**/*</ExcludeByFile>
+                    <ExcludeByFile>**/tests/**/*, **/NativeMethods.cs, **/NewRelic.Api.Agent/NewRelic.cs, **/NewRelic.Agent.Core/AgentManager.cs, **/Agent/Extensions/Providers/**/*</ExcludeByFile>
                     <ExcludeByAttribute>NrExcludeFromCodeCoverage,Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                 </Configuration>
             </DataCollector>


### PR DESCRIPTION
Exclude all files in Agent\Extensions\Providers and subfolders from Unit Test code coverage until we can implement proper testing for wrappers.