### PR TITLE
fix: Reduce exception logging on CallVendorApi failures.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
@@ -49,16 +49,19 @@ namespace NewRelic.Agent.Core.Utilization
                     {
                         var statusCode = response.StatusCode.ToString() ?? string.Empty;
                         var statusDescription = response.StatusDescription ?? string.Empty;
-                        Log.Debug(ex, "CallVendorApi ({0}) failed with WebException with status: {1}; message: {2}", vendorName, statusCode, statusDescription);
+                        // intentionally not passing the exception parameter here
+                        Log.Debug("CallVendorApi ({0}) failed with WebException with status: {1}; message: {2}", vendorName, statusCode, statusDescription);
                     }
                     else
                     {
-                        Log.Debug(ex, "CallVendorApi ({0}) failed", vendorName);
+                        // intentionally not passing the exception parameter here
+                        Log.Debug($"CallVendorApi ({{0}}) failed: {ex.Message}", vendorName);
                     }
                 }
                 else
                 {
-                    Log.Debug(ex, "CallVendorApi ({0}) failed", vendorName);
+                    // intentionally not passing the exception parameter here
+                    Log.Debug($"CallVendorApi ({{0}}) failed: {ex.Message}", vendorName);
                 }
                 return null;
             }


### PR DESCRIPTION
## Description

Reduces exception logging during `CallVendorApi()` failures. 
```
2023-10-24 16:15:55,194 NewRelic  DEBUG: [pid: 6824, tid: 8] CallVendorApi (aws) failed: A socket operation was attempted to an unreachable network. [::ffff:169.254.169.254]:80 (169.254.169.254:80)
2023-10-24 16:15:55,350 NewRelic  DEBUG: [pid: 6824, tid: 8] CallVendorApi (azure) failed: A socket operation was attempted to an unreachable network. [::ffff:169.254.169.254]:80 (169.254.169.254:80)
2023-10-24 16:15:55,532 NewRelic  DEBUG: [pid: 6824, tid: 8] CallVendorApi (gcp) failed: No such host is known. (metadata.google.internal:80)
```
Resolves #2005 