### PR TITLE
ci: Add a integration test status check job that can be used in a branch protection rule.

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -792,3 +792,18 @@ jobs:
             ${{ github.workspace }}\build\BuildArtifacts
             ${{ github.workspace }}\deploy
           if-no-files-found: error
+
+  # This job is necessary in order for us to have a branch protection rule for tests with a matrix
+  # if any of the matrix tests fail, this job fails and the branch protection rule keeps the PR from merging
+  integration-test-status:
+    name: Check Test Matrix Status
+    runs-on: ubuntu-latest
+    needs: [run-integration-tests, run-unbounded-tests]
+    if: always()
+    steps:
+      - name: Successful test run
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing test run
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1          


### PR DESCRIPTION
Turns out you can't have a branch protection rule that depends on a job that uses a matrix. This workaround seems to be the accepted way of handling that -- it adds a new job that checks the status of the matrix of integration and unbounded tests and fails if any of those jobs failed. Based on [this GH thread](https://github.com/orgs/community/discussions/4324#discussioncomment-3477871)

The branch protection rules will be updated (once this PR completes) to depend on this job instead of the two integration test jobs we're currently configured for. 