### PR TITLE
ci: Adjust metric harvest cycle and introduce a delay for linux smoke tests

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/LinuxSmokeTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/LinuxSmokeTestFixtures.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NewRelic.Agent.ContainerIntegrationTests.ContainerFixtures;
@@ -18,6 +20,11 @@ public abstract class LinuxSmokeTestFixtureBase : ContainerFixture
     {
         var address = $"http://localhost:{Port}/weatherforecast";
         GetAndAssertStatusCode(address, System.Net.HttpStatusCode.OK);
+    }
+
+    public void Delay(int seconds)
+    {
+        Task.Delay(TimeSpan.FromSeconds(seconds)).GetAwaiter().GetResult();
     }
 }
 

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/LinuxSmokeTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/LinuxSmokeTests.cs
@@ -21,14 +21,15 @@ public abstract class LinuxSmokeTest<T> : NewRelicIntegrationTest<T> where T : L
         _fixture.Actions(setupConfiguration: () =>
             {
                 var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
-                configModifier.ConfigureFasterMetricsHarvestCycle(5);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
                 configModifier.LogToConsole();
             },
             exerciseApplication: () =>
             {
                 _fixture.ExerciseApplication();
 
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(10));
+                _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
 
                 // shut down the container and wait for the agent log to see it
                 _fixture.ShutdownRemoteApplication();


### PR DESCRIPTION
Changes the metric harvest override to 10 seconds instead of 5 and introduces a delay after exercising the app but before looking for metric harvest. These changes should help resolve flakiness in the linux smoke tests.