### PR TITLE
feat: Instrument OpenAsync() for SQL libraries

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
@@ -62,7 +62,9 @@ namespace NewRelic.Agent.Core.Utilities
                 { "DataReaderWrapperAsync",                                                                         Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
 
                 { "OpenConnectionTracer",                                                                           Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
+                { "OpenConnectionTracerAsync",                                                                           Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
                 { "OpenConnectionWrapper",                                                                          Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
+                { "OpenConnectionWrapperAsync",                                                                     Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
 
                 //The NewRelic.Providers.Wrapper.SerilogLogging.dll depends on the Serilog.dll; therefore, it should
                 //only be loaded by the agent when Serilog is used otherwise assembly load exception will occur.

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -368,7 +368,11 @@ SPDX-License-Identifier: Apache-2.0
       <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlConnection">
         <exactMethodMatcher methodName="Open"/>
       </match>
-
+      <!-- Up until 8.0.33, OpenAsync was not actually async -->
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlConnection" maxVersion="8.0.33">
+        <exactMethodMatcher methodName="OpenAsync"/>
+      </match>
+      
       <!-- MySqlConnector 0.x -->
       <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlConnection">
         <exactMethodMatcher methodName="Open" />
@@ -389,6 +393,61 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="Open" parameters="System.Boolean,System.Threading.CancellationToken"/>
       </match>
     </tracerFactory>
+
+    <!-- DbConnection.OpenAsync() -->
+    <tracerFactory name="OpenConnectionTracerAsync">
+      <!-- built in MS SQL driver (framework) -->
+      <match assemblyName="System.Data" className="System.Data.SqlClient.SqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- built in MS SQL driver (core / nuget) -->
+      <match assemblyName="System.Data.SqlClient" className="System.Data.SqlClient.SqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- MS SQL flagship data access driver -->
+      <match assemblyName="Microsoft.Data.SqlClient" className="Microsoft.Data.SqlClient.SqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- Oracle vendor driver -->
+      <match assemblyName="Oracle.DataAccess" className="Oracle.DataAccess.Client.OracleConnection">
+        <exactMethodMatcher methodName="OpenAsync"/>
+      </match>
+
+      <!-- Oracle vendor driver for ManagedDataAccess -->
+      <match assemblyName="Oracle.ManagedDataAccess" className="Oracle.ManagedDataAccess.Client.OracleConnection">
+        <exactMethodMatcher methodName="OpenAsync"/>
+      </match>
+
+      <!-- MySql (official) driver -->
+      <!-- Up until 8.0.33, OpenAsync was not actually async -->
+      <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlConnection" minVersion="8.0.33">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken"/>
+      </match>
+
+      <!-- MySqlConnector 0.x -->
+      <match assemblyName="MySqlConnector" className="MySql.Data.MySqlClient.MySqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Nullable`1[MySqlConnector.Protocol.Serialization.IOBehavior],System.Threading.CancellationToken" />
+      </match>
+
+      <!-- MySqlConnector 1.x -->
+      <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Nullable`1[MySqlConnector.Protocol.Serialization.IOBehavior],System.Threading.CancellationToken" />
+      </match>
+
+      <!-- IBM DB2 driver -->
+      <match assemblyName="IBM.Data.DB2" className="IBM.Data.DB2.DB2Connection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
+      </match>
+
+      <!-- Npgsql Postgres data provider -->
+      <match assemblyName="Npgsql" className="Npgsql.NpgsqlConnection">
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken"/>
+      </match>
+    </tracerFactory>
+
 
   </instrumentation>
 </extension>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Instrumentation.xml
@@ -411,20 +411,10 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
       </match>
 
-      <!-- Oracle vendor driver -->
-      <match assemblyName="Oracle.DataAccess" className="Oracle.DataAccess.Client.OracleConnection">
-        <exactMethodMatcher methodName="OpenAsync"/>
-      </match>
-
-      <!-- Oracle vendor driver for ManagedDataAccess -->
-      <match assemblyName="Oracle.ManagedDataAccess" className="Oracle.ManagedDataAccess.Client.OracleConnection">
-        <exactMethodMatcher methodName="OpenAsync"/>
-      </match>
-
       <!-- MySql (official) driver -->
       <!-- Up until 8.0.33, OpenAsync was not actually async -->
       <match assemblyName="MySql.Data" className="MySql.Data.MySqlClient.MySqlConnection" minVersion="8.0.33">
-        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken"/>
+        <exactMethodMatcher methodName="OpenAsync" parameters="System.Boolean,System.Threading.CancellationToken"/>
       </match>
 
       <!-- MySqlConnector 0.x -->
@@ -435,11 +425,6 @@ SPDX-License-Identifier: Apache-2.0
       <!-- MySqlConnector 1.x -->
       <match assemblyName="MySqlConnector" className="MySqlConnector.MySqlConnection">
         <exactMethodMatcher methodName="OpenAsync" parameters="System.Nullable`1[MySqlConnector.Protocol.Serialization.IOBehavior],System.Threading.CancellationToken" />
-      </match>
-
-      <!-- IBM DB2 driver -->
-      <match assemblyName="IBM.Data.DB2" className="IBM.Data.DB2.DB2Connection">
-        <exactMethodMatcher methodName="OpenAsync" parameters="System.Threading.CancellationToken" />
       </match>
 
       <!-- Npgsql Postgres data provider -->

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/OpenConnectionWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/OpenConnectionWrapper.cs
@@ -5,30 +5,67 @@ using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace NewRelic.Providers.Wrapper.Sql
 {
-    public class OpenConnectionWrapper : IWrapper
+    public class OpenConnectionWrapper : OpenConnectionWrapperBase
     {
-        public static readonly string[] WrapperNames =
+        private static readonly string[] _tracerNames =
         {
             "OpenConnectionTracer",
-            "OpenConnectionWrapper"
+            "OpenConnectionWrapper",
         };
+
+        public override string[] WrapperNames => _tracerNames;
+        public override bool ExecuteAsAsync => false;
+    }
+
+    public class OpenConnectionAsyncWrapper : OpenConnectionWrapperBase
+    {
+        private static readonly string[] _tracerNames =
+        {
+            "OpenConnectionTracerAsync",
+            "OpenConnectionWrapperAsync"
+        };
+        public override string[] WrapperNames => _tracerNames;
+        public override bool ExecuteAsAsync => true;
+    }
+
+
+    public abstract class OpenConnectionWrapperBase : IWrapper
+    {
+        public abstract string[] WrapperNames { get; }
+
+        public abstract bool ExecuteAsAsync { get; }
 
         public bool IsTransactionRequired => true;
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            return new CanWrapResponse(WrapperNames.Contains(methodInfo.RequestedWrapperName, StringComparer.OrdinalIgnoreCase));
+            var canWrap = WrapperNames.Contains(methodInfo.RequestedWrapperName, StringComparer.OrdinalIgnoreCase);
+            if (canWrap && ExecuteAsAsync)
+            {
+                var method = methodInfo.Method;
+                return TaskFriendlySyncContextValidator.CanWrapAsyncMethod(method.Type.Assembly.GetName().Name, method.Type.FullName, method.MethodName);
+            }
+
+            return new CanWrapResponse(canWrap);
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
+            if (instrumentedMethodCall.IsAsync)
+            {
+                transaction.AttachToAsync();
+            }
+
             var typeName = instrumentedMethodCall.MethodCall.Method.Type.FullName ?? "unknown";
             var segment = transaction.StartMethodSegment(instrumentedMethodCall.MethodCall, typeName, instrumentedMethodCall.MethodCall.Method.MethodName, isLeaf: true);
 
-            return Delegates.GetDelegateFor(segment);
+            return ExecuteAsAsync
+                ? Delegates.GetAsyncDelegateFor<Task>(agent, segment)
+                : Delegates.GetDelegateFor(segment);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/MicrosoftDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/MicrosoftDataSqlClientExerciser.cs
@@ -86,7 +86,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
                 {
@@ -166,7 +166,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
                 {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
@@ -88,7 +88,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
                 {
@@ -169,7 +169,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
                 {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
@@ -88,7 +88,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
                 {
@@ -169,7 +169,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
                 {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
@@ -215,7 +215,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MySql
             using (var connection = new MySqlConnection(MySqlTestConfiguration.MySqlConnectionString))
             using (var command = new MySqlCommand("SELECT _date FROM dates WHERE _date LIKE '2%' ORDER BY _date DESC LIMIT 1", connection))
             {
-                connection.Open();
+                await connection.OpenAsync();
                 result = await action(command);
             }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlExerciser.cs
@@ -48,7 +48,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MySql
             using (var connection = new MySqlConnection(MySqlTestConfiguration.MySqlConnectionString))
             using (var command = new MySqlCommand("SELECT _date FROM dates WHERE _date LIKE '2%' ORDER BY _date DESC LIMIT 10000", connection))
             {
-                connection.Open();
+                await connection.OpenAsync();
                 using (var reader = await command.ExecuteReaderAsync())
                 {
                     while (await reader.ReadAsync())

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/OracleController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/OracleController.cs
@@ -76,7 +76,7 @@ namespace BasicMvcApplication.Controllers
 
             using (var connection = new OracleConnection(connectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new OracleCommand("SELECT DEGREE FROM user_tables WHERE ROWNUM <= 1", connection))
                 {

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/MicrosoftDataSqlClientController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcCoreApplication/Controllers/MicrosoftDataSqlClientController.cs
@@ -75,7 +75,7 @@ namespace BasicMvcApplication.Controllers
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = 'John'", connection))
                 {
@@ -153,7 +153,7 @@ namespace BasicMvcApplication.Controllers
 
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
 
                 using (var command = new SqlCommand("SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN", connection))
                 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -22,13 +22,15 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         private readonly string _expectedTransactionName;
 
         private readonly string _tableName;
+        private readonly string _libraryName;
 
-        public MsSqlAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
+        public MsSqlAsyncTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, string libraryName) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
             _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlAsync";
             _tableName = Utilities.GenerateTableName();
+            _libraryName = libraryName;
 
             _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
             _fixture.AddCommand($"{excerciserName} MsSqlAsync {_tableName}");
@@ -81,6 +83,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
                 new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = expectedDatastoreCallCount },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
 
+                new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/OpenAsync", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = expectedDatastoreCallCount },
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = expectedDatastoreCallCount},
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2 },
@@ -103,7 +106,10 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
                 // The operation metric should not be scoped because the statement metric is scoped instead
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 3, metricScope = _expectedTransactionName },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 1, metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1, metricScope = _expectedTransactionName }
+                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1, metricScope = _expectedTransactionName },
+
+                // Don't double count the open
+                new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/Open" },
             };
             var expectedTransactionTraceSegments = new List<string>
             {
@@ -187,7 +193,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataExerciser")
+                  excerciserName: "SystemDataExerciser",
+                  libraryName: "System.Data.SqlClient")
         {
         }
     }
@@ -199,7 +206,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataSqlClientExerciser")
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  libraryName: "System.Data.SqlClient")
         {
         }
     }
@@ -211,7 +219,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataSqlClientExerciser")
+                  excerciserName: "SystemDataSqlClientExerciser",
+                  libraryName: "System.Data.SqlClient")
         {
         }
     }
@@ -223,7 +232,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
+                  excerciserName: "MicrosoftDataSqlClientExerciser",
+                  libraryName: "Microsoft.Data.SqlClient")
         {
         }
     }
@@ -235,7 +245,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
+                  excerciserName: "MicrosoftDataSqlClientExerciser",
+                  libraryName: "Microsoft.Data.SqlClient")
         {
         }
     }
@@ -248,7 +259,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
+                  excerciserName: "MicrosoftDataSqlClientExerciser",
+                  libraryName: "Microsoft.Data.SqlClient")
         {
         }
     }
@@ -260,7 +272,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
+                  excerciserName: "MicrosoftDataSqlClientExerciser",
+                  libraryName: "Microsoft.Data.SqlClient")
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
@@ -75,7 +75,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 				// The datastore operation happened outside a web transaction so there should be no allWeb metrics
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-
+                // Don't double count the Open
+                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
 				// The operation metric should not be scoped because the statement metric is scoped instead
 				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName },
             };

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
@@ -64,7 +64,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open", callCount = 1},
+                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
@@ -75,7 +75,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
 				// The datastore operation happened outside a web transaction so there should be no allWeb metrics
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-
+                // Don't double count the Open
+                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
 				// The operation metric should not be scoped because the statement metric is scoped instead
 				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName }
             };

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
@@ -64,7 +64,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
                 new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open", callCount = 1},
+                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
                 new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },


### PR DESCRIPTION
This ended up being trickier than expected for a few reasons:
* The default implementation for `DbConnection.OpenAsync()` is not async. I had to check each library to see if they had an override that is actually async.
* MySql has its own implementation of `OpenAsync()`, but it is not async until 8.0.33.
* If an implementation of `OpenAsync()` calls Open(), we don't want to instrument both.

To minimize the test changes, I took existing async tests and switched the `Open` calls to `OpenAsync`.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
