### PR TITLE
Clean up POC branch

### DIFF
--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -55,6 +55,8 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis2Plus.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.NServiceBus.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransit.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.dll",
             };
 
             var wrapperXmls = new[]
@@ -74,6 +76,8 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.StackExchangeRedis2Plus.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.NServiceBus.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml",
             };
 
             ExtensionXsd = $@"{SourceHomeBuilderPath}\extensions\extension.xsd";

--- a/build/ArtifactBuilder/FrameworkAgentComponents.cs
+++ b/build/ArtifactBuilder/FrameworkAgentComponents.cs
@@ -63,7 +63,10 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.WebOptimization.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.WebServices.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AspNetCore.dll",
-                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Owin.dll"
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Owin.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransit.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.dll",
+                
             };
 
             var wrapperXmls = new[]
@@ -99,6 +102,8 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.WebOptimization.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.WebServices.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Misc.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml",
             };
 
             ExtensionXsd = $@"{SourceHomeBuilderPath}\extensions\extension.xsd";

--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -465,6 +465,12 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="ElasticsearchWrapperComponent" Guid="{9C233889-69DD-4B8B-A1A6-ABAC6E27A716}">
         <File Id="ElasticsearchWrapperFile" Name="NewRelic.Providers.Wrapper.Elasticsearch.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Elasticsearch.dll"/>
       </Component>
+      <Component Id="MassTransitWrapperComponent" Guid="{E133AC42-B96B-46E5-BB9B-0E001AB6EC73}">
+        <File Id="MassTransitWrapperFile" Name="NewRelic.Providers.Wrapper.MassTransit.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.MassTransit.dll"/>
+      </Component>
+      <Component Id="MassTransitLegacyWrapperComponent" Guid="{E44779CC-4C76-4AB1-9CE3-5C225A7202FB}">
+        <File Id="MassTransitLegacyWrapperFile" Name="NewRelic.Providers.Wrapper.MassTransitLegacy.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.dll"/>
+      </Component>
 
       <!-- Reference libraries -->
       <Component Id="NewRelicCoreReferenceComponent" Guid="{C196ED1E-0FBA-4D36-9C34-E969B0C9E8C9}">
@@ -520,9 +526,15 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreNServiceBusWrapperComponent" Guid="{E315AE98-119D-4E46-BACB-C28CF6016C19}">
         <File Id="CoreNServiceBusWrapperFile" Name="NewRelic.Providers.Wrapper.NServiceBus.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.NServiceBus.dll"/>
-      </Component>  
+      </Component>
       <Component Id="CoreElasticsearchWrapperComponent" Guid="{531A713C-B46C-41C8-8B21-49CBD4C0A459}">
         <File Id="CoreElasticsearchWrapperFile" Name="NewRelic.Providers.Wrapper.Elasticsearch.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Elasticsearch.dll"/>
+      </Component>
+      <Component Id="CoreMassTransitWrapperComponent" Guid="{9E905BC4-D844-4E9C-AC2E-560C837CDDB8}">
+        <File Id="CoreMassTransitWrapperFile" Name="NewRelic.Providers.Wrapper.MassTransit.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.MassTransit.dll"/>
+      </Component>
+      <Component Id="CoreMassTransitLegacyWrapperComponent" Guid="{8E94ECF6-B1A8-4D83-BDE8-71055FA33C34}">
+        <File Id="CoreMassTransitLegacyWrapperFile" Name="NewRelic.Providers.Wrapper.MassTransitLegacy.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.dll"/>
       </Component>
 
       <!-- Reference libraries -->
@@ -629,6 +641,12 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="ElasticsearchInstrumentationComponent" Guid="{42D85537-D0AB-44EB-8BE5-4B2EEB26DE91}">
         <File Id="ElasticsearchInstrumentationFile" Name="NewRelic.Providers.Wrapper.Elasticsearch.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Elasticsearch.Instrumentation.xml"/>
       </Component>
+      <Component Id="MassTransitInstrumentationComponent" Guid="{D8DBC7D6-0337-4441-A5BB-C6670300144A}">
+        <File Id="MassTransitInstrumentationFile" Name="NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml"/>
+      </Component>
+      <Component Id="MassTransitLegacyInstrumentationComponent" Guid="{FAD302C1-07BE-4770-85E4-F6EE25E287F3}">
+        <File Id="MassTransitLegacyInstrumentationFile" Name="NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml"/>
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CoreNewRelic.Agent.Extensions.Instrumentation" Directory="CoreExtensionsFolder">
@@ -676,6 +694,12 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreElasticsearchInstrumentationComponent" Guid="{02EFBFF6-9DA8-4138-A03F-E9502B631A76}">
         <File Id="CoreElasticsearchInstrumentationFile" Name="NewRelic.Providers.Wrapper.Elasticsearch.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Elasticsearch.Instrumentation.xml"/>
+      </Component>
+      <Component Id="CoreMassTransitInstrumentationComponent" Guid="{7420F63A-BEC7-47E4-A8B3-B81A270DBEB9}">
+        <File Id="CoreMassTransitInstrumentationFile" Name="NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.MassTransit.Instrumentation.xml"/>
+      </Component>
+      <Component Id="CoreMassTransitLegacyInstrumentationComponent" Guid="{A55ED281-B7FA-4BBC-B760-47495EB19BC1}">
+        <File Id="CoreMassTransitLegacyInstrumentationFile" Name="NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.MassTransitLegacy.Instrumentation.xml"/>
       </Component>
     </ComponentGroup>
 

--- a/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
@@ -67,12 +67,12 @@ namespace NewRelic.Agent.Core.Utilities
                 { "OpenConnectionWrapperAsync",                                                                     Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.Sql.dll") },
 
                 //The NewRelic.Providers.Wrapper.SerilogLogging.dll depends on the Serilog.dll; therefore, it should
-                //only be loaded by the agent when Serilog is used otherwise assembly load exception will occur.
+                //only be loaded by the agent when Serilog is used otherwise an assembly load exception will occur.
                 { "SerilogCreateLoggerWrapper",                                                                          Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.SerilogLogging.dll") },
                 { "SerilogDispatchWrapper",                                                                          Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.SerilogLogging.dll") },
 
-                // Both NewRelic.Providers.Wrapper.MassTransit.dll and NewRelic.Providers.Wrapper.MassTransitLegacy.dll depend on MassTransit aseemblys;
-                // therefore, only be loaded by the agent when MassTransit is used otherwise assembly load exception will occur.
+                // Both NewRelic.Providers.Wrapper.MassTransit.dll and NewRelic.Providers.Wrapper.MassTransitLegacy.dll depend on MassTransit assemblies;
+                // therefore, they should only be loaded by the agent when MassTransit is used, otherwise assembly load exceptions will occur.
                 { "TransportConfigWrapper",                                                                          Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.MassTransit.dll") },
                 { "TransportConfigLegacyWrapper",                                                                          Path.Combine(_installPathExtensionsDirectory, "NewRelic.Providers.Wrapper.MassTransitLegacy.dll") }
             };

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/Instrumentation.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/NewRelicFilter.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/NewRelicFilter.cs
@@ -13,6 +13,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
     public class NewRelicFilter : IFilter<ConsumeContext>, IFilter<PublishContext>, IFilter<SendContext>
     {
         private const string SendMethodName = "Send";
+        private const string MessageBrokerVendorName = "MassTransit";
 
         private Method _consumeMethod;
         private Method _publishMethod;
@@ -41,14 +42,14 @@ namespace NewRelic.Providers.Wrapper.MassTransit
 
             var transaction = _agent.CreateTransaction(
                 destinationType: MassTransitHelpers.GetBrokerDestinationType(context.SourceAddress),
-                brokerVendorName: "MassTransit",
+                brokerVendorName: MessageBrokerVendorName,
                 destination: destName);
 
             transaction.AttachToAsync();
 
             transaction.AcceptDistributedTraceHeaders(context.Headers, GetHeaderValue, TransportType.AMQP);
 
-            var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();
@@ -87,7 +88,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
 
             var transaction = _agent.CurrentTransaction;
             MassTransitHelpers.InsertDistributedTraceHeaders(context.Headers, transaction);
-            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();
@@ -105,7 +106,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
 
             var transaction = _agent.CurrentTransaction;
             MassTransitHelpers.InsertDistributedTraceHeaders(context.Headers, transaction);
-            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/TransportConfigWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/TransportConfigWrapper.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, Agent.Api.IAgent agent, ITransaction transaction)
         {
             // This will be run for each bus.  Each bus gets one transport.
-            // We can support more than on transport with this setup.
+            // We can support more than one transport with this setup.
             var configurator = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<IBusFactoryConfigurator>(0);
 
             var spec = new NewRelicPipeSpecification(agent);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/Instrumentation.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/NewRelicFilter.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/NewRelicFilter.cs
@@ -14,6 +14,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
     public class NewRelicFilter : IFilter<ConsumeContext>, IFilter<PublishContext>, IFilter<SendContext>
     {
         private const string SendMethodName = "Send";
+        private const string MessageBrokerVendorName = "MassTransit";
 
         private Method _consumeMethod;
         private Method _publishMethod;
@@ -42,14 +43,14 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
 
             var transaction = _agent.CreateTransaction(
                 destinationType: MassTransitHelpers.GetBrokerDestinationType(context.SourceAddress),
-                brokerVendorName: "MassTransit",
+                brokerVendorName: MessageBrokerVendorName,
                 destination: destName);
 
             transaction.AttachToAsync();
 
             transaction.AcceptDistributedTraceHeaders(context.Headers, GetHeaderValue, TransportType.AMQP);
 
-            var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();
@@ -88,7 +89,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
 
             var transaction = _agent.CurrentTransaction;
             MassTransitHelpers.InsertDistributedTraceHeaders(context.Headers, transaction);
-            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();
@@ -106,7 +107,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
 
             var transaction = _agent.CurrentTransaction;
             MassTransitHelpers.InsertDistributedTraceHeaders(context.Headers, transaction);
-            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, "MassTransit", destName);
+            var segment = transaction.StartMessageBrokerSegment(mc, destType, MessageBrokerAction.Produce, MessageBrokerVendorName, destName);
 
             await next.Send(context);
             segment.End();

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/TransportConfigLegacyWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/TransportConfigLegacyWrapper.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, Agent.Api.IAgent agent, ITransaction transaction)
         {
             // This will be run for each bus.  Each bus gets one transport.
-            // We can support more than on transport with this setup.
+            // We can support more than one transport with this setup.
             var configurator = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<IBusFactoryConfigurator>(0);
 
             var spec = new NewRelicPipeSpecification(agent);


### PR DESCRIPTION
## Description

Refactor a constant string into a constant, and fix some comment typos, to clean up the proof-of-concept branch for MassTransit auto-instrumentation.

Edit: this also adds the new instrumentation assets to the installers.
