### PR TITLE
Fix: Prevent broken traces when HttpClient content headers contain tracing headers. (#1843)

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpClient/SendAsync.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/HttpClient/SendAsync.cs
@@ -135,6 +135,9 @@ namespace NewRelic.Providers.Wrapper.HttpClient
         {
             var setHeaders = new Action<HttpRequestMessage, string, string>((carrier, key, value) =>
             {
+                // Content headers should not contain the expected header keys, but sometimes they do,
+                // and their presence can cause problems downstream by having 2 values for the same key.
+                carrier.Content?.Headers?.Remove(key);
                 // "Add" will throw if value exists, so we must remove it first
                 carrier.Headers?.Remove(key);
                 carrier.Headers?.Add(key, value);

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Controllers/SecondCallController.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Controllers/SecondCallController.cs
@@ -18,7 +18,17 @@ namespace AspNetCoreDistTracingApplication.Controllers
             {
                 using (var httpClient = new HttpClient())
                 {
-                    var result = await httpClient.GetStringAsync(nextUrl);
+                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, nextUrl);
+                    // Purposely include bad traceparent headers to try to break the distributed trace
+                    requestMessage.Headers.TryAddWithoutValidation("traceparent", "bad-traceparent-requestheader");
+                    requestMessage.Content = new StringContent(string.Empty);
+                    // This is not a valid content header, but there are some cases where this has happened
+                    requestMessage.Content.Headers.TryAddWithoutValidation("traceparent", "bad-traceparent-contentheader");
+
+                    //var result = await httpClient.GetStringAsync(nextUrl);
+                    var response = await httpClient.SendAsync(requestMessage);
+                    var result = await response.Content.ReadAsStringAsync();
+
                     return result;
                 }
             }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Fixes #1843.

Prevents duplicate outgoing tracing headers, for HttpClient calls,  by ensuring that the headers are only present as request headers, and that they do not also appear as content headers. An existing Integration Test was updated to ensure that the distributed trace is not broken when tracing headers are part of the Content Headers collection.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
