### PR TITLE
feat: Add support for Serilog.Extensions.Logging and NLog.Extensions.Logging

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
@@ -6,21 +6,18 @@ using System.Collections.Generic;
 
 namespace NewRelic.Agent.Extensions.Logging
 {
-    public enum LogProvider
-    {
-        Log4Net,
-        Serilog,
-        NLog
-    }
-
     public static class LogProviders
     {
-        public static readonly bool[] RegisteredLogProvider = new bool[Enum.GetNames(typeof(LogProvider)).Length];
+        public static bool KnownLogProvider = false;
 
-        public static readonly List<string> Log4NetProviderNames = new List<string> { "Microsoft.Extensions.Logging.Log4NetProvider", "log4net.Extensions.Logging.Log4NetProvider" };
-
-        public static readonly List<string> SerilogProviderNames = new List<string> { "Microsoft.Extensions.Logging.SerilogLoggerProvider", "Serilog.Extensions.Logging.SerilogLoggerProvider" };
-
-        public static readonly List<string> NLogProviderNames = new List<string> { "Microsoft.Extensions.Logging.NLogLoggerProvider", "NLog.Extensions.Logging.NLogLoggerProvider" };
+        public static readonly List<string> KnownLogProviders = new List<string>
+        {
+            "Microsoft.Extensions.Logging.Log4NetProvider",
+            "log4net.Extensions.Logging.Log4NetProvider",
+            "Microsoft.Extensions.Logging.SerilogLoggerProvider",
+            "Serilog.Extensions.Logging.SerilogLoggerProvider",
+            "Microsoft.Extensions.Logging.NLogLoggerProvider",
+            "NLog.Extensions.Logging.NLogLoggerProvider"
+        };
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/LogProviders.cs
@@ -8,9 +8,11 @@ namespace NewRelic.Agent.Extensions.Logging
 {
     public static class LogProviders
     {
-        public static bool KnownLogProvider = false;
+        // This will only be set once, when a Microsoft.Extensions.Logging registration method is called.
+        // It can safely be read concurrently.
+        public static bool KnownMELProviderEnabled = false;
 
-        public static readonly List<string> KnownLogProviders = new List<string>
+        public static readonly List<string> KnownMELProviders = new List<string>
         {
             "Microsoft.Extensions.Logging.Log4NetProvider",
             "log4net.Extensions.Logging.Log4NetProvider",

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
@@ -607,6 +607,18 @@ namespace NewRelic.Reflection
             return methodInfo;
         }
 
+        public Func<TResult> GenerateParameterlessStaticMethodCaller<TResult>(string assemblyName, string typeName, string methodName)
+        {
+            var ownerType = GetType(assemblyName, typeName);
+
+            var methodInfo = ownerType.GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            if (methodInfo == null)
+            {
+                throw new KeyNotFoundException(string.Format("Unable to find method {0} in type {1}", methodName, ownerType.AssemblyQualifiedName));
+            }
+            return (Func<TResult>)methodInfo.CreateDelegate(typeof(Func<TResult>));
+        }
+
         private static PropertyInfo GetPropertyInfo(Type type, string propertyName)
         {
             var propertyInfo = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
@@ -34,12 +34,7 @@ namespace NewRelic.Providers.Wrapper.Logging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Log4Net])
-            {
-                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
-            }
-
-            return new CanWrapResponse(false);
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/AddProviderRegistrationWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/AddProviderRegistrationWrapper.cs
@@ -22,20 +22,14 @@ namespace MicrosoftExtensionsLogging
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
             var provider = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
-            if (LogProviders.Log4NetProviderNames.Contains(provider))
+            if (LogProviders.KnownLogProviders.Contains(provider))
             {
-                LogProviders.RegisteredLogProvider[(int)LogProvider.Log4Net] = true;
-                agent.Logger.Log(Level.Info, "Detected log4net provider in use with Microsoft.Extensions.Logging, disabling log4net instrumentation.");
+                LogProviders.KnownLogProvider = true;
+                agent.Logger.Log(Level.Info, $"Known log provider {provider} in use. Disabling Microsoft.Extensions.Logging instrumentation.");
             }
-            else if (LogProviders.SerilogProviderNames.Contains(provider))
+            else
             {
-                LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog] = true;
-                agent.Logger.Log(Level.Info, "Detected Serilog provider in use with Microsoft.Extensions.Logging, disabling Serilog instrumentation.");
-            }
-            else if (LogProviders.NLogProviderNames.Contains(provider))
-            {
-                LogProviders.RegisteredLogProvider[(int)LogProvider.NLog] = true;
-                agent.Logger.Log(Level.Info, "Detected NLog provider in use with Microsoft.Extensions.Logging, disabling NLog instrumentation.");
+                agent.Logger.Log(Level.Info, $"Log provider {provider} will use Microsoft.Extensions.Logging instrumentation.");
             }
 
             return Delegates.NoOp;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/AddProviderRegistrationWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/AddProviderRegistrationWrapper.cs
@@ -22,9 +22,9 @@ namespace MicrosoftExtensionsLogging
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
             var provider = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
-            if (LogProviders.KnownLogProviders.Contains(provider))
+            if (LogProviders.KnownMELProviders.Contains(provider))
             {
-                LogProviders.KnownLogProvider = true;
+                LogProviders.KnownMELProviderEnabled = true;
                 agent.Logger.Log(Level.Info, $"Known log provider {provider} in use. Disabling Microsoft.Extensions.Logging instrumentation.");
             }
             else

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -75,8 +75,7 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 
             try
             {
-                // We are trying to access this property:
-                // logger.Loggers[0].Logger.ScopeProvider
+                // MEL keeps an array of scope handlers. We can ask one of them for the current scope data.
 
                 // Get the array of ScopeLoggers (logger.ScopeLoggers[])
                 var getLoggersArrayFunc = _getLoggersArray ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<dynamic>(logger.GetType(), "ScopeLoggers");

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -28,7 +28,7 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            if (!LogProviders.KnownLogProvider)
+            if (!LogProviders.KnownMELProviderEnabled)
             {
                 return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -9,7 +9,8 @@ using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Collections.Generic;
 using NewRelic.Reflection;
-using System.Dynamic;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
 
 namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 {
@@ -17,8 +18,7 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
     {
         // Cached accessor functions
         private static Func<object, dynamic> _getLoggersArray;
-        private static Func<object, object> _getLoggerProperty;
-        private static Func<object, MEL.IExternalScopeProvider> _getScopeProvider;
+        private static PropertyInfo _scopeProviderPropertyInfo;
 
         private static bool _contextDataNotSupported = false;
 
@@ -78,24 +78,22 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
                 // We are trying to access this property:
                 // logger.Loggers[0].Logger.ScopeProvider
 
-                // Get the array of Loggers (logger.Loggers[])
-                var getLoggersArrayFunc = _getLoggersArray ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<dynamic>(logger.GetType(), "Loggers");
+                // Get the array of ScopeLoggers (logger.ScopeLoggers[])
+                var getLoggersArrayFunc = _getLoggersArray ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<dynamic>(logger.GetType(), "ScopeLoggers");
                 var loggers = getLoggersArrayFunc(logger);
 
-                // Get the first logger in the array (logger.Loggers[0])
+                // Get the first ScopeLogger in the array (logger.ScopeLoggers[0])
+                // If there is more than one scope logger, they've all received the same data, so the first
+                // one should be fine
                 object firstLogger = loggers.GetValue(0);
 
-                // Get the internal logger (logger.Loggers[0].Logger)
-                var getLoggerPropertyFunc = _getLoggerProperty ??= firstLogger.GetType().GetProperty("Logger").GetValue;
-                object internalLogger = getLoggerPropertyFunc(firstLogger);
-
-                // Get the scope provider from that logger (logger.Loggers[0].Logger.ScopeProvider)
-                var getScopeProviderFunc = _getScopeProvider ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<MEL.IExternalScopeProvider>(internalLogger.GetType(), "ScopeProvider");
-                var scopeProvider = getScopeProviderFunc(internalLogger);
+                // Get the scope provider from that logger (logger.ScopeLoggers[0].ExternalScopeProvider)
+                var scopeProviderPI = _scopeProviderPropertyInfo ??= firstLogger.GetType().GetProperty("ExternalScopeProvider");
+                var scopeProvider = scopeProviderPI.GetValue(firstLogger) as IExternalScopeProvider;
 
                 // Get the context data
                 var harvestedKvps = new Dictionary<string, object>();
-                scopeProvider.ForEachScope((scopeObject, accumulatedKvps) =>
+                scopeProvider?.ForEachScope((scopeObject, accumulatedKvps) =>
                 {
                     if (scopeObject is IEnumerable<KeyValuePair<string, object>> kvps)
                     {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -28,7 +28,11 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            if (!LogProviders.KnownLogProvider)
+            {
+                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+            }
+            return new CanWrapResponse(false);
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
@@ -120,12 +124,6 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
         private AfterWrappedMethodDelegate DecorateLogMessage(MEL.ILogger logger, IAgent agent)
         {
             if (!agent.Configuration.LogDecoratorEnabled)
-            {
-                return Delegates.NoOp;
-            }
-
-            // NLog can alter the message so we want to skip MEL decoration for NLog
-            if (LogProviders.RegisteredLogProvider[(int)LogProvider.NLog])
             {
                 return Delegates.NoOp;
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Xml.Linq;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Logging;
@@ -20,6 +21,7 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
         private static Func<object, DateTime> _getTimestamp;
         private static Func<object, Exception> _getLogException;
         private static Func<object, IDictionary<object, object>> _getPropertiesDictionary;
+        private static Func<IEnumerable<KeyValuePair<string, object>>> _getScopeData;
 
         public bool IsTransactionRequired => false;
 
@@ -120,6 +122,23 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
             foreach (var property in properties)
             {
                 contextData[property.Key.ToString()] = property.Value;
+            }
+
+            // NLog treats and stores Properties and Scope Context differently. If we need to add support for older versions of NLog, it's two calls instead of GetAllProperties():
+            //    NLog.MappedDiagnosticsLogicalContext.GetNames()
+            //       NLog.MappedDiagnosticsLogicalContext.Get(name)
+            try
+            {
+                _getScopeData = _getScopeData ??= VisibilityBypasser.Instance.GenerateParameterlessStaticMethodCaller<IEnumerable<KeyValuePair<string, object>>>("NLog", "NLog.ScopeContext", "GetAllProperties");
+            }
+            catch
+            {
+                _getScopeData = () => new List<KeyValuePair<string, object>>();
+            }
+            var scopeData = _getScopeData();
+            foreach (var pair in scopeData)
+            {
+                contextData[pair.Key] = pair.Value;
             }
 
             return contextData;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NLogLogging/NLogWrapper.cs
@@ -38,12 +38,7 @@ namespace NewRelic.Providers.Wrapper.NLogLogging
             var logEvent = instrumentedMethodCall.MethodCall.MethodArguments[2];
             var logEventType = logEvent.GetType();
 
-            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.NLog])
-            {
-                RecordLogMessage(logEvent, logEventType, agent);
-            }
-
-            // We want this to happen instead of MEL so no provider check here.
+            RecordLogMessage(logEvent, logEventType, agent);
             DecorateLogMessage(logEvent, logEventType, agent);
 
             return Delegates.NoOp;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/NewRelicSerilogSink.cs
@@ -23,11 +23,7 @@ namespace NewRelic.Providers.Wrapper.SerilogLogging
 
         public void Emit(LogEvent logEvent)
         {
-            //This check is to prevent forwarding duplicate logs when Microsoft.Extensions.Logging is used.
-            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog])
-            {
-                RecordLogMessage(logEvent);
-            }
+            RecordLogMessage(logEvent);
         }
 
         private void RecordLogMessage(LogEvent logEvent)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/SerilogCreateLoggerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/SerilogCreateLoggerWrapper.cs
@@ -16,12 +16,7 @@ namespace NewRelic.Providers.Wrapper.SerilogLogging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog])
-            {
-                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
-            }
-
-            return new CanWrapResponse(false);
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/SerilogDispatchWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/SerilogLogging/SerilogDispatchWrapper.cs
@@ -25,12 +25,7 @@ namespace NewRelic.Providers.Wrapper.SerilogLogging
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            if (!LogProviders.RegisteredLogProvider[(int)LogProvider.Serilog])
-            {
-                return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
-            }
-
-            return new CanWrapResponse(false);
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -69,9 +69,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Received gRPC Server response messages: (\d+)";
         public const string SpanStreamingResponseGrpcError = FinestLogLinePrefixRegex + @"ResponseStreamWrapper: consumer \d+ - gRPC RpcException encountered while handling gRPC server responses: (.*)";
         
-        // ContextData related messages
-        public const string ContextDataNotSupportedLogLineRegex = WarnLogLinePrefixRegex + @".* Context data is not supported for this logging framework.";
-
         public AgentLogBase(RemoteApplication remoteApplication)
         {
             _remoteApplication = remoteApplication;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/Common.cs
@@ -11,7 +11,9 @@ namespace NewRelic.Agent.IntegrationTests.Logging
         SerilogWeb,
         NLog,
         DummyMEL,
-        Sitecore
+        Sitecore,
+        SerilogEL,
+        NLogEL
     }
 
     public class LogUtils
@@ -28,6 +30,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                 case LoggingFramework.Serilog:
                     return "serilog";
                 case LoggingFramework.NLog:
+                case LoggingFramework.NLogEL:
                     return "nlog";
                 case LoggingFramework.DummyMEL:
                     return "DummyMEL";
@@ -73,6 +76,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                     }
                 case LoggingFramework.SerilogWeb:
                 case LoggingFramework.Serilog:
+                case LoggingFramework.SerilogEL:
                     switch (level)
                     {
                         case "DEBUG":
@@ -91,6 +95,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging
                             return level;
                     }
                 case LoggingFramework.NLog:
+                case LoggingFramework.NLogEL:
                     switch (level)
                     {
                         case "NOMESSAGE":

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
@@ -70,11 +70,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
         [Fact]
         public void Test()
         {
-            // verify the "not supported" warning was logged
-            var match = _fixture.AgentLog.TryGetLogLines(AgentLogBase.ContextDataNotSupportedLogLineRegex);
-            Assert.Single(match);
-
-            // verify the log data was forwarded, but *without* the attributes
+            // verify the log data was forwarded, but *without* the attributes (since our dummy logger doesn't support them)
             var expectedLogLines = new[]
             {
                 new Assertions.ExpectedLogLine

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
@@ -279,4 +279,58 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
     }
 
     #endregion // Sitecore
+     
+    #region SEL
+    public class SELContextDataFWLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public SELContextDataFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogEL)
+        {
+        }
+    }
+
+    public class SELContextDataFW48Tests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFW48>
+    {
+        public SELContextDataFW48Tests(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogEL)
+        {
+        }
+    }
+
+    public class SELContextDataCoreLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public SELContextDataCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogEL)
+        {
+        }
+    }
+
+    public class SELContextDataCoreOldestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    {
+        public SELContextDataCoreOldestTests(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.SerilogEL)
+        {
+        }
+    }
+
+    #endregion // SEL
+
+    #region NEL
+    public class NELContextDataFWLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public NELContextDataFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLogEL)
+        {
+        }
+    }
+
+    public class NELContextDataCoreLatestTests : ContextDataTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public NELContextDataCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, LoggingFramework.NLogEL)
+        {
+        }
+    }
+
+    #endregion // NEL
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
@@ -34,7 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
         {
             _fixture = fixture;
             _loggingFramework = loggingFramework;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture.SetTimeout(TimeSpan.FromMinutes(20));
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
@@ -34,7 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
         {
             _fixture = fixture;
             _loggingFramework = loggingFramework;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(20));
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -217,22 +217,26 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
-    
+    <!-- Requires Serilog 2.8.0+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
+
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- Requires Serilog 2.9.0+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <!-- Requires Serilog 2.8.0+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <!-- Requires Serilog 2.9.0+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)' == 'net7.0'" />
   </ItemGroup>
 
   <ItemGroup> <!-- Versions below 4.5 did not support netstandard 2.0 -->
@@ -243,6 +247,12 @@
     <PackageReference Include="NLog" Version="4.1.2" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NLog" Version="4.5.11" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NLog" Version="5.2.3" Condition="'$(TargetFramework)' == 'net481'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Requires NLog 5.2.3+ -->
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.3" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.3" Condition="'$(TargetFramework)' == 'net7.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -50,6 +50,17 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                     _log = new SitecoreLoggingAdapter();
 #endif
                     break;
+                case "SERILOGEL":
+#if NETCOREAPP2_1_OR_GREATER || NET48_OR_GREATER
+                    _log = new SerilogExtensionsLoggingAdapter();
+#endif
+                    break;
+                case "NLOGEL":
+#if NET7_0_OR_GREATER || NET481_OR_GREATER
+                    _log = new NLogExtensionsLoggingAdapter();
+#endif
+                    break;
+
                 default:
                     throw new System.ArgumentNullException(nameof(loggingFramework));
             }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogExtensionsLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogExtensionsLoggingAdapter.cs
@@ -1,0 +1,129 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+#if NETCOREAPP2_1_OR_GREATER || NET48_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+using Serilog.Formatting.Json;
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
+{
+    class SerilogExtensionsLoggingAdapter : ILoggingAdapter
+    {
+        private static Microsoft.Extensions.Logging.ILogger _logger;
+
+        public SerilogExtensionsLoggingAdapter()
+        {
+        }
+
+        public void Debug(string message)
+        {
+            _logger.LogDebug(message);
+        }
+
+        public void Info(string message)
+        {
+            _logger.LogInformation(message);
+        }
+
+        public void Info(string message, Dictionary<string, object> context)
+        {
+            using (_logger.BeginScope(context))
+            {
+                _logger.LogInformation(message);
+            }
+        }
+
+        public void InfoWithParam(string message, object param)
+        {
+            _logger.LogInformation(message, param);
+        }
+
+        public void Warn(string message)
+        {
+            _logger.LogWarning(message);
+        }
+
+        public void Error(Exception exception)
+        {
+            _logger.LogError(exception, exception.Message);
+        }
+
+        public void ErrorNoMessage(Exception exception)
+        {
+            _logger.LogError(exception, string.Empty);
+        }
+
+        public void Fatal(string message)
+        {
+            _logger.LogCritical(message);
+        }
+
+        public void NoMessage()
+        {
+            _logger.LogTrace(string.Empty);
+        }
+
+        public void Configure()
+        {
+            CreateMelLogger(LogLevel.Information);
+        }
+
+        public void ConfigureWithInfoLevelEnabled()
+        {
+            CreateMelLogger(LogLevel.Information);
+        }
+
+
+        public void ConfigurePatternLayoutAppenderForDecoration()
+        {
+            CreateMelLogger(LogLevel.Debug, "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Scope} {NewLine}{Exception}");
+        }
+
+        public void ConfigureJsonLayoutAppenderForDecoration()
+        {
+            CreateMelLogger(LogLevel.Debug, new JsonFormatter());
+        }
+
+        private void CreateMelLogger(LogLevel minimumLogLevel) => CreateMelLogger(minimumLogLevel, null, null);
+
+        private void CreateMelLogger(LogLevel minimumLogLevel, string template) => CreateMelLogger(minimumLogLevel, template, null);
+
+        private void CreateMelLogger(LogLevel minimumLogLevel, ITextFormatter format) => CreateMelLogger(minimumLogLevel, null, format);
+
+        private void CreateMelLogger(LogLevel minimumLogLevel, string template, ITextFormatter format)
+        {
+            var config = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .Enrich.FromLogContext();
+
+            if (template != null)
+            {
+                config = config.WriteTo.Console(outputTemplate: template);
+            }
+            if (format != null)
+            {
+                config = config.WriteTo.Console(format);
+            }
+            var serilog = config.CreateLogger();
+
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.SetMinimumLevel(minimumLogLevel);
+                builder.AddSerilog(serilog);
+            });
+            _logger = loggerFactory.CreateLogger<LoggingTester>();
+        }
+
+
+    }
+}
+
+#endif

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Reflection/VisibilityBypasserTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Reflection/VisibilityBypasserTests.cs
@@ -56,6 +56,11 @@ namespace NewRelic.Reflection.UnitTests
         public int GetWriteableIntField { get { return _writeableIntField; } }
     }
 
+    public static class PublicStatic
+    {
+        public static int GetANumber() => 3;
+    }
+
 #pragma warning restore 414
 
     public class FieldAccessTests
@@ -609,6 +614,22 @@ namespace NewRelic.Reflection.UnitTests
 
             Assert.Throws<ArgumentNullException>(() => VisibilityBypasser.Instance.GenerateTypeFactory<string, string>(null, "foo"));
             Assert.Throws<ArgumentNullException>(() => VisibilityBypasser.Instance.GenerateTypeFactory<string, string>("foo", null));
+        }
+    }
+    public class StaticMethodTests
+    {
+        [Test]
+        public void test_static_generator()
+        {
+            var assemblyName = Assembly.GetExecutingAssembly().FullName;
+            var typeName = "NewRelic.Reflection.UnitTests.PublicStatic";
+            var methodName = "GetANumber";
+
+            var method = VisibilityBypasser.Instance.GenerateParameterlessStaticMethodCaller<int>(assemblyName, typeName, methodName);
+            var result = method();
+            Assert.AreEqual(3, result);
+
+            Assert.Throws<KeyNotFoundException>(() => VisibilityBypasser.Instance.GenerateParameterlessStaticMethodCaller<int>(assemblyName, typeName, "NoSuchMethod"));
         }
     }
 }


### PR DESCRIPTION
Previously, if we detected Microsoft.Extensions.Logging and another logger, we would only instrument MEL, in order to avoid double collection of logs. This turned out to be a flawed approach, because MEL does not store any context data. It relies on the underlying logger to handle it. So now, if we detect that scenario, we disable MEL instrumentation. Only if we don't find another logger that we know how to instrument, will we instrument MEL.

In order for us to collect context data from an ILogger via MEL, the logger must implement `IExternalScopeProvider` (specifically the `ForEachScope` function). Scope data can be any object, but we will only collect it if it's a key-value pair (or collection of key-value pairs). This is how NLog and Serilog implement their scope provider, so this seems like a reasonable restriction.

I also found that NLog treats context data and scope data differently. We weren't recording NLog's scope data at all before; now we are.

Addresses #1859

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
