### PR TITLE
ci: add new core tech libraries to the list to scan for updates

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -10,7 +10,7 @@ on:
         default: "1"
         type: string
       testMode:
-        description: "If checked, no notification message will be sent to the team channel."
+        description: "If checked, no notification message will be sent to the team channel, nor will any Github issues be created."
         type: boolean
         default: false
 
@@ -71,15 +71,21 @@ jobs:
             NEW_RELIC_HOST: staging-collector.newrelic.com
             NEW_RELIC_LICENSE_KEY: ${{ secrets.STAGING_LICENSE_KEY }}
             nugets:
-                 "system.data.sqlclient
+                 "elasticsearch.net
+                 elastic.clients.elasticsearch
+                 log4net
+                 microsoft.extensions.logging
                  microsoft.data.sqlclient
+                 microsoft.net.http
                  mongocsharpdriver
                  mongodb.driver
                  mysql.data
                  mysqlconnector
-                 stackexchange.redis
+                 nest
+                 nlog
                  rabbitmq.client
-                 microsoft.net.http
                  restsharp
-                 serilog"
+                 serilog
+                 stackexchange.redis
+                 system.data.sqlclient"
                  


### PR DESCRIPTION
## Description

Part of June 2023 core tech milestone.  Added the following libraries to the list we scan for updates:

```
Microsoft.Extensions.Logging
NLog
log4net
Elasticsearch (NEST)
Elasticsearch (Elasticsearch.Net)
Elasticsearch (Elastic.Clients.Elasticsearch)
```

Here's output from a test run I did on this branch.  I sanity checked the results and they are correct (e.g. NEST and Elasticsearch.NET were updated 8 months ago, so they show as not updated in the past 90 days, but Elastic.Clients.Elasticsearch was updated last month so it shows as updated).

```
nugets: elasticsearch.net elastic.clients.elasticsearch log4net microsoft.extensions.logging microsoft.data.sqlclient microsoft.net.http mongocsharpdriver mongodb.driver mysql.data mysqlconnector nest nlog rabbitmq.client restsharp serilog stackexchange.redis system.data.sqlclient
[18:14:29 INF] Package elasticsearch.net has not been updated in the past 90 days.
[18:14:29 INF] Package elastic.clients.elasticsearch has been updated in the past 90 days.
[18:14:29 INF] Package log4net has not been updated in the past 90 days.
[18:14:29 INF] Package microsoft.extensions.logging has not been updated in the past 90 days.
[18:14:29 INF] Package microsoft.data.sqlclient has not been updated in the past 90 days.
[18:14:29 INF] Package microsoft.net.http has not been updated in the past 90 days.
[18:14:29 INF] Package mongocsharpdriver has been updated in the past 90 days.
[18:14:30 INF] Package mongodb.driver has been updated in the past 90 days.
[18:14:30 INF] Package mysql.data has been updated in the past 90 days.
[18:14:30 INF] Package mysqlconnector has not been updated in the past 90 days.
[18:14:30 INF] Package nest has not been updated in the past 90 days.
[18:14:30 INF] Package nlog has been updated in the past 90 days.
[18:14:31 INF] Package rabbitmq.client has been updated in the past 90 days.
[18:14:31 INF] Package restsharp has not been updated in the past 90 days.
[18:14:31 INF] Package serilog has not been updated in the past 90 days.
[18:14:31 INF] Package stackexchange.redis has been updated in the past 90 days.
[18:14:31 INF] Package system.data.sqlclient has not been updated in the past 90 days.
[18:14:31 INF] Channel will not be alerted: # of new versions=7, webhook available=True, test mode=True
[18:14:31 INF] Issues will not be created: # of new versions=7, token available=True, test mode=True
```

