### PR TITLE
test: add an Elasticsearch 7.x server to test infrastructure and use it to test older clients

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
@@ -33,7 +33,8 @@ namespace NewRelic.Agent.IntegrationTests.Shared
             }
         }
 
-        public static string ElasticUserName {
+        public static string ElasticUserName
+        {
             get
             {
                 if (_elasticUserName == null)
@@ -52,7 +53,8 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                 return _elasticUserName;
             }
         }
-        public static string ElasticPassword {
+        public static string ElasticPassword
+        {
             get
             {
                 if (_elasticPassword == null)
@@ -61,6 +63,75 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                     {
                         var testConfiguration =
                             IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                        _elasticPassword = testConfiguration["Password"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticPassword;
+            }
+        }
+    }
+    public class ElasticSearch7Configuration
+    {
+        private static string _elasticServer;
+        private static string _elasticUserName;
+        private static string _elasticPassword;
+
+        public static string ElasticServer
+        {
+            get
+            {
+                if (_elasticServer == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch7Tests");
+                        _elasticServer = testConfiguration["Server"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+
+                return _elasticServer;
+            }
+        }
+
+        public static string ElasticUserName
+        {
+            get
+            {
+                if (_elasticUserName == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch7Tests");
+                        _elasticUserName = testConfiguration["UserName"];
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception("ElasticServer configuration is invalid.", ex);
+                    }
+                }
+                return _elasticUserName;
+            }
+        }
+        public static string ElasticPassword
+        {
+            get
+            {
+                if (_elasticPassword == null)
+                {
+                    try
+                    {
+                        var testConfiguration =
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch7Tests");
                         _elasticPassword = testConfiguration["Password"];
                     }
                     catch (Exception ex)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -100,23 +100,23 @@
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.116" Condition="'$(TargetFramework)' == 'net7.0'" />
 
-    <!-- Elasticsearch NEST framework references - only able to test newest 7.x with 8.x server -->
+    <!-- Elasticsearch NEST framework references -->
     <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NEST" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NEST" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
-    <!-- Elasticsearch NEST .NET/Core references - only able to test newest 7.x with 8.x server -->
+    <!-- Elasticsearch NEST .NET/Core references -->
     <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
 
-    <!-- Elasticsearch.Net framework references - only able to test newest 7.x with 8.x server -->
+    <!-- Elasticsearch.Net framework references -->
     <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
-    <!-- Elasticsearch.Net .NET/Core references - only able to test newest 7.x with 8.x server -->
+    <!-- Elasticsearch.Net .NET/Core references -->
     <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -101,23 +101,23 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.116" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- Elasticsearch NEST framework references - only able to test newest 7.x with 8.x server -->
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="NEST" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="NEST" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elasticsearch NEST .NET/Core references - only able to test newest 7.x with 8.x server -->
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- Elasticsearch.Net framework references - only able to test newest 7.x with 8.x server -->
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net462'" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net471'" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elasticsearch.Net .NET/Core references - only able to test newest 7.x with 8.x server -->
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <!-- Elastic.Clients.Elasticsearch framework references - only actually testing oldest and newest -->

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
@@ -13,6 +14,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
     internal class ElasticsearchElasticClient : ElasticsearchTestClient
     {
         private ElasticsearchClient _client;
+        protected override Uri Address
+        {
+            get
+            {
+                return new Uri(ElasticSearchConfiguration.ElasticServer);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -21,13 +21,26 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 return new Uri(ElasticSearchConfiguration.ElasticServer);
             }
         }
+        protected override string Username
+        {
+            get
+            {
+                return ElasticSearchConfiguration.ElasticUserName;
+            }
+        }
+        protected override string Password
+        {
+            get
+            {
+                return ElasticSearchConfiguration.ElasticPassword;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
             var settings = new ElasticsearchClientSettings(Address)
-                    .Authentication(new BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
-                    ElasticSearchConfiguration.ElasticPassword)).
+                    .Authentication(new BasicAuthentication(Username, Password)).
                     DefaultIndex(IndexName);
 
             _client = new ElasticsearchClient(settings);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -21,14 +21,26 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 return new Uri(ElasticSearch7Configuration.ElasticServer);
             }
         }
+        protected override string Username
+        {
+            get
+            {
+                return ElasticSearch7Configuration.ElasticUserName;
+            }
+        }
+        protected override string Password
+        {
+            get
+            {
+                return ElasticSearch7Configuration.ElasticPassword;
+            }
+        }
 
-
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
             var settings = new ConnectionSettings(Address).
-                BasicAuthentication(ElasticSearch7Configuration.ElasticUserName,
-                ElasticSearch7Configuration.ElasticPassword).
+                BasicAuthentication(Username,Password).
                 DefaultIndex(IndexName);
 
             _client = new ElasticClient(settings);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
@@ -13,13 +14,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
     internal class ElasticsearchNestClient : ElasticsearchTestClient
     {
         private ElasticClient _client;
+        protected override Uri Address
+        {
+            get
+            {
+                return new Uri(ElasticSearch7Configuration.ElasticServer);
+            }
+        }
+
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
             var settings = new ConnectionSettings(Address).
-                BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
-                ElasticSearchConfiguration.ElasticPassword).
+                BasicAuthentication(ElasticSearch7Configuration.ElasticUserName,
+                ElasticSearch7Configuration.ElasticPassword).
                 DefaultIndex(IndexName);
 
             _client = new ElasticClient(settings);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -14,13 +14,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
     internal class ElasticsearchNetClient : ElasticsearchTestClient
     {
         private ElasticLowLevelClient _client;
+        protected override Uri Address
+        {
+            get
+            {
+                return new Uri(ElasticSearch7Configuration.ElasticServer);
+            }
+        }
+
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
             var settings = new ConnectionConfiguration(Address)
-                .BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
-                    ElasticSearchConfiguration.ElasticPassword)
+                .BasicAuthentication(ElasticSearch7Configuration.ElasticUserName,
+                    ElasticSearch7Configuration.ElasticPassword)
                 .RequestTimeout(TimeSpan.FromMinutes(2));
 
             _client = new ElasticLowLevelClient(settings);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -21,14 +21,26 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 return new Uri(ElasticSearch7Configuration.ElasticServer);
             }
         }
-
+        protected override string Username
+        {
+            get
+            {
+                return ElasticSearch7Configuration.ElasticUserName;
+            }
+        }
+        protected override string Password
+        {
+            get
+            {
+                return ElasticSearch7Configuration.ElasticPassword;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Connect()
         {
             var settings = new ConnectionConfiguration(Address)
-                .BasicAuthentication(ElasticSearch7Configuration.ElasticUserName,
-                    ElasticSearch7Configuration.ElasticPassword)
+                .BasicAuthentication(Username, Password)
                 .RequestTimeout(TimeSpan.FromMinutes(2));
 
             _client = new ElasticLowLevelClient(settings);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using NewRelic.Agent.IntegrationTests.Shared;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -15,6 +14,14 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         protected const string BadIndexName = "_ILLEGAL";
 
         protected abstract Uri Address
+        {
+            get;
+        }
+        protected abstract string Username
+        {
+            get;
+        }
+        protected abstract string Password
         {
             get;
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -14,7 +14,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         protected const string IndexName = "flights";   // Must be lowercase!
         protected const string BadIndexName = "_ILLEGAL";
 
-        protected Uri Address = new Uri(ElasticSearchConfiguration.ElasticServer);
+        protected abstract Uri Address
+        {
+            get;
+        }
 
         public ElasticsearchTestClient() { }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
         protected readonly ConsoleDynamicMethodFixture _fixture;
 
-        protected readonly string _host = GetHostFromElasticServer(ElasticSearchConfiguration.ElasticServer);
+        protected readonly string _host;
 
         protected readonly ClientType _clientType;
 
@@ -39,13 +39,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             _fixture.TestLogger = output;
             _clientType = clientType;
 
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _host = GetHostFromElasticServer(_clientType);
 
-            if (_clientType != ClientType.ElasticClients)
-            {
-                // This lets 7.x clients work with an 8.x server
-                _fixture.SetAdditionalEnvironmentVariable("ELASTIC_CLIENT_APIVERSIONING", "true");
-            }
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
             _fixture.AddCommand($"ElasticsearchExerciser SetClient {clientType}");
 
@@ -180,8 +176,10 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             );
         }
 
-        private static string GetHostFromElasticServer(string elasticServer)
+        private static string GetHostFromElasticServer(ClientType clientType)
         {
+            var elasticServer = clientType == ClientType.ElasticClients ? ElasticSearchConfiguration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
+  
             if (elasticServer.StartsWith("https://"))
             {
                 return elasticServer.Remove(0, "https://".Length);

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -130,7 +130,30 @@ services:
             memlock:
                 soft: -1
                 hard: -1
+        deploy:
+            resources:
+                limits:
+                    memory: 2GB
         container_name: ElasticServer
+
+    elastic7:
+        image: elasticsearch:7.17.10
+        ports:
+            - 9201:9200
+        environment:
+            - discovery.type=single-node
+            - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ElasticPassword}
+            - xpack.security.enabled=true
+            - xpack.security.http.ssl.enabled=false
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        deploy:
+            resources:
+                limits:
+                    memory: 2GB
+        container_name: Elastic7Server
 
     # have to manually set the password for kibana_user - use curl to hit the correct endpoint
     kibana_pw_setup:


### PR DESCRIPTION
This PR allows us to test older versions (all the way back to 7.0.0) of the 7.x clients (NEST and Elasticsearch.Net) to verify our instrumentation's compatibility with the full range of versions we want to support.  We needed to add a 7.x Elasticsearch server to our test infrastructure to enable this.

