### PR TITLE
ci: Update codecov configuration, add some status badges to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <a href="https://opensource.newrelic.com/oss-category/#community-plus"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Community_Plus.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"><img alt="New Relic Open Source community plus project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png"></picture></a>
 
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![build_status](https://github.com/newrelic/newrelic-dotnet-agent/actions/workflows/all_solutions.yml/badge.svg?event=schedule)](https://github.com/newrelic/newrelic-dotnet-agent/actions/workflows/all_solutions.yml)
+[![codecov](https://codecov.io/gh/newrelic/newrelic-dotnet-agent/branch/main/graph/badge.svg?token=VKV9XDVJ2U)](https://codecov.io/gh/newrelic/newrelic-dotnet-agent)
+[![OpenSSF
+Scorecard](https://api.securityscorecards.dev/projects/github.com/newrelic/newrelic-dotnet-agent/badge)](https://api.securityscorecards.dev/projects/github.com/newrelic/newrelic-dotnet-agent)
 # New Relic Monitoring for .NET
 
 #### .NET Agent

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@
 #
 codecov:
   branch: main
-  require_ci_to_pass: true
+  require_ci_to_pass: false # codecov won't wait for all other CI status to pass before sending its status
   notify:
     wait_for_ci: false
 coverage:
@@ -13,14 +13,14 @@ coverage:
   status:
     project:  # project-level settings (i.e., main branch)
       default:
-        target: 80 # must have at least 80% code coverage for the commit to be considered successful
-        threshold: 0.5% # code coverage can drop by 0.5% and still be successful
+        target: auto # target coverage is based on current base commit
+        threshold: 0.5% # code coverage can drop by 0.5% below the base commit's coverage and still be successful
         if_ci_failed: error 
         informational: false  # if true, status will pass regardless regardless of other settings
     patch: # pull request status
       default:
         target: auto
-        threshold: 0% # 0% code coverage on the changes in the patch is ok - sometimes we don't need to update unit tests
+        threshold: 80% # 80% of changed code in a PR must have code coverage for the CI to pass
         if_ci_failed: error 
         informational: false  # if true, status will pass regardless regardless of other settings
         only_pulls: true # individual commits to a branch will not be considered, only pull requests

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,23 +5,25 @@
 #
 codecov:
   branch: main
-  require_ci_to_pass: no
+  require_ci_to_pass: true
   notify:
-    wait_for_ci: no
+    wait_for_ci: false
 coverage:
+  range: "80..100" # 80% or higher is green
   status:
-    project:
+    project:  # project-level settings (i.e., main branch)
+      default:
+        target: 80 # must have at least 80% code coverage for the commit to be considered successful
+        threshold: 0.5% # code coverage can drop by 0.5% and still be successful
+        if_ci_failed: error 
+        informational: false  # if true, status will pass regardless regardless of other settings
+    patch: # pull request status
       default:
         target: auto
-        threshold: 1% # code coverage can drop by 1% and still be successful
-        if_ci_failed: success 
-        informational: true  # if true, status will pass regardless regardless of other settings
-    patch:
-      default:
-        target: auto
-        threshold: 1% # code coverage can drop by 1% and still be successful
-        if_ci_failed: success 
-        informational: true  # if true, status will pass regardless regardless of other settings
+        threshold: 0% # 0% code coverage on the changes in the patch is ok - sometimes we don't need to update unit tests
+        if_ci_failed: error 
+        informational: false  # if true, status will pass regardless regardless of other settings
+        only_pulls: true # individual commits to a branch will not be considered, only pull requests
 comment:
   layout: "reach, diff, files" # change to "reach, diff, flags, files" if we start using flags
   behavior: default # new comment will be posted or existing comment will be edited


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

1. Updates README.md to include a few status badges. It's all the rage these days.  The build status badge comes from the nightly scheduled build.
![image](https://github.com/newrelic/newrelic-dotnet-agent/assets/120425148/b9c9cc4a-64b5-47f1-b302-ad6d6c8668e6)

2. Updates our Codecov configuration in a few important ways:
    * Sets 80% as the minimum coverage level to get a "green" status in the Codecov UI
    * Requires passing Codecov CI run for PR to be merged (admin override is still available, as always)
    * Allows a PR to reduce code coverage by no more than 0.5% below the base commit's code coverage level (i.e., we really want code coverage to increase on every PR)
    * For PRs, 80% of code changed in the PR must be covered by tests or the CI run will fail. **We may need to adjust this value later**
    * Code coverage status reports will only be generated for PRs, not individual branch commits