### PR TITLE
fix: Reinstate max number of log files.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -253,7 +253,7 @@ namespace NewRelic.Agent.Core
                             fileSizeLimitBytes: 50 * 1024 * 1024,
                             encoding: Encoding.UTF8,
                             rollOnFileSizeLimit: true,
-                            retainedFileCountLimit: null, // unlimited number of files
+                            retainedFileCountLimit: 4, // TODO: Will make configurable
                             shared: true,
                             buffered: false
                             );


### PR DESCRIPTION
## Description

Reverts the max number of Agent logs to 4 (It is currently unlimited).

Resolves #1929 
