### PR TITLE
test: Add CodeCov reporting for the Profiler

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -136,7 +136,7 @@ jobs:
         shell: cmd
         run: |
             cd ${{ env.profiler_path }}
-            OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Debug\CommonTest.dll" "ConfigurationTest\bin\x86\Debug\ConfigurationTest.dll" "LoggingTest\bin\x86\Debug\LoggingTest.dll" "MethodRewriterTest\bin\x86\Debug\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Debug\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Debug\SicilyTest.dll"
+            OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Release\CommonTest.dll" "ConfigurationTest\bin\x86\Release\ConfigurationTest.dll" "LoggingTest\bin\x86\Release\LoggingTest.dll" "MethodRewriterTest\bin\x86\Release\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Release\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Release\SicilyTest.dll"
         
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -14,6 +14,11 @@ on:
         description: 'Force a build, even if no files are changed'
         required: true
         type: boolean
+      deploy:
+        description: 'Deploy'
+        required: true
+        default: false # while testing
+        type: boolean
   
   # this workflow can be invoked manually
   workflow_dispatch:
@@ -22,6 +27,11 @@ on:
         description: 'Force a build, even if no files are changed'
         required: true
         default: true
+        type: boolean
+      deploy:
+        description: 'Deploy'
+        required: true
+        default: false # while testing
         type: boolean
 
 permissions:
@@ -77,6 +87,7 @@ jobs:
       profiler_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler
       profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
       output_path: ${{ github.workspace }}\src\Agent\_profilerBuild
+      test_results_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\test-results
 
     steps:
       - name: Checkout
@@ -109,6 +120,29 @@ jobs:
           Write-Host "MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}"
           MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
         shell: powershell
+        
+      - name: Setup VSTest and add to PATH
+        uses: darenm/Setup-VSTest@d9a5dffa3f11d9c27ec42eb69515d3aaeaad9ef8 # 1.2
+        id: setup_vstest
+
+      - name: Setup OpenCppCoverage and add to PATH
+        id: setup_opencppcoverage
+        run: |
+          choco install OpenCppCoverage -y
+          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+
+      - name: Generate Report
+        id: generate_test_report
+        shell: cmd
+        run: |
+        cd ${{ env.profiler_path }}
+        OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Debug\CommonTest.dll" "ConfigurationTest\bin\x86\Debug\ConfigurationTest.dll" "LoggingTest\bin\x86\Debug\LoggingTest.dll" "MethodRewriterTest\bin\x86\Debug\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Debug\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Debug\SicilyTest.dll"
+        
+      - name: Upload coverage reports to Codecov.io
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+            flags: Profiler
+            directory: ${{ env.test_results_path }}
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -149,7 +183,7 @@ jobs:
           rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
         shell: bash
 
-      - name: Build Linux Profler
+      - name: Build Linux Profiler
         run: |
           cd ${{ env.profiler_path }}
           docker-compose build build
@@ -251,7 +285,7 @@ jobs:
         build-linux-x64-profiler,
         build-linux-arm64-profiler,
       ]
-    if: ${{ inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true' }}
+    if: ${{ (inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true') && inputs.deploy }}
     name: Package and Deploy Profiler NuGet
     runs-on: windows-2022
 
@@ -319,6 +353,7 @@ jobs:
     name: Update Profiler Nuget Reference
     runs-on: ubuntu-22.04
     needs: package-and-deploy
+    if: ${{ inputs.deploy }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -143,6 +143,7 @@ jobs:
         with:
             flags: Profiler
             directory: ${{ env.test_results_path }}
+            verbose: true
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -135,8 +135,8 @@ jobs:
         id: generate_test_report
         shell: cmd
         run: |
-        cd ${{ env.profiler_path }}
-        OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Debug\CommonTest.dll" "ConfigurationTest\bin\x86\Debug\ConfigurationTest.dll" "LoggingTest\bin\x86\Debug\LoggingTest.dll" "MethodRewriterTest\bin\x86\Debug\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Debug\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Debug\SicilyTest.dll"
+            cd ${{ env.profiler_path }}
+            OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Debug\CommonTest.dll" "ConfigurationTest\bin\x86\Debug\ConfigurationTest.dll" "LoggingTest\bin\x86\Debug\LoggingTest.dll" "MethodRewriterTest\bin\x86\Debug\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Debug\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Debug\SicilyTest.dll"
         
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -87,7 +87,7 @@ jobs:
       profiler_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler
       profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
       output_path: ${{ github.workspace }}\src\Agent\_profilerBuild
-      test_results_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\test-results
+      test_results_path: src\Agent\NewRelic\Profiler\TestResults
 
     steps:
       - name: Checkout
@@ -136,7 +136,7 @@ jobs:
         shell: cmd
         run: |
             cd ${{ env.profiler_path }}
-            OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:test-results\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Release\CommonTest.dll" "ConfigurationTest\bin\x86\Release\ConfigurationTest.dll" "LoggingTest\bin\x86\Release\LoggingTest.dll" "MethodRewriterTest\bin\x86\Release\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Release\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Release\SicilyTest.dll"
+            OpenCppCoverage.exe --sources Profiler --excluded_sources rapidxml --excluded_sources Profiler\SystemCalls.h --excluded_sources test --modules NewRelic\Profiler --export_type cobertura:TestResults\profiler.xml -- "vstest.console.exe" "CommonTest\bin\x86\Release\CommonTest.dll" "ConfigurationTest\bin\x86\Release\ConfigurationTest.dll" "LoggingTest\bin\x86\Release\LoggingTest.dll" "MethodRewriterTest\bin\x86\Release\MethodRewriterTest.dll" "SignatureParserTest\bin\x86\Release\SignatureParserTest.dll" "Sicily\SicilyTest\bin\x86\Release\SicilyTest.dll"
         
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -144,6 +144,7 @@ jobs:
             flags: Profiler
             directory: ${{ env.test_results_path }}
             verbose: true
+            files: .\profiler.xml
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -17,7 +17,7 @@ on:
       deploy:
         description: 'Deploy'
         required: true
-        default: false # while testing
+        default: true
         type: boolean
   
   # this workflow can be invoked manually
@@ -31,7 +31,7 @@ on:
       deploy:
         description: 'Deploy'
         required: true
-        default: false # while testing
+        default: true
         type: boolean
 
 permissions:
@@ -142,7 +142,6 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
             flags: Profiler
-            verbose: true
             files: ${{ env.test_results_path }}\profiler.xml
 
       - name: Archive Artifacts

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -142,9 +142,8 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
             flags: Profiler
-            directory: ${{ env.test_results_path }}
             verbose: true
-            files: .\profiler.xml
+            files: ${{ env.test_results_path }}\profiler.xml
 
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Upload coverage reports to Codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
+            flags: Agent
             directory: ${{ env.test_results_path }}
 
       - name: Upload coverage report artifact

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ Agent/NewRelic.Agent.IL/NewRelicCoreVersion.h
 Agent/Shared/SharedAssemblyInfoVersion.cs
 Agent/NewRelic/Profiler/Profiler/VersionInfo.h
 
+Agent/NewRelic/Profiler/Profiler/test-results
+
 # Ignore source files generated during build
 Agent/Installer/Core.wxs
 Agent/NewRelic/Agent/Core/AgentInstallConfiguration_Generated.cs

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
@@ -409,7 +409,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"bar", L"", false));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"bar", L"", true));
         }
 
         TEST_METHOD(application_pool_oop_blacklist_without_default)
@@ -424,7 +424,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", false));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", true));
         }
 
         TEST_METHOD(application_pool_oop_whitelist_without_default)
@@ -439,7 +439,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", false));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", true));
         }
 
         TEST_METHOD(application_pool_oop_blacklist)
@@ -454,7 +454,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", false));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", true));
         }
 
         TEST_METHOD(application_pool_oop_whitelist)
@@ -469,7 +469,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", false));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"foo", L"", true));
         }
 
         TEST_METHOD(application_pools_oop_some_white_some_black_some_default_black)
@@ -488,12 +488,12 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteFoo", L"", false));
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteBar", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackFoo", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackBar", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultFoo", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultBar", L"", false));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteFoo", L"", true));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteBar", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackFoo", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackBar", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultFoo", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultBar", L"", true));
         }
 
         TEST_METHOD(application_pools_oop_some_white_some_black_some_default_white)
@@ -512,12 +512,12 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 ");
 
             Configuration configuration(configurationXml, _missingAgentEnabledConfigPair);
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteFoo", L"", false));
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteBar", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackFoo", L"", false));
-            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackBar", L"", false));
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultFoo", L"", false));
-            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultBar", L"", false));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteFoo", L"", true));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"whiteBar", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackFoo", L"", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"blackBar", L"", true));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultFoo", L"", true));
+            Assert::IsTrue(configuration.ShouldInstrument(L"Foo.exe", L"w3wp.exe", L"defaultBar", L"", true));
         }
 
         TEST_METHOD(agent_enabled_via_application_configuration)


### PR DESCRIPTION
* The "Build and Package Profiler" GitHub Action now also runs the Profiler's unit tests and uploads the results to CodeCov
* Added a "Deploy" checkbox to that job (checked by default). You can uncheck this to generate a new CodeCov report without publishing a new Profiler build
* Added an "Agent" flag to our Agent's CodeCov report, so that we can view it separately from the Profiler's coverage
* Increased code coverage for the Profiler from 65% to 75%