### PR TITLE
ci: ensure all_solutions does full build on nightly schedule

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: windows-2022
     needs: check-modified-files
     # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well
-    # run this job if non-workflow files were modified, or if triggered by a release or a manual execution
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.non-workflow-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch')
+    # run this job if non-workflow files were modified, or if triggered by a release, a manual execution or schedule
+    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.non-workflow-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
 
     env:
       fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln


### PR DESCRIPTION
Adjusted the conditions for running the build-fullagent-msi job to make sure it runs when the nightly schedule triggers the workflow.