### PR TITLE
chore: add new methods in VisbilityBypasser to simplify "this or that" usage pattern.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Reflection/VisibilityBypasser.cs
@@ -202,6 +202,25 @@ namespace NewRelic.Reflection
             return owner => (TResult)methodCaller(owner);
         }
 
+        public bool TryGenerateParameterlessMethodCaller<TResult>(string assemblyName, string typeName, string methodName, out Func<object, TResult> accessor)
+        {
+            accessor = null;
+            try
+            {
+                var methodCaller = GenerateParameterlessMethodCaller<TResult>(assemblyName, typeName, methodName);
+                accessor = owner => (TResult)methodCaller(owner);
+                return true;
+            }
+            catch (ArgumentNullException)
+            {
+                throw;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         public Func<TOwner, TParameter, TResult> GenerateOneParameterMethodCaller<TOwner, TParameter, TResult>(string methodName)
         {
             if (methodName == null)
@@ -389,6 +408,25 @@ namespace NewRelic.Reflection
 
             var propertyGetter = GeneratePropertyAccessorInternal(ownerType, resultType, propertyName);
             return owner => (TResult)propertyGetter(owner);
+        }
+
+        public bool TryGeneratePropertyAccessor<TResult>(Type ownerType, string propertyName, out Func<object, TResult> accessor)
+        {
+            accessor = null;
+            try
+            {
+                var propertyGetter = GeneratePropertyAccessor<TResult>(ownerType, propertyName);
+                accessor = owner => (TResult)propertyGetter(owner);
+                return true;
+            }
+            catch (ArgumentNullException)
+            {
+                throw;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public Func<TOwner, TResult> GeneratePropertyAccessor<TOwner, TResult>(string propertyName)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
@@ -99,13 +99,13 @@ namespace NewRelic.Providers.Wrapper.Logging
         {
             var logEventType = logEvent.GetType();
 
-            if (_getGetProperties == null && !VisibilityBypasser.Instance.TryGenerateParameterlessMethodCaller(logEventType.Assembly.ToString(), logEventType.FullName, "GetProperties", out _getProperties))
+            if (_getGetProperties == null && !VisibilityBypasser.Instance.TryGenerateParameterlessMethodCaller(logEventType.Assembly.ToString(), logEventType.FullName, "GetProperties", out _getGetProperties))
             {
                 // Legacy property, mainly used by Sitecore
-                if (VisibilityBypasser.Instance.TryGeneratePropertyAccessor<IDictionary>(logEventType, "MappedContext", out _getProperties))
+                if (VisibilityBypasser.Instance.TryGeneratePropertyAccessor(logEventType, "MappedContext", out _getGetProperties))
                     _legacyVersion = true;
                 else
-                    _getProperties = (x) => null;
+                    _getGetProperties = (x) => null;
             }
 
             var contextData = new Dictionary<string, object>();
@@ -129,7 +129,7 @@ namespace NewRelic.Providers.Wrapper.Logging
                 }
             }
 
-            var propertiesDictionary = _getProperties(logEvent);
+            var propertiesDictionary = _getGetProperties(logEvent);
 
             if (propertiesDictionary != null && propertiesDictionary.Count > 0)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Log4netWrapper.cs
@@ -59,12 +59,16 @@ namespace NewRelic.Providers.Wrapper.Logging
             // Older versions of log4net only allow access to a timestamp in local time
             var getTimestampFunc = _getTimestamp ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<DateTime>(logEventType, "TimeStamp");
 
-            if (_getLogException == null
-                && !VisibilityBypasser.Instance.TryGeneratePropertyAccessor<Exception>(logEventType, "ExceptionObject", out _getLogException)
-                // Legacy property, mainly used by Sitecore
-                && !VisibilityBypasser.Instance.TryGeneratePropertyAccessor<Exception>(logEventType, "m_thrownException", out _getLogException))
+            if (_getLogException == null)
             {
-                _getLogException = (x) => null;
+                if (!VisibilityBypasser.Instance.TryGeneratePropertyAccessor<Exception>(logEventType, "ExceptionObject", out _getLogException))
+                {
+                    // Legacy property, mainly used by Sitecore
+                    if (!VisibilityBypasser.Instance.TryGeneratePropertyAccessor<Exception>(logEventType, "m_thrownException", out _getLogException))
+                    {
+                        _getLogException = (x) => null;
+                    }
+                }
             }
 
             // This will either add the log message to the transaction or directly to the aggregator


### PR DESCRIPTION
Adds a couple of `TryXxx()` methods in `VisibilityBypasser` that simplify calling patterns where we attempt to get a particular property or method, then fall back to getting a different property or method. 

Resolves #1797.