### PR TITLE
test: EventWaitHandle error handling attempt

### DIFF
--- a/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
@@ -63,12 +63,14 @@ namespace HostedWebCore
             EventWaitHandle eventWaitHandle;
             try
             {
+                Program.Log($"Creating EventWaitHandle named {eventWaitHandleName}");
                 eventWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventWaitHandleName);
             }
             catch (Exception ex)
             {
-                Program.Log($"EventWaitHandle ctor failed with exception {ex}. Re-trying with OpenExisting().");
+                Program.Log($"EventWaitHandle creation failed with exception: {ex}. Re-trying with EventWaitHandle.OpenExisting().");
                 eventWaitHandle = EventWaitHandle.OpenExisting(eventWaitHandleName);
+                Program.Log($"EventWaitHandle.OpenExisting() succeeded!");
             }
 
             using (eventWaitHandle)

--- a/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
@@ -58,9 +58,20 @@ namespace HostedWebCore
         public void Run()
         {
             StartWebServer();
-            //The HWC creates this shutdown event and waits for the test runner to set so that it can shutdown.  
-            using (var eventWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset,
-                       "app_server_wait_for_all_request_done_" + _port.ToString()))
+            //The HWC creates this shutdown event and waits for the test runner to set so that it can shutdown.
+            var eventWaitHandleName = "app_server_wait_for_all_request_done_" + _port;
+            EventWaitHandle eventWaitHandle;
+            try
+            {
+                eventWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventWaitHandleName);
+            }
+            catch (Exception ex)
+            {
+                Program.Log($"EventWaitHandle ctor failed with exception {ex}. Re-trying with OpenExisting().");
+                eventWaitHandle = EventWaitHandle.OpenExisting(eventWaitHandleName);
+            }
+
+            using (eventWaitHandle)
             {
                 CreatePidFile();
                 eventWaitHandle.WaitOne(TimeSpan.FromMinutes(ServerTimeoutShutdownMinutes));

--- a/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
@@ -63,14 +63,11 @@ namespace HostedWebCore
             EventWaitHandle eventWaitHandle;
             try
             {
-                Program.Log($"Creating EventWaitHandle named {eventWaitHandleName}");
                 eventWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventWaitHandleName);
             }
-            catch (Exception ex)
+            catch
             {
-                Program.Log($"EventWaitHandle creation failed with exception: {ex}. Re-trying with EventWaitHandle.OpenExisting().");
                 eventWaitHandle = EventWaitHandle.OpenExisting(eventWaitHandleName);
-                Program.Log($"EventWaitHandle.OpenExisting() succeeded!");
             }
 
             using (eventWaitHandle)

--- a/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
@@ -13,7 +13,7 @@ namespace HostedWebCore
 {
     static class Program
     {
-        private static void Log(string format)
+        internal static void Log(string format)
         {
             string prefix = string.Format("[{0} {1}-{2}] HostedWebCore: ", DateTime.Now,
                     System.Diagnostics.Process.GetCurrentProcess().Id,

--- a/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
@@ -13,7 +13,7 @@ namespace HostedWebCore
 {
     static class Program
     {
-        internal static void Log(string format)
+        private static void Log(string format)
         {
             string prefix = string.Format("[{0} {1}-{2}] HostedWebCore: ", DateTime.Now,
                     System.Diagnostics.Process.GetCurrentProcess().Id,


### PR DESCRIPTION
Attempts to work around an intermittent test failure when creating an `EventWaitHandle` by retrying with `EventWaitHandle.OpenExisting()`. No idea if it will help or not, but I don't think it can hurt anything. 

The error we see in CI runs looks like this:
```
 [9/27/2023 9:51:19 AM 1208-1] HostedWebCore: HostedWebCore.exe failed: Reason unknown.: System.IO.FileLoadException: The process cannot access the file because it is being used by another process. (Exception from HRESULT: 0x80070020)
    at System.Runtime.InteropServices.Marshal.ThrowExceptionForHRInternal(Int32 errorCode, IntPtr errorInfo)
    at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
    at HostedWebCore.HostedWebCore.Run() in D:\a\newrelic-dotnet-agent\newrelic-dotnet-agent\tests\Agent\IntegrationTests\HostedWebCore\HostedWebCore.cs:line 62
    at HostedWebCore.Program.Main(String[] args) in D:\a\newrelic-dotnet-agent\newrelic-dotnet-agent\tests\Agent\IntegrationTests\HostedWebCore\Program.cs:line 51
```