### PR TITLE
Disable Oracle integration tests in CI

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -486,7 +486,8 @@ jobs:
             MySql,
             NServiceBus,
             NServiceBus5,
-            Oracle,
+            # Disabling Oracle, see https://issues.newrelic.com/browse/NR-161046
+            #Oracle,
             Postgres,
             RabbitMq,
             Redis,

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -486,7 +486,7 @@ jobs:
             MySql,
             NServiceBus,
             NServiceBus5,
-            # Disabling Oracle, see https://issues.newrelic.com/browse/NR-161046
+            # Disabling Oracle temporarily
             #Oracle,
             Postgres,
             RabbitMq,

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
-            # Oracle is disabled, see https://issues.newrelic.com/browse/NR-161046
+            # Oracle is disabled temporarily
             #namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
             namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Postgres', 'RabbitMq', 'Redis' ]"
           else

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -69,7 +69,9 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
-            namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
+            # Oracle is disabled, see https://issues.newrelic.com/browse/NR-161046
+            #namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
+            namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Postgres', 'RabbitMq', 'Redis' ]"
           else
             # Just use the supplied list of namespaces
             namespaces="[ ${{ github.event.inputs.unbounded-test-namespaces }} ]"


### PR DESCRIPTION
## Description

Due to issues with the Oracle server used in GHA, temporarily disable running the Oracle integration tests in CI.  They can still be run locally using a local container to host the Oracle server.
