### PR TITLE
ci: Extend the wait timer for validating the Linux deploys.

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Wait for APT to update
         if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
         run: |
-          echo "Sleeping 2 minutes to wait for apt to update itself"
-          sleep 120
+          echo "Sleeping 5 minutes to wait for apt to update itself"
+          sleep 300
         shell: bash      
       - name: Validate
         run: |
@@ -75,8 +75,8 @@ jobs:
       - name: Wait for YUM to update
         if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
         run: |
-          echo "Sleeping 2 minutes to wait for yum to update itself"
-          sleep 120
+          echo "Sleeping 5 minutes to wait for yum to update itself"
+          sleep 300
         shell: bash
 
       - name: Validate


### PR DESCRIPTION
## Description

The linux deploy validation tests failed for this release, but when rerun they passed.  We currently have a 2 minute wait time to help prevent this, but it is not enough.  Moving to a 5 minute wait.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
