### PR TITLE
ci: Update workflows based on results of last release.

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -342,7 +342,7 @@ jobs:
   update-apm:
     name: Update System Configuration Page
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.update-apm-version == true }}
+    if: ${{ github.event.inputs.update-apm-version == 'true' }}
     steps:
       - name: Update system configuration page
         run: |
@@ -373,7 +373,7 @@ jobs:
             -d "$PAYLOAD"
 
   publish-release-notes:
-    needs: [deploy-linux, index-download-site]
+    needs: [deploy-linux, deploy-nuget, index-download-site]
     if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Create and Publish Release Notes
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@main
@@ -387,7 +387,7 @@ jobs:
       issues: write
       contents: read
       packages: read
-    needs: [deploy-linux, index-download-site]
+    needs: [deploy-linux, deploy-nuget, index-download-site]
     if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -8,7 +8,10 @@ on:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-
+      external_call:
+        type: boolean
+        default: true
+        required: false
   workflow_call:
     inputs:
       agent_version:
@@ -34,7 +37,12 @@ jobs:
         with:
           disable-sudo: false
           egress-policy: audit
-
+      - name: Wait for APT to update
+        if: ${{ inputs.external_call }}
+        run: |
+          echo "Sleeping 2 minutes to wait for apt to update itself"
+          sleep 120
+        shell: bash      
       - name: Validate
         run: |
           echo 'deb https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
@@ -67,6 +75,13 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3        
         with:
           fetch-depth: 0
+
+      - name: Wait for YUM to update
+        if: ${{ inputs.external_call }}
+        run: |
+          echo "Sleeping 2 minutes to wait for yum to update itself"
+          sleep 120
+        shell: bash
 
       - name: Validate
         run: |

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -1,4 +1,4 @@
-name: Publish .NET Agent Releaase Notes
+name: Publish .NET Agent Release Notes
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
* Updates `deploy_agent.yml` to fix an error in the conditional for running the APM update. Also adjusts some of the dependencies for release notes and post-deploy actions.
* Updates `post_deploy.yml' to introduce a 2-minute delay before validating apt and yum, when the workflow is invoked by an external call. This is to give those repos time to refresh their indexes prior to attempting the validation step.
* Fixes a minor typo in `publish_release_notes.yml`