### PR TITLE
fix: Cache the AgentEnabled setting value.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -197,7 +197,8 @@ namespace NewRelic.Agent.Core.Configuration
                 {
                     lock (_lockObj)
                     {
-                        _agentEnabledAppSettingParsed = bool.TryParse(_configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"), out _appSettingAgentEnabled);
+                        _agentEnabledAppSettingParsed ??= bool.TryParse(_configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"),
+                            out _appSettingAgentEnabled);
                     }
                 }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -183,8 +183,9 @@ namespace NewRelic.Agent.Core.Configuration
 
         public object AgentRunId { get { return _serverConfiguration.AgentRunId; } }
 
-        private static bool? _agentEnabledAppSettingParsed;
-        private static bool _appSettingAgentEnabled;
+        // protected to allow unit test wrapper to manipulate
+        protected static bool? _agentEnabledAppSettingParsed;
+        protected static bool _appSettingAgentEnabled;
         private static readonly object _lockObj = new object();
 
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -183,17 +183,22 @@ namespace NewRelic.Agent.Core.Configuration
 
         public object AgentRunId { get { return _serverConfiguration.AgentRunId; } }
 
+        private bool? _agentEnabled;
         public virtual bool AgentEnabled
         {
             get
             {
+                if (_agentEnabled.HasValue)
+                    return _agentEnabled.Value;
+
                 var agentEnabledAsString = _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled");
 
-                bool agentEnabled;
-                if (!bool.TryParse(agentEnabledAsString, out agentEnabled))
-                    return _localConfiguration.agentEnabled;
+                if (!bool.TryParse(agentEnabledAsString, out var agentEnabled))
+                    _agentEnabled = _localConfiguration.agentEnabled;
 
-                return agentEnabled;
+                _agentEnabled = agentEnabled;
+
+                return _agentEnabled.Value;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -183,8 +183,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         public object AgentRunId { get { return _serverConfiguration.AgentRunId; } }
 
-        private static bool? _agentEnabledAppSettingRead;
-        private static bool _agentEnabledAppSettingParsed;
+        private static bool? _agentEnabledAppSettingParsed;
         private static bool _appSettingAgentEnabled;
         private static readonly object _lockObj = new object();
 
@@ -193,20 +192,17 @@ namespace NewRelic.Agent.Core.Configuration
         {
             get
             {
-                // read from app setting one time only and cache the result in a static
-                if (!_agentEnabledAppSettingRead.HasValue)
+                // read from app setting one time only and cache the result
+                if (!_agentEnabledAppSettingParsed.HasValue)
                 {
                     lock (_lockObj)
                     {
-                        var agentEnabledAppSettingString = _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled");
-                        _agentEnabledAppSettingRead = true;
-
-                        _agentEnabledAppSettingParsed = bool.TryParse(agentEnabledAppSettingString, out _appSettingAgentEnabled);
+                        _agentEnabledAppSettingParsed = bool.TryParse(_configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"), out _appSettingAgentEnabled);
                     }
                 }
 
                 // read from local config if we couldn't parse from app settings
-                return _agentEnabledAppSettingParsed ? _appSettingAgentEnabled : _localConfiguration.agentEnabled;
+                return _agentEnabledAppSettingParsed.Value ? _appSettingAgentEnabled : _localConfiguration.agentEnabled;
             }
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -56,9 +56,31 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void AgentEnabledShouldPassThroughToLocalConfig()
         {
             Assert.IsTrue(_defaultConfig.AgentEnabled);
+
+            _localConfig.agentEnabled = false;
+            Assert.IsFalse(_defaultConfig.AgentEnabled);
+
             _localConfig.agentEnabled = true;
             Assert.IsTrue(_defaultConfig.AgentEnabled);
-            _localConfig.agentEnabled = false;
+        }
+
+        [Test]
+        public void AgentEnabledShouldUseCachedAppSetting()
+        {
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled")).Returns("false");
+
+            Assert.IsFalse(_defaultConfig.AgentEnabled);
+            Assert.IsFalse(_defaultConfig.AgentEnabled);
+
+            Mock.Assert(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"), Occurs.Once());
+        }
+
+        [Test]
+        public void AgentEnabledShouldPreferAppSettingOverLocalConfig()
+        {
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled")).Returns("false");
+            _localConfig.agentEnabled = true;
+
             Assert.IsFalse(_defaultConfig.AgentEnabled);
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -20,6 +20,12 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
     {
         public TestableDefaultConfiguration(IEnvironment environment, configuration localConfig, ServerConfiguration serverConfig, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
             : base(environment, localConfig, serverConfig, runTimeConfiguration, securityPoliciesConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic) { }
+
+        public static void ResetStatics()
+        {
+            _agentEnabledAppSettingParsed = null;
+            _appSettingAgentEnabled = false;
+        }
     }
 
     [TestFixture, Category("Configuration")]
@@ -50,6 +56,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _dnsStatic = Mock.Create<IDnsStatic>();
 
             _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+            TestableDefaultConfiguration.ResetStatics();
         }
 
         [Test]
@@ -79,6 +87,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void AgentEnabledShouldPreferAppSettingOverLocalConfig()
         {
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled")).Returns("false");
+
             _localConfig.agentEnabled = true;
 
             Assert.IsFalse(_defaultConfig.AgentEnabled);


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Caches the value of the `AgentEnabled` configuration setting when it is first read, rather than reading the value from config every time it is accessed.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
