### PR TITLE
ci: Assign a unique network name in docker compose for each test execution to avoid collisions.

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -10,6 +10,7 @@ version: "3"
 # CONTAINER_NAME  The name for the container
 # PLATFORM        The platform that the service runs on -- linux/amd64 or linux/arm64/v8
 # DOTNET_VERSION  The dotnet version number to use (7.0, 8.0, etc)
+# NETWORK_NAME    The name of the externally defined network to use for running these containers.
 #
 # and the usual suspects:
 # NEW_RELIC_LICENSE_KEY
@@ -74,4 +75,9 @@ services:
         extends:
             service: smoketestapp
         build:
-            dockerfile: SmokeTestApp/Dockerfile.centos   
+            dockerfile: SmokeTestApp/Dockerfile.centos
+            
+networks:
+    default:
+        name: ${NETWORK_NAME}
+        driver: bridge

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -10,7 +10,7 @@ version: "3"
 # CONTAINER_NAME  The name for the container
 # PLATFORM        The platform that the service runs on -- linux/amd64 or linux/arm64/v8
 # DOTNET_VERSION  The dotnet version number to use (7.0, 8.0, etc)
-# NETWORK_NAME    The name of the externally defined network to use for running these containers.
+# NETWORK_NAME    The network name to use for containers in this app. Should be unique among all running instances.
 #
 # and the usual suspects:
 # NEW_RELIC_LICENSE_KEY

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
@@ -105,6 +105,7 @@ public class ContainerApplication : RemoteApplication
         startInfo.EnvironmentVariables.Remove("CORECLR_PROFILER");
         startInfo.EnvironmentVariables.Remove("CORECLR_PROFILER_PATH");
         startInfo.EnvironmentVariables.Remove("CORECLR_NEWRELIC_HOME");
+        startInfo.EnvironmentVariables.Remove("NETWORK_NAME");
 
         // Docker compose settings
         var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("Default");
@@ -120,6 +121,7 @@ public class ContainerApplication : RemoteApplication
         startInfo.EnvironmentVariables.Add("AGENT_PATH", newRelicHomeDirectoryPath);
         startInfo.EnvironmentVariables.Add("LOG_PATH", profilerLogDirectoryPath);
         startInfo.EnvironmentVariables.Add("CONTAINER_NAME", ContainerName);
+        startInfo.EnvironmentVariables.Add("NETWORK_NAME", Guid.NewGuid().ToString()); // generate a random network name to keep parallel test execution from failing
 
         if (AdditionalEnvironmentVariables != null)
         {


### PR DESCRIPTION
Assigns a guid as the network name for each test that runs, this should avoid the occasional failures we've seen that have a message like 
```
Error response from daemon: network containerapplications_default is ambiguous (2 matches found on name)
```