### PR TITLE
ci: Run all solutions build only on weekdays

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -17,7 +17,7 @@ on:
         default: false
 
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 9 * * 1-5"
 
 # only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
 concurrency:


### PR DESCRIPTION
Updates the schedule for `all_solutions.yml` so that it only runs on weekdays rather than every day. 

![image](https://github.com/newrelic/newrelic-dotnet-agent/assets/120425148/f4f17bd2-f1a1-4265-a2be-1ec393b2bc77)
