### PR TITLE
ci: Fixed issues with building debug locally

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -9,7 +9,7 @@ Param(
     [ValidateSet("All","x64","x86")][string]$Architecture = "All",
     [string]$HomePath = "$env:NR_DEV_HOMEROOT",
     [string]$gpgKeyPath = "",
-    [switch]$SkipProfilerBuild = $false,
+    # [switch]$SkipProfilerBuild = $false,
     [switch]$KeepNewRelicConfig = $false,
     [switch]$SetSystemEnvironment = $false,
     [switch]$SetSessionEnvironment = $false
@@ -38,18 +38,18 @@ if (($Type -like "Linux" -or $Type -like "All" -or $Type -like "CoreAll" -or $Ty
 . "$rootDirectory\build\build_functions.ps1"
 $HomePath = Get-HomeRootPath $HomePath
 
-######################################
-# Profiler Build (Windows and Linux) #
-######################################
+# ######################################
+# # Profiler Build (Windows and Linux) #
+# ######################################
 
-if (-Not $SkipProfilerBuild) {
-    $profilerBuildScript = "$rootDirectory\src\Agent\NewRelic\Profiler\build\build.ps1"
-    & $profilerBuildScript
-    if ($LastExitCode -ne 0) {
-        Write-Host "Error in Profiler build script. Exiting with code: $LastExitCode.."
-        exit $LastExitCode
-    }
-}
+# if (-Not $SkipProfilerBuild) {
+#     $profilerBuildScript = "$rootDirectory\src\Agent\NewRelic\Profiler\build\build.ps1"
+#     & $profilerBuildScript
+#     if ($LastExitCode -ne 0) {
+#         Write-Host "Error in Profiler build script. Exiting with code: $LastExitCode.."
+#         exit $LastExitCode
+#     }
+# }
 
 #######################
 # Managed Agent Build #

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -9,7 +9,6 @@ Param(
     [ValidateSet("All","x64","x86")][string]$Architecture = "All",
     [string]$HomePath = "$env:NR_DEV_HOMEROOT",
     [string]$gpgKeyPath = "",
-    # [switch]$SkipProfilerBuild = $false,
     [switch]$KeepNewRelicConfig = $false,
     [switch]$SetSystemEnvironment = $false,
     [switch]$SetSessionEnvironment = $false
@@ -37,19 +36,6 @@ if (($Type -like "Linux" -or $Type -like "All" -or $Type -like "CoreAll" -or $Ty
 
 . "$rootDirectory\build\build_functions.ps1"
 $HomePath = Get-HomeRootPath $HomePath
-
-# ######################################
-# # Profiler Build (Windows and Linux) #
-# ######################################
-
-# if (-Not $SkipProfilerBuild) {
-#     $profilerBuildScript = "$rootDirectory\src\Agent\NewRelic\Profiler\build\build.ps1"
-#     & $profilerBuildScript
-#     if ($LastExitCode -ne 0) {
-#         Write-Host "Error in Profiler build script. Exiting with code: $LastExitCode.."
-#         exit $LastExitCode
-#     }
-# }
 
 #######################
 # Managed Agent Build #

--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -156,10 +156,10 @@ function Copy-AgentRoot {
     
     if ($Linux) {
         if ($Architecture -like "x64") {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\Release\netstandard2.0\profiler\linux_x64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_x64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
         }
         if ($Architecture -like "ARM64") {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\Release\netstandard2.0\profiler\linux_arm64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_arm64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
         }
     }
     else {
@@ -170,10 +170,10 @@ function Copy-AgentRoot {
         }
 
         if ($Architecture -like "x64" ) {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\Release\netstandard2.0\profiler\x64\NewRelic.Profiler.dll" -Destination "$Destination" -Force 
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\x64\NewRelic.Profiler.dll" -Destination "$Destination" -Force 
         }
         else {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\Release\netstandard2.0\profiler\x86\NewRelic.Profiler.dll" -Destination "$Destination" -Force 
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\x86\NewRelic.Profiler.dll" -Destination "$Destination" -Force 
         }
     }
 


### PR DESCRIPTION
I accidentally hard-coded the build configuration in the paths for my  changes to `build_functions.ps1` - this PR addresses that issue. 

Also, I forgot to remove the profiler build from `build.ps1` after we moved it to a NuGet package. I intentionally left the profiler build section commented out in case we ever need to come back to it.
