### PR TITLE
fix: Exclude WebResource.axd and ScriptResource.axd from browser instrumentation (via default config).

### DIFF
--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -33,7 +33,12 @@
 			<code>404</code>
 		</ignoreStatusCodes>
 	</errorCollector>
-	<browserMonitoring autoInstrument="true" />
+	<browserMonitoring autoInstrument="true">
+    <requestPathsExcluded>
+      <path regex="WebResource.axd" />
+      <path regex="ScriptResource.axd" />
+    </requestPathsExcluded>
+  </browserMonitoring>
 	<threadProfiling>
 		<ignoreMethod>System.Threading.WaitHandle:InternalWaitOne</ignoreMethod>
 		<ignoreMethod>System.Threading.WaitHandle:WaitAny</ignoreMethod>

--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -35,8 +35,8 @@
 	</errorCollector>
 	<browserMonitoring autoInstrument="true">
     <requestPathsExcluded>
-      <path regex="WebResource.axd" />
-      <path regex="ScriptResource.axd" />
+      <path regex="WebResource\.axd" />
+      <path regex="ScriptResource\.axd" />
     </requestPathsExcluded>
   </browserMonitoring>
 	<threadProfiling>


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Adds request path exclusion rules for `WebResource.axd` and `ScriptResource.axd` to the default `newrelic.config` file. 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
