### PR TITLE
log4net to Serilog: Unit tests plus code cleanup for serilog implementation

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/LogLevelExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LogLevelExtensions.cs
@@ -8,7 +8,7 @@ using Serilog.Events;
 
 namespace NewRelic.Agent.Core
 {
-    internal static class LogLevelExtensions
+    public static class LogLevelExtensions
     {
         private static readonly List<string> DeprecatedLogLevels = new List<string>() { "Alert", "Critical", "Emergency", "Fatal", "Finer", "Trace", "Notice", "Severe", "Verbose", "Fine" };
         public static bool IsLogLevelDeprecated(this string level) => DeprecatedLogLevels.Any(l => l.Equals(level, StringComparison.InvariantCultureIgnoreCase));
@@ -56,7 +56,7 @@ namespace NewRelic.Agent.Core
                 case "OFF":
                     // moderately hack-ish, but setting the level to something higher than Fatal disables logs as per https://stackoverflow.com/a/30864356/2078975
                     return (LogEventLevel)1 + (int)LogEventLevel.Fatal;
-                case AuditLevel:
+                case "AUDIT":
                     Serilog.Log.Logger.Warning("Log level was set to \"Audit\" which is not a valid log level. To enable audit logging, set the auditLog configuration option to true. Log level will be treated as INFO for this run.");
                     return LogEventLevel.Information;
                 default:

--- a/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
@@ -53,8 +53,6 @@ namespace NewRelic.Agent.Core.Logging
                 case Level.Error:
                     _logger.Error(messageString);
                     break;
-                default:
-                    break;
             }
         }
 
@@ -86,10 +84,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void ErrorFormat(string format, params object[] args)
         {
-            if (IsErrorEnabled)
-            {
-                _logger.Error(string.Format(format, args));
-            }
+            _logger.Error(string.Format(format, args));
         }
 
         #endregion Error
@@ -122,10 +117,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void WarnFormat(string format, params object[] args)
         {
-            if (IsWarnEnabled)
-            {
-                _logger.Warning(string.Format(format, args));
-            }
+            _logger.Warning(string.Format(format, args));
         }
 
         #endregion Warn
@@ -158,10 +150,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void InfoFormat(string format, params object[] args)
         {
-            if (IsInfoEnabled)
-            {
-                _logger.Information(string.Format(format, args));
-            }
+            _logger.Information(string.Format(format, args));
         }
 
         #endregion Info
@@ -194,10 +183,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void DebugFormat(string format, params object[] args)
         {
-            if (IsDebugEnabled)
-            {
-                _logger.Debug(string.Format(format, args));
-            }
+            _logger.Debug(string.Format(format, args));
         }
 
         #endregion Debug
@@ -230,11 +216,7 @@ namespace NewRelic.Agent.Core.Logging
         /// </summary>
         public void FinestFormat(string format, params object[] args)
         {
-            if (IsFinestEnabled)
-            {
-                var formattedMessage = string.Format(format, args);
-                _logger.Verbose(formattedMessage);
-            }
+            _logger.Verbose(string.Format(format, args));
         }
 
         #endregion Finest

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/InMemorySinkTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/InMemorySinkTests.cs
@@ -1,0 +1,55 @@
+﻿using NUnit.Framework;
+using Serilog.Events;
+using System;
+using System.Linq;
+using Serilog.Parsing;
+
+namespace NewRelic.Agent.Core.Logging.Tests
+{
+    [TestFixture]
+    public class InMemorySinkTests
+    {
+        private InMemorySink _sink;
+        private LogEvent _logEvent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sink = new InMemorySink();
+            _logEvent = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null, new MessageTemplate("Test", Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>());
+        }
+
+        [Test]
+        public void Emit_Enqueues_LogEvent()
+        {
+            _sink.Emit(_logEvent);
+            Assert.AreEqual(1, _sink.LogEvents.Count());
+        }
+
+        [Test]
+        public void LogEvents_ReturnsCorrectEvents()
+        {
+            _sink.Emit(_logEvent);
+            var logEvents = _sink.LogEvents;
+
+            Assert.AreEqual(1, logEvents.Count());
+            Assert.AreEqual(_logEvent, logEvents.First());
+        }
+
+        [Test]
+        public void Clear_LogEvents_EmptiesQueue()
+        {
+            _sink.Emit(_logEvent);
+            _sink.Clear();
+            Assert.AreEqual(0, _sink.LogEvents.Count());
+        }
+
+        [Test]
+        public void Dispose_ClearsLogEvents()
+        {
+            _sink.Emit(_logEvent);
+            _sink.Dispose();
+            Assert.AreEqual(0, _sink.LogEvents.Count());
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/LogLevelExtensionsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/LogLevelExtensionsTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using NewRelic.Core.Logging;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Events;
+using Telerik.JustMock;
+using ILogger = Serilog.ILogger;
+
+namespace NewRelic.Agent.Core.Logging.Tests
+{
+    [TestFixture]
+    public class LogLevelExtensionsTests
+    {
+        private ILogger _serilogLogger;
+
+        [SetUp]
+        public void Setup()
+        {
+            _serilogLogger = Mock.Create<Serilog.ILogger>();
+            Serilog.Log.Logger = _serilogLogger;
+        }
+        [Test]
+        [TestCase("Alert", ExpectedResult = true)]
+        [TestCase("Critical", ExpectedResult = true)]
+        [TestCase("Emergency", ExpectedResult = true)]
+        [TestCase("Fatal", ExpectedResult = true)]
+        [TestCase("Finer", ExpectedResult = true)]
+        [TestCase("Trace", ExpectedResult = true)]
+        [TestCase("Notice", ExpectedResult = true)]
+        [TestCase("Severe", ExpectedResult = true)]
+        [TestCase("Verbose", ExpectedResult = true)]
+        [TestCase("Fine", ExpectedResult = true)]
+        [TestCase("Other", ExpectedResult = false)]
+        [TestCase("", ExpectedResult = false)]
+        [TestCase(null, ExpectedResult = false)]
+        public bool IsLogLevelDeprecated_ReturnsCorrectResult(string logLevel)
+        {
+            return logLevel.IsLogLevelDeprecated();
+        }
+
+        [Test]
+        [TestCase("Verbose", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("Fine", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("Finer", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("Finest", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("Trace", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("All", ExpectedResult = LogEventLevel.Verbose)]
+        [TestCase("Debug", ExpectedResult = LogEventLevel.Debug)]
+        [TestCase("Info", ExpectedResult = LogEventLevel.Information)]
+        [TestCase("Notice", ExpectedResult = LogEventLevel.Information)]
+        [TestCase("Warn", ExpectedResult = LogEventLevel.Warning)]
+        [TestCase("Alert", ExpectedResult = LogEventLevel.Warning)]
+        [TestCase("Error", ExpectedResult = LogEventLevel.Error)]
+        [TestCase("Critical", ExpectedResult = LogEventLevel.Error)]
+        [TestCase("Emergency", ExpectedResult = LogEventLevel.Error)]
+        [TestCase("Fatal", ExpectedResult = LogEventLevel.Error)]
+        [TestCase("Severe", ExpectedResult = LogEventLevel.Error)]
+        [TestCase("Off", ExpectedResult = (LogEventLevel)6)]
+        [TestCase(LogLevelExtensions.AuditLevel, ExpectedResult = LogEventLevel.Information)]
+        [TestCase("NonExistent", ExpectedResult = LogEventLevel.Information)]
+        public LogEventLevel MapToSerilogLogLevel_ReturnsCorrectResult(string configLogLevel)
+        {
+            return configLogLevel.MapToSerilogLogLevel();
+        }
+
+        [Test]
+        public void MapToSerilogLogLevel_LogsDeprecationWarning_IfLogLevelIsDeprecated()
+        {
+            string deprecatedLogLevel = "Severe";
+            deprecatedLogLevel.MapToSerilogLogLevel();
+
+            Mock.Assert(() => _serilogLogger.Warning(Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void MapToSerilogLogLevel_LogsWarning_IfLogLevelIsAudit()
+        {
+            string auditLevel = LogLevelExtensions.AuditLevel;
+            auditLevel.MapToSerilogLogLevel();
+
+            Mock.Assert(() => _serilogLogger.Warning(Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void MapToSerilogLogLevel_LogsWarning_IfLogLevelIsInvalid()
+        {
+            string deprecatedLogLevel = "FOOBAR";
+            deprecatedLogLevel.MapToSerilogLogLevel();
+
+            Mock.Assert(() => _serilogLogger.Warning(Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        [TestCase(LogEventLevel.Verbose, ExpectedResult = "FINEST")]
+        [TestCase(LogEventLevel.Debug, ExpectedResult = "DEBUG")]
+        [TestCase(LogEventLevel.Information, ExpectedResult = "INFO")]
+        [TestCase(LogEventLevel.Warning, ExpectedResult = "WARN")]
+        [TestCase(LogEventLevel.Error, ExpectedResult = "ERROR")]
+        public string TranslateLogLevel_ReturnsCorrectResult(LogEventLevel logEventLevel)
+        {
+            return logEventLevel.TranslateLogLevel();
+        }
+
+        [Test]
+        public void TranslateLogLevel_Throws_IfLogEventLevelIsInvalid()
+        {
+            var invalidLogLevel = (LogEventLevel)9999;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => invalidLogLevel.TranslateLogLevel());
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/LoggerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/LoggerTests.cs
@@ -1,0 +1,240 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.Extensions.Logging;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using Serilog;
+using Serilog.Events;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.Logging.Tests
+{
+    [TestFixture]
+    public class LoggerTests
+    {
+        private Logger _logger;
+        private Serilog.ILogger _serilogLogger;
+        private string _testMessage;
+        private Exception _testException;
+        private string _testFormat;
+        private object[] _testArgs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _serilogLogger = Mock.Create<Serilog.ILogger>();
+            Log.Logger = _serilogLogger;
+            _logger = new Logger();
+
+            _testMessage = "Test message";
+            _testException = new Exception("Test exception");
+            _testFormat = "Test format {0}";
+            _testArgs = new object[] { "arg1" };
+        }
+
+        [Test]
+        [TestCase(Level.Finest, LogEventLevel.Verbose)]
+        [TestCase(Level.Debug, LogEventLevel.Debug)]
+        [TestCase(Level.Info, LogEventLevel.Information)]
+        [TestCase(Level.Warn, LogEventLevel.Warning)]
+        [TestCase(Level.Error, LogEventLevel.Error)]
+        public void IsEnabledFor_Level_ReturnsCorrectValue(Level level, LogEventLevel logEventLevel)
+        {
+            Mock.Arrange(() => _serilogLogger.IsEnabled(logEventLevel)).Returns(true);
+
+            var result = _logger.IsEnabledFor(level);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsEnabledFor_UnsupportedLevel_ReturnsFalse()
+        {
+            var result = _logger.IsEnabledFor((Level)9999);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        [TestCase(Level.Finest, LogEventLevel.Verbose)]
+        [TestCase(Level.Debug, LogEventLevel.Debug)]
+        [TestCase(Level.Info, LogEventLevel.Information)]
+        [TestCase(Level.Warn, LogEventLevel.Warning)]
+        [TestCase(Level.Error, LogEventLevel.Error)]
+        public void Log_ValidLevel_CallsSerilogLogger(Level level, LogEventLevel logEventLevel)
+        {
+            string message = "Test message";
+            Mock.Arrange(() => _serilogLogger.IsEnabled(logEventLevel)).Returns(true);
+            _logger.Log(level, message);
+
+            switch (level)
+            {
+                case Level.Finest:
+                    Mock.Assert(() => _serilogLogger.Verbose(message), Occurs.Once());
+                    break;
+                case Level.Debug:
+                    Mock.Assert(() => _serilogLogger.Debug(message), Occurs.Once());
+                    break;
+                case Level.Info:
+                    Mock.Assert(() => _serilogLogger.Information(message), Occurs.Once());
+                    break;
+                case Level.Warn:
+                    Mock.Assert(() => _serilogLogger.Warning(message), Occurs.Once());
+                    break;
+                case Level.Error:
+                    Mock.Assert(() => _serilogLogger.Error(message), Occurs.Once());
+                    break;
+            }
+        }
+
+        [Test]
+        public void Log_UnsupportedLevel_NoSerilogCalls()
+        {
+            _logger.Log((Level)9999, _testMessage);
+            Mock.Assert(() => _serilogLogger.Verbose(Arg.AnyString), Occurs.Never());
+            Mock.Assert(() => _serilogLogger.Debug(Arg.AnyString), Occurs.Never());
+            Mock.Assert(() => _serilogLogger.Information(Arg.AnyString), Occurs.Never());
+            Mock.Assert(() => _serilogLogger.Warning(Arg.AnyString), Occurs.Never());
+            Mock.Assert(() => _serilogLogger.Error(Arg.AnyString), Occurs.Never());
+        }
+
+
+        [Test]
+        public void IsErrorEnabled_ReturnsCorrectValue()
+        {
+            Mock.Arrange(() => _serilogLogger.IsEnabled(LogEventLevel.Error)).Returns(true);
+
+            var result = _logger.IsErrorEnabled;
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Error_LogsError()
+        {
+            string message = "Test Error";
+            _logger.Error(message);
+
+            Mock.Assert(() => _serilogLogger.Error(message), Occurs.Once());
+        }
+
+        [Test]
+        public void Error_Exception_LogsError()
+        {
+            var exception = new Exception("Test Exception");
+            _logger.Error(exception);
+
+            Mock.Assert(() => _serilogLogger.Error(exception, ""), Occurs.Once());
+        }
+
+        // Level methods
+
+        [Test]
+        public void IsEnabledFor_ShouldCallSerilogLoggerIsEnabled()
+        {
+            _logger.IsEnabledFor(Level.Debug);
+            Mock.Assert(() => _serilogLogger.IsEnabled(Arg.IsAny<LogEventLevel>()), Occurs.Once());
+        }
+
+        // Error methods
+
+        [Test]
+        public void Error_Message_CallsSerilogLoggerError()
+        {
+            _logger.Error(_testMessage);
+            Mock.Assert(() => _serilogLogger.Error(_testMessage), Occurs.Once());
+        }
+
+        [Test]
+        public void Error_Exception_CallsSerilogLoggerError()
+        {
+            _logger.Error(_testException);
+            Mock.Assert(() => _serilogLogger.Error(_testException, Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void ErrorFormat_CallsSerilogLoggerError()
+        {
+            _logger.ErrorFormat(_testFormat, _testArgs);
+            Mock.Assert(() => _serilogLogger.Error(Arg.AnyString), Occurs.Once());
+        }
+
+        // Warn methods
+
+        [Test]
+        public void Warn_Message_CallsSerilogLoggerWarning()
+        {
+            _logger.Warn(_testMessage);
+            Mock.Assert(() => _serilogLogger.Warning(_testMessage), Occurs.Once());
+        }
+
+        [Test]
+        public void Warn_Exception_CallsSerilogLoggerWarning()
+        {
+            _logger.Warn(_testException);
+            Mock.Assert(() => _serilogLogger.Warning(_testException, Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void WarnFormat_CallsSerilogLoggerWarning()
+        {
+            _logger.WarnFormat(_testFormat, _testArgs);
+            Mock.Assert(() => _serilogLogger.Warning(Arg.AnyString), Occurs.Once());
+        }
+
+        // Info methods
+
+        [Test]
+        public void Info_Message_CallsSerilogLoggerInformation()
+        {
+            _logger.Info(_testMessage);
+            Mock.Assert(() => _serilogLogger.Information(_testMessage), Occurs.Once());
+        }
+
+        [Test]
+        public void Info_Exception_CallsSerilogLoggerInformation()
+        {
+            _logger.Info(_testException);
+            Mock.Assert(() => _serilogLogger.Information(_testException, Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void InfoFormat_CallsSerilogLoggerInformation()
+        {
+
+            _logger.InfoFormat(_testFormat, _testArgs);
+            Mock.Assert(() => _serilogLogger.Information(Arg.AnyString), Occurs.Once());
+        }
+
+        // Debug methods
+
+        [Test]
+        public void Debug_Message_CallsSerilogLoggerDebug()
+        {
+            _logger.Debug(_testMessage);
+            Mock.Assert(() => _serilogLogger.Debug(_testMessage), Occurs.Once());
+        }
+
+        [Test]
+        public void Debug_Exception_CallsSerilogLoggerDebug()
+        {
+            _logger.Debug(_testException);
+            Mock.Assert(() => _serilogLogger.Debug(_testException, Arg.AnyString), Occurs.Once());
+        }
+
+        [Test]
+        public void DebugFormat_CallsSerilogLoggerDebug()
+        {
+            _logger.DebugFormat(_testFormat, _testArgs);
+            Mock.Assert(() => _serilogLogger.Debug(Arg.AnyString), Occurs.Once());
+        }
+        [TearDown]
+        public void TearDown()
+        {
+            _logger = null;
+            _serilogLogger = null;
+        }
+    }
+}


### PR DESCRIPTION
Adds unit tests for the `Logger` and `InMemorySink` class, as well as tests for `LogLevelExtensions`.