### PR TITLE
fix: Format and log audit-level messages only when audit logging is enabled.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -156,10 +156,14 @@ namespace NewRelic.Agent.Core.DataTransport
             }
         }
 
-        private static void AuditLog(Direction direction, Source source, string uri)
+        private void AuditLog(Direction direction, Source source, string uri)
         {
-            var message = string.Format(AuditLogFormat, direction, source, Strings.ObfuscateLicenseKeyInAuditLog(uri, LicenseKeyParameterName));
-            Logging.AuditLog.Log(message);
+            if (Logging.AuditLog.IsAuditLogEnabled)
+            {
+                var message = string.Format(AuditLogFormat, direction, source,
+                    Strings.ObfuscateLicenseKeyInAuditLog(uri, LicenseKeyParameterName));
+                Logging.AuditLog.Log(message);
+            }
         }
 
         private Uri GetUri(string method, ConnectionInfo connectionInfo)

--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -13,21 +13,23 @@ namespace NewRelic.Agent.Core.Logging
         private static Lazy<ILogger> _lazyAuditLogger = new Lazy<ILogger>(() =>
             Serilog.Log.Logger.ForContext(LogLevelExtensions.AuditLevel, LogLevelExtensions.AuditLevel));
 
+        public static bool IsAuditLogEnabled { get; private set; }
+
         /// <summary>
         /// Logs <paramref name="message"/> at the AUDIT level. This log level should be used only as dictated by the security team to satisfy auditing requirements.
         /// </summary>
         public static void Log(string message)
         {
+            if (IsAuditLogEnabled)
                 // use Fatal log level to ensure audit log messages never get filtered due to level restrictions
                 _lazyAuditLogger.Value.Fatal(message);
         }
 
         internal static LoggerConfiguration IncludeOnlyAuditLog(this LoggerConfiguration loggerConfiguration)
         {
-            return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is not null");
+            IsAuditLogEnabled = true; // set a flag so we can short-circuit when audit log is not enabled
 
-            //return loggerConfiguration.Filter.ByIncludingOnly(logEvent =>
-            //    logEvent.Properties.ContainsKey(LogLevelExtensions.AuditLevel));
+            return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is not null");
         }
         internal static LoggerConfiguration ExcludeAuditLog(this LoggerConfiguration loggerConfiguration)
         {

--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -10,10 +10,21 @@ namespace NewRelic.Agent.Core.Logging
     public static class AuditLog
     {
         // a lazy ILogger instance that injects an "Audit" property
-        private static Lazy<ILogger> _lazyAuditLogger = new Lazy<ILogger>(() =>
-            Serilog.Log.Logger.ForContext(LogLevelExtensions.AuditLevel, LogLevelExtensions.AuditLevel));
+        private static Lazy<ILogger> _lazyAuditLogger = LazyAuditLogger();
 
         public static bool IsAuditLogEnabled { get; set; } //setter is public only for unit tests, not expected to be use anywhere else
+
+        // for unit tests only
+        public static void ResetLazyLogger()
+        {
+            _lazyAuditLogger = LazyAuditLogger();
+        }
+
+        private static Lazy<ILogger> LazyAuditLogger()
+        {
+            return new Lazy<ILogger>(() =>
+                Serilog.Log.Logger.ForContext(LogLevelExtensions.AuditLevel, LogLevelExtensions.AuditLevel));
+        }
 
         /// <summary>
         /// Logs <paramref name="message"/> at the AUDIT level. This log level should be used only as dictated by the security team to satisfy auditing requirements.

--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -13,7 +13,7 @@ namespace NewRelic.Agent.Core.Logging
         private static Lazy<ILogger> _lazyAuditLogger = new Lazy<ILogger>(() =>
             Serilog.Log.Logger.ForContext(LogLevelExtensions.AuditLevel, LogLevelExtensions.AuditLevel));
 
-        public static bool IsAuditLogEnabled { get; private set; }
+        public static bool IsAuditLogEnabled { get; set; } //setter is public only for unit tests, not expected to be use anywhere else
 
         /// <summary>
         /// Logs <paramref name="message"/> at the AUDIT level. This log level should be used only as dictated by the security team to satisfy auditing requirements.
@@ -25,14 +25,17 @@ namespace NewRelic.Agent.Core.Logging
                 _lazyAuditLogger.Value.Fatal(message);
         }
 
-        internal static LoggerConfiguration IncludeOnlyAuditLog(this LoggerConfiguration loggerConfiguration)
+        public static LoggerConfiguration IncludeOnlyAuditLog(this LoggerConfiguration loggerConfiguration)
         {
-            IsAuditLogEnabled = true; // set a flag so we can short-circuit when audit log is not enabled
+            IsAuditLogEnabled = true; // set a flag so Log() can short-circuit when audit log is not enabled
 
             return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is not null");
         }
-        internal static LoggerConfiguration ExcludeAuditLog(this LoggerConfiguration loggerConfiguration)
+
+        public static LoggerConfiguration ExcludeAuditLog(this LoggerConfiguration loggerConfiguration)
         {
+            IsAuditLogEnabled = false; // set a flag so Log() can short-circuit when audit log is not enabled
+
             return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is null");
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
@@ -39,7 +39,6 @@ namespace NewRelic.Agent.Core.DataTransport
 
             _mockILogger = Mock.Create<ILogger>();
             Log.Logger = _mockILogger;
-
         }
 
         private HttpCollectorWire CreateHttpCollectorWire(Dictionary<string, string> requestHeadersMap = null)
@@ -314,12 +313,12 @@ namespace NewRelic.Agent.Core.DataTransport
             Assert.AreEqual(false, _mockHttpMessageHandler.SendAsyncInvoked);
         }
 
-        [Test]
         [TestCase(false)]
         [TestCase(true)]
         public void SendData_ShouldNotCallAuditLog_UnlessAuditLogIsEnabled(bool isEnabled)
         {
             // Arrange
+            AuditLog.ResetLazyLogger();
             Mock.Arrange(() => _configuration.AgentLicenseKey).Returns("license_key");
             Mock.Arrange(() => _configuration.CollectorMaxPayloadSizeInBytes).Returns(1024);
 
@@ -341,7 +340,7 @@ namespace NewRelic.Agent.Core.DataTransport
             AuditLog.IsAuditLogEnabled = isEnabled;
 
             // Act
-            var response = collectorWire.SendData("test_method", connectionInfo, serializedData, Guid.NewGuid());
+            var _ = collectorWire.SendData("test_method", connectionInfo, serializedData, Guid.NewGuid());
 
             // Assert
             Mock.Assert(() => mockForContextLogger.Fatal(Arg.AnyString), isEnabled ? Occurs.Exactly(3) : Occurs.Never());

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
@@ -15,6 +15,8 @@ using NUnit.Framework;
 using System.Threading.Tasks;
 using System.Threading;
 using NewRelic.Agent.Core.Exceptions;
+using NewRelic.Agent.Core.Logging;
+using Serilog;
 using Telerik.JustMock;
 
 namespace NewRelic.Agent.Core.DataTransport
@@ -26,6 +28,7 @@ namespace NewRelic.Agent.Core.DataTransport
         private IAgentHealthReporter _agentHealthReporter;
         private IHttpClientFactory _httpClientFactory;
         private MockHttpMessageHandler _mockHttpMessageHandler;
+        private ILogger _mockILogger;
 
         [SetUp]
         public void SetUp()
@@ -33,6 +36,10 @@ namespace NewRelic.Agent.Core.DataTransport
             _configuration = Mock.Create<IConfiguration>();
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
             _httpClientFactory = Mock.Create<IHttpClientFactory>();
+
+            _mockILogger = Mock.Create<ILogger>();
+            Log.Logger = _mockILogger;
+
         }
 
         private HttpCollectorWire CreateHttpCollectorWire(Dictionary<string, string> requestHeadersMap = null)
@@ -305,6 +312,39 @@ namespace NewRelic.Agent.Core.DataTransport
             Mock.Assert(() => _agentHealthReporter.ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit("test_method"), Occurs.Once());
             Mock.Assert(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>()), Occurs.Never());
             Assert.AreEqual(false, _mockHttpMessageHandler.SendAsyncInvoked);
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void SendData_ShouldNotCallAuditLog_UnlessAuditLogIsEnabled(bool isEnabled)
+        {
+            // Arrange
+            Mock.Arrange(() => _configuration.AgentLicenseKey).Returns("license_key");
+            Mock.Arrange(() => _configuration.CollectorMaxPayloadSizeInBytes).Returns(1024);
+
+            var connectionInfo = new ConnectionInfo(_configuration);
+            var serializedData = "{ \"key\": \"value\" }";
+            var httpResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+
+            CreateMockHttpClient(httpResponse, false);
+
+            var collectorWire = CreateHttpCollectorWire();
+
+            // ensure that .ForContext() just returns the mock logger instance
+            Mock.Arrange(() => _mockILogger.ForContext(Arg.AnyString, Arg.AnyObject, false))
+                .Returns(() => _mockILogger);
+
+            AuditLog.IsAuditLogEnabled = isEnabled;
+
+            // Act
+            var response = collectorWire.SendData("test_method", connectionInfo, serializedData, Guid.NewGuid());
+
+            // Assert
+            Mock.Assert(() => _mockILogger.Fatal(Arg.AnyString), isEnabled ? Occurs.Exactly(3) : Occurs.Never());
         }
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
@@ -334,9 +334,9 @@ namespace NewRelic.Agent.Core.DataTransport
 
             var collectorWire = CreateHttpCollectorWire();
 
-            // ensure that .ForContext() just returns the mock logger instance
+            var mockForContextLogger = Mock.Create<ILogger>();
             Mock.Arrange(() => _mockILogger.ForContext(Arg.AnyString, Arg.AnyObject, false))
-                .Returns(() => _mockILogger);
+                .Returns(() => mockForContextLogger);
 
             AuditLog.IsAuditLogEnabled = isEnabled;
 
@@ -344,7 +344,7 @@ namespace NewRelic.Agent.Core.DataTransport
             var response = collectorWire.SendData("test_method", connectionInfo, serializedData, Guid.NewGuid());
 
             // Assert
-            Mock.Assert(() => _mockILogger.Fatal(Arg.AnyString), isEnabled ? Occurs.Exactly(3) : Occurs.Never());
+            Mock.Assert(() => mockForContextLogger.Fatal(Arg.AnyString), isEnabled ? Occurs.Exactly(3) : Occurs.Never());
         }
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NUnit.Framework;
+using Serilog;
+using Serilog.Configuration;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.Logging.Tests
+{
+    [TestFixture]
+    public class AuditLogTests
+    {
+        private ILogger _mockILogger;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockILogger = Mock.Create<ILogger>();
+            Log.Logger = _mockILogger;
+
+            // reset state for each test
+            AuditLog.IsAuditLogEnabled = false;
+        }
+
+        [Test]
+        public void IncludeOnlyAuditLog_EnablesAuditLog()
+        {
+            Assert.False(AuditLog.IsAuditLogEnabled);
+
+            var _ = new LoggerConfiguration().IncludeOnlyAuditLog();
+
+            Assert.True(AuditLog.IsAuditLogEnabled);
+        }
+
+        [Test]
+        public void ExcludeAuditLog_DisablesAuditLog()
+        {
+            AuditLog.IsAuditLogEnabled = true;
+
+            var _ = new LoggerConfiguration().ExcludeAuditLog();
+
+            Assert.False(AuditLog.IsAuditLogEnabled);
+        }
+
+        [Test]
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Log_OnlyLogsWhenAuditLogEnabled(bool logEnabled)
+        {
+            // ensure that .ForContext() just returns the mock logger instance
+            Mock.Arrange(() => _mockILogger.ForContext(Arg.AnyString, Arg.AnyObject, false))
+                .Returns(() => _mockILogger);
+        
+            AuditLog.IsAuditLogEnabled = logEnabled;
+
+            var message = "This is an audit message";
+
+            AuditLog.Log(message);
+
+            Mock.Assert(() => _mockILogger.Fatal(message), logEnabled ? Occurs.Once() : Occurs.Never());
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
@@ -20,7 +20,14 @@ namespace NewRelic.Agent.Core.Logging.Tests
             Log.Logger = _mockILogger;
 
             // reset state for each test
+            AuditLog.ResetLazyLogger();
             AuditLog.IsAuditLogEnabled = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AuditLog.ResetLazyLogger();
         }
 
         [Test]
@@ -43,9 +50,8 @@ namespace NewRelic.Agent.Core.Logging.Tests
             Assert.False(AuditLog.IsAuditLogEnabled);
         }
 
-        [Test]
-        [TestCase(false)]
         [TestCase(true)]
+        [TestCase(false)]
         public void Log_OnlyLogsWhenAuditLogEnabled(bool logEnabled)
         {
             var mockForContextLogger = Mock.Create<ILogger>();

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
@@ -48,9 +48,9 @@ namespace NewRelic.Agent.Core.Logging.Tests
         [TestCase(true)]
         public void Log_OnlyLogsWhenAuditLogEnabled(bool logEnabled)
         {
-            // ensure that .ForContext() just returns the mock logger instance
+            var mockForContextLogger = Mock.Create<ILogger>();
             Mock.Arrange(() => _mockILogger.ForContext(Arg.AnyString, Arg.AnyObject, false))
-                .Returns(() => _mockILogger);
+                .Returns(() => mockForContextLogger);
         
             AuditLog.IsAuditLogEnabled = logEnabled;
 
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.Logging.Tests
 
             AuditLog.Log(message);
 
-            Mock.Assert(() => _mockILogger.Fatal(message), logEnabled ? Occurs.Once() : Occurs.Never());
+            Mock.Assert(() => mockForContextLogger.Fatal(message), logEnabled ? Occurs.Once() : Occurs.Never());
         }
     }
 }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description
Adds code to check whether audit logging is enabled before going to the trouble of formatting audit log messages and sending them to Serilog. 

(Note that Serilog would already suppress sending those messages if audit logging was disabled, so there's no functional change with this PR, only an optimization to reduce unnecessary string formatting and Serilog calls.)

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
