### PR TITLE
fix: Escape single quotes in RUM script when html content is contained in single quotes. (#1513)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -52,7 +52,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         // Specification for Javascript insertion: https://newrelic.atlassian.net/wiki/spaces/eng/pages/50299103/BAM+Agent+Auto-Instrumentation
         public virtual string WriteScriptHeaders(string content)
         {
-            // look for <html> tag, see if it's preceeded by a single quote - if so, escape single quotes in the RUM script
+            // look for an <html> tag, see if it's preceeded by a single quote - if so, escape single quotes in the RUM script
             // this occurs in cases (such as WebResource.axd scripts) where we've decided that the content type is one we should
             // inject, but the actual content is a script that injects the html (such as into a frame). If that script uses single
             // quotes around the html, we have to escape any single quotes in the RUM script to ensure the resulting html is valid.

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -11,7 +11,10 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
     public class Class_BrowserMonitoringWriter
     {
         private readonly string _jsScript =
-                    "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"customString\":\"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
+            "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"customString\":\"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"}</script>";
+
+        private readonly string _jsScriptWithSingleQuotes =
+            "<script type=\"text/javascript\">window.NREUM||(NREUM={});NREUM.info = {\"beacon\":\"staging-beacon-N.newrelic.com\",\"errorBeacon:\":\"staging-jserror.newrelic.com\",\"licenseKey\":\"a4fa192fe5\",\"applicationID\":\"48102\",\"transactionName\":\"ZlIAbEACVxFYVkBbDV8YJldGLVwWelpaRhBeWw5dQExxDVRQG3sMVVIa\",\"queueTime\":\"0\",\"applicationTime\":\"37\", \"customString\":\"$1\", \"ttGuid\":\"BD0436479135FF3F\",\"agent\":\"js-agent.newrelic.com/nr-248.min.js\"};let o=(()=>{if(n)return window;throw new Error('New Relic browser agent shutting down due to error.')})();</script>";
 
         [Test]
         public void empty_input_results_in_empty_output()
@@ -61,8 +64,12 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         public void html_without_head_tag_but_with_body_text_in_script()
         {
             // ARRANGE
-            string content = "<html> <body><script type=\"text/javascript\">var thing = \"<body\";</script><p>Yo Adrian!</p> </body></html>";
-            string expected = string.Format("<html> {0}<body><script type=\"text/javascript\">var thing = \"<body\";</script><p>Yo Adrian!</p> </body></html>", _jsScript);
+            string content =
+                "<html> <body><script type=\"text/javascript\">var thing = \"<body\";</script><p>Yo Adrian!</p> </body></html>";
+            string expected =
+                string.Format(
+                    "<html> {0}<body><script type=\"text/javascript\">var thing = \"<body\";</script><p>Yo Adrian!</p> </body></html>",
+                    _jsScript);
 
             // ACT
             BrowserMonitoringWriter writer = new BrowserMonitoringWriter(() => _jsScript);
@@ -108,7 +115,9 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         {
             // ARRANGE
             string content = "<html><head bestevar='Boston Red Sox'></head><body><p>YoAdrian!</p></body></html>";
-            string expected = string.Format("<html><head bestevar='Boston Red Sox'>{0}</head><body><p>YoAdrian!</p></body></html>", _jsScript);
+            string expected =
+                string.Format("<html><head bestevar='Boston Red Sox'>{0}</head><body><p>YoAdrian!</p></body></html>",
+                    _jsScript);
 
             // ACT
             BrowserMonitoringWriter writer = new BrowserMonitoringWriter(() => _jsScript);
@@ -180,10 +189,10 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
                                        "<meta name=\"viewport\" content=\"width=device-width\" />" +
                                        "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=9\">";
             string contentRemaining = "<link href=\"/MVC4-WebApp-Performance/Content/site.css\" rel=\"stylesheet\"/>" +
-                "<script src=\"/MVC4-WebApp-Performance/Scripts/modernizr-2.6.2.js\"></script>" +
-                "<script src=\"/mvc3_rum/Scripts/jquery-1.7.1.min.js\" type=\"text/javascript\"></script>" +
-                "<script src=\"/mvc3_rum/Scripts/modernizr-2.5.3.js\" type=\"text/javascript\"></script>" +
-                "</head><body><p>YoAdrian!</p></body></html>";
+                                      "<script src=\"/MVC4-WebApp-Performance/Scripts/modernizr-2.6.2.js\"></script>" +
+                                      "<script src=\"/mvc3_rum/Scripts/jquery-1.7.1.min.js\" type=\"text/javascript\"></script>" +
+                                      "<script src=\"/mvc3_rum/Scripts/modernizr-2.5.3.js\" type=\"text/javascript\"></script>" +
+                                      "</head><body><p>YoAdrian!</p></body></html>";
 
             string expected = string.Format("{0}{1}{2}", contentUpToXUATag, _jsScript, contentRemaining);
 
@@ -205,7 +214,8 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
                                       "document.write(\"<script type=\"text/javascript\"> <head></head> }" +
                                       "</script></body></html>";
 
-            string expected = string.Format("{0}{1}{2}{3}", contentUpToHead, _jsScript, contentPartTwo, contentPartThree);
+            string expected = string.Format("{0}{1}{2}{3}", contentUpToHead, _jsScript, contentPartTwo,
+                contentPartThree);
 
             // ACT
             BrowserMonitoringWriter writer = new BrowserMonitoringWriter(() => _jsScript);
@@ -216,7 +226,8 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         }
 
         [Test]
-        public void html_with_simple_openclose_head_tags_and_script_with_embedded_head_that_has_X_UA_COMPATIBLE_meta_tag()
+        public void
+            html_with_simple_openclose_head_tags_and_script_with_embedded_head_that_has_X_UA_COMPATIBLE_meta_tag()
         {
             // ARRANGE
             string contentUpToHead = "<html><head>";
@@ -225,7 +236,8 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
                                       "document.write(\"<script type=\"text/javascript\"> <head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=9\"></head> }" +
                                       "</script></body></html>";
 
-            string expected = string.Format("{0}{1}{2}{3}", contentUpToHead, _jsScript, contentPartTwo, contentPartThree);
+            string expected = string.Format("{0}{1}{2}{3}", contentUpToHead, _jsScript, contentPartTwo,
+                contentPartThree);
 
             // ACT
             BrowserMonitoringWriter writer = new BrowserMonitoringWriter(() => _jsScript);
@@ -272,5 +284,24 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             var result = writer.WriteScriptHeaders(data);
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        public void frame_document_write_using_single_quotes_injection_escapes_RUM_single_quotes()
+        {
+            var upToBody = "xmlRequestFrame.document.write('<html>";
+            var restOfScript = "<body><form method=\"post\"><input type=\"hidden\" name=\"__CALLBACKLOADSCRIPT\" value=\"t\"></form></body></html>');";
+            var data =
+                 upToBody + restOfScript;
+
+            var expected = $"{upToBody}{EscapeSingleQuotes(_jsScriptWithSingleQuotes)}{restOfScript}";
+
+            var writer = new BrowserMonitoringWriter(() => _jsScriptWithSingleQuotes);
+
+            var result = writer.WriteScriptHeaders(data);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private string EscapeSingleQuotes(string script) => script.Replace("\'", "\\\'");
     }
 }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

In certain cases (such as a `WebResource.axd` file that is serving javascript that writes an html document to a frame), the html content may be enclosed in single quotes. Even though the content is javascript, the content type may show up as `text/html`, which triggers our injection logic to fire.

An example (from a GTSE) might look like this:
```
xmlRequestFrame = document.frames[callbackFrameID];
if (xmlRequestFrame && xmlRequestFrame.document) {
  window.clearInterval(interval);
  xmlRequestFrame.document.write("");
  xmlRequestFrame.document.close();
  xmlRequestFrame.document.write('<html><body><form method="post"><input type="hidden" name="__CALLBACKLOADSCRIPT" value="t"></form></body></html>');
  xmlRequestFrame.document.close();
}
```

When we inject the RUM script into that quoted html content, we need to escape any single quotes that occur in the script or the resulting javascript will be invalid. 

This fix looks at the content to see if the `<html>` tag is preceded by a single quote and that the subsequent `</html>` tag is followed by a single quote. If so, the RUM script is passed through a function that escapes all single quotes in it (i.e.,  `'` gets replaced with `\'`).

Unit tests were added for this condition but I was unable to create an integration test that exercises this scenario in a "real world" condition.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
