### PR TITLE
ci: ArtifactBuilder parse nuget pack output to find package file name

### DIFF
--- a/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
+++ b/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
@@ -11,6 +11,7 @@ namespace ArtifactBuilder.Artifacts
         private const string NuGetHelperLibraryName = "NewRelic.NuGetHelper.dll";
 
         private string _version;
+        private string _nuGetPackageName;
 
         public AzureSiteExtension() : base(nameof(AzureSiteExtension))
         {
@@ -26,7 +27,7 @@ namespace ArtifactBuilder.Artifacts
             package.CopyToContent($@"{RepoRootDirectory}\build\NewRelic.NuGetHelper\bin\{NuGetLibraryName}");
             package.CopyToContent($@"{RepoRootDirectory}\build\NewRelic.NuGetHelper\bin\{XmlLibraryName}");
             package.SetVersion(_version);
-            package.Pack();
+            _nuGetPackageName = package.Pack();
         }
 
         private string ReadVersionFromFile()
@@ -68,8 +69,11 @@ namespace ArtifactBuilder.Artifacts
 
         private string Unpack()
         {
+            if (string.IsNullOrEmpty(_nuGetPackageName))
+                throw new PackagingException("NuGet package name not found. Did you call InternalBuild()?");
+
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Azure.WebSites.Extension.{_version}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, _nuGetPackageName);
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -11,6 +11,7 @@ namespace ArtifactBuilder.Artifacts
         private readonly AgentComponents _coreAgentComponents;
         private readonly AgentComponents _coreAgentArm64Components;
         private readonly AgentComponents _coreAgentX86Components;
+        private string _nuGetPackageName;
 
         public NugetAgent(string configuration)
             : base(nameof(NugetAgent))
@@ -76,7 +77,7 @@ namespace ArtifactBuilder.Artifacts
 
             package.SetVersion(_frameworkAgentComponents.Version);
 
-            package.Pack();
+            _nuGetPackageName = package.Pack();
         }
 
         private static void TransformNewRelicConfig(string newRelicConfigPath)
@@ -120,8 +121,11 @@ namespace ArtifactBuilder.Artifacts
 
         private string Unpack()
         {
+            if (string.IsNullOrEmpty(_nuGetPackageName))
+                throw new PackagingException("NuGet package name not found. Did you call InternalBuild()?");
+
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, _nuGetPackageName);
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
@@ -9,6 +9,7 @@ namespace ArtifactBuilder.Artifacts
     {
         private readonly AgentComponents _frameworkAgentComponents;
         private readonly AgentComponents _coreAgentComponents;
+        private string _nuGetPackageName;
 
         public NugetAgentApi(string configuration)
             : base(nameof(NugetAgentApi))
@@ -34,7 +35,7 @@ namespace ArtifactBuilder.Artifacts
             package.CopyToRoot(_frameworkAgentComponents.NewRelicLicenseFile);
             package.CopyToRoot(_frameworkAgentComponents.NewRelicThirdPartyNoticesFile);
             package.SetVersion(_frameworkAgentComponents.Version);
-            package.Pack();
+            _nuGetPackageName = package.Pack();
         }
 
         private void ValidateContent()
@@ -52,8 +53,11 @@ namespace ArtifactBuilder.Artifacts
 
         private string Unpack()
         {
+            if (string.IsNullOrEmpty(_nuGetPackageName))
+                throw new PackagingException("NuGet package name not found. Did you call InternalBuild()?");
+
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelic.Agent.Api.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, _nuGetPackageName);
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
@@ -7,6 +7,7 @@ namespace ArtifactBuilder.Artifacts
     public class NugetAzureCloudServices : Artifact
     {
         private readonly AgentComponents _frameworkAgentComponents;
+        private string _nuGetPackageName;
 
         public NugetAzureCloudServices(string configuration)
             : base(nameof(NugetAzureCloudServices))
@@ -29,7 +30,7 @@ namespace ArtifactBuilder.Artifacts
             package.CopyToLib(_frameworkAgentComponents.AgentApiDll);
             package.CopyToContent($@"{RepoRootDirectory}\src\_build\x64-{Configuration}\Installer\{GetMsiName()}");
             package.SetVersion(_frameworkAgentComponents.Version);
-            package.Pack();
+            _nuGetPackageName = package.Pack();
         }
 
         private void DoInstallerReplacements(string agentInstaller)
@@ -77,8 +78,11 @@ namespace ArtifactBuilder.Artifacts
 
         private string Unpack()
         {
+            if (string.IsNullOrEmpty(_nuGetPackageName))
+                throw new PackagingException("NuGet package name not found. Did you call InternalBuild()?");
+
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
-            var nugetFile = Path.Join(OutputDirectory, $"NewRelicWindowsAzure.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg");
+            var nugetFile = Path.Join(OutputDirectory, _nuGetPackageName);
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
@@ -19,6 +19,7 @@ namespace ArtifactBuilder.Artifacts
         public string Configuration { get; }
         public string Platform { get; }
         private readonly AgentComponents _frameworkAgentComponents;
+        private string _nuGetPackageName;
 
         private string RootDirectory => $@"{StagingDirectory}\content\newrelic";
 
@@ -38,7 +39,7 @@ namespace ArtifactBuilder.Artifacts
 
             agentInfo.WriteToDisk(RootDirectory);
             package.SetVersion(_frameworkAgentComponents.Version);
-            package.Pack();
+            _nuGetPackageName = package.Pack();
         }
 
         private void TransformNewRelicConfig()
@@ -85,13 +86,12 @@ namespace ArtifactBuilder.Artifacts
 
         private string Unpack()
         {
+            if (string.IsNullOrEmpty(_nuGetPackageName))
+                throw new PackagingException("NuGet package name not found. Did you call InternalBuild()?");
+
             var unpackDir = Path.Join(OutputDirectory, "unpacked");
 
-            // The two packages have different naming conventions
-            var fileName = Platform == "x64" ?
-                $"NewRelic.Azure.WebSites.{Platform}.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg" :
-                $"NewRelic.Azure.WebSites.{_frameworkAgentComponents.MaybeSemanticVersion}.nupkg";
-            var nugetFile = Path.Join(OutputDirectory, fileName);
+            var nugetFile = Path.Join(OutputDirectory, _nuGetPackageName);
 
             NuGetHelpers.Unpack(nugetFile, unpackDir);
             return unpackDir;

--- a/build/ArtifactBuilder/NugetPackage.cs
+++ b/build/ArtifactBuilder/NugetPackage.cs
@@ -98,9 +98,9 @@ namespace ArtifactBuilder
             FileHelpers.CopyFile(filePaths, $@"{StagingDirectory}\{subDirectory}");
         }
 
-        public void Pack()
+        public string Pack()
         {
-            NuGetHelpers.Pack(NuspecFilePath, OutputDirectory);
+            return NuGetHelpers.Pack(NuspecFilePath, OutputDirectory);
         }
     }
 }


### PR DESCRIPTION
Modifies ArtifactBuilder to parse the output from the `nuget pack` command to find the actual `.nupkg` filename that was created, eliminating the need to manually build the filename in the `Unpack()` step.

Validated by running `.\build\package.ps1` locally and verifying that all NuGet packages were successfully created and validated.