### PR TITLE
ci: Dotty will now create issues in our repo for new package versions it finds

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -24,6 +24,8 @@ jobs:
   nuget-slack-notifications:
     name: Check for core technology package updates
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     continue-on-error: false
     
     env:
@@ -60,6 +62,7 @@ jobs:
 
         env:
             DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
+            DOTTY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CORECLR_ENABLE_PROFILING: 1
             CORECLR_NEWRELIC_HOME: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic
             CORECLR_PROFILER: "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NewRelic.Agent.Api" Version="10.3.0" />
+    <PackageReference Include="Octokit" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Part of June 2023 Innovation Days.  Our nightly workflow that checks for new versions of core tech libraries will create issues in our repo so we don't lose track of the need to update the versions we test.