### PR TITLE
fix: Remove the retained file count limit for Agent log files.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -253,7 +253,7 @@ namespace NewRelic.Agent.Core
                             fileSizeLimitBytes: 50 * 1024 * 1024,
                             encoding: Encoding.UTF8,
                             rollOnFileSizeLimit: true,
-                            retainedFileCountLimit: 4,
+                            retainedFileCountLimit: null, // unlimited number of files
                             shared: true,
                             buffered: false
                             );


### PR DESCRIPTION
Removes the 4-file limit on retained Agent log files. Logs will still roll at 50MB, but an unlimited number will be retained.

Resolves #1878 