### PR TITLE
ci: let the ArtifactBuilder's content validation logic handle semantic versioning of NuGet packages

### DIFF
--- a/build/ArtifactBuilder/AgentComponents.cs
+++ b/build/ArtifactBuilder/AgentComponents.cs
@@ -100,6 +100,23 @@ namespace ArtifactBuilder
             }
         }
 
+        // This will return the full four-component version string, unless the fourth component is zero, in which case it returns three components
+        public string MaybeSemanticVersion
+        {
+            get
+            {
+                var version = new Version(Version);
+                if (version.Revision == 0)
+                {
+                    return version.ToString(3);
+                }
+                else
+                {
+                    return version.ToString(4);
+                }
+            }
+        }
+
         protected abstract string SourceHomeBuilderPath { get; }
         protected abstract List<string> IgnoredHomeBuilderFiles { get; }
         protected abstract void CreateAgentComponents();

--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -121,7 +121,7 @@ namespace ArtifactBuilder.Artifacts
         private string Unpack()
         {
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.{_frameworkAgentComponents.Version}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
@@ -53,7 +53,7 @@ namespace ArtifactBuilder.Artifacts
         private string Unpack()
         {
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.Api.{_frameworkAgentComponents.Version}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.Api.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
@@ -78,7 +78,7 @@ namespace ArtifactBuilder.Artifacts
         private string Unpack()
         {
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelicWindowsAzure.{_frameworkAgentComponents.Version}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, $"NewRelicWindowsAzure.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
@@ -89,8 +89,8 @@ namespace ArtifactBuilder.Artifacts
 
             // The two packages have different naming conventions
             var fileName = Platform == "x64" ?
-                $"NewRelic.Azure.WebSites.{Platform}.{_frameworkAgentComponents.Version}.nupkg" :
-                $"NewRelic.Azure.WebSites.{_frameworkAgentComponents.Version}.nupkg";
+                $"NewRelic.Azure.WebSites.{Platform}.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg" :
+                $"NewRelic.Azure.WebSites.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg";
             var nugetFile = Path.Join(OutputDirectory, fileName);
 
             NuGetHelpers.Unpack(nugetFile, unpackDir);


### PR DESCRIPTION
The Unpack() method in the content validation logic for NuGet packages needs to handle the possibility that the version string might only have three components (major.minor.patch) if the fourth component of the agent DLL string is zero.
