### PR TITLE
fix: Update install script to correctly stop and restart IIS.

### DIFF
--- a/build/Packaging/NugetAzureCloudServices/content/newrelic.cmd
+++ b/build/Packaging/NugetAzureCloudServices/content/newrelic.cmd
@@ -54,9 +54,9 @@ IF %NR_ERROR_LEVEL% EQU 0 (
 	:: 	if we are in a Worker Role then there is no need to restart W3SVC _or_
 	:: 	if we are emulating locally then do not restart W3SVC
 	IF "%IsWorkerRole%" EQU "false" (
-		ECHO Restarting IIS and W3SVC to pick up the new environment variables. >> "%RoleRoot%\nr-%NR_INSTALLID%.log" 2>&1
-		IISRESET
-		NET START W3SVC
+		ECHO Restarting IIS to pick up the new environment variables. >> "%RoleRoot%\nr-%NR_INSTALLID%.log" 2>&1
+		IISRESET /STOP
+		IISRESET /START
 	)
 
 	IF %ERRORLEVEL% EQU 0 (


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Based on [this blog article](https://powershelladministrator.com/2014/09/08/net-stopstart-w3svc-and-stopstart-service-w3svc-vs-iisrest-stopstart/comment-page-1/), I modified the `newrelic.cmd` script to do
```
IISRESET /STOP
IISRESET /START
```
which results in `%ERRORLEVEL%` being `0` in cases where the w3svc was already stopped.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
