### PR TITLE
test: Extend harvest from 15 to 45 seconds for MySql tests.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinWebApiAsyncTests.cs
@@ -34,9 +34,9 @@ namespace NewRelic.Agent.IntegrationTests.Owin
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterErrorTracesHarvestCycle(15);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(30);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(30);
+                    configModifier.ConfigureFasterErrorTracesHarvestCycle(30);
 
                     var instrumentationFilePath = Path.Combine(fixture.DestinationNewRelicExtensionsDirectoryPath, "CustomInstrumentation.xml");
 
@@ -82,7 +82,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
             var generalMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsSeen", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", callCount = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"Supportability/AnalyticsEvents/TotalEventsCollected", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"Apdex"},
                 new Assertions.ExpectedMetric { metricName = @"ApdexAll"},
                 new Assertions.ExpectedMetric { metricName = @"HttpDispatcher", CallCountAllHarvests = ExpectedTransactionCount },

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
@@ -35,9 +35,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(45);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(45);
+                    configModifier.ConfigureFasterSqlTracesHarvestCycle(45);
 
                     configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -55,9 +55,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     var configModifier = new NewRelicConfigModifier(configPath);
 
                     configModifier
-                        .ConfigureFasterMetricsHarvestCycle(15)
-                        .ConfigureFasterTransactionTracesHarvestCycle(15)
-                        .ConfigureFasterSqlTracesHarvestCycle(15)
+                        .ConfigureFasterMetricsHarvestCycle(45)
+                        .ConfigureFasterTransactionTracesHarvestCycle(45)
+                        .ConfigureFasterSqlTracesHarvestCycle(45)
                         .ForceTransactionTraces()
                         .SetLogLevel("finest");
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
@@ -36,9 +36,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(45);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(45);
+                    configModifier.ConfigureFasterSqlTracesHarvestCycle(45);
 
                     configModifier.ForceTransactionTraces();
                     configModifier.SetLogLevel("finest");

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
@@ -34,9 +34,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                 {
                     var configPath = fixture.DestinationNewRelicConfigFilePath;
                     var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(45);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(45);
+                    configModifier.ConfigureFasterSqlTracesHarvestCycle(45);
 
                     configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
@@ -52,6 +52,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
 


### PR DESCRIPTION
The overnight run failed again, even after adding the "warmup" code. So we'll just extend the MySql harvest interval to 45 seconds which should make things more stable. Maybe. I hope.