### PR TITLE
Adding alternate instrumentation point and first pass at tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/Instrumentation.xml
@@ -12,6 +12,9 @@ SPDX-License-Identifier: Apache-2.0
       <match assemblyName="MassTransit" className="MassTransit.Configuration.TransportRegistrationBusFactory`1" minVersion="8.0.0">
         <exactMethodMatcher methodName="CreateBus" />
       </match>
+      <match assemblyName="MassTransit" className="MassTransit.BusFactoryExtensions" minVersion="8.0.0">
+        <exactMethodMatcher methodName="Build" parameters="MassTransit.IBusFactory,MassTransit.Configuration.IBusConfiguration,System.Collections.Generic.IEnumerable`1[MassTransit.ValidationResult]" />
+      </match>
     </tracerFactory>
 
   </instrumentation>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/TransportConfigWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/TransportConfigWrapper.cs
@@ -22,6 +22,8 @@ namespace NewRelic.Providers.Wrapper.MassTransit
         {
             // This will be run for each bus.  Each bus gets one transport.
             // We can support more than one transport with this setup.
+            // Note that there are two instrumentation points that can get us here, and the first parameter is different for both,
+            // but they both implement IBusFactoryConfigurator, which is what we need
             var configurator = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<IBusFactoryConfigurator>(0);
 
             var spec = new NewRelicPipeSpecification(agent);

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/Instrumentation.xml
@@ -9,8 +9,11 @@ SPDX-License-Identifier: Apache-2.0
 
     <tracerFactory name="TransportConfigLegacyWrapper">
 
-      <match assemblyName="MassTransit" className="MassTransit.Registration.TransportRegistrationBusFactory" maxVersion="7.99.0">
+      <match assemblyName="MassTransit" className="MassTransit.Registration.TransportRegistrationBusFactory" maxVersion="8.0.0">
         <exactMethodMatcher methodName="CreateBus" />
+      </match>
+      <match assemblyName="MassTransit" className="MassTransit.BusFactoryExtensions" maxVersion="8.0.0">
+        <exactMethodMatcher methodName="Build" parameters="MassTransit.IBusFactory,MassTransit.Configuration.IBusConfiguration,System.Collections.Generic.IEnumerable`1[GreenPipes.ValidationResult]" />
       </match>
     </tracerFactory>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/TransportConfigLegacyWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/TransportConfigLegacyWrapper.cs
@@ -22,6 +22,8 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
         {
             // This will be run for each bus.  Each bus gets one transport.
             // We can support more than one transport with this setup.
+            // Note that there are two instrumentation points that can get us here, and the first parameter is different for both,
+            // but they both implement IBusFactoryConfigurator, which is what we need
             var configurator = instrumentedMethodCall.MethodCall.MethodArguments.ExtractNotNullAs<IBusFactoryConfigurator>(0);
 
             var spec = new NewRelicPipeSpecification(agent);

--- a/tests/Agent/IntegrationTests/IntegrationTests/MassTransit/MassTransitConsumeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/MassTransit/MassTransitConsumeTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+using System;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using System.Collections;
+
+namespace NewRelic.Agent.IntegrationTests.MassTransit
+{
+    public abstract class MassTransitConsumeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+        private string _queueName;
+
+        public MassTransitConsumeTestsBase(TFixture fixture, ITestOutputHelper output, bool useStartBus) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+            _queueName = Guid.NewGuid().ToString();
+
+            if (useStartBus)
+            {
+                _fixture.AddCommand($"MassTransitExerciser StartBus {_queueName}");
+            }
+            else
+            {
+                _fixture.AddCommand("MassTransitExerciser StartHost");
+            }
+            _fixture.AddCommand("MassTransitExerciser Publish one");
+            _fixture.AddCommand("MassTransitExerciser Publish two");
+            _fixture.AddCommand("MassTransitExerciser Publish three");
+
+            if (useStartBus)
+            {
+                _fixture.AddCommand($"MassTransitExerciser StopBus");
+            }
+            else
+            {
+                _fixture.AddCommand("MassTransitExerciser StopHost");
+            }
+
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.ForceTransactionTraces();
+                    configModifier.SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric { metricName = $"MessageBroker/MassTransit/Queue/Consume/Named/{_queueName}", callCount = 1},
+                new Assertions.ExpectedMetric { metricName = $"MessageBroker/MassTransit/Queue/Produce/Named/{_queueName}", callCount = 1},
+
+                new Assertions.ExpectedMetric { metricName = $"MessageBroker/MassTransit/Queue/Consume/Named/{_queueName}", callCount = 1, metricScope = $"OtherTransaction/Message/MassTransit/Queue/Named/{_queueName}"},
+                new Assertions.ExpectedMetric { metricName = $"MessageBroker/MassTransit/Queue/Produce/Named/{_queueName}", callCount = 1, metricScope = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MassTransitExerciser/Publish"},
+            };
+
+            Assertions.MetricsExist(expectedMetrics, metrics);
+
+            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MassTransitExerciser/Publish");
+
+            Assert.NotNull( transactionEvent );
+        }
+    }
+    [NetFrameworkTest]
+    public class MassTransitConsumeTestsFW462 : MassTransitConsumeTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public MassTransitConsumeTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+    [NetFrameworkTest]
+    public class MassTransitConsumeTestsFWLatest : MassTransitConsumeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public MassTransitConsumeTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+    [NetCoreTest]
+    public class MassTransitConsumeTestsCore60 : MassTransitConsumeTestsBase<ConsoleDynamicMethodFixtureCore60>
+    {
+        public MassTransitConsumeTestsCore60(ConsoleDynamicMethodFixtureCore60 fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+    [NetCoreTest]
+    public class MassTransitConsumeTestsCoreLatest : MassTransitConsumeTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MassTransitConsumeTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
+        {
+        }
+    }
+
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MassTransit/MassTransitExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MassTransit/MassTransitExerciser.cs
@@ -8,6 +8,10 @@ using NewRelic.Api.Agent;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+#if NET7_0_OR_GREATER
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+#endif
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries
 {
@@ -15,8 +19,50 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
     class MassTransitExerciser
     {
         CancellationTokenSource _cts;
+#if NET7_0_OR_GREATER
+        Task _hostedServiceTask;
+        IHost _host;
+        IBus _bus;
+#else
         IBusControl _bus;
+#endif
 
+// Note that StartHost/Stophost and StartBus/StopBus are two different
+// setup methods
+#if NET7_0_OR_GREATER
+        [LibraryMethod]
+        public void StartHost()
+        {
+            _host = CreateMassTransitHost();
+            _bus = _host.Services.GetService<IBus>();
+            _cts = new CancellationTokenSource();
+            _hostedServiceTask = _host.RunAsync(_cts.Token);
+        }
+
+        private static IHost CreateMassTransitHost()
+        {
+            var builder = Host.CreateDefaultBuilder().ConfigureServices((hostContext, services) =>
+            {
+                services.AddMassTransit(x =>
+                {
+                    x.AddConsumer<MessageConsumer>();
+                    x.UsingInMemory((context, cfg) =>
+                    {
+                        cfg.ConfigureEndpoints(context);
+                    });
+                });
+            });
+            return builder.Build();
+        }
+
+        [LibraryMethod]
+        public void StopHost()
+        {
+            _cts.Cancel();
+            _hostedServiceTask.Wait();
+            _hostedServiceTask.Dispose();
+        }
+#else
         [LibraryMethod]
         public async Task StartBus(string queueName)
         {
@@ -36,15 +82,16 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
         {
             await _bus.StopAsync();
         }
+#endif
 
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task Publish(string text)
+        public async Task Publish(string message)
         {
-            var message = new Message() { Text = text };
-            await _bus.Publish(message);
-            ConsoleMFLogger.Info($"Sent message {text}");
+            var order = new Message() { Text = message };
+            await _bus.Publish(order);
+            ConsoleMFLogger.Info($"Sent message {message}");
 
             // This sleep ensures that this transaction method is the one sampled for transaction trace data
             Thread.Sleep(1000);
@@ -63,6 +110,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries
             // This sleep ensures that this transaction method is the one sampled for transaction trace data
             Thread.Sleep(1000);
         }
+
 
     }
 }


### PR DESCRIPTION
A few things to note, as this is still a work in progress:
* The preprocessor directives are needed because of the dependency on `Microsoft.Extensions.Hosting`, which we already have a dependency on elsewhere and the versions are tricky to align
* Naming the queue doesn't work yet, so the metric checks in the tests won't pass. We may need to give up on that approach.
* I'm not sure we need two different wrappers? The code seems to work and is identical in both.
* The tests call `Publish` but our `Send` filter is being invoked (I know they're all called "Send" but it's the one with a `SendContext` when I was expecting the one with a `PublishContext`). But it's getting the action as "Publish" so I'm not sure if that's correct or not.