### PR TITLE
Initial Serilog Logging Implementation

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -1301,8 +1301,6 @@ namespace NewRelic.Agent.Core.Config
         
         private bool auditLogField;
         
-        private System.Nullable<configurationLogFileLockingModel> fileLockingModelField;
-        
         /// <summary>
         /// configurationLog class constructor
         /// </summary>
@@ -1378,42 +1376,6 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.auditLogField = value;
-            }
-        }
-        
-        [System.Xml.Serialization.XmlAttributeAttribute()]
-        public configurationLogFileLockingModel fileLockingModel
-        {
-            get
-            {
-                if (this.fileLockingModelField.HasValue)
-                {
-                    return this.fileLockingModelField.Value;
-                }
-                else
-                {
-                    return default(configurationLogFileLockingModel);
-                }
-            }
-            set
-            {
-                this.fileLockingModelField = value;
-            }
-        }
-        
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool fileLockingModelSpecified
-        {
-            get
-            {
-                return this.fileLockingModelField.HasValue;
-            }
-            set
-            {
-                if (value==false)
-                {
-                    this.fileLockingModelField = null;
-                }
             }
         }
         

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -347,19 +347,6 @@
                             </xs:annotation>
                         </xs:attribute>
 
-                        <xs:attribute name="fileLockingModel">
-                            <xs:annotation>
-                                <xs:documentation>
-                                    Controls how agent-produced log files are to be locked.	Experimental.
-                                </xs:documentation>
-                            </xs:annotation>
-                            <xs:simpleType>
-                                <xs:restriction base="xs:string">
-                                    <xs:enumeration value="exclusive"/>
-                                    <xs:enumeration value="minimal"/>
-                                </xs:restriction>
-                            </xs:simpleType>
-                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
 

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -586,22 +586,6 @@ namespace NewRelic.Agent.Core.Config
             return "newrelic_agent_" + Strings.SafeFileName(name) + ".log";
         }
 
-        public bool FileLockingModelSpecified
-        {
-            get
-            {
-                return fileLockingModelSpecified;
-            }
-        }
-
-        public configurationLogFileLockingModel FileLockingModel
-        {
-            get
-            {
-                return fileLockingModel;
-            }
-        }
-
         public bool Console
         {
             get

--- a/src/Agent/NewRelic/Agent/Core/Config/ILogConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ILogConfig.cs
@@ -9,9 +9,6 @@ namespace NewRelic.Agent.Core.Config
 
         string GetFullLogFileName();
 
-        bool FileLockingModelSpecified { get; }
-        configurationLogFileLockingModel FileLockingModel { get; }
-
         bool Console { get; }
 
         bool IsAuditLogEnabled { get; }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
@@ -63,15 +63,8 @@ namespace NewRelic.Agent.Core.Configuration
 
         private static void UpdateLogLevel(configuration localConfiguration)
         {
-            var hierarchy = log4net.LogManager.GetRepository(Assembly.GetCallingAssembly()) as log4net.Repository.Hierarchy.Hierarchy;
-            var logger = hierarchy.Root;
-
-            var logLevel = logger.Hierarchy.LevelMap[localConfiguration.LogConfig.LogLevel];
-            if (logLevel != null && logLevel != logger.Level)
-            {
-                Log.InfoFormat("The log level was updated to {0}", logLevel);
-                logger.Level = logLevel;
-            }
+            Log.InfoFormat("The log level was updated to {0}", localConfiguration.LogConfig.LogLevel);
+            LoggerBootstrapper.UpdateLoggingLevel(localConfiguration.LogConfig.LogLevel);
         }
 
         private void OnServerConfigurationUpdated(ServerConfigurationUpdatedEvent serverConfigurationUpdatedEvent)

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
+    <!--<PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />-->
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="ILRepack" Version="2.0.16" />
@@ -108,7 +108,7 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Console'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Debug'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />
+      <!--<ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />-->
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.File'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.ValueTuple'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Memory'" />
@@ -127,14 +127,16 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Console'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Debug'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />
+      <!--<ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />-->
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.File'" />
+      <!-- System.Diagnostics.EventLog is required for Serilog.Sinks.EventLog -->
+      <!--<ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Diagnostics.EventLog'" />-->
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'ICSharpCode.SharpZipLib'" />
     </ItemGroup>
 
     <PropertyGroup>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">19</ILRepackIncludeCount>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">15</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">18</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">14</ILRepackIncludeCount>
     </PropertyGroup>
 
     <Error Text="ILRepack of $(AssemblyName) ($(TargetFramework)) failed. A dependency is missing. Expected $(ILRepackIncludeCount) dependencies but found @(ILRepackInclude-&gt;Count())." Condition="@(ILRepackInclude-&gt;Count()) != $(ILRepackIncludeCount)" />

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -37,9 +37,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="ILRepack" Version="2.0.16" />
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
   </ItemGroup>
@@ -80,11 +84,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RootProjectDirectory)\src\Agent\Shared\SharedLog4NetRepository.cs">
-      <Link>Properties\SharedLog4NetRepository.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
@@ -105,8 +104,12 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Castle.Core'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Castle.Windsor'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'ICSharpCode.SharpZipLib'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'log4net'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Console'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Debug'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.File'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.ValueTuple'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Memory'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Runtime.CompilerServices.Unsafe'" />
@@ -120,14 +123,18 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Grpc.Net.Common'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Grpc.Net.Client'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Autofac'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'log4net'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Console'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Debug'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.EventLog'" />
+      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.File'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'ICSharpCode.SharpZipLib'" />
     </ItemGroup>
 
     <PropertyGroup>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">15</ILRepackIncludeCount>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">11</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">19</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">15</ILRepackIncludeCount>
     </PropertyGroup>
 
     <Error Text="ILRepack of $(AssemblyName) ($(TargetFramework)) failed. A dependency is missing. Expected $(ILRepackIncludeCount) dependencies but found @(ILRepackInclude-&gt;Count())." Condition="@(ILRepackInclude-&gt;Count()) != $(ILRepackIncludeCount)" />

--- a/src/Agent/NewRelic/Agent/Core/Labels/LabelsService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Labels/LabelsService.cs
@@ -12,7 +12,7 @@ namespace NewRelic.Agent.Core.Labels
 {
     public class LabelsService : ILabelsService
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(typeof(LabelsService));
+        private readonly Serilog.ILogger Log = Serilog.Log.Logger;
 
         private const int MaxLabels = 64;
         private const int MaxLength = 255;
@@ -45,18 +45,18 @@ namespace NewRelic.Agent.Core.Labels
                     .ToList();
 
                 if (labels.Count == MaxLabels)
-                    Log.WarnFormat("Maximum number of labels reached, some may have been dropped.");
+                    Log.Warning("Maximum number of labels reached, some may have been dropped.");
 
                 return labels;
             }
             catch (Exception exception)
             {
-                Log.WarnFormat("Failed to parse labels configuration string: {0}", exception);
+                Log.Warning("Failed to parse labels configuration string: {0}", exception);
                 return Enumerable.Empty<Label>();
             }
         }
 
-        private static Label CreateLabelFromString(string typeAndValueString)
+        private Label CreateLabelFromString(string typeAndValueString)
         {
             if (typeAndValueString == null)
                 throw new ArgumentNullException("typeAndValueString");
@@ -87,11 +87,11 @@ namespace NewRelic.Agent.Core.Labels
             return new Label(typeTruncated, valueTruncated);
         }
 
-        private static string Truncate(string value)
+        private string Truncate(string value)
         {
             var result = value.TruncateUnicodeStringByLength(MaxLength);
             if (result.Length != value.Length)
-                Log.WarnFormat("Truncated label key from {0} to {1}", value, result);
+                Log.Warning("Truncated label key from {0} to {1}", value, result);
 
             return result;
         }

--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -5,15 +5,13 @@ namespace NewRelic.Agent.Core.Logging
 {
     public static class AuditLog
     {
-        private static readonly log4net.ILog Logger = log4net.LogManager.GetLogger(typeof(AuditLog));
-
         /// <summary>
         /// Logs <paramref name="message"/> at the AUDIT level, a custom log level that is not well-defined in popular logging providers like log4net. This log level should be used only as dictated by the security team to satisfy auditing requirements.
         /// </summary>
         public static void Log(string message)
         {
-            var auditLogLevel = LoggerBootstrapper.GetAuditLevel();
-            Logger.Logger.Log(typeof(AuditLog), auditLogLevel, message, null);
+            // use Fatal log level to ensure audit log messages never get filtered due to level restrictions
+            Serilog.Log.Logger.Fatal("{Message} {Audit}", message, LoggerBootstrapper.GetAuditLevel());
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Logging/CustomAuditLogTextFormatter.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/CustomAuditLogTextFormatter.cs
@@ -1,0 +1,19 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace NewRelic.Agent.Core
+{
+    class CustomAuditLogTextFormatter : ITextFormatter
+    {
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            logEvent.Properties.TryGetValue("Message", out var message);
+
+            output.Write($"{logEvent.Timestamp.ToUniversalTime():yyyy-MM-dd HH:mm:ss,fff} NewRelic  AUDIT: {message}{output.NewLine}");
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Logging/CustomTextFormatter.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/CustomTextFormatter.cs
@@ -1,0 +1,24 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace NewRelic.Agent.Core
+{
+    class CustomTextFormatter : ITextFormatter
+    {
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            // try to get process and thread id
+            logEvent.Properties.TryGetValue("pid", out var pid);
+            logEvent.Properties.TryGetValue("tid", out var tid);
+
+            // format matches the log4net format, but adds the Exception property (if present in the message as a separate property) to the end, after the newline
+            // if that's not desired, take the Exception property out and refactor calls to `Serilog.Log.Logger.LogXxxx(exception, message)` so the exception is
+            // formatted into the message 
+            output.Write($"{logEvent.Timestamp.ToUniversalTime():yyyy-MM-dd HH:mm:ss,fff} NewRelic {logEvent.Level.TranslateLogLevel(),6}: [pid: {pid?.ToString()}, tid: {tid?.ToString()}] {logEvent.MessageTemplate}{output.NewLine}{logEvent.Exception}");
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Logging/LogLevelExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LogLevelExtensions.cs
@@ -1,0 +1,63 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Serilog.Events;
+
+namespace NewRelic.Agent.Core
+{
+    internal static class LogLevelExtensions
+    {
+        /// <summary>
+        /// Map a configfile loglevel to the equivalent Serilog loglevel </summary>
+        /// <param name="configLogLevel"></param>
+        /// <returns></returns>
+        public static LogEventLevel MapToSerilogLogLevel(this string configLogLevel)
+        {
+            switch (configLogLevel.ToUpper())
+            {
+                case "FINEST":
+                    return LogEventLevel.Verbose;
+                case "DEBUG":
+                    return LogEventLevel.Debug;
+                case "INFO":
+                    return LogEventLevel.Information;
+                case "WARN": 
+                    return LogEventLevel.Warning;
+                case "OFF":
+                    // moderately hack-ish, but setting the level to something higher than Fatal disables logs as per https://stackoverflow.com/a/30864356/2078975
+                    return (LogEventLevel)1 + (int)LogEventLevel.Fatal; 
+                default:
+                    // TODO: Add checking for deprecated log levels ??
+                    Serilog.Log.Logger.Warning($"Invalid log level '{configLogLevel}' specified. Using log level 'Info' by default.");
+                    return LogEventLevel.Information;
+            }
+        }
+
+        /// <summary>
+        /// Translates Serilog log level to the "legacy" Log4Net levels to ensure log file consistency
+        /// </summary>
+        /// <param name="logEventLevel"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static string TranslateLogLevel(this LogEventLevel logEventLevel)
+        {
+            switch (logEventLevel)
+            {
+                case LogEventLevel.Verbose:
+                    return "FINEST";
+                case LogEventLevel.Debug:
+                    return "DEBUG";
+                case LogEventLevel.Information:
+                    return "INFO";
+                case LogEventLevel.Warning:
+                    return "WARN";
+                case LogEventLevel.Error:
+                    return "ERR";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logEventLevel), logEventLevel, null);
+            }
+        }
+
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -1,20 +1,20 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Filter;
-using log4net.Layout;
 using NewRelic.Agent.Core.Config;
-using NewRelic.Agent.Core.Logging;
-using NewRelic.Core.Logging;
-using NewRelic.SystemInterfaces;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
-using log4netLogger = log4net.Repository.Hierarchy.Logger;
+using System.Linq;
+using System.Text;
+using NewRelic.Agent.Core.Logging;
+#if NETSTANDARD2_0
+using System.Runtime.InteropServices;
+#endif
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Logger = NewRelic.Agent.Core.Logging.Logger;
 
 namespace NewRelic.Agent.Core
 {
@@ -22,372 +22,251 @@ namespace NewRelic.Agent.Core
     {
 
         /// <summary>
-        /// The name of the Audit log appender.
+        /// The name of the event log to log to.
         /// </summary>
-        private static readonly string AuditLogAppenderName = "AuditLog";
-
-        /// <summary>
-        /// The name of the Console log appender.
-        /// </summary>
-        private static readonly string ConsoleLogAppenderName = "ConsoleLog";
-
-        /// <summary>
-        /// The name of the temporary event log appender.
-        /// </summary>
-        private static readonly string TemporaryEventLogAppenderName = "TemporaryEventLog";
-
-#if NETFRAMEWORK
-		/// <summary>
-		/// The name of the event log appender.
-		/// </summary>
-		private static readonly string EventLogAppenderName = "EventLog";
-
-		/// <summary>
-		/// The name of the event log to log to.
-		/// </summary>
-		private static readonly string EventLogName = "Application";
+        private static readonly string EventLogName = "Application";
 
 		/// <summary>
 		/// The event source name.
 		/// </summary>
 		private static readonly string EventLogSourceName = "New Relic .NET Agent";
-#endif
+
+        ///// <summary>
+        ///// The numeric level of the Audit log.
+        ///// </summary>
+        //private static int AuditLogLevel = 150000;
 
         /// <summary>
-        /// The numeric level of the Audit log.
+        /// The string name of the Audit log level.
         /// </summary>
-        private static int AuditLogLevel = 150000;
-
-        /// <summary>
-        /// The string name of the Audit log.
-        /// </summary>
-        private static string AuditLogName = "Audit";
+        private static string AuditLogLevelName = "Audit";
 
         // Watch out!  If you change the time format that the agent puts into its log files, other log parsers may fail.
-        private static ILayout AuditLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %level: %message\r\n");
-        private static ILayout FileLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %6level: [pid: %property{pid}, tid: %property{threadid}] %message\r\n");
+        //private static ILayout AuditLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %level: %message\r\n");
+        //private static ILayout FileLogLayout = new PatternLayout("%utcdate{yyyy-MM-dd HH:mm:ss,fff} NewRelic %6level: [pid: %property{pid}, tid: %property{threadid}] %message\r\n");
 
-        private static ILayout eventLoggerLayout = new PatternLayout("%level: %message");
 
-        private static string STARTUP_APPENDER_NAME = "NEWRELIC_DOTNET_AGENT_STARTUP_APPENDER";
+        private static LoggingLevelSwitch _loggingLevelSwitch = new LoggingLevelSwitch();
 
-        private static List<Level> DeprecatedLogLevels = new List<Level>() { Level.Alert, Level.Critical, Level.Emergency, Level.Fatal, Level.Finer, Level.Trace, Level.Notice, Level.Severe, Level.Verbose, Level.Fine };
+        public static void UpdateLoggingLevel(string newLogLevel)
+        {
+            _loggingLevelSwitch.MinimumLevel = newLogLevel.MapToSerilogLogLevel();
+        }
 
         public static void Initialize()
         {
-            CreateAuditLogLevel();
-            var hierarchy = log4net.LogManager.GetRepository(Assembly.GetCallingAssembly()) as log4net.Repository.Hierarchy.Hierarchy;
-            var logger = hierarchy.Root;
+            var startupLoggerConfig = new LoggerConfiguration()
+                .Enrich.With(new ThreadIdEnricher())
+                .Enrich.With(new ProcessIdEnricher())
+                .MinimumLevel.Information()
+                .ConfigureInMemoryLogSink()
+                .ConfigureEventLogSink()
+                // TODO: Remove console log sink when in-memory sink is implemented
+                .ConfigureConsoleSink();
 
-            // initially we will log to console and event log so it should only log items that need action
-            logger.Level = Level.Info;
-
-            GlobalContext.Properties["pid"] = new ProcessStatic().GetCurrentProcess().Id;
-
-            SetupStartupLogAppender(logger);
-            SetupConsoleLogAppender(logger);
-            SetupTemporaryEventLogAppender(logger);
+            // set the global Serilog logger to our startup logger instance, this gets replaced when ConfigureLogger() is called
+            Serilog.Log.Logger = startupLoggerConfig.CreateLogger();
         }
 
         /// <summary>
         /// Configures the agent logger.
         /// </summary>
-        /// <param name="debug">
-        /// A <see cref="bool"/>
-        /// </param>
-        /// <param name="config">
-        /// A <see cref="ILogConfig"/>
-        /// </param>
-        /// <returns>
-        /// A <see cref="ILogger"/>
-        /// </returns>
         /// <remarks>This should only be called once, as soon as you have a valid config.</remarks>
         public static void ConfigureLogger(ILogConfig config)
         {
-            var hierarchy = log4net.LogManager.GetRepository(Assembly.GetCallingAssembly()) as log4net.Repository.Hierarchy.Hierarchy;
-            var logger = hierarchy.Root;
+            SetupLogLevel(config);
 
-            SetupLogLevel(logger, config);
+            var loggerConfig = new LoggerConfiguration()
+                .Enrich.With(new ThreadIdEnricher())
+                .Enrich.With(new ProcessIdEnricher())
+                .ConfigureFileSink(config)
+                .ConfigureAuditLogSink(config)
+                .ConfigureDebugSink();
 
-            SetupFileLogAppender(logger, config);
-            SetupAuditLogger(logger, config);
-            SetupDebugLogAppender(logger);
-            logger.RemoveAppender(TemporaryEventLogAppenderName);
-
-            if (!config.Console)
+            if (config.Console)
             {
-                logger.RemoveAppender(ConsoleLogAppenderName);
+                loggerConfig = loggerConfig.ConfigureConsoleSink();
             }
 
-            logger.Repository.Configured = true;
+            var startupLogger = Serilog.Log.Logger;
 
-            // We have now bootstrapped the agent logger, so
-            // remove the startup appender, then send its messages 
-            // to the agent logger, which will get picked up by 
-            // the other appenders.
-            ShutdownStartupLogAppender(logger);
+            // configure the global singleton logger instance (which remains specific to the Agent by way of ILRepack)
+            var configuredLogger = loggerConfig.CreateLogger();
 
-            Log.Initialize(new Logger());
+            EchoInMemoryLogsToConfiguredLogger(configuredLogger);
+
+            Serilog.Log.Logger = configuredLogger;
+
+            NewRelic.Core.Logging.Log.Initialize(new Logger());
         }
 
         /// <summary>
-        /// Gets the log4net Level of the "Audit" log level.
+        /// Gets a string identifying the Audit log level
         /// </summary>
-        /// <returns>The "Audit" log4net Level.</returns>
-        public static Level GetAuditLevel()
+        public static string GetAuditLevel() => AuditLogLevelName;
+
+        private static void EchoInMemoryLogsToConfiguredLogger(Serilog.ILogger configuredLogger)
         {
-            return LogManager.GetRepository(Assembly.GetCallingAssembly()).LevelMap[AuditLogName];
-        }
-
-        private static void ShutdownStartupLogAppender(log4netLogger logger)
-        {
-            var startupAppender = logger.GetAppender(STARTUP_APPENDER_NAME) as MemoryAppender;
-            if (startupAppender != null)
-            {
-                LoggingEvent[] events = startupAppender.GetEvents();
-                logger.RemoveAppender(startupAppender);
-
-                if (events != null)
-                {
-                    foreach (LoggingEvent logEvent in events)
-                    {
-                        logger.Log(logEvent.Level, logEvent.MessageObject, null);
-                    }
-                }
-            }
-        }
-
-        private static FileAppender.LockingModelBase GetFileLockingModel(ILogConfig config)
-        {
-            if (config.FileLockingModelSpecified)
-            {
-                if (config.FileLockingModel.Equals(configurationLogFileLockingModel.minimal))
-                {
-                    return (FileAppender.LockingModelBase)new FileAppender.MinimalLock();
-                }
-                else
-                {
-                    return new FileAppender.ExclusiveLock();
-                }
-
-            }
-            return new FileAppender.MinimalLock();
-        }
-
-        /// <summary>
-        /// Creates a new AuditLogName log level at level AuditLogLevel (higher than Emergency log level) and registers it as a log4net level.
-        /// </summary>
-        private static void CreateAuditLogLevel()
-        {
-            Level auditLevel = new Level(AuditLogLevel, AuditLogName);
-            LogManager.GetRepository(Assembly.GetCallingAssembly()).LevelMap.Add(auditLevel);
-        }
-
-        /// <summary>
-        /// Returns a filter set to immediately deny any log events that are "Audit" level.
-        /// </summary>
-        /// <returns>A filter set to imediately deny any log events that are "Audit" level.</returns>
-        private static IFilter GetNoAuditFilter()
-        {
-            LevelMatchFilter filter = new LevelMatchFilter();
-            filter.LevelToMatch = GetAuditLevel();
-            filter.AcceptOnMatch = false;
-            return filter;
-        }
-
-        /// <summary>
-        /// Returns a filter set to immediately accept any log events that are "Audit" level.
-        /// </summary>
-        /// <returns>A filter set to immediately accept any log events that are "Audit" level.</returns>
-        private static IFilter GetAuditFilter()
-        {
-            LevelMatchFilter filter = new LevelMatchFilter();
-            filter.LevelToMatch = GetAuditLevel();
-            filter.AcceptOnMatch = true;
-            return filter;
+            // TODO: copy logs from inMemory logger and emit them to Serilog.Log.Logger
+            // possible example:
+            //foreach (LogEvent logEvent in InMemorySink.Instance.LogEvents)
+            //{
+            //    configuredLogger.Write(logEvent.Level, logEvent.Exception, logEvent.MessageTemplate.Render(logEvent.Properties));
+            //}
+            //InMemorySink.Instance.Dispose();
         }
 
         /// <summary>
         /// Sets the log level for logger to either the level provided by the config or an public default.
         /// </summary>
-        /// <param name="logger">The logger to set the level of.</param>
         /// <param name="config">The LogConfig to look for the level setting in.</param>
-        private static void SetupLogLevel(log4netLogger logger, ILogConfig config)
+        private static void SetupLogLevel(ILogConfig config)
         {
-            logger.Level = logger.Hierarchy.LevelMap[config.LogLevel];
-
-            if (logger.Level == null)
-            {
-                logger.Level = log4net.Core.Level.Info;
-            }
-
-            if (logger.Level == GetAuditLevel())
-            {
-                logger.Level = Level.Info;
-                logger.Log(Level.Warn, $"Log level was set to {AuditLogName} which is not a valid log level. To enable audit logging, set the auditLog configuration option to true. Log level will be treated as INFO for this run.", null);
-            }
-
-            if (IsLogLevelDeprecated(logger.Level))
-            {
-                logger.Log(Level.Warn, string.Format(
-                    "The log level, {0}, set in your configuration file has been deprecated. The agent will still log correctly, but you should change to a supported logging level as described in newrelic.config or the online documentation.",
-                    logger.Level.ToString()), null);
-            }
+            _loggingLevelSwitch.MinimumLevel = config.LogLevel.MapToSerilogLogLevel();
         }
 
-        private static bool IsLogLevelDeprecated(Level level)
+        // TODO: implement but don't use log4net log levels enum
+        //private static bool IsLogLevelDeprecated(Level level)
+        //{
+        //    foreach (var l in DeprecatedLogLevels)
+        //    {
+        //        if (l.Name.Equals(level.Name, StringComparison.InvariantCultureIgnoreCase)) return true;
+        //    }
+        //    return false;
+        //}
+
+        private static LoggerConfiguration ConfigureInMemoryLogSink(this LoggerConfiguration loggerConfiguration)
         {
-            foreach (var l in DeprecatedLogLevels)
-            {
-                if (l.Name.Equals(level.Name, StringComparison.InvariantCultureIgnoreCase)) return true;
-            }
-            return false;
+            // TODO Configure the (yet-to-be-implemented) in-memory sink
+
+            return loggerConfiguration;
         }
 
         /// <summary>
-        /// A memory appender for logging to memory during startup. Log messages will be re-logged after configuration is loaded.
+        /// Add the Event Log sink if running on Windows
         /// </summary>
-        /// <param name="logger"></param>
-        private static void SetupStartupLogAppender(log4netLogger logger)
+        /// <param name="loggerConfiguration"></param>
+        private static LoggerConfiguration ConfigureEventLogSink(this LoggerConfiguration loggerConfiguration)
         {
-            var startupAppender = new MemoryAppender();
-            startupAppender.Name = STARTUP_APPENDER_NAME;
-            startupAppender.Layout = LoggerBootstrapper.FileLogLayout;
-            startupAppender.ActivateOptions();
+            var addEventLogSink = true;
 
-            logger.AddAppender(startupAppender);
-            logger.Repository.Configured = true;
-        }
-
-        /// <summary>
-        /// A temporary event log appender for logging during startup (before config is loaded)
-        /// </summary>
-        /// <param name="logger"></param>
-        private static void SetupTemporaryEventLogAppender(log4netLogger logger)
-        {
-#if NETFRAMEWORK
-			var appender = new EventLogAppender();
-			appender.Layout = eventLoggerLayout;
-			appender.Name = TemporaryEventLogAppenderName;
-			appender.LogName = EventLogName;
-			appender.ApplicationName = EventLogSourceName;
-			appender.Threshold = Level.Warn;
-			appender.AddFilter(GetNoAuditFilter());
-			appender.ActivateOptions();
-
-			logger.AddAppender(appender);
+#if NETSTANDARD2_0
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                addEventLogSink = false;
+            }
 #endif
+
+            if (addEventLogSink)
+            {
+                loggerConfiguration
+                    .WriteTo.Logger(configuration =>
+                    {
+                        ExcludeAuditLog(configuration);
+                        configuration
+                            .WriteTo.EventLog(
+                                source: EventLogSourceName,
+                                logName: EventLogName,
+                                restrictedToMinimumLevel: LogEventLevel.Warning
+                            );
+                    });
+            }
+
+            return loggerConfiguration;
         }
 
         /// <summary>
-        /// Setup the event log appender and attach it to a logger.
+        /// Configure the debug sink
         /// </summary>
-        /// <param name="logger">The logger you want to attach the event log appender to.</param>
-        /// <param name="config">The configuration for the appender.</param>
-        private static void SetupEventLogAppender(log4netLogger logger, ILogConfig config)
-        {
-#if NETFRAMEWORK
-			var appender = new EventLogAppender();
-			appender.Layout = eventLoggerLayout;
-			appender.Threshold = Level.Warn;
-			appender.Name = EventLogAppenderName;
-			appender.LogName = EventLogName;
-			appender.ApplicationName = EventLogSourceName;
-			appender.AddFilter(GetNoAuditFilter());
-			appender.ActivateOptions();
-
-			logger.AddAppender(appender);
-#endif
-        }
-
-        /// <summary>
-        /// Setup the debug log appender and attach it to a logger.
-        /// </summary>
-        /// <param name="logger">The logger you want to attach the event log appender to.</param>
-        private static void SetupDebugLogAppender(log4netLogger logger)
+        private static LoggerConfiguration ConfigureDebugSink(this LoggerConfiguration loggerConfiguration)
         {
 #if DEBUG
-			// Create the debug appender and connect it to our logger.
-			var debugAppender = new DebugAppender();
-			debugAppender.Layout = FileLogLayout;
-			debugAppender.AddFilter(GetNoAuditFilter());
-			logger.AddAppender(debugAppender);
+            loggerConfiguration
+                .WriteTo.Logger(configuration =>
+                {
+                    configuration
+                        .MinimumLevel.ControlledBy(_loggingLevelSwitch)
+                        .ExcludeAuditLog()
+                        .WriteTo.Debug(formatter: new CustomTextFormatter());
+                });
 #endif
+            return loggerConfiguration;
         }
 
         /// <summary>
-        /// Setup the console log appender and attach it to a logger.
+        /// Configure the console sink
         /// </summary>
-        /// <param name="logger">The logger you want to attach the console log appender to.</param>
-        private static void SetupConsoleLogAppender(log4netLogger logger)
+        private static LoggerConfiguration ConfigureConsoleSink(this LoggerConfiguration loggerConfiguration)
         {
-            var appender = new ConsoleAppender();
-            appender.Name = ConsoleLogAppenderName;
-            appender.Layout = FileLogLayout;
-            appender.AddFilter(GetNoAuditFilter());
-            appender.ActivateOptions();
-            logger.AddAppender(appender);
+            return loggerConfiguration
+                .WriteTo.Logger(configuration =>
+                {
+                    configuration
+                        .MinimumLevel.ControlledBy(_loggingLevelSwitch)
+                        .ExcludeAuditLog()
+                        .WriteTo.Console(formatter: new CustomTextFormatter());
+                });
         }
 
         /// <summary>
-        /// Setup the file log appender and attach it to a logger.
+        /// Configure the file log sink
         /// </summary>
-        /// <param name="logger">The logger you want to attach the file appender to.</param>
+        /// <param name="loggerConfiguration"></param>
         /// <param name="config">The configuration for the appender.</param>
-        /// <exception cref="System.Exception">If an exception occurs, the Event Log Appender is setup
-        /// to handle output.</exception>
-        private static void SetupFileLogAppender(log4netLogger logger, ILogConfig config)
+        private static LoggerConfiguration ConfigureFileSink(this LoggerConfiguration loggerConfiguration, ILogConfig config)
         {
             string logFileName = config.GetFullLogFileName();
 
             try
             {
-                var appender = SetupRollingFileAppender(config, logFileName, "FileLog", FileLogLayout);
-                appender.AddFilter(GetNoAuditFilter());
-                appender.ActivateOptions();
-                logger.AddAppender(appender);
+                loggerConfiguration
+                    .WriteTo
+                    .Logger(configuration =>
+                    {
+                        configuration
+                            .MinimumLevel.ControlledBy(_loggingLevelSwitch)
+                            .ExcludeAuditLog()
+                            .ConfigureRollingLogSink(logFileName, new CustomTextFormatter());
+                    });
             }
             catch (Exception)
             {
-                // Fallback to the event logger if we cannot setup a file logger.
-                SetupEventLogAppender(logger, config);
+                // Fallback to the event log sink if we cannot setup a file logger.
+                loggerConfiguration.ConfigureEventLogSink();
             }
+
+            return loggerConfiguration;
         }
 
         /// <summary>
         /// Setup the audit log file appender and attach it to a logger.
         /// </summary>
-        /// <param name="logger">The logger you want to attach the audit log appender to.</param>
-        /// <param name="config">The configuration for the appender.</param>
-        private static void SetupAuditLogger(log4netLogger logger, ILogConfig config)
+        private static LoggerConfiguration ConfigureAuditLogSink(this LoggerConfiguration loggerConfiguration, ILogConfig config)
         {
-            if (!config.IsAuditLogEnabled) return;
+            if (!config.IsAuditLogEnabled) return loggerConfiguration;
 
             string logFileName = config.GetFullLogFileName().Replace(".log", "_audit.log");
 
-            try
-            {
-                var appender = SetupRollingFileAppender(config, logFileName, AuditLogAppenderName, AuditLogLayout);
-                appender.AddFilter(GetAuditFilter());
-                appender.AddFilter(new DenyAllFilter());
-                appender.ActivateOptions();
-                logger.AddAppender(appender);
-            }
-            catch (Exception)
-            { }
+            return loggerConfiguration
+                .WriteTo
+                .Logger(configuration =>
+                {
+                    configuration
+                        .MinimumLevel.Fatal()
+                        .IncludeOnlyAuditLog()
+                        .ConfigureRollingLogSink(logFileName, new CustomAuditLogTextFormatter());
+                });
         }
 
         /// <summary>
         /// Sets up a rolling file appender using defaults shared for all our rolling file appenders.
         /// </summary>
-        /// <param name="config">The configuration for the appender.</param>
+        /// <param name="loggerConfiguration"></param>
         /// <param name="fileName">The name of the file this appender will write to.</param>
-        /// <param name="appenderName">The name of this appender.</param>
+        /// <param name="textFormatter"></param>
         /// <remarks>This does not call appender.ActivateOptions or add the appender to the logger.</remarks>
-        private static RollingFileAppender SetupRollingFileAppender(ILogConfig config, string fileName, string appenderName, ILayout layout)
+        private static LoggerConfiguration ConfigureRollingLogSink(this LoggerConfiguration loggerConfiguration, string fileName, ITextFormatter textFormatter)
         {
-            var log = log4net.LogManager.GetLogger(typeof(AgentManager));
-
             // check that the log file is accessible
             try
             {
@@ -395,37 +274,46 @@ namespace NewRelic.Agent.Core
                 var directory = Path.GetDirectoryName(fileName);
                 if (!Directory.Exists(directory))
                     Directory.CreateDirectory(directory);
-
                 using (File.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)) { }
             }
             catch (Exception exception)
             {
-                log.ErrorFormat("Unable to write the {0} log to \"{1}\": {2}", appenderName, fileName, exception.Message);
+                Serilog.Log.Logger.Warning(exception, $"Unable to write logfile at \"{fileName}\"", fileName);
                 throw;
             }
 
             try
             {
-                var appender = new RollingFileAppender();
-
-                appender.LockingModel = GetFileLockingModel(config);
-                appender.Layout = layout;
-                appender.File = fileName;
-                appender.Encoding = System.Text.Encoding.UTF8;
-                appender.AppendToFile = true;
-                appender.RollingStyle = RollingFileAppender.RollingMode.Size;
-                appender.MaxSizeRollBackups = 4;
-                appender.MaxFileSize = 50 * 1024 * 1024; // 50MB
-                appender.StaticLogFileName = true;
-                appender.ImmediateFlush = true;
-
-                return appender;
+                return loggerConfiguration
+                    .WriteTo.File(
+                        path: fileName,
+                        formatter: textFormatter,
+                        fileSizeLimitBytes: 50 * 1024 * 1024,
+                        encoding: Encoding.UTF8,
+                        rollOnFileSizeLimit: true,
+                        retainedFileCountLimit: 4,
+                        buffered: false
+                    );
             }
             catch (Exception exception)
             {
-                log.ErrorFormat("Unable to configure the {0} log file appender for \"{1}\": {2}", appenderName, fileName, exception.Message);
+                Serilog.Log.Logger.Error(exception, $"Unable to configure file logging for \"{fileName}\"");
                 throw;
             }
         }
+
+        private static LoggerConfiguration IncludeOnlyAuditLog(this LoggerConfiguration loggerConfiguration)
+        {
+            return loggerConfiguration.Filter.ByIncludingOnly(logEvent =>
+                logEvent.Properties.ContainsKey(AuditLogLevelName));
+
+        }
+        private static LoggerConfiguration ExcludeAuditLog(this LoggerConfiguration loggerConfiguration)
+        {
+            return loggerConfiguration.Filter.ByExcluding(logEvent =>
+                logEvent.Properties.ContainsKey(AuditLogLevelName));
+
+        }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Logging/ProcessIdEnricher - Copy.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/ProcessIdEnricher - Copy.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NewRelic.Agent.Core
+{
+    class ThreadIdEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
+                "tid", Thread.CurrentThread.ManagedThreadId));
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Logging/ProcessIdEnricher.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/ProcessIdEnricher.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.SystemInterfaces;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace NewRelic.Agent.Core
+{
+    class ProcessIdEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
+                "pid", new ProcessStatic().GetCurrentProcess().Id));
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -373,7 +373,7 @@ namespace NewRelic.Agent.Core
             finally
             {
                 Dispose();
-                log4net.LogManager.Shutdown();
+                Serilog.Log.CloseAndFlush();
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentShim.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentShim.cs
@@ -15,12 +15,9 @@ namespace NewRelic.Agent.Core
     /// </summary>
     public class AgentShim
     {
-        private static log4net.ILog Log;
-
         static void Initialize()
         {
             AgentInitializer.InitializeAgent();
-            Log = log4net.LogManager.GetLogger(typeof(AgentShim));
         }
 
 #if NETSTANDARD2_0
@@ -229,7 +226,7 @@ namespace NewRelic.Agent.Core
             {
                 try
                 {
-                    Log.Debug("Exception occurred in AgentShim.GetTracer", exception);
+                    Serilog.Log.Logger.Debug(exception, "Exception occurred in AgentShim.GetTracer");
                 }
                 catch
                 {
@@ -263,7 +260,7 @@ namespace NewRelic.Agent.Core
                 ITracer tracer = tracerObject as ITracer;
                 if (tracer == null)
                 {
-                    Log.ErrorFormat("AgentShim.FinishTracer received a tracer object but it was not an ITracer. {0}", tracerObject);
+                    Serilog.Log.Logger.Error($"AgentShim.FinishTracer received a tracer object but it was not an ITracer. {tracerObject}");
                     return;
                 }
 
@@ -271,7 +268,7 @@ namespace NewRelic.Agent.Core
                 Exception exception = exceptionObject as Exception;
                 if (exception == null && exceptionObject != null)
                 {
-                    Log.ErrorFormat("AgentShim.FinishTracer received an exception object but it was not an Exception. {0}", exceptionObject);
+                    Serilog.Log.Logger.Error($"AgentShim.FinishTracer received an exception object but it was not an Exception. {exceptionObject}");
                     return;
                 }
 
@@ -291,7 +288,7 @@ namespace NewRelic.Agent.Core
             {
                 try
                 {
-                    Log.Debug("Exception occurred in AgentShim.FinishTracer", exception);
+                    Serilog.Log.Logger.Debug(exception,"Exception occurred in AgentShim.FinishTracer");
                 }
                 catch
                 {

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/RuntimeEnvironmentInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using NewRelic.Core.CodeAttributes;
+using NewRelic.Core.Logging;
 
 namespace NewRelic.Agent.Core
 {
@@ -88,8 +89,7 @@ namespace NewRelic.Agent.Core
             }
             catch (Exception ex)
             {
-                log4net.ILog logger = log4net.LogManager.GetLogger(typeof(RuntimeEnvironmentInfo));
-                logger.Debug($"Unable to report Operating System: Unexpected exception in GetFreeBSDVersion: {ex}");
+                Serilog.Log.Logger.Debug(ex, "Unable to report Operating System: Unexpected exception in GetFreeBSDVersion.");
             }
 #endif
             return string.Empty;
@@ -152,8 +152,7 @@ namespace NewRelic.Agent.Core
             }
             catch (Exception ex)
             {
-                log4net.ILog logger = log4net.LogManager.GetLogger(typeof(RuntimeEnvironmentInfo));
-                logger.Debug($"Unable to report Operating System: Unexpected exception in LoadDistroInfo: {ex}");
+                Serilog.Log.Logger.Debug(ex, $"Unable to report Operating System: Unexpected exception in LoadDistroInfo.");
             }
 
             return result;

--- a/src/Agent/NewRelic/Agent/Core/Utilities/EventBus.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/EventBus.cs
@@ -8,7 +8,6 @@ namespace NewRelic.Agent.Core.Utilities
 {
     public static class EventBus<T>
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(typeof(EventBus<T>));
         private static event Action<T> Events = T => { };
         private static readonly ReaderWriterLock Lock = new ReaderWriterLock();
         private static readonly ReaderLockGuard ReaderLockGuard = new ReaderLockGuard(Lock);
@@ -63,7 +62,7 @@ namespace NewRelic.Agent.Core.Utilities
                 }
                 catch (Exception exception)
                 {
-                    Log.Error($"Exception thrown from event handler.  Event handlers should not let exceptions bubble out of them: {exception}");
+                    Serilog.Log.Logger.Error(exception, "Exception thrown from event handler. Event handlers should not let exceptions bubble out of them.");
                 }
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/RequestBus.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/RequestBus.cs
@@ -15,8 +15,6 @@ namespace NewRelic.Agent.Core.Utilities
     /// Responders are not required to answer and there may not be a responder setup for any given request so you must be prepared to handle either no callback, an empty enumeration or default(TResponse), depending on which Post overload you use.</remarks>
     public static class RequestBus<TRequest, TResponse>
     {
-        private static readonly log4net.ILog Log = log4net.LogManager.GetLogger(typeof(RequestBus<TRequest, TResponse>));
-
         public delegate void ResponsesCallback(IEnumerable<TResponse> responses);
 
         public delegate void ResponseCallback(TResponse response);
@@ -73,7 +71,7 @@ namespace NewRelic.Agent.Core.Utilities
                 }
                 catch (Exception exception)
                 {
-                    Log.Error($"Exception thrown from request handler.  Request handlers should not let exceptions bubble out of them: {exception}");
+                    Serilog.Log.Logger.Error(exception, "Exception thrown from request handler.  Request handlers should not let exceptions bubble out of them.");
                 }
             }
 

--- a/src/Agent/Shared/SharedLog4NetRepository.cs
+++ b/src/Agent/Shared/SharedLog4NetRepository.cs
@@ -1,5 +1,0 @@
-// Copyright 2020 New Relic, Inc. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-// This ensures that we use a different logging repository from the rest of the process that we end up in.
-[assembly: log4net.Config.Repository("NewRelic Log4Net Repository")]

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -44,11 +44,6 @@
     <ProjectReference Include="..\NewRelic.Agent.TestUtilities\NewRelic.Agent.TestUtilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(RootProjectDirectory)\src\Agent\Shared\SharedLog4NetRepository.cs">
-      <Link>Properties\SharedLog4NetRepository.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="BrowserMonitoring\rum_loader_insertion_location\basic.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This PR represents the initial implementation of Serilog in place of log4net. 

## Notes:
* The Agent starts and runs and logs with the same format as log4net used to emit. 
* Many Unit tests and some Integration tests will fail at present. That's ok, we'll work on them later.
* There are a number of *TODO* comments (mostly in LoggerBootstrapper) representing work that is still remaining to be done. Future PRs will address those items.
* Support for logging to Windows EventLog is currently commented out until issues related to ILRepack'ing the right set of assemblies are ironed out.