### PR TITLE
feat: MongoDB instrumentation update

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
     <tracerFactory name="MongoCollectionImplWrapper">
       <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionImpl`1">
         <exactMethodMatcher methodName="AggregateAsync"/>
+        <exactMethodMatcher methodName="AggregateToCollectionAsync"/>
         <exactMethodMatcher methodName="BulkWriteAsync"/>
         <exactMethodMatcher methodName="CountAsync"/>
         <exactMethodMatcher methodName="CountDocumentsAsync"/>
@@ -19,8 +20,9 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="FindOneAndUpdateAsync"/>
         <exactMethodMatcher methodName="MapReduceAsync"/>
         <exactMethodMatcher methodName="WatchAsync"/>
-      
+
         <exactMethodMatcher methodName="Aggregate"/>
+        <exactMethodMatcher methodName="AggregateToCollection"/>
         <exactMethodMatcher methodName="BulkWrite"/>
         <exactMethodMatcher methodName="Count"/>
         <exactMethodMatcher methodName="CountDocuments"/>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -46,19 +46,21 @@ SPDX-License-Identifier: Apache-2.0
 
   <tracerFactory name="MongoDatabaseWrapper">
     <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoDatabaseImpl">
-    <exactMethodMatcher methodName="CreateCollection"/>
-    <exactMethodMatcher methodName="CreateView"/>
-    <exactMethodMatcher methodName="DropCollection"/>
-    <exactMethodMatcher methodName="ListCollections"/>
-    <exactMethodMatcher methodName="RenameCollection"/>
-    <exactMethodMatcher methodName="RunCommand"/>
+      <exactMethodMatcher methodName="CreateCollection"/>
+      <exactMethodMatcher methodName="CreateView"/>
+      <exactMethodMatcher methodName="DropCollection"/>
+      <exactMethodMatcher methodName="ListCollections"/>
+      <exactMethodMatcher methodName="ListCollectionNames"/>
+      <exactMethodMatcher methodName="RenameCollection"/>
+      <exactMethodMatcher methodName="RunCommand"/>
 
-    <exactMethodMatcher methodName="CreateCollectionAsync"/>
-    <exactMethodMatcher methodName="CreateViewAsync"/>
-    <exactMethodMatcher methodName="DropCollectionAsync"/>
-    <exactMethodMatcher methodName="ListCollectionsAsync"/>
-    <exactMethodMatcher methodName="RenameCollectionAsync"/>
-    <exactMethodMatcher methodName="RunCommandAsync"/>
+      <exactMethodMatcher methodName="CreateCollectionAsync"/>
+      <exactMethodMatcher methodName="CreateViewAsync"/>
+      <exactMethodMatcher methodName="DropCollectionAsync"/>
+      <exactMethodMatcher methodName="ListCollectionsAsync"/>
+      <exactMethodMatcher methodName="ListCollectionNamesAsync"/>
+      <exactMethodMatcher methodName="RenameCollectionAsync"/>
+      <exactMethodMatcher methodName="RunCommandAsync"/>
     </match>
   </tracerFactory>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -4,105 +4,107 @@ Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 <extension xmlns="urn:newrelic-extension">
-	<instrumentation>
-		<tracerFactory name="MongoCollectionImplWrapper">
-			<match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionImpl`1">
-				<exactMethodMatcher methodName="AggregateAsync"/>
-				<exactMethodMatcher methodName="BulkWriteAsync"/>
-				<exactMethodMatcher methodName="CountAsync"/>
-				<exactMethodMatcher methodName="DistinctAsync"/>
-				<exactMethodMatcher methodName="FindAsync"/>
-				<exactMethodMatcher methodName="FindOneAndDeleteAsync"/>
-				<exactMethodMatcher methodName="FindOneAndReplaceAsync"/>
-				<exactMethodMatcher methodName="FindOneAndUpdateAsync"/>
-				<exactMethodMatcher methodName="MapReduceAsync"/>
-				<exactMethodMatcher methodName="WatchAsync"/>
-			
-				<exactMethodMatcher methodName="Aggregate"/>
-				<exactMethodMatcher methodName="BulkWrite"/>
-				<exactMethodMatcher methodName="Count"/>
-				<exactMethodMatcher methodName="Distinct"/>
-				<exactMethodMatcher methodName="FindSync"/>
-				<exactMethodMatcher methodName="FindOneAndDelete"/>
-				<exactMethodMatcher methodName="FindOneAndReplace"/>
-				<exactMethodMatcher methodName="FindOneAndUpdate"/>
-				<exactMethodMatcher methodName="MapReduce"/>
-				<exactMethodMatcher methodName="Watch"/>
-			</match>
-		</tracerFactory>
+  <instrumentation>
+    <tracerFactory name="MongoCollectionImplWrapper">
+      <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionImpl`1">
+        <exactMethodMatcher methodName="AggregateAsync"/>
+        <exactMethodMatcher methodName="BulkWriteAsync"/>
+        <exactMethodMatcher methodName="CountAsync"/>
+        <exactMethodMatcher methodName="CountDocumentsAsync"/>
+        <exactMethodMatcher methodName="DistinctAsync"/>
+        <exactMethodMatcher methodName="FindAsync"/>
+        <exactMethodMatcher methodName="FindOneAndDeleteAsync"/>
+        <exactMethodMatcher methodName="FindOneAndReplaceAsync"/>
+        <exactMethodMatcher methodName="FindOneAndUpdateAsync"/>
+        <exactMethodMatcher methodName="MapReduceAsync"/>
+        <exactMethodMatcher methodName="WatchAsync"/>
+      
+        <exactMethodMatcher methodName="Aggregate"/>
+        <exactMethodMatcher methodName="BulkWrite"/>
+        <exactMethodMatcher methodName="Count"/>
+        <exactMethodMatcher methodName="CountDocuments"/>
+        <exactMethodMatcher methodName="Distinct"/>
+        <exactMethodMatcher methodName="FindSync"/>
+        <exactMethodMatcher methodName="FindOneAndDelete"/>
+        <exactMethodMatcher methodName="FindOneAndReplace"/>
+        <exactMethodMatcher methodName="FindOneAndUpdate"/>
+        <exactMethodMatcher methodName="MapReduce"/>
+        <exactMethodMatcher methodName="Watch"/>
+      </match>
+    </tracerFactory>
 
-	<tracerFactory name="AsyncCursorWrapper">
-	  <match assemblyName="MongoDB.Driver.Core" className="MongoDB.Driver.Core.Operations.AsyncCursor`1">
-		<exactMethodMatcher methodName="GetNextBatch"/>
-		<exactMethodMatcher methodName="GetNextBatchAsync"/>
-	  </match>
-	</tracerFactory>
+  <tracerFactory name="AsyncCursorWrapper">
+    <match assemblyName="MongoDB.Driver.Core" className="MongoDB.Driver.Core.Operations.AsyncCursor`1">
+    <exactMethodMatcher methodName="GetNextBatch"/>
+    <exactMethodMatcher methodName="GetNextBatchAsync"/>
+    </match>
+  </tracerFactory>
 
-	<tracerFactory name="MongoDatabaseWrapper">
-	  <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoDatabaseImpl">
-		<exactMethodMatcher methodName="CreateCollection"/>
-		<exactMethodMatcher methodName="CreateView"/>
-		<exactMethodMatcher methodName="DropCollection"/>
-		<exactMethodMatcher methodName="ListCollections"/>
-		<exactMethodMatcher methodName="RenameCollection"/>
-		<exactMethodMatcher methodName="RunCommand"/>
+  <tracerFactory name="MongoDatabaseWrapper">
+    <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoDatabaseImpl">
+    <exactMethodMatcher methodName="CreateCollection"/>
+    <exactMethodMatcher methodName="CreateView"/>
+    <exactMethodMatcher methodName="DropCollection"/>
+    <exactMethodMatcher methodName="ListCollections"/>
+    <exactMethodMatcher methodName="RenameCollection"/>
+    <exactMethodMatcher methodName="RunCommand"/>
 
-		<exactMethodMatcher methodName="CreateCollectionAsync"/>
-		<exactMethodMatcher methodName="CreateViewAsync"/>
-		<exactMethodMatcher methodName="DropCollectionAsync"/>
-		<exactMethodMatcher methodName="ListCollectionsAsync"/>
-		<exactMethodMatcher methodName="RenameCollectionAsync"/>
-		<exactMethodMatcher methodName="RunCommandAsync"/>
-	  </match>
-	</tracerFactory>
+    <exactMethodMatcher methodName="CreateCollectionAsync"/>
+    <exactMethodMatcher methodName="CreateViewAsync"/>
+    <exactMethodMatcher methodName="DropCollectionAsync"/>
+    <exactMethodMatcher methodName="ListCollectionsAsync"/>
+    <exactMethodMatcher methodName="RenameCollectionAsync"/>
+    <exactMethodMatcher methodName="RunCommandAsync"/>
+    </match>
+  </tracerFactory>
 
-	<tracerFactory name="MongoQueryProviderImplWrapper">
-	  <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.Linq.MongoQueryProviderImpl`1">
-		<exactMethodMatcher methodName="ExecuteModel"/>
-		<exactMethodMatcher methodName="ExecuteModelAsync"/>
-	  </match>
-	</tracerFactory>
+  <tracerFactory name="MongoQueryProviderImplWrapper">
+    <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.Linq.MongoQueryProviderImpl`1">
+    <exactMethodMatcher methodName="ExecuteModel"/>
+    <exactMethodMatcher methodName="ExecuteModelAsync"/>
+    </match>
+  </tracerFactory>
 
-	<tracerFactory name="MongoIndexManagerBaseWrapper">
-	  <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoIndexManagerBase`1">
-		<exactMethodMatcher methodName="CreateOne"/>
-		<exactMethodMatcher methodName="CreateOneAsync"/>
-	  </match>
-	</tracerFactory>
+  <tracerFactory name="MongoIndexManagerBaseWrapper">
+    <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoIndexManagerBase`1">
+    <exactMethodMatcher methodName="CreateOne"/>
+    <exactMethodMatcher methodName="CreateOneAsync"/>
+    </match>
+  </tracerFactory>
 
-	<tracerFactory name="MongoIndexManagerWrapper">
-	  <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionImpl`1+MongoIndexManager">
-		<exactMethodMatcher methodName="CreateMany"/>
-		<exactMethodMatcher methodName="DropAll"/>
-		<exactMethodMatcher methodName="DropOne"/>
-		<exactMethodMatcher methodName="List"/>
+  <tracerFactory name="MongoIndexManagerWrapper">
+    <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionImpl`1+MongoIndexManager">
+    <exactMethodMatcher methodName="CreateMany"/>
+    <exactMethodMatcher methodName="DropAll"/>
+    <exactMethodMatcher methodName="DropOne"/>
+    <exactMethodMatcher methodName="List"/>
 
-		<exactMethodMatcher methodName="CreateManyAsync"/>
-		<exactMethodMatcher methodName="DropAllAsync"/>
-		<exactMethodMatcher methodName="DropOneAsync"/>
-		<exactMethodMatcher methodName="ListAsync"/>
-	  </match>
-	</tracerFactory>
+    <exactMethodMatcher methodName="CreateManyAsync"/>
+    <exactMethodMatcher methodName="DropAllAsync"/>
+    <exactMethodMatcher methodName="DropOneAsync"/>
+    <exactMethodMatcher methodName="ListAsync"/>
+    </match>
+  </tracerFactory>
 
-	<tracerFactory name="MongoCollectionBaseWrapper">
-	  <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionBase`1">
-		<exactMethodMatcher methodName="DeleteMany"/>
-		<exactMethodMatcher methodName="DeleteOne"/>
-		<exactMethodMatcher methodName="InsertOne"/>
-		<exactMethodMatcher methodName="InsertMany"/>
-		<exactMethodMatcher methodName="ReplaceOne"/>
-		<exactMethodMatcher methodName="UpdateMany"/>
-		<exactMethodMatcher methodName="UpdateOne"/>
+  <tracerFactory name="MongoCollectionBaseWrapper">
+    <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoCollectionBase`1">
+    <exactMethodMatcher methodName="DeleteMany"/>
+    <exactMethodMatcher methodName="DeleteOne"/>
+    <exactMethodMatcher methodName="InsertOne"/>
+    <exactMethodMatcher methodName="InsertMany"/>
+    <exactMethodMatcher methodName="ReplaceOne"/>
+    <exactMethodMatcher methodName="UpdateMany"/>
+    <exactMethodMatcher methodName="UpdateOne"/>
 
-		<exactMethodMatcher methodName="DeleteManyAsync"/>
-		<exactMethodMatcher methodName="DeleteOneAsync"/>
-		<exactMethodMatcher methodName="InsertOneAsync"/>
-		<exactMethodMatcher methodName="InsertManyAsync"/>
-		<exactMethodMatcher methodName="ReplaceOneAsync"/>
-		<exactMethodMatcher methodName="UpdateManyAsync"/>
-		<exactMethodMatcher methodName="UpdateOneAsync"/>
-	  </match>
-	</tracerFactory>
+    <exactMethodMatcher methodName="DeleteManyAsync"/>
+    <exactMethodMatcher methodName="DeleteOneAsync"/>
+    <exactMethodMatcher methodName="InsertOneAsync"/>
+    <exactMethodMatcher methodName="InsertManyAsync"/>
+    <exactMethodMatcher methodName="ReplaceOneAsync"/>
+    <exactMethodMatcher methodName="UpdateManyAsync"/>
+    <exactMethodMatcher methodName="UpdateOneAsync"/>
+    </match>
+  </tracerFactory>
 
   </instrumentation>
 </extension>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -55,6 +55,7 @@ SPDX-License-Identifier: Apache-2.0
       <exactMethodMatcher methodName="ListCollectionNames"/>
       <exactMethodMatcher methodName="RenameCollection"/>
       <exactMethodMatcher methodName="RunCommand"/>
+      <exactMethodMatcher methodName="Watch"/>
 
       <exactMethodMatcher methodName="AggregateAsync"/>
       <exactMethodMatcher methodName="AggregateToCollectionAsync"/>
@@ -65,6 +66,7 @@ SPDX-License-Identifier: Apache-2.0
       <exactMethodMatcher methodName="ListCollectionNamesAsync"/>
       <exactMethodMatcher methodName="RenameCollectionAsync"/>
       <exactMethodMatcher methodName="RunCommandAsync"/>
+      <exactMethodMatcher methodName="WatchAsync"/>
     </match>
   </tracerFactory>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -46,6 +46,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <tracerFactory name="MongoDatabaseWrapper">
     <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoDatabaseImpl">
+      <exactMethodMatcher methodName="Aggregate"/>
       <exactMethodMatcher methodName="CreateCollection"/>
       <exactMethodMatcher methodName="CreateView"/>
       <exactMethodMatcher methodName="DropCollection"/>
@@ -54,6 +55,7 @@ SPDX-License-Identifier: Apache-2.0
       <exactMethodMatcher methodName="RenameCollection"/>
       <exactMethodMatcher methodName="RunCommand"/>
 
+      <exactMethodMatcher methodName="AggregateAsync"/>
       <exactMethodMatcher methodName="CreateCollectionAsync"/>
       <exactMethodMatcher methodName="CreateViewAsync"/>
       <exactMethodMatcher methodName="DropCollectionAsync"/>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -12,6 +12,7 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="CountAsync"/>
         <exactMethodMatcher methodName="CountDocumentsAsync"/>
         <exactMethodMatcher methodName="DistinctAsync"/>
+        <exactMethodMatcher methodName="EstimatedDocumentCountAsync"/>
         <exactMethodMatcher methodName="FindAsync"/>
         <exactMethodMatcher methodName="FindOneAndDeleteAsync"/>
         <exactMethodMatcher methodName="FindOneAndReplaceAsync"/>
@@ -24,6 +25,7 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="Count"/>
         <exactMethodMatcher methodName="CountDocuments"/>
         <exactMethodMatcher methodName="Distinct"/>
+        <exactMethodMatcher methodName="EstimatedDocumentCount"/>
         <exactMethodMatcher methodName="FindSync"/>
         <exactMethodMatcher methodName="FindOneAndDelete"/>
         <exactMethodMatcher methodName="FindOneAndReplace"/>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MongoDb26/Instrumentation.xml
@@ -47,6 +47,7 @@ SPDX-License-Identifier: Apache-2.0
   <tracerFactory name="MongoDatabaseWrapper">
     <match assemblyName="MongoDB.Driver" className="MongoDB.Driver.MongoDatabaseImpl">
       <exactMethodMatcher methodName="Aggregate"/>
+      <exactMethodMatcher methodName="AggregateToCollection"/>
       <exactMethodMatcher methodName="CreateCollection"/>
       <exactMethodMatcher methodName="CreateView"/>
       <exactMethodMatcher methodName="DropCollection"/>
@@ -56,6 +57,7 @@ SPDX-License-Identifier: Apache-2.0
       <exactMethodMatcher methodName="RunCommand"/>
 
       <exactMethodMatcher methodName="AggregateAsync"/>
+      <exactMethodMatcher methodName="AggregateToCollectionAsync"/>
       <exactMethodMatcher methodName="CreateCollectionAsync"/>
       <exactMethodMatcher methodName="CreateViewAsync"/>
       <exactMethodMatcher methodName="DropCollectionAsync"/>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -429,6 +429,31 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<IAsyncCursor<CustomMongoDbEntity>> AggregateAsync()
+        {
+
+            var document = new CustomMongoDbEntity { Id = new ObjectId(), Name = "Fred Flintstone" };
+            Collection.InsertOne(document);
+
+            var match = new BsonDocument
+            {
+                {
+                    "$match",
+                    new BsonDocument
+                    {
+                        { "Name", "Fred Flintstone" }
+                    }
+                }
+            };
+
+            var pipeline = new[] { match };
+            var result = Collection.AggregateAsync<CustomMongoDbEntity>(pipeline);
+            return await result;
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public long Count()
         {
             var document = new CustomMongoDbEntity { Id = new ObjectId(), Name = "Fred Flintstone" };
@@ -496,6 +521,29 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
 
             return await Collection.DistinctAsync<string>("Name", filter);
         }
+
+// EstimatedDocumentCount{Async} did not exist in driver version 2.3 which is bound to net462 in MultiFunctionApplicationHelpers.csproj
+#if !MONGODRIVER23
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public long EstimatedDocumentCount()
+        {
+            var document = new CustomMongoDbEntity { Id = new ObjectId(), Name = "Fred Flintstone" };
+            Collection.InsertOne(document);
+            return Collection.EstimatedDocumentCount();
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<long> EstimatedDocumentCountAsync()
+        {
+            var document = new CustomMongoDbEntity { Id = new ObjectId(), Name = "Fred Flintstone" };
+            await Collection.InsertOneAsync(document);
+            return await Collection.EstimatedDocumentCountAsync();
+        }
+#endif
 
         [LibraryMethod]
         [Transaction]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// A number of methods tested here do not exist in MongoDB.Driver version 2.3 which is the oldest we support. It is bound to the net462 TFM in MultiFunctionApplicationHelpers.csproj
+// Several methods exercised here do not exist in MongoDB.Driver version 2.3 which is the oldest we support on .NET Framework. It is bound to the net462 TFM in MultiFunctionApplicationHelpers.csproj
 #if NET462
 #define MONGODRIVER2_3
 #endif
 
+// Some methods exercised here do not exist in MongoDB.Driver version 2.8.1 which is the oldest we support on .NET Core. It is bound to the net6.0 TFM in MultiFunctionApplicationHelpers.csproj
 #if NET6_0
 #define MONGODRIVER2_8_1
 #endif
@@ -799,6 +800,27 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
             var collections = cursor.ToList();
             return collections.Count;
         }
+
+#if !MONGODRIVER2_3
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public int ListCollectionNames()
+        {
+            var collections = Db.ListCollectionNames().ToList();
+            return collections.Count();
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<int> ListCollectionNamesAsync()
+        {
+            var cursor = await Db.ListCollectionNamesAsync();
+            var collections = cursor.ToList();
+            return collections.Count;
+        }
+#endif
 
         [LibraryMethod]
         [Transaction]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -21,6 +21,7 @@ using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using System.Runtime.CompilerServices;
 using NewRelic.Api.Agent;
 using System;
+using System.Web.Http.Results;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
 {
@@ -732,7 +733,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
 
         #endregion
 
-        #region Database
+#region Database
 
 #if !MONGODRIVER2_3 && !MONGODRIVER2_8_1
 
@@ -984,9 +985,44 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
             return result.ToString();
         }
 
-#endregion
+#if !MONGODRIVER2_3
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string WatchDB()
+        {
+            try
+            {
+                var result = Db.Watch();
+                return "Ok";
+            }
+            catch (MongoCommandException)
+            {
+                return "Got exception but it is ok!";
+            }
+        }
 
-#region IndexManager
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> WatchDBAsync()
+        {
+            try
+            {
+                var result = await Db.WatchAsync();
+                return "Ok";
+            }
+            catch (MongoCommandException)
+            {
+                return "Got exception but it is ok!";
+            }
+        }
+
+#endif
+
+        #endregion
+
+        #region IndexManager
 
         [LibraryMethod]
         [Transaction]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -730,9 +730,55 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
         }
 #endif
 
-#endregion
+        #endregion
 
-#region Database
+        #region Database
+
+#if !MONGODRIVER2_3 && !MONGODRIVER2_8_1
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public string AggregateDB()
+        {
+            var listLocalSessions = new BsonDocument
+            {
+                {
+                    "$listLocalSessions",
+                    new BsonDocument
+                    {
+                        // empty
+                    }
+                }
+            };
+
+            var pipeline = new[] { listLocalSessions };
+            var result = Db.Aggregate<BsonDocument>(pipeline);
+            return result.FirstOrDefault().ToString();
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task<string> AggregateDBAsync()
+        {
+            var listLocalSessions = new BsonDocument
+            {
+                {
+                    "$listLocalSessions",
+                    new BsonDocument
+                    {
+                        // empty
+                    }
+                }
+            };
+
+            var pipeline = new[] { listLocalSessions };
+            var result = await Db.AggregateAsync<BsonDocument>(pipeline);
+            return result.FirstOrDefault().ToString();
+        }
+
+#endif
 
         [LibraryMethod]
         [Transaction]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -840,7 +840,15 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
             };
 
             var pipeline = new[] { listLocalSessions, outStage };
-            await Db.AggregateToCollectionAsync<BsonDocument>(pipeline);
+            try
+            {
+                await Db.AggregateToCollectionAsync<BsonDocument>(pipeline);
+            }
+            catch
+            {
+                // This method is throwing an exception in net471 for unknown reasons. However, we just need the method to execute
+                // so our instrumentation runs and generates the expected metric, so just swallow the exception.
+            }
         }
 
 #endif

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MongoDB/MongoDBDriverExerciser.cs
@@ -778,6 +778,70 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB
             return result.FirstOrDefault().ToString();
         }
 
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void AggregateDBToCollection()
+        {
+            var listLocalSessions = new BsonDocument
+            {
+                {
+                    "$listLocalSessions",
+                    new BsonDocument
+                    {
+                        // empty
+                    }
+                }
+            };
+
+            var outStage = new BsonDocument
+            {
+                {
+                    "$out",
+                    new BsonDocument
+                    {
+                        { "db", _dbName },
+                        { "coll", _defaultCollectionName }
+                    }
+                }
+            };
+
+            var pipeline = new[] { listLocalSessions, outStage };
+            Db.AggregateToCollection<BsonDocument>(pipeline);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task AggregateDBToCollectionAsync()
+        {
+            var listLocalSessions = new BsonDocument
+            {
+                {
+                    "$listLocalSessions",
+                    new BsonDocument
+                    {
+                        // empty
+                    }
+                }
+            };
+
+            var outStage = new BsonDocument
+            {
+                {
+                    "$out",
+                    new BsonDocument
+                    {
+                        { "db", _dbName },
+                        { "coll", _defaultCollectionName }
+                    }
+                }
+            };
+
+            var pipeline = new[] { listLocalSessions, outStage };
+            await Db.AggregateToCollectionAsync<BsonDocument>(pipeline);
+        }
+
 #endif
 
         [LibraryMethod]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -16,18 +16,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     {
         private readonly ConsoleDynamicMethodFixture _fixture;
 
-        private bool _clientVersion23;
+        private MongoDBDriverVersion _driverVersion;
 
         private string _mongoUrl;
 
         private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
 
-        public MongoDBDriverCollectionTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, bool clientVersion23 = false) : base(fixture)
+        public MongoDBDriverCollectionTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
             _mongoUrl = mongoUrl;
-            _clientVersion23 = clientVersion23;
+            _driverVersion = driverVersion;
 
             _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
             _fixture.AddCommand("MongoDbDriverExerciser Count");
@@ -36,16 +36,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _fixture.AddCommand("MongoDbDriverExerciser DistinctAsync");
             _fixture.AddCommand("MongoDbDriverExerciser MapReduce");
             _fixture.AddCommand("MongoDbDriverExerciser MapReduceAsync");
-
-            // the following commands are unavailable in MongoDB.Driver version 2.3
-            if (!_clientVersion23)
-            {
-                _fixture.AddCommand("MongoDbDriverExerciser Watch");
-                _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
-                _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
-                _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
-            }
-
             _fixture.AddCommand("MongoDbDriverExerciser InsertOne");
             _fixture.AddCommand("MongoDbDriverExerciser InsertOneAsync");
             _fixture.AddCommand("MongoDbDriverExerciser InsertMany");
@@ -71,6 +61,15 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
             _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
             _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
+
+            // the following commands are unavailable in MongoDB.Driver version 2.3
+            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+            {
+                _fixture.AddCommand("MongoDbDriverExerciser Watch");
+                _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
+                _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
+                _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
+            }
 
             _fixture.AddActions
             (
@@ -98,261 +97,52 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             Assert.NotNull(m);
         }
 
-        [Fact]
-        public void Count()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Count");
-            Assert.NotNull(m);
-        }
+        [Theory]
+        [InlineData("Count", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("CountAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("Distinct", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("DistinctAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("MapReduce", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("MapReduceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("InsertOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("InsertOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("InsertMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("InsertManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("ReplaceOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("ReplaceOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("UpdateOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("UpdateOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("UpdateMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("UpdateManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("DeleteOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("DeleteOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("DeleteMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("DeleteManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindSync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndDelete", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndDeleteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndReplace", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndReplaceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndUpdate", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("FindOneAndUpdateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("BulkWrite", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("BulkWriteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("Aggregate", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        //[InlineData("AggregateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
 
-        [Fact]
-        public void CountAsync()
+        // Methods unavailable in driver version 2.3
+        [InlineData("CountDocuments", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("CountDocumentsAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        public void CheckForMethodMetrics(string methodName, MongoDBDriverVersion minVersion)
         {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CountAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void CountDocuments()
-        {
-            if (!_clientVersion23)
+            if (_driverVersion >= minVersion)
             {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CountDocuments");
-                Assert.NotNull(m);
+                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{methodName}");
+                Assert.True(m != null, $"Did not find metric for db operation named {methodName}");
             }
-        }
-
-        [Fact]
-        public void CountDocumentsAsync()
-        {
-            if (!_clientVersion23)
-            {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CountDocumentsAsync");
-                Assert.NotNull(m);
-            }
-        }
-
-        [Fact]
-        public void Distinct()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Distinct");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DistinctAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DistinctAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void MapReduce()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/MapReduce");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void MapReduceAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/MapReduceAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void Watch()
-        {
-            if (!_clientVersion23)
-            {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Watch");
-                Assert.NotNull(m);
-            }
-        }
-
-        [Fact]
-        public void WatchAsync()
-        {
-            if (!_clientVersion23)
-            {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/WatchAsync");
-                Assert.NotNull(m);
-            }
-        }
-
-        [Fact]
-        public void InsertOne()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/InsertOne");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void InsertOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/InsertOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void InsertMany()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/InsertMany");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void InsertManyAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/InsertManyAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ReplaceOne()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/ReplaceOne");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ReplaceOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/ReplaceOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void UpdateOne()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/UpdateOne");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void UpdateOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/UpdateOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void UpdateMany()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/UpdateMany");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void UpdateManyAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/UpdateManyAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DeleteOne()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DeleteOne");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DeleteOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DeleteOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DeleteMany()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DeleteMany");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DeleteManyAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DeleteManyAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindSync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindSync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndDelete()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndDelete");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndDeleteAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndDeleteAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndReplace()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndReplace");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndReplaceAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndReplaceAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndUpdate()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndUpdate");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void FindOneAndUpdateAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/FindOneAndUpdateAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void BulkWrite()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/BulkWrite");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void BulkWriteAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/BulkWriteAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void Aggregate()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Aggregate");
-            Assert.NotNull(m);
         }
 
     }
@@ -361,7 +151,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFWLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public MongoDBDriverCollectionTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
         {
         }
     }
@@ -370,7 +160,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFW48 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW48>
     {
         public MongoDBDriverCollectionTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
         {
         }
     }
@@ -379,7 +169,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFW471 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public MongoDBDriverCollectionTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
         {
         }
     }
@@ -390,7 +180,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         public MongoDBDriverCollectionTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
             // 2.3 doesn't support the Watch/WatchAsync methods
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, clientVersion23: true)
+            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
         {
         }
     }
@@ -399,7 +189,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsCoreLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MongoDBDriverCollectionTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
         {
         }
     }
@@ -408,9 +198,16 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsCoreOldest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
     {
         public MongoDBDriverCollectionTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
         {
         }
+    }
+
+    public enum MongoDBDriverVersion
+    {
+        OldestSupportedOnFramework, // 2.3
+        OldestSupportedOnCore, // 2.8.1
+        GreaterThan211 // 2.11 or greater
     }
 
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -30,55 +30,57 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _driverVersion = driverVersion;
 
             _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            _fixture.AddCommand("MongoDbDriverExerciser Count");
-            _fixture.AddCommand("MongoDbDriverExerciser CountAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser Distinct");
-            _fixture.AddCommand("MongoDbDriverExerciser DistinctAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser MapReduce");
-            _fixture.AddCommand("MongoDbDriverExerciser MapReduceAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertOne");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertMany");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOne");
-            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateOne");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateMany");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteOne");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteMany");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindSync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDelete");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDeleteAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplace");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplaceAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdate");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdateAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
-            _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
+            // Async methods first
             _fixture.AddCommand("MongoDbDriverExerciser AggregateAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser CountAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser DeleteManyAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser DeleteOneAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser DistinctAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser FindAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDeleteAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplaceAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdateAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser InsertManyAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser InsertOneAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser MapReduceAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOneAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser UpdateManyAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser UpdateOneAsync");
+             // Then sync methods
+            _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
+            _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
+            _fixture.AddCommand("MongoDbDriverExerciser Count");
+            _fixture.AddCommand("MongoDbDriverExerciser DeleteMany");
+            _fixture.AddCommand("MongoDbDriverExerciser DeleteOne");
+            _fixture.AddCommand("MongoDbDriverExerciser Distinct");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDelete");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplace");
+            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdate");
+            _fixture.AddCommand("MongoDbDriverExerciser FindSync");
+            _fixture.AddCommand("MongoDbDriverExerciser MapReduce");
+            _fixture.AddCommand("MongoDbDriverExerciser InsertMany");
+            _fixture.AddCommand("MongoDbDriverExerciser InsertOne");
+            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOne");
+            _fixture.AddCommand("MongoDbDriverExerciser UpdateMany");
+            _fixture.AddCommand("MongoDbDriverExerciser UpdateOne");
 
             // the following commands are unavailable in MongoDB.Driver version 2.3
             if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
             {
-                _fixture.AddCommand("MongoDbDriverExerciser Watch");
+                _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
+                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
                 _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
                 _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
-                _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
                 _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCount");
-                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
+                _fixture.AddCommand("MongoDbDriverExerciser Watch");
             }
 
             // the following commands are unavailable in MongoDB.Driver versions <2.11
             if (_driverVersion >= MongoDBDriverVersion.AtLeast2_11)
             {
-                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
                 _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollectionAsync");
+                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
             }
 
             _fixture.AddActions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -61,6 +61,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
             _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
             _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
+            _fixture.AddCommand("MongoDbDriverExerciser AggregateAsync");
 
             // the following commands are unavailable in MongoDB.Driver version 2.3
             if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
@@ -69,6 +70,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
                 _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
                 _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
                 _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
+                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCount");
+                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
             }
 
             _fixture.AddActions
@@ -129,11 +132,13 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [InlineData("BulkWrite", MongoDBDriverVersion.OldestSupportedOnFramework)]
         [InlineData("BulkWriteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
         [InlineData("Aggregate", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        //[InlineData("AggregateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("AggregateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
 
         // Methods unavailable in driver version 2.3
         [InlineData("CountDocuments", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("CountDocumentsAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("EstimatedDocumentCount", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("EstimatedDocumentCountAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
         public void CheckForMethodMetrics(string methodName, MongoDBDriverVersion minVersion)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -74,6 +74,13 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
                 _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
             }
 
+            // the following commands are unavailable in MongoDB.Driver versions <2.11
+            if (_driverVersion >= MongoDBDriverVersion.AtLeast2_11)
+            {
+                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
+                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollectionAsync");
+            }
+
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -141,6 +148,11 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         [InlineData("EstimatedDocumentCountAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+
+        //Methods availabile in driver versions >= 2.11
+        [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
+        [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
+
         public void CheckForMethodMetrics(string methodName, MongoDBDriverVersion minVersion)
         {
             if (_driverVersion >= minVersion)
@@ -156,7 +168,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFWLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public MongoDBDriverCollectionTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -165,7 +177,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFW48 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW48>
     {
         public MongoDBDriverCollectionTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -174,7 +186,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsFW471 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public MongoDBDriverCollectionTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -194,7 +206,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverCollectionTestsCoreLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MongoDBDriverCollectionTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.GreaterThan211)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -212,7 +224,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     {
         OldestSupportedOnFramework, // 2.3
         OldestSupportedOnCore, // 2.8.1
-        GreaterThan211 // 2.11 or greater
+        AtLeast2_11 // 2.11 or greater
     }
 
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -45,6 +45,12 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
                 _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
             }
 
+            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnCore)
+            {
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBAsync");
+            }
+
             _fixture.AddActions
             (
                 setupConfiguration: () =>
@@ -92,6 +98,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         // Methods not available in driver version 2.3
         [InlineData("ListCollectionNames", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("ListCollectionNamesAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        // Methods not available in driver version 2.8
+        [InlineData("Aggregate", MongoDBDriverVersion.AtLeast2_11)]
+        [InlineData("AggregateAsync", MongoDBDriverVersion.AtLeast2_11)]
         public void CheckForOperationMetrics(string operationName, MongoDBDriverVersion minVersion)
         {
             if (_driverVersion >= minVersion)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -17,6 +17,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         private string _mongoUrl;
         private MongoDBDriverVersion _driverVersion;
 
+        private readonly string DatastoreStatementPathBase = "Datastore/statement/MongoDB";
+        private readonly string DatastoreOperationPathBase = "Datastore/operation/MongoDB";
+
         public MongoDBDriverDatabaseTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion)  : base(fixture)
         {
             _fixture = fixture;
@@ -68,107 +71,36 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             Assert.NotNull(m);
         }
 
-        [Fact]
-        public void CreateCollection()
+        [Theory]
+        [InlineData("createTestCollection", "CreateCollection")]
+        [InlineData("createTestCollectionAsync", "CreateCollectionAsync")]
+        [InlineData("dropTestCollection", "DropCollection")]
+        [InlineData("dropTestCollectionAsync", "DropCollectionAsync")]
+        public void CheckForStatementMetrics(string collectionName, string operationName)
         {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/statement/MongoDB/createTestCollection/CreateCollection");
-
+            var m = _fixture.AgentLog.GetMetricByName($"{DatastoreStatementPathBase}/{collectionName}/{operationName}");
             Assert.NotNull(m);
         }
 
-        [Fact]
-        public void CreateCollectionAsync()
+        [Theory]
+        [InlineData("ListCollections", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("ListCollectionsAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("RenameCollection", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("RenameCollectionAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("RunCommand", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        [InlineData("RunCommandAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+        // Methods not available in driver version 2.3
+        [InlineData("ListCollectionNames", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("ListCollectionNamesAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        public void CheckForOperationMetrics(string operationName, MongoDBDriverVersion minVersion)
         {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/statement/MongoDB/createTestCollectionAsync/CreateCollectionAsync");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropCollection()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/statement/MongoDB/dropTestCollection/DropCollection");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropCollectionAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/statement/MongoDB/dropTestCollectionAsync/DropCollectionAsync");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ListCollections()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollections");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ListCollectionsAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollectionsAsync");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ListCollectionNames()
-        {
-            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+            if (_driverVersion >= minVersion)
             {
-                var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollectionNames");
-
+                var m = _fixture.AgentLog.GetMetricByName($"{DatastoreOperationPathBase}/{operationName}");
                 Assert.NotNull(m);
             }
         }
 
-        [Fact]
-        public void ListCollectionNamesAsync()
-        {
-            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
-            {
-                var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollectionNamesAsync");
-
-                Assert.NotNull(m);
-            }
-        }
-
-        [Fact]
-        public void RenameCollection()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/RenameCollection");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void RenameCollectionAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/RenameCollectionAsync");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void RunCommand()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/RunCommand");
-
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void RunCommandAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/RunCommandAsync");
-
-            Assert.NotNull(m);
-        }
     }
 
     [NetFrameworkTest]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -28,31 +28,33 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _driverVersion = driverVersion;
 
             _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateCollection");
+             // Async methods first
             _fixture.AddCommand("MongoDBDriverExerciser CreateCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropCollection");
             _fixture.AddCommand("MongoDBDriverExerciser DropCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser ListCollections");
             _fixture.AddCommand("MongoDBDriverExerciser ListCollectionsAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser RenameCollection");
             _fixture.AddCommand("MongoDBDriverExerciser RenameCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser RunCommand");
             _fixture.AddCommand("MongoDBDriverExerciser RunCommandAsync");
+            // Then sync methods
+            _fixture.AddCommand("MongoDBDriverExerciser CreateCollection");
+            _fixture.AddCommand("MongoDBDriverExerciser DropCollection");
+            _fixture.AddCommand("MongoDBDriverExerciser ListCollections");
+            _fixture.AddCommand("MongoDBDriverExerciser RenameCollection");
+            _fixture.AddCommand("MongoDBDriverExerciser RunCommand");
 
             if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
             {
-                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
                 _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser WatchDB");
                 _fixture.AddCommand("MongoDBDriverExerciser WatchDBAsync");
+                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
+                _fixture.AddCommand("MongoDBDriverExerciser WatchDB");
             }
 
             if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnCore)
             {
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
                 _fixture.AddCommand("MongoDBDriverExerciser AggregateDBAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
                 _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollectionAsync");
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
             }
 
             _fixture.AddActions

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -15,12 +15,14 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     {
         private readonly ConsoleDynamicMethodFixture _fixture;
         private string _mongoUrl;
+        private MongoDBDriverVersion _driverVersion;
 
-        public MongoDBDriverDatabaseTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl)  : base(fixture)
+        public MongoDBDriverDatabaseTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion)  : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
             _mongoUrl = mongoUrl;
+            _driverVersion = driverVersion;
 
             _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
             _fixture.AddCommand("MongoDBDriverExerciser CreateCollection");
@@ -33,6 +35,12 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _fixture.AddCommand("MongoDBDriverExerciser RenameCollectionAsync");
             _fixture.AddCommand("MongoDBDriverExerciser RunCommand");
             _fixture.AddCommand("MongoDBDriverExerciser RunCommandAsync");
+
+            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+            {
+                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
+                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
+            }
 
             _fixture.AddActions
             (
@@ -109,6 +117,28 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         }
 
         [Fact]
+        public void ListCollectionNames()
+        {
+            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+            {
+                var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollectionNames");
+
+                Assert.NotNull(m);
+            }
+        }
+
+        [Fact]
+        public void ListCollectionNamesAsync()
+        {
+            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+            {
+                var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/ListCollectionNamesAsync");
+
+                Assert.NotNull(m);
+            }
+        }
+
+        [Fact]
         public void RenameCollection()
         {
             var m = _fixture.AgentLog.GetMetricByName("Datastore/operation/MongoDB/RenameCollection");
@@ -145,7 +175,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverDatabaseTestsFWLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
         public MongoDBDriverDatabaseTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -154,7 +184,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverDatabaseTestsFW48 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW48>
     {
         public MongoDBDriverDatabaseTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -163,7 +193,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverDatabaseTestsFW471 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW471>
     {
         public MongoDBDriverDatabaseTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -173,7 +203,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     {
         public MongoDBDriverDatabaseTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
             // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
         {
         }
     }
@@ -182,7 +212,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverDatabaseTestsCoreLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
         public MongoDBDriverDatabaseTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
         {
         }
     }
@@ -191,7 +221,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
     public class MongoDBDriverDatabaseTestsCoreOldest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
     {
         public MongoDBDriverDatabaseTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
         {
         }
     }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -49,6 +49,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             {
                 _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
                 _fixture.AddCommand("MongoDBDriverExerciser AggregateDBAsync");
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
+                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollectionAsync");
             }
 
             _fixture.AddActions
@@ -101,6 +103,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         // Methods not available in driver version 2.8
         [InlineData("Aggregate", MongoDBDriverVersion.AtLeast2_11)]
         [InlineData("AggregateAsync", MongoDBDriverVersion.AtLeast2_11)]
+        [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
+        [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
         public void CheckForOperationMetrics(string operationName, MongoDBDriverVersion minVersion)
         {
             if (_driverVersion >= minVersion)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -43,6 +43,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             {
                 _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
                 _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
+                _fixture.AddCommand("MongoDBDriverExerciser WatchDB");
+                _fixture.AddCommand("MongoDBDriverExerciser WatchDBAsync");
             }
 
             if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnCore)
@@ -100,6 +102,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
         // Methods not available in driver version 2.3
         [InlineData("ListCollectionNames", MongoDBDriverVersion.OldestSupportedOnCore)]
         [InlineData("ListCollectionNamesAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
+        [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
         // Methods not available in driver version 2.8
         [InlineData("Aggregate", MongoDBDriverVersion.AtLeast2_11)]
         [InlineData("AggregateAsync", MongoDBDriverVersion.AtLeast2_11)]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -62,75 +62,23 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             Assert.NotNull(m);
         }
 
-        [Fact]
-        public void CreateOne()
+        [Theory]
+        [InlineData("CreateOne")]
+        [InlineData("CreateOneAsync")]
+        [InlineData("CreateMany")]
+        [InlineData("CreateManyAsync")]
+        [InlineData("DropAll")]
+        [InlineData("DropAllAsync")]
+        [InlineData("DropOne")]
+        [InlineData("DropOneAsync")]
+        [InlineData("List")]
+        [InlineData("ListAsync")]
+        public void CheckForOperationMetrics(string operationName)
         {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CreateOne");
+            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{operationName}");
             Assert.NotNull(m);
         }
 
-        [Fact]
-        public void CreateOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CreateOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void CreateMany()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CreateMany");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void CreateManyAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/CreateManyAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropAll()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DropAll");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropAllAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DropAllAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropOne()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DropOne");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void DropOneAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/DropOneAsync");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void List()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/List");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ListAsync()
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/ListAsync");
-            Assert.NotNull(m);
-        }
     }
 
     [NetFrameworkTest]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -25,16 +25,18 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
             _mongoUrl = mongoUrl;
 
             _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateOne");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateOneAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateMany");
+            // Async methods first
             _fixture.AddCommand("MongoDBDriverExerciser CreateManyAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropAll");
+            _fixture.AddCommand("MongoDBDriverExerciser CreateOneAsync");
             _fixture.AddCommand("MongoDBDriverExerciser DropAllAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropOne");
             _fixture.AddCommand("MongoDBDriverExerciser DropOneAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser List");
             _fixture.AddCommand("MongoDBDriverExerciser ListAsync");
+            // Then sync
+            _fixture.AddCommand("MongoDBDriverExerciser CreateMany");
+            _fixture.AddCommand("MongoDBDriverExerciser CreateOne");
+            _fixture.AddCommand("MongoDBDriverExerciser DropAll");
+            _fixture.AddCommand("MongoDBDriverExerciser DropOne");
+            _fixture.AddCommand("MongoDBDriverExerciser List");
 
             _fixture.AddActions
             (


### PR DESCRIPTION
## Description

This PR resolves #1637 and adds instrumentation for the following `MongoDB.Driver` methods previously ignored by the agent:

- IMongoCollection:
  - CountDocuments[Async]
  - EstimatedDocumentCount[Async]
  - AggregateToCollection[Async]
- IMongoDatabase:
  - ListCollectionNames[Async]
  - Aggregate[Async]
  - AggregateToCollection[Async]
  - Watch[Async]

This PR also refactors most of the MongoDB.Driver integration tests to use the `Theory` feature of XUnit to reduce test code duplication.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
