### PR TITLE
feat: Add new span attributes to more closely match OTel spec

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -43,7 +43,9 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<float, double> DatabaseDuration { get; }
         AttributeDefinition<string, string> DbCollection { get; }
         AttributeDefinition<string, string> DbInstance { get; }
+        AttributeDefinition<string, string> DbOperation { get; }
         AttributeDefinition<string, string> DbStatement { get; }
+        AttributeDefinition<string, string> DbSystem { get; }
         AttributeDefinition<string, string> DistributedTraceId { get; }
         AttributeDefinition<TimeSpan, double> Duration { get; }
         AttributeDefinition<bool, bool> IsErrorExpected { get; }
@@ -91,6 +93,8 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> RequestUri { get; }
         AttributeDefinition<int?, string> ResponseStatus { get; }
         AttributeDefinition<bool, bool> Sampled { get; }
+        AttributeDefinition<string, string> ServerAddress { get; }
+        AttributeDefinition<long, long> ServerPort { get; }
         AttributeDefinition<SpanCategory, string> SpanCategory { get; }
         AttributeDefinition<string, string> SpanErrorClass { get; }
         AttributeDefinition<string, string> SpanErrorMessage { get; }
@@ -102,6 +106,7 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> SyntheticsMonitorIdForTraces { get; }
         AttributeDefinition<string, string> SyntheticsResourceId { get; }
         AttributeDefinition<string, string> SyntheticsResourceIdForTraces { get; }
+        AttributeDefinition<long, long> ThreadId { get; }
         AttributeDefinition<DateTime, long> Timestamp { get; }
         AttributeDefinition<DateTime, long> TimestampForError { get; }
         AttributeDefinition<TimeSpan, double> TotalTime { get; }
@@ -476,6 +481,12 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 
+        private AttributeDefinition<long, long> _threadId;
+        public AttributeDefinition<long, long> ThreadId => _threadId ?? (_threadId =
+            AttributeDefinitionBuilder.CreateLong("thread.id", AttributeClassification.Intrinsics)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
         private AttributeDefinition<string, string> _component;
         public AttributeDefinition<string, string> Component => _component ?? (_component =
             AttributeDefinitionBuilder.CreateString("component", AttributeClassification.Intrinsics)
@@ -513,6 +524,18 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 
+        private AttributeDefinition<string, string> _dbSystem;
+        public AttributeDefinition<string, string> DbSystem => _dbSystem ?? (_dbSystem =
+            AttributeDefinitionBuilder.CreateString("db.system", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<string, string> _dbOperation;
+        public AttributeDefinition<string, string> DbOperation => _dbOperation ?? (_dbOperation =
+            AttributeDefinitionBuilder.CreateString("db.operation", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
         private AttributeDefinition<string, string> _dbCollection;
         public AttributeDefinition<string, string> DbCollection => _dbCollection ?? (_dbCollection =
             AttributeDefinitionBuilder.CreateString("db.collection", AttributeClassification.AgentAttributes)
@@ -546,7 +569,19 @@ namespace NewRelic.Agent.Core.Attributes
 
         private AttributeDefinition<string, string> _httpMethod;
         public AttributeDefinition<string, string> HttpMethod => _httpMethod ?? (_httpMethod =
-            AttributeDefinitionBuilder.CreateString("http.method", AttributeClassification.AgentAttributes)
+            AttributeDefinitionBuilder.CreateString("http.request.method", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<string, string> _serverAddress;
+        public AttributeDefinition<string, string> ServerAddress => _serverAddress ?? (_serverAddress =
+            AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.Intrinsics)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<long, long> _serverPort;
+        public AttributeDefinition<long, long> ServerPort => _serverPort ?? (_serverPort =
+            AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.Intrinsics)
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -44,6 +44,8 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<string, string> DbCollection { get; }
         AttributeDefinition<string, string> DbInstance { get; }
         AttributeDefinition<string, string> DbOperation { get; }
+        AttributeDefinition<string, string> DbServerAddress { get; }
+        AttributeDefinition<long, long> DbServerPort { get; }
         AttributeDefinition<string, string> DbStatement { get; }
         AttributeDefinition<string, string> DbSystem { get; }
         AttributeDefinition<string, string> DistributedTraceId { get; }
@@ -582,6 +584,18 @@ namespace NewRelic.Agent.Core.Attributes
         private AttributeDefinition<long, long> _serverPort;
         public AttributeDefinition<long, long> ServerPort => _serverPort ?? (_serverPort =
             AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.Intrinsics)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<string, string> _dbServerAddress;
+        public AttributeDefinition<string, string> DbServerAddress => _dbServerAddress ?? (_dbServerAddress =
+            AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter));
+
+        private AttributeDefinition<long, long> _dbServerPort;
+        public AttributeDefinition<long, long> DbServerPort => _dbServerPort ?? (_dbServerPort =
+            AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.AgentAttributes)
                 .AppliesTo(AttributeDestinations.SpanEvent)
                 .Build(_attribFilter));
 

--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.Core.Segments
 {
     public class DatastoreSegmentData : AbstractSegmentData, IDatastoreSegmentData
     {
-        private readonly static ConnectionInfo EmptyConnectionInfo = new ConnectionInfo(null, null, null);
+        private readonly static ConnectionInfo EmptyConnectionInfo = new ConnectionInfo(null, null, null, null);
 
         public override SpanCategory SpanCategory => SpanCategory.Datastore;
 
@@ -31,7 +31,10 @@ namespace NewRelic.Agent.Core.Segments
         public DatastoreVendor DatastoreVendorName => _parsedSqlStatement.DatastoreVendor;
         public string Model => _parsedSqlStatement.Model;
         public string CommandText { get; set; }
+        public string Vendor => _connectionInfo.Vendor;
         public string Host => _connectionInfo.Host;
+        public int? Port => _connectionInfo.Port;
+        public string PathOrId => _connectionInfo.PathOrId;
         public string PortPathOrId => _connectionInfo.PortPathOrId;
         public string DatabaseName => _connectionInfo.DatabaseName;
         public Func<object> GetExplainPlanResources { get; set; }
@@ -219,10 +222,18 @@ namespace NewRelic.Agent.Core.Segments
                 AttribDefs.DbCollection.TrySetValue(attribVals, _parsedSqlStatement.Model);
             }
 
+            AttribDefs.DbSystem.TrySetValue(attribVals, Vendor);
             AttribDefs.DbInstance.TrySetValue(attribVals, DatabaseName);
+            AttribDefs.DbOperation.TrySetValue(attribVals, Operation);
             AttribDefs.PeerAddress.TrySetValue(attribVals, $"{Host}:{PortPathOrId}");
-            AttribDefs.PeerHostname.TrySetValue(attribVals, Host);
             AttribDefs.SpanKind.TrySetDefault(attribVals);
+            // peer.hostname and server.address must match
+            AttribDefs.PeerHostname.TrySetValue(attribVals, Host);
+            AttribDefs.ServerAddress.TrySetValue(attribVals, Host);
+            if (Port != null)
+            {
+                AttribDefs.ServerPort.TrySetValue(attribVals, Port.Value);
+            }
         }
 
         public void SetConnectionInfo(ConnectionInfo connInfo)

--- a/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/DatastoreSegmentData.cs
@@ -229,10 +229,10 @@ namespace NewRelic.Agent.Core.Segments
             AttribDefs.SpanKind.TrySetDefault(attribVals);
             // peer.hostname and server.address must match
             AttribDefs.PeerHostname.TrySetValue(attribVals, Host);
-            AttribDefs.ServerAddress.TrySetValue(attribVals, Host);
+            AttribDefs.DbServerAddress.TrySetValue(attribVals, Host);
             if (Port != null)
             {
-                AttribDefs.ServerPort.TrySetValue(attribVals, Port.Value);
+                AttribDefs.DbServerPort.TrySetValue(attribVals, Port.Value);
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Segments/ExternalSegmentData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/ExternalSegmentData.cs
@@ -93,6 +93,8 @@ namespace NewRelic.Agent.Core.Segments
             AttribDefs.Component.TrySetValue(attribVals, _segmentState.TypeName);
             AttribDefs.SpanKind.TrySetDefault(attribVals);
             AttribDefs.HttpStatusCode.TrySetValue(attribVals, _httpStatusCode);   //Attrib handles null
+            AttribDefs.ServerAddress.TrySetValue(attribVals, Uri.Host);
+            AttribDefs.ServerPort.TrySetValue(attribVals, Uri.Port);
         }
 
         public override string GetTransactionTraceName()

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -441,5 +441,26 @@ namespace NewRelic.Agent.Core.Segments
         {
             return EnumNameCache<SpanCategory>.GetName(Data.SpanCategory);
         }
+
+        public static int? CheckAllSameThread(ICollection<Segment> segments)
+        {
+            if (segments == null)
+                return null;
+
+            int? threadId = null;
+
+            foreach (Segment segment in segments)
+            {
+                if (threadId == null)
+                {
+                    threadId = segment.ThreadId;
+                }
+                else if (threadId != segment.ThreadId)
+                {
+                    return null;
+                }
+            }
+            return threadId;
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Spans/SpanEventMaker.cs
@@ -85,6 +85,12 @@ namespace NewRelic.Agent.Core.Spans
             _attribDefs.SpanCategory.TrySetValue(spanAttributes, SpanCategory.Generic);
             _attribDefs.NrEntryPoint.TrySetValue(spanAttributes, true);
 
+            var threadId = Segment.CheckAllSameThread(immutableTransaction.Segments);
+            if (threadId != null)
+            {
+                _attribDefs.ThreadId.TrySetValue(spanAttributes, threadId.Value);
+            }
+
             spanAttributes.AddRange(transactionAttribValues.GetAttributeValues(AttributeClassification.UserAttributes));
 
             spanAttributes.MakeImmutable();

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/IConnectionInfo.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/IConnectionInfo.cs
@@ -5,10 +5,25 @@ namespace NewRelic.Agent.Extensions.Parsing
 {
     public class ConnectionInfo
     {
-        public ConnectionInfo(string host, string portPathOrId, string databaseName, string instanceName = null)
+        public ConnectionInfo(string vendor, string host, int port, string databaseName, string instanceName = null)
         {
+            Vendor = vendor;
             Host = ValueOrUnknown(host);
-            PortPathOrId = ValueOrUnknown(portPathOrId);
+            if (port >= 0)
+            {
+                Port = port;
+            }
+            PathOrId = string.Empty;
+            DatabaseName = ValueOrUnknown(databaseName);
+            InstanceName = instanceName;
+        }
+
+        public ConnectionInfo(string vendor, string host, string pathOrId, string databaseName, string instanceName = null)
+        {
+            Vendor = vendor;
+            Host = ValueOrUnknown(host);
+            Port = null;
+            PathOrId = ValueOrUnknown(pathOrId);
             DatabaseName = ValueOrUnknown(databaseName);
             InstanceName = instanceName;
         }
@@ -18,8 +33,11 @@ namespace NewRelic.Agent.Extensions.Parsing
             return string.IsNullOrEmpty(value) ? "unknown" : value;
         }
 
+        public string Vendor { get; private set; }
         public string Host { get; private set; }
-        public string PortPathOrId { get; private set; }
+        public string PortPathOrId { get => (Port != null) ? Port.ToString() : PathOrId; }
+        public int? Port { get; private set; } = null;
+        public string PathOrId { get; private set; } = string.Empty;
         public string DatabaseName { get; private set; }
         public string InstanceName { get; private set; }
     }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Constants.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Providers/Wrapper/Constants.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace NewRelic.Agent.Extensions.Providers.Wrapper
@@ -80,6 +81,24 @@ namespace NewRelic.Agent.Extensions.Providers.Wrapper
         CosmosDB,
         Elasticsearch,
         Other
+    }
+
+    public static class DatastoreVendorExtensions
+    {
+        // Convert our internal enum to the matching OTel "known" name for a database provider
+        public static string ToKnownName(this DatastoreVendor vendor)
+        {
+            switch (vendor)
+            {
+                case DatastoreVendor.Other:
+                    return "other_sql";
+                case DatastoreVendor.IBMDB2:
+                    return "db2";
+                // The others match our enum name
+                default:
+                    return vendor.ToString().ToLower();
+            }
+        }
     }
 
     public static class EnumNameCache<TEnum> // c# 7.3: where TEnum : System.Enum	

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/ExecuteItemQueryAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/ExecuteItemQueryAsyncWrapper.cs
@@ -78,7 +78,7 @@ namespace NewRelic.Providers.Wrapper.CosmosDb
             var segment = transaction.StartDatastoreSegment(
                 instrumentedMethodCall.MethodCall,
                 new ParsedSqlStatement(DatastoreVendor.CosmosDB, model, operation),
-                connectionInfo: endpoint != null ? new ConnectionInfo(endpoint.Host, endpoint.Port.ToString(), databaseName) : new ConnectionInfo(string.Empty, string.Empty, databaseName),
+                connectionInfo: endpoint != null ? new ConnectionInfo(DatastoreVendor.CosmosDB.ToKnownName(), endpoint.Host, endpoint.Port, databaseName) : new ConnectionInfo(string.Empty, string.Empty, string.Empty, databaseName),
                 commandText : querySpec != null ? _queryGetter.Invoke(querySpec) : string.Empty,
                 isLeaf: true);
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/RequestInvokerHandlerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/RequestInvokerHandlerWrapper.cs
@@ -67,7 +67,7 @@ namespace NewRelic.Providers.Wrapper.CosmosDb
             var segment = transaction.StartDatastoreSegment(
                 instrumentedMethodCall.MethodCall,
                 new ParsedSqlStatement(DatastoreVendor.CosmosDB, model, operation),
-                connectionInfo: endpoint != null ? new ConnectionInfo(endpoint.Host, endpoint.Port.ToString(), databaseName) : new ConnectionInfo(string.Empty, string.Empty, databaseName),
+                connectionInfo: endpoint != null ? new ConnectionInfo(DatastoreVendor.CosmosDB.ToKnownName(), endpoint.Host, endpoint.Port, databaseName) : new ConnectionInfo(string.Empty, string.Empty, string.Empty, databaseName),
                 isLeaf: true);
 
             return Delegates.GetAsyncDelegateFor<Task>(agent, segment);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
@@ -66,7 +66,7 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
             }
 
             var transactionExperimental = transaction.GetExperimentalApi();
-            var datastoreSegmentData = transactionExperimental.CreateDatastoreSegmentData(new ParsedSqlStatement(DatastoreVendor.Elasticsearch, model, operation), new ConnectionInfo(string.Empty, string.Empty, string.Empty), string.Empty, null);
+            var datastoreSegmentData = transactionExperimental.CreateDatastoreSegmentData(new ParsedSqlStatement(DatastoreVendor.Elasticsearch, model, operation), new ConnectionInfo(DatastoreVendor.Elasticsearch.ToKnownName(), string.Empty, string.Empty, string.Empty), string.Empty, null);
             var segment = transactionExperimental.StartSegment(instrumentedMethodCall.MethodCall);
             segment.GetExperimentalApi().SetSegmentData(datastoreSegmentData).MakeLeaf();
 
@@ -269,7 +269,7 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
         {
             var segmentExperimentalApi = segment.GetExperimentalApi();
             var data = segmentExperimentalApi.SegmentData as IDatastoreSegmentData;
-            data.SetConnectionInfo(new ConnectionInfo(uri.Host, uri.Port.ToString(), string.Empty));
+            data.SetConnectionInfo(new ConnectionInfo(DatastoreVendor.Elasticsearch.ToKnownName(), uri.Host, uri.Port, string.Empty));
             segmentExperimentalApi.SetSegmentData(data);
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/ServiceStackRedis/SendCommandWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/ServiceStackRedis/SendCommandWrapper.cs
@@ -76,9 +76,13 @@ namespace NewRelic.Providers.Wrapper.ServiceStackRedis
 
             var host = TryGetPropertyName(PropertyHost, contextObject) ?? "unknown";
             host = ConnectionStringParserHelper.NormalizeHostname(host, agent.Configuration.UtilizationHostName);
-            var portPathOrId = TryGetPropertyName(PropertyPortPathOrId, contextObject);
+            var port = TryGetPropertyName(PropertyPortPathOrId, contextObject);
+            if (!int.TryParse(port, out int portNum))
+            {
+                portNum = -1;
+            }
             var databaseName = TryGetPropertyName(PropertyDatabaseName, contextObject);
-            var connectionInfo = new ConnectionInfo(host, portPathOrId, databaseName);
+            var connectionInfo = new ConnectionInfo(DatastoreVendor.Redis.ToKnownName(), host, portNum, databaseName);
 
             var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, ParsedSqlStatement.FromOperation(DatastoreVendor.Redis, operation), connectionInfo);
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis/Common.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis/Common.cs
@@ -102,18 +102,18 @@ namespace NewRelic.Providers.Wrapper.StackExchangeRedis
             var dnsEndpoint = endpoint as DnsEndPoint;
             var ipEndpoint = endpoint as IPEndPoint;
 
-            string port = null;
+            int port = -1;
             string host = null;
 
             if (dnsEndpoint != null)
             {
-                port = dnsEndpoint.Port.ToString();
+                port = dnsEndpoint.Port;
                 host = ConnectionStringParserHelper.NormalizeHostname(dnsEndpoint.Host, utilizationHostName);
             }
 
             if (ipEndpoint != null)
             {
-                port = ipEndpoint.Port.ToString();
+                port = ipEndpoint.Port;
                 host = ConnectionStringParserHelper.NormalizeHostname(ipEndpoint.Address.ToString(), utilizationHostName);
             }
 
@@ -122,7 +122,7 @@ namespace NewRelic.Providers.Wrapper.StackExchangeRedis
                 return null;
             }
 
-            return new ConnectionInfo(host, port, null);
+            return new ConnectionInfo(DatastoreVendor.Redis.ToKnownName(), host, port, null, null);
         }
 
         private static string GetCommandNameFromEnumValue(Enum commandValue)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
@@ -117,16 +117,16 @@ namespace NewRelic.Providers.Wrapper.StackExchangeRedis2Plus
         {
             if (endpoint is DnsEndPoint dnsEndpoint)
             {
-                var port = dnsEndpoint.Port.ToString();
+                var port = dnsEndpoint.Port;
                 var host = ConnectionStringParserHelper.NormalizeHostname(dnsEndpoint.Host, _agent.Configuration.UtilizationHostName);
-                return new ConnectionInfo(host, port, null);
+                return new ConnectionInfo(DatastoreVendor.Redis.ToKnownName(), host, port, null, null);
             }
 
             if (endpoint is IPEndPoint ipEndpoint)
             {
-                var port = ipEndpoint.Port.ToString();
+                var port = ipEndpoint.Port;
                 var host = ConnectionStringParserHelper.NormalizeHostname(ipEndpoint.Address.ToString(), _agent.Configuration.UtilizationHostName);
-                return new ConnectionInfo(host, port, null);
+                return new ConnectionInfo(DatastoreVendor.Redis.ToKnownName(), host, port, null, null);
             }
 
             return null;

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/IConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/IConnectionStringParser.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Parsing.ConnectionString
         private const int CacheCapacity = 1000;
         private static readonly SimpleCache<string, ConnectionInfo> _connectionInfoCache = new SimpleCache<string, ConnectionInfo>(CacheCapacity);
 
-        private static readonly ConnectionInfo Empty = new ConnectionInfo(null, null, null);
+        private static readonly ConnectionInfo Empty = new ConnectionInfo(null, null, null, null);
 
         public static ConnectionInfo FromConnectionString(DatastoreVendor vendor, string connectionString, string utilizationHostName)
         {

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/IbmDb2ConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/IbmDb2ConnectionStringParser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -27,7 +28,7 @@ namespace NewRelic.Parsing.ConnectionString
             var portPathOrId = ParsePortPathOrId();
             var databaseName = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _databaseNameKeys)?.Value;
 
-            return new ConnectionInfo(host, portPathOrId, databaseName);
+            return new ConnectionInfo(DatastoreVendor.IBMDB2.ToKnownName(), host, portPathOrId, databaseName);
         }
 
         private string ParseHost()

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/MsSqlConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/MsSqlConnectionStringParser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -27,7 +28,7 @@ namespace NewRelic.Parsing.ConnectionString
             var portPathOrId = ParsePortPathOrId();
             var databaseName = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _databaseNameKeys)?.Value;
             var instanceName = ParseInstanceName();
-            return new ConnectionInfo(host, portPathOrId, databaseName, instanceName);
+            return new ConnectionInfo(DatastoreVendor.MySQL.ToKnownName(), host, portPathOrId, databaseName, instanceName);
         }
 
         private string ParseHost()

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/MySqlConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/MySqlConnectionStringParser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Collections.Generic;
 using System.Data.Common;
 
@@ -30,12 +31,24 @@ namespace NewRelic.Parsing.ConnectionString
             else if (host != null)
                 host = ConnectionStringParserHelper.NormalizeHostname(host, utilizationHostName);
 
-            var portPathOrId = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _portKeys)?.Value;
-            if (portPathOrId == null && host != null) portPathOrId = "default";
-
             var databaseName = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _databaseNameKeys)?.Value;
 
-            return new ConnectionInfo(host, portPathOrId, databaseName);
+            var port = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _portKeys)?.Value;
+            if (port == null && host != null)
+            {
+                return new ConnectionInfo(DatastoreVendor.MySQL.ToKnownName(), host, "default", databaseName);
+            }
+            else
+            {
+                int portNum;
+                if (!int.TryParse(port, out portNum))
+                {
+                    portNum = -1;
+                }
+                return new ConnectionInfo(DatastoreVendor.MySQL.ToKnownName(), host, portNum, databaseName);
+            }
+
+
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/PostgresConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/PostgresConnectionStringParser.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Collections.Generic;
 using System.Data.Common;
 
@@ -27,10 +28,15 @@ namespace NewRelic.Parsing.ConnectionString
             if (host != null)
                 host = ConnectionStringParserHelper.NormalizeHostname(host, utilizationHostName);
 
-            var portPathOrId = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _portKeys)?.Value;
             var databaseName = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _databaseNameKeys)?.Value;
 
-            return new ConnectionInfo(host, portPathOrId, databaseName);
+            var port = ConnectionStringParserHelper.GetKeyValuePair(_connectionStringBuilder, _portKeys)?.Value;
+            if (port == null || !int.TryParse(port, out int portNum))
+            {
+                portNum = -1;
+            }
+
+            return new ConnectionInfo(DatastoreVendor.Postgres.ToKnownName(), host, portNum, databaseName);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Parsing/ConnectionString/StackExchangeRedisConnectionStringParser.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/ConnectionString/StackExchangeRedisConnectionStringParser.cs
@@ -4,6 +4,7 @@
 using NewRelic.Agent.Extensions.Parsing;
 using System.Linq;
 using NewRelic.Agent.Helpers;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 
 namespace NewRelic.Parsing.ConnectionString
 {
@@ -40,10 +41,14 @@ namespace NewRelic.Parsing.ConnectionString
                 // We can only capture the first server we detect.  It could be that there are many....
                 var hostPortPair = section.Split(StringSeparators.Colon);
                 var port = hostPortPair.Length == 2 ? hostPortPair[1] : null;
-                return new ConnectionInfo(ConnectionStringParserHelper.NormalizeHostname(hostPortPair[0], utilizationHostName), port, null);
+                if(!int.TryParse(port, out int portNum))
+                {
+                    portNum = -1;
+                }
+                return new ConnectionInfo(DatastoreVendor.Redis.ToKnownName(), ConnectionStringParserHelper.NormalizeHostname(hostPortPair[0], utilizationHostName), portNum, null);
             }
 
-            return new ConnectionInfo(null, null, null);
+            return new ConnectionInfo(null, null, null, null);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using Azure;
+using Couchbase.Core;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
+using System.Net.NetworkInformation;
+using System.Net.PeerToPeer.Collaboration;
+using System.Reflection;
+using System.Windows.Forms;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -76,6 +84,16 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
                 new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 2 },
                 new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
             };
+            var expectedAgentAttributes = new List<string>
+            {
+                "db.system",
+                "db.operation",
+                "db.instance",
+                "peer.address",
+                "peer.hostname",
+                "server.address",
+                "server.port"
+            };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
             var spanEvents = _fixture.AgentLog.GetSpanEvents();
@@ -85,7 +103,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
             NrAssert.Multiple
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Equal(6, operationDatastoreSpans.Count())
+                () => Assert.Equal(6, operationDatastoreSpans.Count()),
+                () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, IntegrationTestHelpers.Models.SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
+
             );
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -155,6 +155,16 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             {
                 new Assertions.ExpectedMetric { metricName = $"Datastore/statement/Elasticsearch/{expectedIndexName}/{expectedOperationName}", metricScope = expectedTransactionName, callCount = 1 },
             };
+            var expectedAgentAttributes = new List<string>
+            {
+                "db.system",
+                "db.operation",
+                "db.instance",
+                "peer.address",
+                "peer.hostname",
+                "server.address",
+                "server.port"
+            };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
@@ -172,7 +182,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assert.Single(operationDatastoreSpans),
-                () => Assert.Equal(_host, uri)
+                () => Assert.Equal(_host, uri),
+                () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, IntegrationTestHelpers.Models.SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
             );
         }
 

--- a/tests/Agent/UnitTests/CompositeTests/AgentWrapperApiExtensions.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AgentWrapperApiExtensions.cs
@@ -56,7 +56,7 @@ namespace CompositeTests
         public static ISegment StartDatastoreRequestSegmentOrThrow(this IAgent agent, string operation, DatastoreVendor vendor, string model, string commandText = null, MethodCall methodCall = null, string host = null, string portPathOrId = null, string databaseName = null, IDictionary<string, IConvertible> queryParameters = null)
         {
             methodCall = methodCall ?? GetDefaultMethodCall(agent);
-            var segment = agent.CurrentTransaction.StartDatastoreSegment(methodCall, new ParsedSqlStatement(vendor, model, operation), new ConnectionInfo(host, portPathOrId, databaseName), commandText, queryParameters);
+            var segment = agent.CurrentTransaction.StartDatastoreSegment(methodCall, new ParsedSqlStatement(vendor, model, operation), new ConnectionInfo(vendor.ToKnownName(), host, portPathOrId, databaseName), commandText, queryParameters);
             if (segment == null)
                 throw new NullReferenceException("segment");
 
@@ -67,7 +67,7 @@ namespace CompositeTests
         {
             methodCall = methodCall ?? GetDefaultMethodCall(agent);
             var xTransaction = (ITransactionExperimental)agent.CurrentTransaction;
-            var segment = xTransaction.StartStackExchangeRedisSegment(RuntimeHelpers.GetHashCode(methodCall), ParsedSqlStatement.FromOperation(vendor, operation), new ConnectionInfo(host, portPathOrId, databaseName), relativeStartTime, relativeEndTime);
+            var segment = xTransaction.StartStackExchangeRedisSegment(RuntimeHelpers.GetHashCode(methodCall), ParsedSqlStatement.FromOperation(vendor, operation), new ConnectionInfo(vendor.ToKnownName(), host, portPathOrId, databaseName), relativeStartTime, relativeEndTime);
             if (segment == null)
                 throw new NullReferenceException("segment");
 

--- a/tests/Agent/UnitTests/CompositeTests/DistributedTracingTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/DistributedTracingTests.cs
@@ -255,10 +255,13 @@ namespace CompositeTests
             TestPayloadInfoMatchesSpanInfo(Payload, rootSpan, actualSpan, "http");
 
             var agentAttributes = actualSpan.AgentAttributes();
+            var intrinsicAttributes = actualSpan.IntrinsicAttributes();
 
             //The specific test
             Assert.AreEqual(url, agentAttributes["http.url"]);
-            Assert.AreEqual(method, agentAttributes["http.method"]);
+            Assert.AreEqual(method, agentAttributes["http.request.method"]);
+            Assert.AreEqual("127.0.0.2", intrinsicAttributes["server.address"]);
+            Assert.AreEqual(123, intrinsicAttributes["server.port"]);
         }
 
         private static Dictionary<string, string> NewRelicHeaders

--- a/tests/Agent/UnitTests/Core.UnitTest/Segments/SimpleSegmentDataTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Segments/SimpleSegmentDataTests.cs
@@ -49,6 +49,49 @@ namespace NewRelic.Agent.Core.Segments.Tests
             Assert.AreEqual(666, segment.ThreadId);
         }
 
+
+        [Test]
+        public void CheckAllSameThread()
+        {
+            int? threadId;
+            threadId = Segment.CheckAllSameThread(null);
+            Assert.IsNull(threadId);
+
+            // All different
+            var segments = new List<Segment>();
+            for (int i = 0; i < 3; i++)
+            {
+                var segment = new Segment(createTransactionSegmentState(100 + i, null, i), new MethodCallData("type", "method", 1));
+                segment.SetSegmentData(new SimpleSegmentData("test" + i));
+                segments.Add(segment);
+            }
+            threadId = Segment.CheckAllSameThread(segments);
+            Assert.IsNull(threadId);
+
+            // All same
+            segments = new List<Segment>();
+            for (int i = 0; i < 3; i++)
+            {
+                var segment = new Segment(createTransactionSegmentState(10 + i, null, 10), new MethodCallData("type", "method", 1));
+                segment.SetSegmentData(new SimpleSegmentData("test" + i));
+                segments.Add(segment);
+            }
+            threadId = Segment.CheckAllSameThread(segments);
+            Assert.AreEqual(10, threadId.Value);
+
+            // Some different
+            segments = new List<Segment>();
+            for (int i = 0; i < 10; i++)
+            {
+                var segment = new Segment(createTransactionSegmentState(1 + i, null, i % 3), new MethodCallData("type", "method", 1));
+                segment.SetSegmentData(new SimpleSegmentData("test" + i));
+                segments.Add(segment);
+            }
+            threadId = Segment.CheckAllSameThread(segments);
+            Assert.IsNull(threadId);
+        }
+
+
         [Test]
         public void IsCombinableWith_ReturnsTrue_ForIdenticalSegments()
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -162,7 +162,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             _childGenericSegment.SetSegmentData(new SimpleSegmentData(SegmentName));
 
             // Datastore Segments
-            _connectionInfo = new ConnectionInfo("localhost", "1234", "default", "maininstance");
+            _connectionInfo = new ConnectionInfo(DatastoreVendor.MSSQL.ToKnownName(), "localhost", 1234, "default", "maininstance");
             _parsedSqlStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, System.Data.CommandType.Text, ShortQuery);
 
             _obfuscatedSql = _databaseService.GetObfuscatedSql(ShortQuery, DatastoreVendor.MSSQL);
@@ -440,8 +440,10 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             (
                 () => Assert.AreEqual(DatastoreCategory, (string)spanEventIntrinsicAttributes["category"]),
                 () => Assert.AreEqual(DatastoreVendor.MSSQL.ToString(), (string)spanEventIntrinsicAttributes["component"]),
-                () => Assert.AreEqual(_parsedSqlStatement.Model, (string)spanEventAgentAttributes["db.collection"]),
-
+                () => Assert.AreEqual(DatastoreVendor.MSSQL.ToKnownName(), (string)spanEventAgentAttributes["db.system"]),
+                () => Assert.AreEqual(_parsedSqlStatement.Operation, (string)spanEventAgentAttributes["db.operation"]),
+                () => Assert.AreEqual(_connectionInfo.Host, (string)spanEventIntrinsicAttributes["server.address"]),
+                () => Assert.AreEqual(_connectionInfo.Port.Value, spanEventIntrinsicAttributes["server.port"]),
 
                 //This also tests the lazy instantiation on span event attrib values
                 () => Assert.AreEqual(_obfuscatedSql, (string)spanEventAgentAttributes["db.statement"]),
@@ -459,7 +461,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             var testSegment = new Segment(CreateTransactionSegmentState(3, null, 777), new MethodCallData(MethodCallType, MethodCallMethod, 1));
             testSegment.SetSegmentData(new DatastoreSegmentData(_databaseService,
                 parsedSqlStatement: new ParsedSqlStatement(DatastoreVendor.CosmosDB, string.Empty, "ReadDatabase"),
-                connectionInfo: new ConnectionInfo("localhost", "1234", "default", "maininstance")));
+                connectionInfo: new ConnectionInfo("none", "localhost", "1234", "default", "maininstance")));
 
             // ARRANGE
             var segments = new List<Segment>()

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventWireModelTests.cs
@@ -70,7 +70,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
                 },
                 new Dictionary<string, object>
                 {
-                    { "http.method","GET" }
+                    { "http.request.method","GET" }
                 }
             };
 
@@ -113,7 +113,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
                     },
                     new Dictionary<string, object>
                     {
-                        { "http.method","GET" }
+                        { "http.request.method","GET" }
                     }
                 },
                 new[] {
@@ -130,7 +130,7 @@ namespace NewRelic.Agent.Core.Spans.Tests
                     },
                     new Dictionary<string, object>
                     {
-                        { "http.method","POST" }
+                        { "http.request.method","POST" }
                     }
                 }
             };

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/DatastoreSegmentTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/DatastoreSegmentTransformerTests.cs
@@ -283,7 +283,7 @@ namespace NewRelic.Agent.Core.Transformers
         private Segment GetSegment(DatastoreVendor vendor, string operation, string model, double duration, CrossApplicationResponseData catResponseData = null, string host = null, string portPathOrId = null)
         {
             var methodCallData = new MethodCallData("foo", "bar", 1);
-            var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, operation), null, new ConnectionInfo(host, portPathOrId, null));
+            var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, operation), null, new ConnectionInfo("none", host, portPathOrId, null));
             var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/SqlTraceMakerTests.cs
@@ -152,7 +152,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private Segment BuildSegment(DatastoreVendor vendor, string model, string commandText, TimeSpan startTime = new TimeSpan(), TimeSpan? duration = null, string name = "", MethodCallData methodCallData = null, IEnumerable<KeyValuePair<string, object>> parameters = null, string host = null, string portPathOrId = null, string databaseName = null)
         {
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, null), commandText,
-                new ConnectionInfo(host, portPathOrId, databaseName));
+                new ConnectionInfo("none", host, portPathOrId, databaseName));
             methodCallData = methodCallData ?? new MethodCallData("typeName", "methodName", 1);
 
             var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TestTransactions.cs
@@ -118,7 +118,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
                 txSegmentState = TransactionSegmentStateHelpers.GetItransactionSegmentState();
 
             methodCallData = methodCallData ?? new MethodCallData("typeName", "methodName", 1);
-            var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, null), commandText, new ConnectionInfo(host, portPathOrId, databaseName));
+            var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(vendor, model, null), commandText, new ConnectionInfo("none", host, portPathOrId, databaseName));
             var segment = new Segment(txSegmentState, methodCallData);
             segment.SetSegmentData(data);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionTraceMakerTests.cs
@@ -338,7 +338,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             var data = new DatastoreSegmentData(_databaseService, new ParsedSqlStatement(DatastoreVendor.MSSQL, "test_table", "SELECT"),
                 "SELECT * FROM test_table",
-                new ConnectionInfo("My Host", "My Port", "My Database"));
+                new ConnectionInfo("My Vendor", "My Host", "My Port", "My Database"));
 
             var segment = new Segment(TransactionSegmentStateHelpers.GetItransactionSegmentState(), methodCallData);
             segment.SetSegmentData(data);


### PR DESCRIPTION
This was trickier than first expected for a few reasons:
* For database calls, we want the port, but what we store is the "port, path, or ID" and we don't record which it is. I had to split out the port at creation time.
* The "known values" for database providers that OTel uses are close to, but not exactly the same as, the ones we use
* The request for managed Thread ID doesn't really align with the way .NET handles async work. For now at least, we'll only provide the Thread ID if all Segments occur on the same thread.
* Both database calls and HTTP requests now have `server.address` and `server.port` attributes, but they're optional for database calls (making them Agent attributes) and required for HTTP requests (making them Intrinsic attributes)

Resolves #1942 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
