### PR TITLE
fix: Update Serilog EventLog sink configuration to enable event source creation.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -115,19 +115,26 @@ namespace NewRelic.Agent.Core
 #if NETFRAMEWORK
             const string eventLogName = "Application";
             const string eventLogSourceName = "New Relic .NET Agent";
-
-            loggerConfiguration
-                    .WriteTo.Logger(configuration =>
-                    {
-                        configuration
-                        .ExcludeAuditLog()
-                        .WriteTo.EventLog(
-                            source: eventLogSourceName,
-                            logName: eventLogName,
-                            restrictedToMinimumLevel: LogEventLevel.Warning,
-                            outputTemplate: "{Level}: {Message}{NewLine}{Exception}"
-                        );
-                    });
+            try
+            {
+                loggerConfiguration
+                        .WriteTo.Logger(configuration =>
+                        {
+                            configuration
+                            .ExcludeAuditLog()
+                            .WriteTo.EventLog(
+                                source: eventLogSourceName,
+                                logName: eventLogName,
+                                restrictedToMinimumLevel: LogEventLevel.Warning,
+                                outputTemplate: "{Level}: {Message}{NewLine}{Exception}",
+                                manageEventSource: true // Serilog will create the event source if it doesn't exist *and* if the app is running with admin privileges
+                            );
+                        });
+            }
+            catch
+            {
+                // ignored -- there's nothing we can do at this point, as EventLog is our "fallback" logger and if it fails, we're out of luck
+            }
 #endif
             return loggerConfiguration;
         }


### PR DESCRIPTION
Enables the `manageEventSource` parameter on the SeriLog `EventLog()` sink constructor. This will allow the Agent to attempt to create the `New Relic .NET Agent` event source on the local machine if it doesn't exist. Note that this attempt will only succeed if the application is running with Administrator privileges. Note that this code is currently applicable only to .NET Framework applications.

If source creation fails, Serilog will catch the exception internally. I've also added a just-in-case `try/catch` block around the call to configure the EventLog sink. In any case, the Agent will continue to operate, though it will be unable to log to EventLog.