### PR TITLE
ci: Ignore .md file changes when deciding whether to run the all_solutions jobs.

### DIFF
--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -38,6 +38,5 @@ jobs:
               filters: |
                 non-workflow-files-changed:
                   - '!.github/**'
-                  - '!**/*.md'
               list-files: 'csv'
     

--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -35,8 +35,9 @@ jobs:
             id: filter
             with:
               base: ${{ github.ref }}
-              filters: |
+              filters: | # ignore changes in the .github folder structure and changes to .md files
                 non-workflow-files-changed:
                   - '!.github/**'
+                  - '!**.md'
               list-files: 'csv'
     

--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -38,6 +38,6 @@ jobs:
               filters: | # ignore changes in the .github folder structure and changes to .md files
                 non-workflow-files-changed:
                   - '!.github/**'
-                  - '!**.md'
+                  - '!**/*.md'
               list-files: 'csv'
     

--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -30,12 +30,12 @@ jobs:
             uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
             with:
               fetch-depth: 0
-          - name: Verified which files were modified
+          - name: Verify which files were modified
             uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
             id: filter
             with:
               base: ${{ github.ref }}
-              filters: | # ignore changes in the .github folder structure and changes to .md files
+              filters: |
                 non-workflow-files-changed:
                   - '!.github/**'
                   - '!**/*.md'


### PR DESCRIPTION
Minor update to ignore changes to `.md` files, there's no need to run the all_solutions build if that's the only file that was changed.