### PR TITLE
ci: Update all solutions workflow to create self-signed cert only on non-release builds.

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -46,6 +46,9 @@ jobs:
       agentVersion: ${{ steps.agentVersion.outputs.version }}
 
     steps:
+      - name: echo event name and input value
+        run: echo ${{ github.event_name }} - ${{ github.event.inputs.build-for-release }}
+
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3        
         with:
@@ -114,7 +117,7 @@ jobs:
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: github.event_name == 'pull_request' || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'false' }} || github.event_name == 'schedule'
+        if: ${{ github.event_name == 'pull_request' }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'false' }} || ${{ github.event_name == 'schedule' }}
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -46,9 +46,6 @@ jobs:
       agentVersion: ${{ steps.agentVersion.outputs.version }}
 
     steps:
-      - name: echo event name and input value
-        run: echo ${{ github.event_name }} - ${{ github.event.inputs.build-for-release }}
-
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3        
         with:
@@ -100,7 +97,7 @@ jobs:
           if-no-files-found: error
 
       - name: Convert Code Signing Certificate Into File
-        if: ${{ github.event.release }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true' }}
+        if: ${{ github.event.release || (github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true') }}
         id: write_cert
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
@@ -110,14 +107,14 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
-        if: ${{ github.event.release }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true' }}
+        if: ${{ github.event.release || (github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true') }}
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: ${{ github.event_name == 'pull_request' }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'false' }} || ${{ github.event_name == 'schedule' }}
+        if: ${{ (github.event_name == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'false') || github.event_name == 'schedule' }}
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -9,6 +9,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      build-for-release:
+        description: 'Set to "true" when manually building for a release. Otherwise, "False"'
+        required: true
+        default: 'false'
 
   schedule:
     - cron: "0 9 * * *"
@@ -91,7 +96,7 @@ jobs:
           if-no-files-found: error
 
       - name: Convert Code Signing Certificate Into File
-        if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release == 'true' }})
         id: write_cert
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
@@ -101,14 +106,14 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
-        if: ${{ github.event.release }} || github.event_name == 'workflow_dispatch'
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release == 'true' }})
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release != 'true' }}) || github.event_name == 'schedule'
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -11,9 +11,10 @@ on:
   workflow_dispatch:
     inputs:
       build-for-release:
-        description: 'Set to "true" when manually building for a release. Otherwise, "False"'
+        description: 'Set to true when manually building for a release. Otherwise, false'
         required: true
-        default: 'false'
+        type: boolean
+        default: false
 
   schedule:
     - cron: "0 9 * * *"
@@ -96,7 +97,7 @@ jobs:
           if-no-files-found: error
 
       - name: Convert Code Signing Certificate Into File
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release == 'true' }})
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release }})
         id: write_cert
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
@@ -106,14 +107,14 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release == 'true' }})
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release }})
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ${{ inputs.build-for-release != 'true' }}) || github.event_name == 'schedule'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !${{ github.event.inputs.build-for-release }}) || github.event_name == 'schedule'
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -97,7 +97,7 @@ jobs:
           if-no-files-found: error
 
       - name: Convert Code Signing Certificate Into File
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'true' }})
+        if: ${{ github.event.release }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true' }}
         id: write_cert
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
@@ -107,14 +107,14 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'true'}})
+        if: ${{ github.event.release }} || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'true' }}
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'false' }}) || github.event_name == 'schedule'
+        if: github.event_name == 'pull_request' || ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-for-release == 'false' }} || github.event_name == 'schedule'
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       build-for-release:
-        description: 'Set to true when manually building for a release. Otherwise, false'
+        description: 'This is a Release build. Use the "real" code signing certificate.'
         required: true
         type: boolean
         default: false
@@ -97,7 +97,7 @@ jobs:
           if-no-files-found: error
 
       - name: Convert Code Signing Certificate Into File
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release }})
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'true' }})
         id: write_cert
         run: |
           $filePath = '${{ github.workspace }}\newrelic_code_sign_cert.pfx'
@@ -107,14 +107,14 @@ jobs:
         shell: powershell
 
       - name: Install Code Signing Certificate
-        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release }})
+        if: ${{ github.event.release }} || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'true'}})
         run: |
           Write-Host "certutil.exe -f -user -p <passphrase> -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot"
           certutil.exe -f -user -p ${{ secrets.CERT_PASSPHRASE }} -importPFX ${{ steps.write_cert.outputs.filePath }} NoRoot
         shell: powershell
 
       - name: Create Self-signed code signing cert
-        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !${{ github.event.inputs.build-for-release }}) || github.event_name == 'schedule'
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.build-for-release == 'false' }}) || github.event_name == 'schedule'
         run: |
           Write-Host "New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)"
           New-SelfSignedCertificate -DnsName "Self-signed code signing cert" -Type CodeSigning -CertStoreLocation Cert:\CurrentUser\My -NotAfter (Get-Date).AddYears(100)


### PR DESCRIPTION
Adds an input for the workflow_dispatch trigger to indicate whether we're manually running the workflow for purposes of creating a release. If `true`, we use the "real" code signing cert; otherwise, we use a self-signed cert.