### PR TITLE
chore: Add dockerfile and docker-compose to build arm64 profiler locally

### DIFF
--- a/src/Agent/NewRelic/Profiler/docker-compose.yml
+++ b/src/Agent/NewRelic/Profiler/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.4'
 
 services:
 
@@ -19,3 +19,12 @@ services:
             - .:/profiler
             - $CORECLR_NEWRELIC_HOME:/agent
         working_dir: /profiler/linux/
+    build_arm64:
+        platform: linux/arm64/v8
+        build:
+            context: linux/.
+            dockerfile: Arm64Dockerfile
+        command: bash -c "dos2unix ./build_profiler.sh && chmod 777 build_profiler.sh && ./build_profiler.sh"
+        volumes:
+            - .:/profiler
+        working_dir: /profiler/linux

--- a/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
@@ -1,0 +1,37 @@
+# This builds an Ubuntu image, clones the coreclr github repo and builds it.
+# It then sets up the environment for compiling the New Relic .NET profiler.
+
+FROM ubuntu:18.04
+
+RUN apt-get update -q -y
+RUN apt-get install -q -y \
+  wget \
+  curl \
+  git \
+  dos2unix \
+  software-properties-common \
+  make \
+  binutils \
+  libc++-dev \
+  clang-3.9 \
+  lldb-3.9 \
+  build-essential
+  
+RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
+RUN wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+
+# The CoreCLR build notes say their repos should be pulled into a `git` directory.
+# Not sure how necessary that is.
+RUN mkdir /root/git
+WORKDIR /root/git
+
+RUN git clone --branch release/3.1 https://github.com/dotnet/coreclr.git
+
+RUN curl -sSL https://virtuoso-testing.s3.us-west-2.amazonaws.com/cmake-3.9.0-rc3-aarch64.tar.gz | tar -xzC ~
+RUN chmod 777 ~/cmake-3.9.0-rc3-aarch64/bin/cmake
+
+RUN ln -s ~/cmake-3.9.0-rc3-aarch64/bin/cmake /usr/bin/cmake || true
+RUN rm /usr/bin/cc || true
+RUN ln -s /usr/bin/clang-3.9 /usr/bin/cc
+RUN rm /usr/bin/c++ || true
+RUN ln -s /usr/bin/clang++-3.9 /usr/bin/c++


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

I needed to test some arm64 applications locally with a custom build of the profiler for arm64. I used the dockerfile and docker-compose definitions in this PR to build custom versions of the profiler locally so that I could use those custom builds to test within a test application.

This could be a first step in making the build/ci process more consistent between the x64 and arm64 linux profiler builds. In the meantime, this can simplify the process for testing the arm64 profiler locally.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
