### PR TITLE
feat: Add more detail to "heartbeat" message in log

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthEvent.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthEvent.cs
@@ -6,6 +6,12 @@ namespace NewRelic.Agent.Core.AgentHealth
     public enum AgentHealthEvent
     {
         TransactionGarbageCollected,
-        WrapperShutdown
+        WrapperShutdown,
+        Transaction,
+        Log,
+        Custom,
+        Error,
+        Span,
+        InfiniteTracingSpan
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 {
     public class AgentHealthReporter : ConfigurationBasedService, IAgentHealthReporter
     {
-        private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(2);
 
         private readonly IMetricBuilder _metricBuilder;
         private readonly IScheduler _scheduler;

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -22,7 +22,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 {
     public class AgentHealthReporter : ConfigurationBasedService, IAgentHealthReporter
     {
-        private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(5);
 
         private readonly IMetricBuilder _metricBuilder;
         private readonly IScheduler _scheduler;
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.Core.AgentHealth
         {
             _metricBuilder = metricBuilder;
             _scheduler = scheduler;
-            _scheduler.ExecuteEvery(LogRecurringLogs, _timeBetweenExecutions);
+            _scheduler.ExecuteEvery(LogPeriodicReport, _timeBetweenExecutions);
             var agentHealthEvents = Enum.GetValues(typeof(AgentHealthEvent)) as AgentHealthEvent[];
             foreach (var agentHealthEvent in agentHealthEvents)
             {
@@ -58,24 +58,30 @@ namespace NewRelic.Agent.Core.AgentHealth
         public override void Dispose()
         {
             base.Dispose();
-            _scheduler.StopExecuting(LogRecurringLogs);
+            _scheduler.StopExecuting(LogPeriodicReport);
         }
 
-        private void LogRecurringLogs()
+        private void LogPeriodicReport()
         {
             foreach (var data in _recurringLogDatas)
             {
                 data?.LogAction(data.Message);
             }
-
+            
+            List<string> events = new List<string>();
             foreach (var counter in _agentHealthEventCounters)
             {
                 if (counter.Value != null && counter.Value.Value > 0)
                 {
                     var agentHealthEvent = counter.Key;
                     var timesOccured = counter.Value.Exchange(0);
-                    Log.Info($"Event {agentHealthEvent} has occurred {timesOccured} times in the last {_timeBetweenExecutions.TotalSeconds} seconds");
+                    events.Add(string.Format("{0} {1} {2}", timesOccured, agentHealthEvent, (timesOccured == 1) ? "event" : "events"));
                 }
+            }
+            if (events.Count > 0)
+            {
+                var message = string.Join(", ", events);
+                Log.Info($"In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
             }
         }
 
@@ -142,7 +148,11 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public void ReportTransactionEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildTransactionEventsRecollectedMetric(count));
 
-        public void ReportTransactionEventsSent(int count) => TrySend(_metricBuilder.TryBuildTransactionEventsSentMetric(count));
+        public void ReportTransactionEventsSent(int count)
+        {
+            TrySend(_metricBuilder.TryBuildTransactionEventsSentMetric(count));
+            _agentHealthEventCounters[AgentHealthEvent.Transaction]?.Add(count);
+        }
 
         #endregion TransactionEvents
 
@@ -165,7 +175,12 @@ namespace NewRelic.Agent.Core.AgentHealth
         public void ReportCustomEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildCustomEventsRecollectedMetric(count));
 
         // Note: Though not required by APM like the transaction event supportability metrics, this metric should still be created to maintain consistency
-        public void ReportCustomEventsSent(int count) => TrySend(_metricBuilder.TryBuildCustomEventsSentMetric(count));
+        public void ReportCustomEventsSent(int count)
+        {
+            TrySend(_metricBuilder.TryBuildCustomEventsSentMetric(count));
+            _agentHealthEventCounters[AgentHealthEvent.Custom]?.Add(count);
+
+        }
 
         #endregion CustomEvents
 
@@ -183,7 +198,11 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public void ReportErrorEventSeen() => TrySend(_metricBuilder.TryBuildErrorEventsSeenMetric());
 
-        public void ReportErrorEventsSent(int count) => TrySend(_metricBuilder.TryBuildErrorEventsSentMetric(count));
+        public void ReportErrorEventsSent(int count)
+        {
+            TrySend(_metricBuilder.TryBuildErrorEventsSentMetric(count));
+            _agentHealthEventCounters[AgentHealthEvent.Error]?.Add(count);
+        }
 
         #endregion ErrorEvents
 
@@ -381,7 +400,11 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public void ReportSpanEventCollected(int count) => TrySend(_metricBuilder.TryBuildSpanEventsSeenMetric(count));
 
-        public void ReportSpanEventsSent(int count) => TrySend(_metricBuilder.TryBuildSpanEventsSentMetric(count));
+        public void ReportSpanEventsSent(int count)
+        {
+            TrySend(_metricBuilder.TryBuildSpanEventsSentMetric(count));
+            _agentHealthEventCounters[AgentHealthEvent.Span]?.Add(count);
+        }
 
         #endregion Span 
 
@@ -429,6 +452,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 _infiniteTracingSpanBatchSizeMin = Math.Min(_infiniteTracingSpanBatchSizeMin, countSpans);
                 _infiniteTracingSpanBatchSizeMax = Math.Max(_infiniteTracingSpanBatchSizeMax, countSpans);
             }
+            _agentHealthEventCounters[AgentHealthEvent.InfiniteTracingSpan]?.Add((int)countSpans);
 
         }
 
@@ -616,7 +640,11 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public void ReportLoggingEventCollected() => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsCollectedMetric());
 
-        public void ReportLoggingEventsSent(int count) => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsSentMetric(count));
+        public void ReportLoggingEventsSent(int count)
+        {
+            TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsSentMetric(count));
+            _agentHealthEventCounters[AgentHealthEvent.Log]?.Add(count);
+        }
 
         public void ReportLoggingEventsDropped(int droppedCount)=> TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(droppedCount));
 

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -78,11 +78,8 @@ namespace NewRelic.Agent.Core.AgentHealth
                     events.Add(string.Format("{0} {1} {2}", timesOccured, agentHealthEvent, (timesOccured == 1) ? "event" : "events"));
                 }
             }
-            if (events.Count > 0)
-            {
-                var message = string.Join(", ", events);
-                Log.Info($"In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
-            }
+            var message = events.Count > 0 ? string.Join(", ", events) : "No events";
+            Log.Info($"In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
         }
 
         public void ReportSupportabilityCountMetric(string metricName, long count = 1)

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -63,7 +63,7 @@ namespace NewRelic.Agent.Core.Aggregators
         }
         protected override void Harvest()
         {
-            Log.Debug("Metric harvest starting.");
+            Log.Finest("Metric harvest starting.");
 
             foreach (var source in _outOfBandMetricSources)
             {

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -63,7 +63,7 @@ namespace NewRelic.Agent.Core.Aggregators
         }
         protected override void Harvest()
         {
-            Log.Info("Metric harvest starting.");
+            Log.Debug("Metric harvest starting.");
 
             foreach (var source in _outOfBandMetricSources)
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthHeartbeatTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthHeartbeatTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.WireModels;
+using NewRelic.Testing.Assertions;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.AgentHealth
+{
+    internal class FakeScheduler : IScheduler
+    {
+        protected Action _action;
+        public void ExecuteOnce(Action action, TimeSpan timeUntilExecution)
+        {
+            _action = action;
+        }
+
+        public void ExecuteEvery(Action action, TimeSpan timeBetweenExecutions, TimeSpan? optionalInitialDelay = null)
+        {
+            _action = action;
+        }
+
+        public void StopExecuting(Action action, TimeSpan? timeToWaitForInProgressAction = null)
+        {
+            _action = null;
+        }
+
+        public void ForceExecute()
+        {
+            _action?.Invoke();
+        }
+    }
+
+    [TestFixture]
+    internal class AgentHealthHeartbeatTests
+    {
+        public static IMetricBuilder GetSimpleMetricBuilder()
+        {
+            var metricNameService = Mock.Create<IMetricNameService>();
+            Mock.Arrange(() => metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
+            return new MetricWireModel.MetricBuilder(metricNameService);
+        }
+
+        [Test]
+        public void HeartbeatTest()
+        {
+            var scheduler = new FakeScheduler();
+            var reporter = new AgentHealthReporter(GetSimpleMetricBuilder(), scheduler);
+            using (var logger = new TestUtilities.Logging())
+            {
+                // Make sure all the event types get seen in the log
+                reporter.ReportTransactionEventsSent(1);
+                reporter.ReportCustomEventsSent(2);
+                reporter.ReportErrorEventsSent(3);
+                reporter.ReportSpanEventsSent(4);
+                reporter.ReportInfiniteTracingSpanEventsSent(5);
+                reporter.ReportLoggingEventsSent(6);
+
+                scheduler.ForceExecute();
+
+                NrAssert.Multiple(
+                    () => Assert.IsTrue(logger.HasMessageThatContains("1 Transaction")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("2 Custom")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("3 Error")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("4 Span")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("5 InfiniteTracingSpan")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("6 Log")),
+                    () => Assert.IsFalse(logger.HasMessageThatContains("No events"))
+                    );
+
+                // Make sure they all update their cumulative counts
+                for (int twice = 0; twice < 2; twice++)
+                {
+                    reporter.ReportTransactionEventsSent(1);
+                    reporter.ReportCustomEventsSent(2);
+                    reporter.ReportErrorEventsSent(3);
+                    reporter.ReportSpanEventsSent(4);
+                    reporter.ReportInfiniteTracingSpanEventsSent(5);
+                    reporter.ReportLoggingEventsSent(6);
+                }
+
+                scheduler.ForceExecute();
+                NrAssert.Multiple(
+                    () => Assert.IsTrue(logger.HasMessageThatContains("2 Transaction")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("4 Custom")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("6 Error")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("8 Span")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("10 InfiniteTracingSpan")),
+                    () => Assert.IsTrue(logger.HasMessageThatContains("12 Log")),
+                    () => Assert.IsFalse(logger.HasMessageThatContains("No events"))
+                    );
+
+                // Make sure they get cleared out between triggers
+                scheduler.ForceExecute();
+
+                Assert.IsTrue(logger.HasMessageThatContains("No events"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Right now there is very little information logged by the Agent at Info level, by design. One of the things that does get logged is a simple `Metric harvest starting.`, which can be used to show that the Agent is still alive and doing work. The goal with this change is to record something a little more useful. Instead, every (5) minutes, the Agent will log how many events it has seen in that window.

Before:
```
2023-06-12 07:44:14,961 NewRelic   INFO: [pid: 5832, tid: 10] Metric harvest starting.
2023-06-12 07:45:15,501 NewRelic   INFO: [pid: 5832, tid: 17] Metric harvest starting.
2023-06-12 07:46:15,730 NewRelic   INFO: [pid: 5832, tid: 29] Metric harvest starting.
2023-06-12 07:47:15,947 NewRelic   INFO: [pid: 5832, tid: 11] Metric harvest starting.
2023-06-12 07:48:16,182 NewRelic   INFO: [pid: 5832, tid: 11] Metric harvest starting.
2023-06-12 07:49:16,763 NewRelic   INFO: [pid: 5832, tid: 25] Metric harvest starting.
```

After:
```
2023-08-31 23:23:11,003 NewRelic   INFO: [pid: 50188, tid: 47] In the last 5 minutes: 112 Transaction events, 1 Log event, 44 Span events
2023-08-31 23:28:11,003 NewRelic   INFO: [pid: 25376, tid: 40] In the last 5 minutes: No events
2023-08-31 23:33:11,021 NewRelic   INFO: [pid: 50188, tid: 29] In the last 5 minutes: 35 Transaction events, 15 Span events
```
This has a few troubleshooting benefits, even if logging is only set to Info level:
* Can tell quickly that the Agent is running and collecting data
* Gives you a rough idea of how busy the Agent is
* Can see what kinds of data collection are enabled

Some other approaches I considered but decided against:
* Logging our Supportability metrics (too noisy)
* Metadata about the agent (is it connected, how long has it been running, etc)

But I am open to other suggestions for things to report. When I started I hadn't realized we already had a periodic logging mechanism in place, so it's very easy to add new data.