### PR TITLE
feat: add support for MySql.Data version 8.0.33+

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -83,10 +83,16 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteNonQuery" />
       </match>
 
-      <!-- MySql (official) driver -->
-      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand">
+      <!-- MySql (official) driver-->
+
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand" maxVersion="8.0.33">
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior" />
         <exactMethodMatcher methodName="ExecuteNonQuery" />
+      </match>
+
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand" minVersion="8.0.33">
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Boolean,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySql CoreLabs driver -->
@@ -227,9 +233,14 @@ SPDX-License-Identifier: Apache-2.0
       </match>
 
       <!-- MySql (official) driver -->
-      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader">
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader" maxVersion="8.0.33">
         <exactMethodMatcher methodName="NextResult" />
         <exactMethodMatcher methodName="Read" />
+      </match>
+
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader" minVersion="8.0.33">
+        <exactMethodMatcher methodName="NextResultAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ReadAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySqlConnector 0.x -->

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -25,6 +25,7 @@ SPDX-License-Identifier: Apache-2.0
     </tracerFactory>
 
 
+    <!-- NOTE: Only put non-async instrumentation points in this tracerFactory, async methods go in SqlCommandTracerAsync (below) -->
     <tracerFactory name="SqlCommandTracer">
 
       <!-- built in MS SQL driver (framework) -->
@@ -84,15 +85,10 @@ SPDX-License-Identifier: Apache-2.0
       </match>
 
       <!-- MySql (official) driver-->
-
+      <!-- Starting in 8.0.33 the non-async methods are just passthroughs to async methods which are instrumented in the SqlCommandTracerAsync factory -->
       <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand" maxVersion="8.0.33">
         <exactMethodMatcher methodName="ExecuteReader" parameters="System.Data.CommandBehavior" />
         <exactMethodMatcher methodName="ExecuteNonQuery" />
-      </match>
-
-      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand" minVersion="8.0.33">
-        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Boolean,System.Threading.CancellationToken" />
-        <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySql CoreLabs driver -->
@@ -136,6 +132,7 @@ SPDX-License-Identifier: Apache-2.0
       </match>
     </tracerFactory>
 
+    <!-- NOTE: Only put async instrumentation points in this tracerFactory, non-async methods go in SqlCommandTracer (above) -->
     <tracerFactory name="SqlCommandTracerAsync">
 
       <!-- built in MS SQL driver (framework) -->
@@ -163,6 +160,13 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteScalarAsync" parameters="System.Threading.CancellationToken" />
         <exactMethodMatcher methodName="ExecuteXmlReaderAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- MySql (official) driver-->
+      <!-- Prior to 8.0.33 we instrument non-async methods in the SqlCommandTracer factory above -->
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlCommand" minVersion="8.0.33">
+        <exactMethodMatcher methodName="ExecuteReaderAsync" parameters="System.Data.CommandBehavior,System.Boolean,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ExecuteNonQueryAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySqlConnector 0.x -->

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -199,6 +199,7 @@ SPDX-License-Identifier: Apache-2.0
     </tracerFactory>
 
     <!-- DataReader methods. DISABLED by default due to possible performance impact. Set enabled to "true" (or omit completely) to enable this instrumentation. -->
+    <!-- NOTE: this tracer factory is for non-async method instrumentation only.  For async methods, use the DataReaderTracerAsync factory below -->
     <tracerFactory name="DataReaderTracer" enabled="false">
       <!-- built in MS SQL driver (framework) -->
       <match assemblyName="System.Data" className="System.Data.SqlClient.SqlDataReader">
@@ -237,14 +238,10 @@ SPDX-License-Identifier: Apache-2.0
       </match>
 
       <!-- MySql (official) driver -->
+      <!-- In version 8.0.33 these methods became async and are instrumented in the DataReaderTracerAsync factory below -->
       <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader" maxVersion="8.0.33">
         <exactMethodMatcher methodName="NextResult" />
         <exactMethodMatcher methodName="Read" />
-      </match>
-
-      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader" minVersion="8.0.33">
-        <exactMethodMatcher methodName="NextResultAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
-        <exactMethodMatcher methodName="ReadAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySqlConnector 0.x -->
@@ -281,6 +278,7 @@ SPDX-License-Identifier: Apache-2.0
       </match>
     </tracerFactory>
 
+    <!-- NOTE: this tracer factory is for async method instrumentation only.  For non-async methods, use the DataReaderTracer factory above -->
     <tracerFactory name="DataReaderTracerAsync" enabled="false">
       <!-- built in MS SQL driver (framework) -->
       <match assemblyName="System.Data" className="System.Data.SqlClient.SqlDataReader">
@@ -297,6 +295,12 @@ SPDX-License-Identifier: Apache-2.0
       <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlDataReader">
         <exactMethodMatcher methodName="NextResultAsync" />
         <exactMethodMatcher methodName="ReadAsync" />
+      </match>
+
+      <!-- Prior to version 8.0.33 these methods were synchroous and are instrumented in the DataReaderTracer factory above -->
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlDataReader" minVersion="8.0.33">
+        <exactMethodMatcher methodName="NextResultAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
+        <exactMethodMatcher methodName="ReadAsync" parameters="System.Boolean,System.Threading.CancellationToken" />
       </match>
 
       <!-- MySqlConnector 0.x -->

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -60,11 +60,11 @@
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySql.Data" Version="8.0.15" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySql.Data" Version="8.0.30" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MySql.Data" Version="8.0.32.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySql.Data" Version="8.0.33" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySql.Data .NET/Core references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MySql.Data" Version="8.0.32.1" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="MySql.Data" Version="8.0.33" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- MongoDB.Driver .NET Framework references -->
     <!-- 2.3.0 is the oldest version we support, 2.17.1 is the newest version as of October 2022 -->

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -60,10 +60,12 @@
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySql.Data" Version="8.0.15" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySql.Data" Version="8.0.30" Condition="'$(TargetFramework)' == 'net48'" />
+    <!-- MySql.Data v8.0.33 is a breaking change for the agent and requires agent version 10.11.1 or greater -->
     <PackageReference Include="MySql.Data" Version="8.0.33" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySql.Data .NET/Core references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <!-- MySql.Data v8.0.33 is a breaking change for the agent and requires agent version 10.11.1 or greater -->
     <PackageReference Include="MySql.Data" Version="8.0.33" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- MongoDB.Driver .NET Framework references -->


### PR DESCRIPTION
## Description

MySql.Data version 8.0.33 reorganized its methods internally so that all of the methods we instrumented previously (ExecuteReader, ExecuteNonQuery, Read, NextResult) became pass-throughs to async versions that perform the same work.

This PR updates the instrumentation file for the Sql wrapper to add the new async instrumentation points for MySql.Data 8.0.33 and higher.

