### PR TITLE
chore: Update .editorconfig to always save as UTF-8 without BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+charset = utf-8 # supposed to get rid of the BOM issue
 
 ###############################
 # .NET Coding Conventions     #


### PR DESCRIPTION
Updates `.editorconfig` so that Visual Studio always saves files as UTF-8 without the BOM header. Doesn't fix any existing files that have the header unless you open and save them, but maybe this will reduce occurrences in the future. 