### PR TITLE
chore: remove mongocsharpdriver from Dotty's list of concerns

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -77,7 +77,6 @@ jobs:
                  microsoft.extensions.logging
                  microsoft.data.sqlclient
                  microsoft.net.http
-                 mongocsharpdriver
                  mongodb.driver
                  mysql.data
                  mysqlconnector


### PR DESCRIPTION
`mongocsharpdriver` doesn't need to be in Dotty's list of packages to watch for updates.  It's the legacy C# client package for MongoDB.  MongoDB.Driver is the modern C# client that we stay on top of updates for.  We only support (and test) 1.x versions of mongocsharpdriver.
