### PR TITLE
chore: Update Arm64 base image to use a pinned image.

### DIFF
--- a/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
@@ -1,7 +1,8 @@
 # This builds an Ubuntu image, clones the coreclr github repo and builds it.
 # It then sets up the environment for compiling the New Relic .NET profiler.
 
-FROM ubuntu:18.04
+# ubuntu:18.04 - multi-platform image
+FROM ubuntu@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98 
 
 RUN apt-get update -q -y
 RUN apt-get install -q -y \


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the Arm64 profiler build docker image to use a pinned image. This should resolve the problem reported by the code scanner. The image is pinned to the ubuntu 18.04 multi-platform image, which docker-compose will resolve the appropriate platform when the build and run commands are executed.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
