### PR TITLE
chore: update latest versions of instrumented libraries tested

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -94,11 +94,11 @@
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.608" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.88" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.111" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" Condition="'$(TargetFramework)' == 'net481'" />
     
     <!-- StackExchange.Redis .NET/Core references -->
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.111" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.116" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- Elasticsearch NEST framework references - only able to test newest 7.x with 8.x server -->
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net462'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -141,7 +141,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net48'" />
 
-    <PackageReference Include="Serilog" Version="2.12.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="3.0.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net481'" />
 
@@ -153,7 +153,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 
-    <PackageReference Include="Serilog" Version="2.12.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="Serilog" Version="3.0.1" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net7.0'" />
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -73,12 +73,12 @@
     <PackageReference Include="MongoDB.Driver" Version="2.3.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.2" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MongoDB.Driver .NET/Core references -->
     <!-- Minimum version we can use with .NET core 3.0 or greater is 2.8.1, due to this bug: https://github.com/mongodb/mongo-csharp-driver/pull/372 -->
     <PackageReference Include="MongoDB.Driver" Version="2.8.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.2" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- MySqlConnector framework references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION
Update the latest version tested of the following instrumented libraries:

Serilog (3.0.1)
MongoDB.Driver (2.20.0)
Stackexchange.Redis (2.6.116)

Associated docs site updates: https://github.com/nr-ahemsath/docs-website/tree/add-new-mongodb-instrumented-methods-10-12-0 (not a PR yet because this contains updates that won't be valid until agent version 10.12.0 is released)