### PR TITLE
fix: Detect Docker container id on cgroup v2.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -275,8 +275,6 @@ namespace NewRelic.Agent.Core.Utilization
         {
 #if NETSTANDARD2_0
             bool isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            int subsystemsIndex = 1;
-            int controlGroupIndex = 2;
 
             if (isLinux)
             {
@@ -284,7 +282,7 @@ namespace NewRelic.Agent.Core.Utilization
                 {
                     var fileContent = File.ReadAllText("/proc/self/mountinfo");
                     var vendorModel = TryGetDockerCGroupV2(fileContent)
-                                      ?? TryGetDockerCGroupV1(subsystemsIndex, controlGroupIndex);
+                                      ?? TryGetDockerCGroupV1();
 
                     return vendorModel;
                 }
@@ -298,8 +296,11 @@ namespace NewRelic.Agent.Core.Utilization
         }
 
 #if NETSTANDARD2_0
-        public static IVendorModel TryGetDockerCGroupV1(int subsystemsIndex, int controlGroupIndex)
+        public static IVendorModel TryGetDockerCGroupV1()
         {
+            int subsystemsIndex = 1;
+            int controlGroupIndex = 2;
+
             string id = null;
             var fileLines = File.ReadAllLines("/proc/self/cgroup");
 

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -286,8 +286,9 @@ namespace NewRelic.Agent.Core.Utilization
 
                     return vendorModel;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Log.Finest(ex, "Failed to parse Docker container id.");
                     return null;
                 }
             }

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.Core.Utilization
     {
         private const string ValidateMetadataRegex = @"^[a-zA-Z0-9-_. /]*$";
 #if NETSTANDARD2_0
-        private const string ContainerIdV1Regex = @"[0-9a-f]{64}";
+        private const string ContainerIdV1Regex = @".*:cpu:/docker/([0-9a-f]{64}).*";
         private const string ContainerIdV2Regex = ".*/docker/containers/([0-9a-f]{64})/.*";
 #endif
 
@@ -96,11 +96,16 @@ namespace NewRelic.Agent.Core.Utilization
             // If Docker info is set to be checked, it must be checked for all vendors.
             if (_configuration.UtilizationDetectDocker)
             {
-                var dockerVendorInfo = GetDockerVendorInfo();
-                if (dockerVendorInfo != null)
+#if NETSTANDARD2_0
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    vendors.Add(dockerVendorInfo.VendorName, dockerVendorInfo);
+                    var dockerVendorInfo = GetDockerVendorInfo(new FileReaderWrapper());
+                    if (dockerVendorInfo != null)
+                    {
+                        vendors.Add(dockerVendorInfo.VendorName, dockerVendorInfo);
+                    }
                 }
+#endif
             }
 
             if (_configuration.UtilizationDetectKubernetes)
@@ -271,20 +276,16 @@ namespace NewRelic.Agent.Core.Utilization
             }
         }
 
-        private IVendorModel GetDockerVendorInfo()
-        {
 #if NETSTANDARD2_0
-            bool isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-
-            if (isLinux)
-            {
+        public IVendorModel GetDockerVendorInfo(IFileReaderWrapper fileReaderWrapper)
+        {
                 IVendorModel vendorModel = null;
                 try
                 {
-                    var fileContent = File.ReadAllText("/proc/self/mountinfo");
+                    var fileContent = fileReaderWrapper.ReadAllText("/proc/self/mountinfo");
                     vendorModel = TryGetDockerCGroupV2(fileContent);
                     if (vendorModel == null)
-                        Log.Finest( "Found /proc/self/mountinfo but failed to parse Docker container id.");
+                        Log.Finest("Found /proc/self/mountinfo but failed to parse Docker container id.");
 
                 }
                 catch (Exception ex)
@@ -296,9 +297,10 @@ namespace NewRelic.Agent.Core.Utilization
                 {
                     try
                     {
-                        vendorModel = TryGetDockerCGroupV1();
+                        var fileContent = fileReaderWrapper.ReadAllText("/proc/self/cgroup");
+                        vendorModel = TryGetDockerCGroupV1(fileContent);
                         if (vendorModel == null)
-                            Log.Finest( "Found /proc/self/cgroup but failed to parse Docker container id.");
+                            Log.Finest("Found /proc/self/cgroup but failed to parse Docker container id.");
                     }
                     catch (Exception ex)
                     {
@@ -308,41 +310,25 @@ namespace NewRelic.Agent.Core.Utilization
                 }
 
                 return vendorModel;
-            }
-#endif
-            return null;
         }
 
-#if NETSTANDARD2_0
-        public static IVendorModel TryGetDockerCGroupV1()
+        private IVendorModel TryGetDockerCGroupV1(string fileContent)
         {
-            int subsystemsIndex = 1;
-            int controlGroupIndex = 2;
-
             string id = null;
-            var fileLines = File.ReadAllLines("/proc/self/cgroup");
-
-            foreach (var line in fileLines)
+            var matches = Regex.Matches(fileContent, ContainerIdV1Regex);
+            if (matches.Count > 0)
             {
-                var elements = line.Split(StringSeparators.Colon);
-                var cpuSubsystem = elements[subsystemsIndex].Split(StringSeparators.Comma)
-                    .FirstOrDefault(subsystem => subsystem == "cpu");
-                if (cpuSubsystem != null)
+                var firstMatch = matches[0];
+                if (firstMatch.Success && firstMatch.Groups.Count > 1 && firstMatch.Groups[1].Success)
                 {
-                    var controlGroup = elements[controlGroupIndex];
-                    var match = Regex.Match(controlGroup, ContainerIdV1Regex);
-
-                    if (match.Success)
-                    {
-                        id = match.Value;
-                    }
+                    id = firstMatch.Groups[1].Value;
                 }
             }
 
             return id == null ? null : new DockerVendorModel(id);
         }
 
-        public static IVendorModel TryGetDockerCGroupV2(string fileContent)
+        private IVendorModel TryGetDockerCGroupV2(string fileContent)
         {
             string id = null;
             var matches = Regex.Matches(fileContent, ContainerIdV2Regex);
@@ -418,4 +404,19 @@ namespace NewRelic.Agent.Core.Utilization
             return Regex.IsMatch(data, ValidateMetadataRegex);
         }
     }
+#if NETSTANDARD2_0
+    // needed for unit testing only
+    public interface IFileReaderWrapper
+    {
+        string ReadAllText(string fileName);
+    }
+
+    public class FileReaderWrapper : IFileReaderWrapper
+    {
+        public string ReadAllText(string fileName)
+        {
+            return File.ReadAllText(fileName);
+        }
+    }
+#endif
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Configuration;
+using NewRelic.Agent.TestUtilities;
 using NewRelic.SystemInterfaces;
 using NUnit.Framework;
 using Telerik.JustMock;
@@ -280,6 +281,54 @@ namespace NewRelic.Agent.Core.Utilization
             Assert.Null(model);
         }
 
+#if NET
+        [Test]
+        public void GetVendors_GetDockerVendorInfoV2_Succeeds()
+        {
+            var content = @"
+1425 1301 0:290 / / rw,relatime master:314 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/SEESBOIUB4X3HZXQDX5TSEQ7BN:/var/lib/docker/overlay2/l/MOPJN3KMFAIZGI5ENZ4O34OONV:/var/lib/docker/overlay2/l/HDHJSGZM5PTRBYHW5EAYHS7XRU:/var/lib/docker/overlay2/l/DPNQ4BZTYI2XJTICBFBZQ3LYGY:/var/lib/docker/overlay2/l/WHFN2B5YEUTYPT77F26T57WB5I:/var/lib/docker/overlay2/l/P7VISFMMKEWRYA7L34PW2O2J54:/var/lib/docker/overlay2/l/ZWNBERDCDMC6LTZHJ4L64AC5LD:/var/lib/docker/overlay2/l/UGWQJ4NGWITVZZNEXAK7ZHDQDD:/var/lib/docker/overlay2/l/IZ5XCLZYFBF7BC4XULL7IJWT3Q:/var/lib/docker/overlay2/l/EGK3Y3BMJAVWDQZLM4DFYAZQNJ:/var/lib/docker/overlay2/l/LNHVYS3UDT2S2TTN2TF3JVSHFH,upperdir=/var/lib/docker/overlay2/14399ff93af039f15ee6a9633110eaf5ac552802c589e7c5595e32adfb635d39/diff,workdir=/var/lib/docker/overlay2/14399ff93af039f15ee6a9633110eaf5ac552802c589e7c5595e32adfb635d39/work
+1426 1425 0:293 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+1427 1425 0:294 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1428 1427 0:295 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
+1429 1425 0:296 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
+1453 1429 0:297 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+1454 1453 0:56 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/cpuset ro,nosuid,nodev,noexec,relatime master:75 - cgroup cpuset rw,cpuset
+1455 1453 0:57 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/cpu ro,nosuid,nodev,noexec,relatime master:76 - cgroup cpu rw,cpu
+1456 1453 0:58 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/cpuacct ro,nosuid,nodev,noexec,relatime master:77 - cgroup cpuacct rw,cpuacct
+1457 1453 0:59 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/blkio ro,nosuid,nodev,noexec,relatime master:78 - cgroup blkio rw,blkio
+1458 1453 0:60 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:79 - cgroup memory rw,memory
+1459 1453 0:61 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/devices ro,nosuid,nodev,noexec,relatime master:80 - cgroup devices rw,devices
+1460 1453 0:62 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/freezer ro,nosuid,nodev,noexec,relatime master:81 - cgroup freezer rw,freezer
+1461 1453 0:63 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/net_cls ro,nosuid,nodev,noexec,relatime master:82 - cgroup net_cls rw,net_cls
+1462 1453 0:64 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/perf_event ro,nosuid,nodev,noexec,relatime master:83 - cgroup perf_event rw,perf_event
+1463 1453 0:65 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/net_prio ro,nosuid,nodev,noexec,relatime master:84 - cgroup net_prio rw,net_prio
+1464 1453 0:66 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/hugetlb ro,nosuid,nodev,noexec,relatime master:85 - cgroup hugetlb rw,hugetlb
+1465 1453 0:67 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/pids ro,nosuid,nodev,noexec,relatime master:86 - cgroup pids rw,pids
+1466 1453 0:68 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/rdma ro,nosuid,nodev,noexec,relatime master:87 - cgroup rdma rw,rdma
+1467 1453 0:69 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/misc ro,nosuid,nodev,noexec,relatime master:88 - cgroup misc rw,misc
+1468 1453 0:132 /docker/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb /sys/fs/cgroup/systemd ro,nosuid,nodev,noexec,relatime master:89 - cgroup cgroup rw,name=systemd
+1469 1427 0:292 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
+1470 1427 0:298 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
+1471 1425 8:64 /data/docker/containers/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb/resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/sde rw,discard,errors=remount-ro,data=ordered
+1472 1425 8:64 /data/docker/containers/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb/hostname /etc/hostname rw,relatime - ext4 /dev/sde rw,discard,errors=remount-ro,data=ordered
+1473 1425 8:64 /data/docker/containers/adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb/hosts /etc/hosts rw,relatime - ext4 /dev/sde rw,discard,errors=remount-ro,data=ordered
+1312 1426 0:293 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
+1313 1426 0:293 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
+1314 1426 0:293 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
+1315 1426 0:293 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
+1316 1426 0:299 / /proc/acpi ro,relatime - tmpfs tmpfs ro
+1339 1426 0:294 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1340 1426 0:294 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1341 1426 0:294 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1342 1429 0:300 / /sys/firmware ro,relatime - tmpfs tmpfs ro
+";
+
+
+            var model = (DockerVendorModel)VendorInfo.TryGetDockerCGroupV2(content);
+            Assert.NotNull(model);
+            Assert.AreEqual("adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb", model.Id);
+        }
+#endif
         private void SetEnvironmentVariable(string variableName, string value, EnvironmentVariableTarget environmentVariableTarget)
         {
             Mock.Arrange(() => _environment.GetEnvironmentVariable(variableName, environmentVariableTarget)).Returns(value);


### PR DESCRIPTION
Updates our Docker container id lookup to support the newer cgroup v2 standard, parsing `/proc/self/mountinfo` to obtain the container id. 

The new lookup is executed first and if not successful, we fall back to the original (cgroup v1) lookup.

Adds a unit test to verify the parsing logic for `/proc/self/mountinfo`.

Tested in staging and saw the container id being reported as expected:
![image](https://github.com/newrelic/newrelic-dotnet-agent/assets/120425148/99a450da-013c-448e-b03f-b8e4c7d3a1ee)
