### PR TITLE
fix: Remove invalid trailing comma added to W3C tracestate header.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
@@ -12,6 +12,7 @@ using NewRelic.Core.DistributedTracing;
 using NewRelic.Core.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NewRelic.Agent.Core.DistributedTracing
 {
@@ -162,7 +163,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
             var newRelicTracestate = $"{accountKey}@nr={version}-{parentType}-{parentAccountId}-{appId}-{spanId}-{transactionId}-{sampled}-{priority}-{timestampInMillis}";
             var otherVendorTracestates = string.Empty;
 
-            if (transaction.TracingState?.VendorStateEntries != null)
+            if (transaction.TracingState?.VendorStateEntries != null && transaction.TracingState.VendorStateEntries.Any())
             {
                 otherVendorTracestates = string.Join(",", transaction.TracingState.VendorStateEntries);
             }

--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
@@ -162,12 +162,15 @@ namespace NewRelic.Agent.Core.DistributedTracing
             var newRelicTracestate = $"{accountKey}@nr={version}-{parentType}-{parentAccountId}-{appId}-{spanId}-{transactionId}-{sampled}-{priority}-{timestampInMillis}";
             var otherVendorTracestates = string.Empty;
 
-            if (transaction.TracingState != null)
+            if (transaction.TracingState?.VendorStateEntries != null)
             {
-                if (transaction.TracingState.VendorStateEntries != null)
-                {
-                    otherVendorTracestates = string.Join(",", transaction.TracingState.VendorStateEntries);
-                }
+                otherVendorTracestates = string.Join(",", transaction.TracingState.VendorStateEntries);
+            }
+
+            // If otherVendorTracestates is null/empty we get a trailing comma.
+            if (string.IsNullOrWhiteSpace(otherVendorTracestates))
+            {
+                return newRelicTracestate;
             }
 
             return string.Join(",", newRelicTracestate, otherVendorTracestates);


### PR DESCRIPTION
## Description

- Refactors DistributedTracePayloadHandler.BuildTracestate to detect empty vendor states and not use string.Join to create the tracestate which could result in trailing commas.
- Adds unit tests to confirm that we don't add trailing commas.

Resolves #1775 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
