### PR TITLE
fix: Handle empty Request.Path values in AspNetCore middleware wrapper.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -157,13 +157,15 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
         private ITransaction SetupTransaction(HttpRequest request)
         {
             var path = request.Path.Value;
-            path = "/".Equals(path) ? "ROOT" : path.Substring(1);
+
+            // if path is empty, consider it the same as /
+            path = request.Path == PathString.Empty || path.Equals("/") ? "ROOT" : path.Substring(1);
 
             var transaction = _agent.CreateTransaction(
-                isWeb: true,
-                category: EnumNameCache<WebTransactionType>.GetName(WebTransactionType.ASP),
-                transactionDisplayName: path,
-                doNotTrackAsUnitOfWork: true);
+                    isWeb: true,
+                    category: EnumNameCache<WebTransactionType>.GetName(WebTransactionType.ASP),
+                    transactionDisplayName: path,
+                    doNotTrackAsUnitOfWork: true);
 
             transaction.SetRequestMethod(request.Method);
             transaction.SetUri(request.Path);


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Addresses an obscure bug where the AspNetCore middleware could be called with an empty `HttpRequest.Path`. 

I was unable to create an integration test to verify this fix, but did validate that debugging and forcing `HttpRequest.Path` to be `PathString.Empty` doesn't cause an exception like it did in the previous code.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
