### PR TITLE
fix: Stop double injecting headers with HttpClient on .NET Framework

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpClient/SendAsync.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpClient/SendAsync.cs
@@ -61,7 +61,9 @@ namespace NewRelic.Providers.Wrapper.HttpClient
 
             var externalSegmentData = transactionExperimental.CreateExternalSegmentData(uri, method);
             var segment = transactionExperimental.StartSegment(instrumentedMethodCall.MethodCall);
-            segment.GetExperimentalApi().SetSegmentData(externalSegmentData);
+            segment.GetExperimentalApi()
+                .SetSegmentData(externalSegmentData)
+                .MakeLeaf();
 
             if (agent.Configuration.ForceSynchronousTimingCalculationHttpClient)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/SerializeHeadersWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpWebRequest/SerializeHeadersWrapper.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Linq;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
@@ -31,6 +30,16 @@ namespace NewRelic.Providers.Wrapper.HttpWebRequest
             if (request.Headers == null)
             {
                 throw new NullReferenceException("request.Headers");
+            }
+
+            // We should only inject headers with this instrumentation if HttpWebRequest created an external segment.
+            // Both HttpClient and RestSharp instrumentation have their own header injection support and do not rely
+            // on this instrumentation to inject the necessary headers. Other instrumentation rely on leaf segments
+            // to prevent this instrumentation from running.
+            if (!transaction.CurrentSegment.IsExternal)
+            {
+                transaction.LogFinest("Skipping HttpWebRequest header injection because the current segment was not created by HttpWebRequest.");
+                return Delegates.NoOp;
             }
 
             var setHeaders = new Action<System.Net.HttpWebRequest, string, string>((carrier, key, value) =>


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

When HttpClient is used in a .NET Framework application it executes both our HttpClient and HttpWebRequest, because on .NET Framework HttpClient relies on code in HttpWebRequest. HttpClient instrumentation always attempts to create the external segment and inject the appropriate outbound headers (and process the response). HttpWebRequest instrumentation uses 2 separate instrumentation points: 1. to create the external segment (and process the response), and 2. to inject the outbound headers. Most of the time when an application uses HttpClient on .net framework, the HttpWebRequest instrumentation does not find a valid transaction (because of the async behavior in HttpClient) and the HttpWebRequest instrumentation does not attempt to inject any outbound headers. Sometimes, HttpWebRequest code to serialize headers is executed on a thread that has access to the transaction, in this situation the HttpWebRequest instrumentation will attempt to inject outbound headers even though the HttpClient instrumentation already injected the outbound headers. This attempt to inject the outbound headers, will use the wrong segment/span as the parent span in that outbound context, and can lead to a situation where the distributed trace may show some incorrect parenting in the trace.

This problem seems to be the root cause for the WCF server tests sometimes reporting an unexpected metric value.

The fix has 2 parts:

1. Makes the external segment created by HttpClient instrumentation a leaf segment to prevent other instrumentation from executing when that segment is the current segment.
2. Update the HttpWebRequest instrumentation to only inject headers when the current segment is an external segment, which should only happen if the HttpWebRequest instrumentation created the current segment.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
