### PR TITLE
chore: Separate MultiFunctionApplicationHelpers project from the test runner projects.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogString.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogString.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Agent.IntegrationTestHelpers
+{
+    public class AgentLogString : AgentLogBase
+    {
+        private readonly string _logContents;
+
+        public AgentLogString(string logContents)
+            : base(null)
+        {
+            _logContents = logContents;
+        }
+
+        public override IEnumerable<string> GetFileLines()
+        {
+            return _logContents.Split('\n');
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/ConsoleDynamicMethodFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/ConsoleDynamicMethodFixture.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace MultiFunctionApplicationHelpers
+namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 {
     public class ConsoleDynamicMethodFixtureFWLatest : ConsoleDynamicMethodFixtureFW481
     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/VulnerabilityManagementTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/VulnerabilityManagementTests.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.IO;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DataUsageSupportabilityMetricsTests.cs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Testing.Assertions;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -53,7 +51,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
             // Logging commands
-            _fixture.AddCommand($"LoggingTester SetFramework log4net");
+            _fixture.AddCommand($"LoggingTester SetFramework log4net {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester ConfigureWithInfoLevelEnabled");
 
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessageInTransaction ThisIsAInfoLogMessage INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System.Linq;
 using Xunit;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/CustomSpanNameApiTests.cs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.Api
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ErrorGroupCallbackTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionNameTests.cs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.Models;
-using NewRelic.Testing.Assertions;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionUserIdTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/TransactionUserIdTests.cs
@@ -4,9 +4,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AppDomainCaching/AppDomainCachingTests.cs
@@ -3,8 +3,8 @@
 
 
 using System;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetStandardLibraryInstrumentation.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System.Collections.Generic;
 using System.IO;

--- a/tests/Agent/IntegrationTests/IntegrationTests/Configuration/GuidConfigurationTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Configuration/GuidConfigurationTest.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/AttributeInstrumentationTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -10,6 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.CustomInstrumentation
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CustomInstrumentation/ForceNewTransactionTests.cs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/ConnectSetApplicationNameTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DataTransmission/FasterEventHarvestTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.IO;

--- a/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/HttpClientInstrumentation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/HttpClientInstrumentation/HttpClientInstrumentation.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingFlakyTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.InfiniteTracing

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
-using Xunit;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.InfiniteTracing

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -61,7 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\NewRelic.Testing.Assertions\NewRelic.Testing.Assertions.csproj" />
-    <ProjectReference Include="..\SharedApplications\Common\MultiFunctionApplicationHelpers\MultiFunctionApplicationHelpers.csproj" />
     <ProjectReference Include="..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />
     <ProjectReference Include="..\Models\Models.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNotSupportedTests.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
 
             string context = string.Join(",", _expectedAttributes.Select(x => x.Key + "=" + x.Value).ToArray());

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ContextData
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
 
             string context = string.Join(",", _expectedAttributes.Select(x => x.Key + "=" + x.Value).ToArray());

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/HSMOrCSPDisablesForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/HSMOrCSPDisablesForwardingTests.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.HsmAndCsp
             _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage One DEBUG");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage Two INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LocalDecorationTests.cs
@@ -5,8 +5,8 @@ using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LocalDecoration
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure{layoutType}LayoutAppenderForDecoration");
             if (logWithParam)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelDenyListTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelDenyListTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,7 +27,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             _fixture.TestLogger = output;
 
             //_fixture.AddCommand("RootCommands LaunchDebugger");
-            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand("LoggingTester Configure");
 
             _fixture.AddCommand("LoggingTester CreateSingleLogMessage DebugMessage DEBUG");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/LogLevelTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.LogLevelDetection
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester ConfigureWithInfoLevelEnabled");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage ShouldNotBeForwardedDebugMessage DEBUG");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage ShouldBeForwardedInfoMessage INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MaxSamplesStoredTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +21,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MaxSamplesStored
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage One DEBUG");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage Two INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/MetricsAndForwardingTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -57,7 +57,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.MetricsAndForwarding
             _fixture.TestLogger = output;
             _canHaveLogsOutsideTransaction = _loggingFramework != LoggingFramework.SerilogWeb;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
 
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage {OutsideTransactionInfoMessage} INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ZeroMaxSamplesStoredTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.Logging.ZeroMaxSamplesStored
             _fixture.SetTimeout(System.TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework}");
+            _fixture.AddCommand($"LoggingTester SetFramework {loggingFramework} {RandomPortGenerator.NextPort()}");
             _fixture.AddCommand($"LoggingTester Configure");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage One DEBUG");
             _fixture.AddCommand($"LoggingTester CreateSingleLogMessage Two INFO");

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -4,9 +4,9 @@
 #if NETFRAMEWORK
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Agent.IntegrationTests.WCF;
 using Xunit;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -3,8 +3,8 @@
 
 #if NETFRAMEWORK
 using System.Collections.Generic;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 using System;
-using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -9,7 +9,7 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
 using System;
-using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.RestSharp
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
@@ -5,10 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
@@ -3,8 +3,8 @@
 
 #if NETFRAMEWORK
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Testing.Assertions;
 using System;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests_IISHosted.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests_IISHosted.cs
@@ -3,8 +3,8 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests_SelfHosted.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests_SelfHosted.cs
@@ -3,8 +3,8 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFEmptyTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFEmptyTestBase.cs
@@ -4,8 +4,8 @@
 #if NETFRAMEWORK
 using System;
 using System.IO;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLegacyTestBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLegacyTestBase.cs
@@ -3,7 +3,6 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
@@ -14,6 +13,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.WCF
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLogHelpers.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFLogHelpers.cs
@@ -3,9 +3,9 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceExternalCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceExternalCallsTests.cs
@@ -3,7 +3,7 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceExternalCallsTestsBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceExternalCallsTestsBase.cs
@@ -5,8 +5,8 @@
 #if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
@@ -13,6 +12,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.WCF.Service
 {

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests_IISHosted.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests_IISHosted.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests_SelfHosted.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFServiceTests_SelfHosted.cs
@@ -3,8 +3,8 @@
 
 
 #if NETFRAMEWORK
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using Xunit.Abstractions;
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -283,7 +283,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
-    <ProjectReference Include="..\..\..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />
     <ProjectReference Include="..\..\..\Models\Models.csproj" />
     <ProjectReference Include="..\..\..\Shared\Shared.csproj" />
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -283,7 +283,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
-    <ProjectReference Include="..\..\..\Models\Models.csproj" />
     <ProjectReference Include="..\..\..\Shared\Shared.csproj" />
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />
   </ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Transport;
 using NewRelic.Agent.IntegrationTests.Shared;
-using Xunit;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -56,7 +55,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var record = FlightRecord.GetSample();
             var response = _client.Index(record, IndexName);
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            if (!response.IsSuccess())
+            {
+                throw new Exception($"Response was not successful. {response.ElasticsearchServerError}");
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -66,7 +68,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.IndexAsync(record, IndexName);
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            AssertResponseIsSuccess(response);
 
             return response.IsSuccess();
         }
@@ -83,7 +85,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 )
             );
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            AssertResponseIsSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -98,7 +100,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 )
             );
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            AssertResponseIsSuccess(response);
 
             return response.Total;
         }
@@ -110,7 +112,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = _client.IndexMany(records, IndexName);
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            AssertResponseIsSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -120,7 +122,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.IndexManyAsync(records, IndexName);
 
-            Assert.True(response.IsSuccess(), $"Elasticsearch server error: {response.ElasticsearchServerError}");
+            AssertResponseIsSuccess(response);
 
             return response.IsSuccess();
         }
@@ -158,7 +160,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = client.Ping();
 
-            Assert.False(response.IsSuccess());
+            if (response.IsSuccess())
+            {
+                throw new Exception("Expected the call to fail, but it succeeded.");
+            }
+        }
+
+        private static void AssertResponseIsSuccess<T>(T response)
+            where T : Elastic.Transport.Products.Elasticsearch.ElasticsearchResponse
+        {
+            if (!response.IsSuccess())
+            {
+                throw new Exception($"Response was not successful. {response.ElasticsearchServerError}");
+            }
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Nest;
 using NewRelic.Agent.IntegrationTests.Shared;
-using Xunit;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -56,7 +55,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var record = FlightRecord.GetSample();
             var response = _client.IndexDocument(record);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -65,7 +64,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var record = FlightRecord.GetSample();
             var response = await _client.IndexDocumentAsync(record);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
 
             return response.IsValid;
         }
@@ -76,7 +75,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var records = FlightRecord.GetSamples(3);
             var response = _client.IndexMany(records);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -85,7 +84,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var record = FlightRecord.GetSample();
             var response = await _client.IndexDocumentAsync(record);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
 
             return response.IsValid;
         }
@@ -104,7 +103,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                    )
                 );
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -121,7 +120,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                    )
                 );
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
 
             return response.Total;
         }
@@ -147,7 +146,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = _client.MultiSearch(msd);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -171,7 +170,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.MultiSearchAsync(msd);
 
-            Assert.True(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            AssertResponseIsValid(response);
 
             return response.TotalResponses;
         }
@@ -188,7 +187,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var client = new ElasticClient(settings);
 
             var response = client.Ping();
-            Assert.False(response.IsValid, $"Elasticsearch server error: {response.ServerError}");
+            if (response.IsValid)
+            {
+                throw new Exception($"Response was successful but we expected an error. {response.ServerError}");
+            }
+        }
+
+        private static void AssertResponseIsValid<T>(T response)
+            where T : IResponse
+        {
+            if (!response.IsValid)
+            {
+                throw new Exception($"Response was not successful. Elasitcsearch server error: {response.ServerError}");
+            }
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using NewRelic.Agent.IntegrationTests.Shared;
-using Xunit;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
@@ -52,7 +51,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var record = FlightRecord.GetSample();
             var response = _client.Index<BytesResponse>(IndexName, record.Id.ToString(), PostData.Serializable(record));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -62,7 +61,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.IndexAsync<StringResponse>(IndexName, record.Id.ToString(), PostData.Serializable(record));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
 
             return response.Success;
         }
@@ -81,7 +80,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = _client.Bulk<BytesResponse>(PostData.MultiJson(bulkIndex));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -98,7 +97,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.BulkAsync<BytesResponse>(PostData.MultiJson(bulkIndex));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
 
             return response.Success;
         }
@@ -122,7 +121,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 }
             }));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -144,7 +143,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 }
             }));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
 
             return 0;
         }
@@ -175,7 +174,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             }
             var response = _client.MultiSearch<StringResponse>(IndexName, PostData.MultiJson(multiSearchData));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -205,7 +204,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var response = await _client.MultiSearchAsync<StringResponse>(IndexName, PostData.MultiJson(multiSearchData));
 
-            Assert.True(response.Success, $"Elasticsearch server error: {response}");
+            AssertResponseSuccess(response);
 
             return 0;
         }
@@ -222,7 +221,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             var client = new ElasticLowLevelClient(settings);
             var response = client.Ping<StringResponse>();
 
-            Assert.False(response.Success, $"Elasticsearch server error: {response}");
+            if (response.Success)
+            {
+                throw new Exception($"Response was successful but expected a failure. Elasitcsearch response: {response}");
+            }
+        }
+
+        private static void AssertResponseSuccess<T>(T response)
+            where T : IApiCallDetails
+        {
+            if (!response.Success)
+            {
+                throw new Exception($"Response was not successful. Elasitcsearch response: {response}");
+            }
         }
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
-using NewRelic.IntegrationTests.Models;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
 {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -17,7 +17,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         private static ILoggingAdapter _log;
 
         [LibraryMethod]
-        public static void SetFramework(string loggingFramework)
+        public static void SetFramework(string loggingFramework, string loggingPort)
         {
             switch (loggingFramework.ToUpper())
             {
@@ -29,7 +29,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                     break;
                 case "SERILOGWEB": // .NET 7.0 ONLY
 #if NET7_0    
-                    _log = new SerilogLoggingWebAdapter();
+                    _log = new SerilogLoggingWebAdapter(loggingPort);
 #endif
                     break;
                 case "MICROSOFTLOGGING":

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Person.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Person.cs
@@ -4,7 +4,7 @@
 
 using Newtonsoft.Json;
 
-namespace NewRelic.IntegrationTests.Models
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation
 {
     public class Person
     {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NewRelic.Agent.IntegrationTestHelpers;
 using Serilog;
 using Serilog.Events;
 
@@ -21,26 +20,28 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
     class SerilogLoggingWebAdapter : ILoggingAdapter
     {
         private static readonly HttpClient _client = new HttpClient();
+        private readonly string _loggingPort;
         private string _uriBase;
 
-        public SerilogLoggingWebAdapter()
+        public SerilogLoggingWebAdapter(string loggingPort)
         {
+            _loggingPort = loggingPort;
         }
 
         public void Debug(string message)
         {
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=DEBUG&message=" + message).Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=DEBUG&message=" + message).Result;
         }
 
         public void Info(string message)
         {
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=INFO&message=" + message).Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=INFO&message=" + message).Result;
         }
         public void Info(string message, Dictionary<string, object> context)
         {
             var contextString = string.Join(", ", context.Select(c => c.Key + "=" + c.Value));
 
-            var result = _client.GetStringAsync(_uriBase + "testContext?message=" + message + "&contextData=" + contextString).Result;
+            _ = _client.GetStringAsync(_uriBase + "testContext?message=" + message + "&contextData=" + contextString).Result;
         }
 
         public void InfoWithParam(string message, object param)
@@ -50,7 +51,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         public void Warn(string message)
         {
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=WARN&message=" + message).Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=WARN&message=" + message).Result;
         }
 
         public void Error(Exception exception)
@@ -66,17 +67,17 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             // In this case we are not passing the exact Exception to the test app, just the message.
             // The test app will create an Exception for us.
             // As long as it has the same message and class with a stacktrace of any kind, its good for test.
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=NOMESSAGE&message=" + string.Empty).Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=NOMESSAGE&message=" + string.Empty).Result;
         }
 
         public void Fatal(string message)
         {
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=FATAL&message=" + message).Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=FATAL&message=" + message).Result;
         }
 
         public void NoMessage()
         {
-            var result = _client.GetStringAsync(_uriBase + "test?logLevel=FATAL&message=EMPTY").Result;
+            _ = _client.GetStringAsync(_uriBase + "test?logLevel=FATAL&message=EMPTY").Result;
         }
 
         public void Configure()
@@ -106,8 +107,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         { 
             var logger = loggerConfig.CreateLogger();
 
-            var port = RandomPortGenerator.NextPort();
-            _uriBase = "http://localhost:" + port + "/";
+            _uriBase = "http://localhost:" + _loggingPort + "/";
             var hostTask = CreateHostBuilder(_uriBase).Build().RunAsync();
 
             Console.WriteLine("URI: " + _uriBase);

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverAsyncCursorTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using System;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlAsyncTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamAsyncTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
@@ -5,10 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
@@ -6,10 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
@@ -6,10 +6,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
@@ -7,8 +7,8 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
-using MultiFunctionApplicationHelpers;
 using System;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -5,10 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Collections.Generic;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncCmdHandlerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbAsyncEventHandlerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbPublishTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5ReceiveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5ReceiveTests.cs
@@ -3,6 +3,7 @@
 
 
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,6 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using Assert = Xunit.Assert;
-using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus5
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5SendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5SendTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarTests.cs
@@ -5,11 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
-using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorAsyncTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryTests.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
@@ -5,8 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqDistributedTracingTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System;
 using System.Collections.Generic;
 using Xunit;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqW3cTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqW3cTracingTests.cs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
@@ -3,6 +3,7 @@
 
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Testing.Assertions;
 using System;
@@ -10,7 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using MultiFunctionApplicationHelpers;
 
 namespace NewRelic.Agent.UnboundedIntegrationTests.Redis
 {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -44,10 +44,12 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.3.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MySqlConnector" Version="2.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="CouchbaseNetClient" Version="2.3.8" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
@@ -68,7 +70,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\NewRelic.Testing.Assertions\NewRelic.Testing.Assertions.csproj" />
     <ProjectReference Include="..\IntegrationTestHelpers\IntegrationTestHelpers.csproj" />
-    <ProjectReference Include="..\SharedApplications\Common\MultiFunctionApplicationHelpers\MultiFunctionApplicationHelpers.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
   


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

A first step towards #1883.

In this PR the following changes were made.

- The MultiFunctionApplicationHelpers project is updated to contain only the code that can be used in a test application.
  - The ConsoleApplication fixture is moved into the IntegrationTestHelpers project and its namespace is updated
  - XUnit was removed, and the assertions are replaced by if statements and thrown exceptions
- All references to the ConsoleApplication fixture were updated to use the new namespace
- The unbounded tests project was updated to add dependencies to the mysqlconnector and microsoft.data.sqlclient libraries, instead of relying on transitive dependencies from the MultiFunctionApplication helpers (these versions are independent of the version(s) being tested).
- The Integration tests and Unbounded Integration tests projects were updated to stop referencing the MultifunctionApplicationHelpers project. 
- The unique port required for the SerilogWebAdapter tests are now passed from the test runner to the test application
- Removed the Models project from the MultiFunctionApplicationHelpers project
  - Moved the Person model to the logging library where it is used

The only remaining dependencies for the MultiFunctionApplicationHelpers project are the following.
- The Shared project which contains the necessary secrets for the test apps and libraries
- The current Agent Api so that the Api can be used within the test apps and libraries
- A separate test library project
- The instrumented libraries that are being tested

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
