### PR TITLE
feat: Log a warning when an unsupported .NET version is detected.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/NewRelic.Agent.Core/AgentManager.cs
@@ -268,7 +268,7 @@ namespace NewRelic.Agent.Core
 
                 foreach (var ev in environmentVariables)
                 {
-                    if (!String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(ev)))
+                    if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(ev)))
                     {
                         Log.DebugFormat("Environment Variable {0} value: {1}", ev, System.Environment.GetEnvironmentVariable(ev));
                     }
@@ -276,7 +276,7 @@ namespace NewRelic.Agent.Core
 
                 foreach (var evs in environmentVariablesSensitive)
                 {
-                    if (!String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(evs)))
+                    if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(evs)))
                     {
                         Log.DebugFormat("Environment Variable {0} is configured with a value. Not logging potentially sensitive value", evs);
                     }
@@ -285,6 +285,17 @@ namespace NewRelic.Agent.Core
                 Log.Debug($".NET Runtime Version: {RuntimeInformation.FrameworkDescription}");
             }
 
+#if NETFRAMEWORK
+            if (NewRelic.Core.DotnetVersion.IsUnsupportedDotnetFrameworkVersion(AgentInstallConfiguration.DotnetFrameworkVersion))
+            {
+                Log.WarnFormat("Unsupported installed .NET Framework version {0} dectected. Please use a version of .NET Framework >= 4.6.2.", AgentInstallConfiguration.DotnetFrameworkVersion);
+            }
+#else
+            if (NewRelic.Core.DotnetVersion.IsUnsupportedDotnetCoreVersion(AgentInstallConfiguration.DotnetCoreVersion))
+            {
+                Log.WarnFormat("Unsupported .NET version {0} detected. Please use a version of .NET >= net6.", AgentInstallConfiguration.DotnetCoreVersion);
+            }
+#endif
         }
 
         private void StartServices()

--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -5,6 +5,8 @@
 using Microsoft.Win32;
 #endif
 
+using System.Collections.Generic;
+
 namespace NewRelic.Core
 {
     public enum DotnetFrameworkVersion
@@ -122,5 +124,29 @@ namespace NewRelic.Core
             return DotnetCoreVersion.Other;
         }
 #endif
+
+        public static bool IsUnsupportedDotnetCoreVersion(DotnetCoreVersion version)
+        {
+            // Newer versions of .net will be flagged as Other until we update our version checking logic.
+            // So we can either check against a supported list, or an unsupported list, but the supported list
+            // is smaller.
+            var supportedDotnetCoreVersions = new List<DotnetCoreVersion> { DotnetCoreVersion.net6, DotnetCoreVersion.net7, DotnetCoreVersion.Other };
+            return !supportedDotnetCoreVersions.Contains(version);
+        }
+
+        public static bool IsUnsupportedDotnetFrameworkVersion(DotnetFrameworkVersion version)
+        {
+            // For .net framework we can maintain a list of unsupported versions to check against
+            // so that newer versions of .net framework will not be listed as an unsupported version.
+            var unsupportedDotnetFrameworkVersions = new List<DotnetFrameworkVersion> {
+                DotnetFrameworkVersion.LessThan45,
+                DotnetFrameworkVersion.net45,
+                DotnetFrameworkVersion.net451,
+                DotnetFrameworkVersion.net452,
+                DotnetFrameworkVersion.net46,
+                DotnetFrameworkVersion.net461
+            };
+            return unsupportedDotnetFrameworkVersions.Contains(version);
+        }
     }
 }

--- a/tests/NewRelic.Core.Tests/DotnetVersionTests.cs
+++ b/tests/NewRelic.Core.Tests/DotnetVersionTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NUnit.Framework;
+
+namespace NewRelic.Core.Tests
+{
+    [TestFixture]
+    public class DotnetVersionTests
+    {
+        [TestCase(DotnetCoreVersion.LessThan30, ExpectedResult = true)]
+        [TestCase(DotnetCoreVersion.netcoreapp30, ExpectedResult = true)]
+        [TestCase(DotnetCoreVersion.netcoreapp31, ExpectedResult = true)]
+        [TestCase(DotnetCoreVersion.net5, ExpectedResult = true)]
+        [TestCase(DotnetCoreVersion.net6, ExpectedResult = false)]
+        [TestCase(DotnetCoreVersion.net7, ExpectedResult = false)]
+        [TestCase(DotnetCoreVersion.Other, ExpectedResult = false)]
+        public bool IsUnsupportedDotnetCoreVersion(DotnetCoreVersion version)
+        {
+            return DotnetVersion.IsUnsupportedDotnetCoreVersion(version);
+        }
+
+        [TestCase(DotnetFrameworkVersion.LessThan45, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net45, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net451, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net452, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net46, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net461, ExpectedResult = true)]
+        [TestCase(DotnetFrameworkVersion.net462, ExpectedResult = false)]
+        [TestCase(DotnetFrameworkVersion.net47, ExpectedResult = false)]
+        [TestCase(DotnetFrameworkVersion.net471, ExpectedResult = false)]
+        [TestCase(DotnetFrameworkVersion.net472, ExpectedResult = false)]
+        [TestCase(DotnetFrameworkVersion.net48, ExpectedResult = false)]
+        [TestCase(DotnetFrameworkVersion.net481, ExpectedResult = false)]
+        public bool IsUnsupportedDotnetFrameworkVersion(DotnetFrameworkVersion version)
+        {
+            return DotnetVersion.IsUnsupportedDotnetFrameworkVersion(version);
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Resolves #1850.

Adds a warning to the managed agent logs when an unsupported version of .net is detected. 
- For .net and .net core it checks the version of the runtime used by the application. 
- For .net framework it checks the installed .net framework version (not the targeted version) that the application is running on.

Additional profiler warnings are not generated.

- For .net/.net core the profiler will only attach if the application is running on netcoreapp3.1 or greater. We cannot specifically check for net6 in the profiler, but we could check for net5. However the differences between those versions are unlikely to trigger a scenario where we could publish a warning in the profiler log and the managed log would not also contain a warning.
- For .net framework the profiler will not attach unless .net framework >= 4.6.1 is installed. We cannot easily check for .net framework 4.6.2. No additional warning is necessary in this case.

Other notes:

- There is not a simple way for the agent to automatically detect if a .net framework application is targeting an unsupported version. This would involve knowing which assembly to check for the TargetFrameworkAttribute.
- If a supported .net framework version is installed and the application is targeting an unsupported framework, the agent can still dynamically load dependencies from the installed framework version. However, the compatibility quirks mode that is enabled by the unsupported target version may lead to unexpected behavior differences.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
