### PR TITLE
fix: Fix misleading log message on transaction name change. (#1857)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Wrapper/AgentWrapperApi/Builders/CandidateTransactionName.cs
+++ b/src/Agent/NewRelic/Agent/Core/Wrapper/AgentWrapperApi/Builders/CandidateTransactionName.cs
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders
                         _transaction.LogFinest($"Ignoring transaction name {FormatTransactionName(transactionName, priority)} because existing transaction name is frozen.");
                     else if (_currentTransactionName == null)
                         _transaction.LogFinest($"Setting transaction name to {FormatTransactionName(transactionName, priority)} from [nothing]");
-                    else if (priority > _highestPriority)
+                    else if ((priority == TransactionNamePriority.UserTransactionName) || (priority > _highestPriority))
                         _transaction.LogFinest($"Setting transaction name to {FormatTransactionName(transactionName, priority)} from {FormatTransactionName(_currentTransactionName, _highestPriority)}");
                     else
                         _transaction.LogFinest($"Ignoring transaction name {FormatTransactionName(transactionName, priority)} in favor of existing name {FormatTransactionName(_currentTransactionName, _highestPriority)}");

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -68,7 +68,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string SpanStreamingSuccessfullySentLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Attempting to send (\d+) item\(s\) - Success";
         public const string SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Received gRPC Server response messages: (\d+)";
         public const string SpanStreamingResponseGrpcError = FinestLogLinePrefixRegex + @"ResponseStreamWrapper: consumer \d+ - gRPC RpcException encountered while handling gRPC server responses: (.*)";
-        
+
+        // Transactions (either with an ID or "noop")
+        public const string TransactionLinePrefix = FinestLogLinePrefixRegex + @"Trx ([a-fA-F0-9]*|Noop): ";
+
         public AgentLogBase(RemoteApplication remoteApplication)
         {
             _remoteApplication = remoteApplication;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionNameTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using System.Collections.Generic;
+using System.Linq;
+using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Api
+{
+    public abstract class TransactionNameTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    {
+        protected readonly TFixture Fixture;
+
+        public TransactionNameTests(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            Fixture = fixture;
+            Fixture.TestLogger = output;
+
+            Fixture.AddCommand("ApiCalls TestSetTransactionName TestGroup OriginalName,NewName");
+
+            Fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(Fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                    configModifier.SetLogLevel("finest");
+                }
+            );
+
+            Fixture.Initialize();
+        }
+
+        [Fact]
+        public void TestSetTransactionName()
+        {
+            var setNameLines = Fixture.AgentLog.TryGetLogLines(AgentLogBase.TransactionLinePrefix + "Setting transaction name to.*?");
+            Assert.Equal(2, setNameLines.Count());
+
+            Assert.NotNull(Fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/TestGroup/NewName"));
+            Assert.Null(Fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/TestGroup/OriginalName"));
+
+            // Note the trailing space is necessary here, or we'll find "Ignoring transaction_segment_term with invalid prefix" which is unrelated
+            var notConnectedLogLine = Fixture.AgentLog.TryGetLogLine(AgentLogBase.TransactionLinePrefix + "Ignoring transaction name ");
+            Assert.Null(notConnectedLogLine);
+
+        }
+    }
+
+    [NetFrameworkTest]
+    public class TransactionNameTestsFW : TransactionNameTests<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public TransactionNameTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class TransactionNameTestsCore : TransactionNameTests<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public TransactionNameTestsCore(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
@@ -82,5 +82,23 @@ namespace MultiFunctionApplicationHelpers.Libraries
             }
             return errorGroupName;
         }
+
+        /// <summary>
+        /// Tests setting the current transaction name via the API
+        /// </summary>
+        /// <param name="category">Category</param>
+        /// <param name="names">Comma-separated list of names to be applied, in order</param>
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestSetTransactionName(string category, string names)
+        {
+            var namesList = names.Split(',');
+            foreach (var name in namesList)
+            {
+                NewRelic.Api.Agent.NewRelic.SetTransactionName(category, name);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Calling `SetTransactionName()` more than once would change the name, but the log would incorrectly report that it hadn't changed. I would have liked to combine the setting and logging logic, but the current structure seems deliberate for performance reasons.