### PR TITLE
ci: Add exception handling to reduce test failures

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -290,11 +290,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             return RemoteProcess.WaitForExit(milliseconds);
         }
 
-        public void Kill()
-        {
-            RemoteProcess?.Kill();
-        }
-
         public int? ExitCode => RemoteProcess.HasExited
             ? RemoteProcess.ExitCode
             : (int?)null;
@@ -361,7 +356,14 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
                     catch (Exception ex)
                     {
                         TestLogger?.WriteLine($"[RemoteApplication] FAILED sending shutdown signal to named pipe \"{shutdownChannelName}\": {ex}.");
-                        RemoteProcess.Kill();
+                        try
+                        {
+                            RemoteProcess.Kill();
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
                     }
                 }
             }
@@ -376,7 +378,14 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
                 catch (Exception ex)
                 {
                     TestLogger?.WriteLine($"[RemoteApplication] FAILED sending shutdown signal to wait handle \"{shutdownChannelName}\": {ex}.");
-                    RemoteProcess.Kill();
+                    try
+                    {
+                        RemoteProcess.Kill();
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
             }
 


### PR DESCRIPTION
Adds exception handling around calls to `RemoteProcess.Kill()` to ignore any exceptions that might get thrown due to the process having already terminated.

See https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/5830835047/job/15813713007#step:9:74 for an example of this error.