### PR TITLE
ci: Update site extension release workflow to run on windows-latest

### DIFF
--- a/.github/workflows/siteextension_release.yml
+++ b/.github/workflows/siteextension_release.yml
@@ -23,7 +23,7 @@ jobs:
   run-artifactbuilder:
     if: ${{ github.event.release }}
     name: Run ArtifactBuilder
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     env:
       artifacts_script_path: ${{ github.workspace }}\build


### PR DESCRIPTION
artifact-builder targets .NET 7 now, needs a newer runner... 