### PR TITLE
test: Make infinite tracing integration test more stable.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -65,6 +65,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         // Infinite trace
         public const string SpanStreamingServiceConnectedLogLineRegex = InfoLogLinePrefixRegex + @"SpanStreamingService: gRPC channel to endpoint (.*) connected.(.*)";
+        public const string SpanStreamingServiceStreamConnectedLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - gRPC request stream connected (.*)";
         public const string SpanStreamingSuccessfullySentLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Attempting to send (\d+) item\(s\) - Success";
         public const string SpanStreamingSuccessfullyProcessedByServerResponseLogLineRegex = FinestLogLinePrefixRegex + @"SpanStreamingService: consumer \d+ - Received gRPC Server response messages: (\d+)";
         public const string SpanStreamingResponseGrpcError = FinestLogLinePrefixRegex + @"ResponseStreamWrapper: consumer \d+ - gRPC RpcException encountered while handling gRPC server responses: (.*)";

--- a/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/InfiniteTracing/InfiniteTracingTests.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.InfiniteTracing
                 exerciseApplication: () =>
                 {
                     // Wait for 8T to connect
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanStreamingServiceConnectedLogLineRegex, TimeSpan.FromSeconds(15));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanStreamingServiceStreamConnectedLogLineRegex, TimeSpan.FromSeconds(15));
                     // Now send the command to make the 8T Span
                     _fixture.SendCommand("InfiniteTracingTester Make8TSpan");
                     // Now wait to see that the 8T spans were sent successfully


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

In https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/6200910159/job/16837606190?pr=1920 the infinite tracing test failed because the test only waited for the grpc connection to be established before triggering the 1 instrumented method call. However, spans will only be transmitted over infinite tracing after at least 1 stream is connected. This delay between the grpc connection and the stream connection being established can lead to the generated span being sent via either infinite tracing or normal distributed tracing (depending on when the span is created). To make the test more stable, it now waits until at least 1 stream is connected before triggering the instrumented method.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
