### PR TITLE
ci: Update markdown check workflow to only run on schedule

### DIFF
--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - '**.md' # only run when there are changes to markdown files in a push to any branch
+    branches-ignore:
+      - "release-please**" # don't run on the release please branch
   schedule:
     - cron: "0 9 * * 1-5" # run once a day, M-F
   workflow_dispatch:
@@ -20,8 +22,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
 
-    # don't run this job if triggered by Dependabot
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # don't run this job if triggered by Dependabot or the team bot (i.e., Release Please)
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dotnet-agent-team-bot' }}
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -1,11 +1,6 @@
 name: Check Markdown links
 
 on: 
-  push:
-    paths:
-      - '**.md' # only run when there are changes to markdown files in a push to any branch
-    branches-ignore:
-      - "release-please**" # don't run on the release please branch
   schedule:
     - cron: "0 9 * * 1-5" # run once a day, M-F
   workflow_dispatch:
@@ -22,8 +17,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
 
-    # don't run this job if triggered by Dependabot or the team bot (i.e., Release Please)
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'dotnet-agent-team-bot' }}
+    # don't run this job if triggered by Dependabot
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Modifies `markdowncheck.yml` to run only on a daily schedule. 

I'll subscribe the `dotnet-agent-github` channel to get notifications about the scheduled run.