### PR TITLE
ci: Update debian image used in package deploy Dockerfile

### DIFF
--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:buster-20230703-slim
 
 RUN apt-get update && apt-get install -y \
     apt-utils \

--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:stable-slim
 
 RUN apt-get update && apt-get install -y \
     apt-utils \

--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20230202-slim
+FROM debian:stable
 
 RUN apt-get update && apt-get install -y \
     apt-utils \


### PR DESCRIPTION
Updates debian image to latest (buster-20230703-slim) to address security vulnerabilities reported by Snyk. 