### PR TITLE
other: update the profiler log message about ignored assemblies

### DIFF
--- a/src/Agent/NewRelic/Profiler/Profiler/Function.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Function.h
@@ -127,7 +127,7 @@ namespace NewRelic { namespace Profiler
             }
             else
             {
-                LogTrace(ToStdWString(assemblyName.get()), L" is an ignored assembly");
+                LogTrace(L"Not searching ", ToStdWString(assemblyName.get()), L" for transaction or trace attributes");
             }
 
 


### PR DESCRIPTION
## Description

This PR improves the log message the profiler writes out (at finest/trace level) about ignoring certain assemblies (NewRelic.*, System.*, Microsoft.*) when searching for the `[Transaction]` and `[Trace]` instrumentation attributes.

