### PR TITLE
fix: Include config file path in the "Agent is disabled " message on all platforms.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -111,6 +111,14 @@ namespace NewRelic.Agent.Core.Config
 				value = new ValueWithProvenance<string>(ConfigurationManager.AppSettings[key],
 					"ConfigurationManager app setting");
 			}
+#else
+            if (value?.Value == null)
+            {
+                var configMgrStatic = new ConfigurationManagerStatic();
+                var configValue = configMgrStatic.GetAppSetting(key);
+                if (configValue != null)
+                    value = new ValueWithProvenance<string>(configValue, configMgrStatic.AppSettingsFilePath);
+            }
 #endif
             return value;
         }

--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -152,7 +152,7 @@ namespace NewRelic.Agent.Core
         private void AssertAgentEnabled(configuration config)
         {
             if (!Configuration.AgentEnabled)
-                throw new Exception(string.Format("The New Relic agent is disabled.  Update {0}  to re-enable it.", config.AgentEnabledAt));
+                throw new Exception(string.Format("The New Relic agent is disabled.  Update {0}  to re-enable it.", config.AgentEnabledAt ?? config.ConfigurationFileName));
 
             if ("REPLACE_WITH_LICENSE_KEY".Equals(Configuration.AgentLicenseKey))
                 throw new Exception("Please set your license key.");


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

At startup, an exception is thrown when the agent is disabled via config. That message includes the path to the config file where the agent is disabled. For .NET 6+ applications, the path is empty. 

This PR modifies the logic in `ConfigurationLoader.GetConfigSetting()` to include looking at the `appsettings.json` file for .NET 6+ applications and to include the path to the file in the message. As a final fallback, the location of the `newrelic.config` file is used in the message.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
