### PR TITLE
ci: fix propagation delay in  YUM / Apt validation

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -1,6 +1,5 @@
 name: Post Deploy for the .NET Agent
 
-
 on:
   workflow_dispatch:
     inputs:
@@ -8,6 +7,10 @@ on:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
+      external_call:
+        type: boolean
+        default: true
+        required: false
   workflow_call:
     inputs:
       agent_version:
@@ -34,7 +37,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
+        if: ${{ github.inputs.external_call }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -73,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
+        if: ${{ github.inputs.external_call }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300


### PR DESCRIPTION
The conditional that determines whether to delay 5 minutes before attempting to validate Apt / Yum deployment was broken. Fixed it using a pattern that we've used in other workflows. 