### PR TITLE
test: Add retry logic when attempting to start the WebCore process

### DIFF
--- a/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/HostedWebCore.cs
@@ -69,8 +69,28 @@ namespace HostedWebCore
 
         private void StartWebServer()
         {
-            var hresult = NativeMethods.WebCoreActivate(ApplicationHostConfigFilePath, null, @".NET Agent Integration Test Web Host");
-            Marshal.ThrowExceptionForHR(hresult);
+            int maxRetries = 3;
+            int curRetry = 0;
+
+            while (true)
+            {
+                try
+                {
+                    var hResult = NativeMethods.WebCoreActivate(ApplicationHostConfigFilePath, null, @".NET Agent Integration Test Web Host");
+                    Marshal.ThrowExceptionForHR(hResult);
+
+                    return; // success
+                }
+                catch
+                {
+                    if (curRetry++ < maxRetries)
+                    {
+                        Thread.Sleep(500);
+                    }
+                    else
+                        throw; // all retries failed
+                }
+            }
         }
 
         private static void CreatePidFile()


### PR DESCRIPTION
Adds a bit of wait-and-retry logic to `HostedWebCore` to address intermittent failures when we use P/Invoke to start the hosted web service. 

The stack trace indicating the failure looks something like 
```
[9/27/2023 9:51:19 AM 1208-1] HostedWebCore: HostedWebCore.exe failed: Reason unknown.: System.IO.FileLoadException: The process cannot access the file because it is being used by another process. (Exception from HRESULT: 0x80070020)
    at System.Runtime.InteropServices.Marshal.ThrowExceptionForHRInternal(Int32 errorCode, IntPtr errorInfo)
    at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
    at HostedWebCore.HostedWebCore.Run() in D:\a\newrelic-dotnet-agent\newrelic-dotnet-agent\tests\Agent\IntegrationTests\HostedWebCore\HostedWebCore.cs:line 62
    at HostedWebCore.Program.Main(String[] args) in D:\a\newrelic-dotnet-agent\newrelic-dotnet-agent\tests\Agent\IntegrationTests\HostedWebCore\Program.cs:line 51
```