### PR TITLE
ci: Placeholder implementation for new linux smoke test workflow

### DIFF
--- a/.github/workflows/run_linux_smoke_tests.yml
+++ b/.github/workflows/run_linux_smoke_tests.yml
@@ -1,0 +1,33 @@
+name: .NET Agent Linux Smoke Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID of the build workflow (all_solutions.yml) to use the agent from. ID can be found in URL for run.'
+        required: true
+
+env:
+  DOTNET_NOLOGO: true
+  NR_DEV_BUILD_HOME: false
+
+
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+
+  run-linux-smoke-tests:
+    name: Run Linux Smoke Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3        
+        with:
+          fetch-depth: 0


### PR DESCRIPTION
Need to get this merged to main so I can manually invoke the real workflow from the linux smoke test branch. 