### PR TITLE
ci: Update AwsLamba unit tests to .NET 7.0

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: dotnet restore
 
       - name: Build & Run Unit Tests
-        run: dotnet test --verbosity minimal --no-restore --settings tests\UnitTests.runsettings --results-directory ${{ env.test_results_path }} --filter 'FullyQualifiedName!~AwsLambda'
+        run: dotnet test --verbosity minimal --no-restore --settings tests\UnitTests.runsettings --results-directory ${{ env.test_results_path }}
 
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: dotnet restore
 
       - name: Build & Run Unit Tests
-        run: dotnet test --verbosity minimal --no-restore --settings tests\UnitTests.runsettings --results-directory ${{ env.test_results_path }}
+        run: dotnet test --verbosity minimal --no-restore --settings tests\UnitTests.runsettings --results-directory ${{ env.test_results_path }} --filter 'FullyQualifiedName!~AwsLambda'
 
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/AwsLambdaOpenTracerTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaOpenTracerTests/AwsLambdaOpenTracerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>NewRelic.Tests.AwsLambda.AwsLambdaOpenTracerTests</RootNamespace>
     <AssemblyName>NewRelic.Tests.AwsLambda.AwsLambdaOpenTracerTests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>NewRelic.Tests.AwsLambda.AwsLambdaWrapperTests</RootNamespace>
     <AssemblyName>NewRelic.Tests.AwsLambda.AwsLambdaWrapperTests</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Fixes unit test workflow failure related to .NET Core 3.1 no longer being available on the test runners. (A better solution would be to either remove or exclude the AwsLambda unit test projects since we don't need them, but this will work for now.)