### PR TITLE
ci: Add sha to pin debian:buster-slim image

### DIFF
--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20230703-slim
+FROM debian:buster-20230703-slim@sha256:cddb688e1263b9752275b064171ef6ac9c70ae21a77c774339aecfb53690b9a1
 
 RUN apt-get update && apt-get install -y \
     apt-utils \


### PR DESCRIPTION
Resolves a code security alert by pinning the debian:buster image with a sha. 