### PR TITLE
chore: Reduce profiler iscoreclr checks and use correct tokenizer

### DIFF
--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
@@ -50,15 +50,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                     
                     _instructions->Append(_X("ldnull"));
                     BuildObjectArrayOfParameters();
-
-                    if (_isCoreClr)
-                    {
-                        _instructions->Append(_X("call   instance object [System.Private.CoreLib]System.Reflection.MethodBase::Invoke(object, object[])"));
-                    }
-                    else
-                    {
-                        _instructions->Append(_X("call   instance object [mscorlib]System.Reflection.MethodBase::Invoke(object, object[])"));
-                    }
+                    _instructions->Append(_X("call   instance object [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Reflection.MethodBase::Invoke(object, object[])"));
 
                     if (_methodSignature->_returnType->_kind == SignatureParser::ReturnType::Kind::VOID_RETURN_TYPE)
                     {

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
@@ -72,7 +72,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         {
             _instructions->Append(CEE_LDARG_0);
             _instructions->Append(CEE_CALL, _X("class System.Reflection.Assembly System.Reflection.Assembly::LoadFrom(string)"));
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load assembly."), true, _isCoreClr);
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load assembly."), true);
             _instructions->Append(CEE_RET);
         }
 
@@ -83,7 +83,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_CALL, _X("class System.Reflection.Assembly System.CannotUnloadAppDomainException::LoadAssemblyOrThrow(string)"));
             _instructions->Append(CEE_LDARG_1);
             _instructions->Append(CEE_CALLVIRT, _X("instance class System.Type System.Reflection.Assembly::GetType(string)"));
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load type from assembly via reflection."), true, _isCoreClr);
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load type from assembly via reflection."), true);
             _instructions->Append(CEE_RET);
         }
 
@@ -111,7 +111,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             }
             _instructions->AppendLabel(_X("after_GetMethod"));
 
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load method from type via reflection."), true, _isCoreClr);
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("Failed to load method from type via reflection."), true);
             _instructions->Append(CEE_RET);
         }
 
@@ -123,7 +123,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         void BuildStoreMethodInAppDomainStorageOrThrow()
         {
             _instructions->Append(CEE_CALL, _X("class System.AppDomain System.AppDomain::get_CurrentDomain()"));
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true, _isCoreClr);
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true);
             _instructions->Append(CEE_LDARG_1);
             _instructions->Append(CEE_LDARG_0);
             _instructions->Append(CEE_CALLVIRT, _X("instance void System.AppDomain::SetData(string, object)"));
@@ -134,7 +134,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         void BuildGetMethodFromAppDomainStorage()
         {
             _instructions->Append(CEE_CALL, _X("class System.AppDomain System.AppDomain::get_CurrentDomain()"));
-            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true, _isCoreClr);
+            ThrowExceptionIfStackItemIsNull(_instructions, _X("System.AppDomain.CurrentDomain == null."), true);
             _instructions->Append(CEE_LDARG_0);
             _instructions->Append(CEE_CALLVIRT, _X("instance object System.AppDomain::GetData(string)"));
             _instructions->Append(CEE_CASTCLASS, _X("class System.Reflection.MethodInfo"));

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -94,24 +94,10 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 {
                     // directly invoke delegate to finish the tracer
                     loadTracerFunc();
-                    if (_isCoreClr)
-                    {
-                        _instructions->Append(_X("castclass  class [System.Private.CoreLib]System.Action`2<object,class [mscorlib]System.Exception>"));
-                    }
-                    else
-                    {
-                        _instructions->Append(_X("castclass  class [mscorlib]System.Action`2<object,class [mscorlib]System.Exception>"));
-                    }
+                    _instructions->Append(_X("castclass  class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Action`2<object, class[") + _instructions->GetCoreLibAssemblyName() + _X("]System.Exception>"));
                     loadReturnValueFunc();
                     loadExceptionFunc();
-                    if (_isCoreClr)
-                    {
-                        _instructions->Append(CEE_CALLVIRT, _X("instance void [System.Private.CoreLib]System.Action`2<object,class [System.Private.CoreLib]System.Exception>::Invoke(!0,!1)"));
-                    }
-                    else
-                    {
-                        _instructions->Append(CEE_CALLVIRT, _X("instance void [mscorlib]System.Action`2<object,class [mscorlib]System.Exception>::Invoke(!0,!1)"));
-                    }
+                    _instructions->Append(CEE_CALLVIRT, _X("instance void [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Action`2<object,class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Exception>::Invoke(!0,!1)"));
                 },
                 [&]() { _instructions->Append(CEE_POP); }
             );
@@ -172,14 +158,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             // tracer = delegates[0].Invoke(null, new object[] { tracerFactoryName, tracerFactoryArgs, metricName, assemblyName, type, typeName, functionName, argumentSignatureString, this, new object[], functionId });
             _instructions->Append(_X("ldnull"));
             _instructions->Append(_X("ldc.i4.s   11"));
-            if (_isCoreClr)
-            {
-                _instructions->Append(_X("newarr     [System.Private.CoreLib]System.Object"));
-            }
-            else
-            {
-                _instructions->Append(_X("newarr     [mscorlib]System.Object"));
-            }
+            _instructions->Append(_X("newarr     [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Object"));
             _instructions->Append(_X("dup"));
             _instructions->Append(_X("ldc.i4.0"));
             _instructions->Append(_X("ldstr      ") + instrumentationPoint->TracerFactoryName);
@@ -187,14 +166,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(_X("dup"));
             _instructions->Append(_X("ldc.i4.1"));
             _instructions->Append(CEE_LDC_I4, instrumentationPoint->TracerFactoryArgs);
-            if (_isCoreClr)
-            {
-                _instructions->Append(_X("box [mscorlib]System.UInt32"));
-            }
-            else
-            {
-                _instructions->Append(_X("box [mscorlib]System.UInt32"));
-            }
+            _instructions->Append(_X("box [") + _instructions->GetCoreLibAssemblyName() + _X("]System.UInt32"));
             _instructions->Append(_X("stelem.ref"));
             _instructions->Append(_X("dup"));
             _instructions->Append(_X("ldc.i4.2"));
@@ -207,14 +179,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(_X("dup"));
             _instructions->Append(_X("ldc.i4.4"));
             _instructions->Append(CEE_LDTOKEN, _function->GetTypeToken());
-            if (_isCoreClr)
-            {
-                _instructions->Append(_X("call class [System.Private.CoreLib]System.Type [System.Private.CoreLib]System.Type::GetTypeFromHandle(valuetype [System.Private.CoreLib]System.RuntimeTypeHandle)"));
-            }
-            else
-            {
-                _instructions->Append(_X("call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)"));
-            }
+            _instructions->Append(_X("call class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Type [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Type::GetTypeFromHandle(valuetype [") + _instructions->GetCoreLibAssemblyName() + _X("]System.RuntimeTypeHandle)"));
             _instructions->Append(_X("stelem.ref"));
             _instructions->Append(_X("dup"));
             _instructions->Append(_X("ldc.i4.5"));
@@ -244,14 +209,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(_X("ldc.i4.s 10"));
             // It's important to upcast the function id here.  It's an int on WIN32
             _instructions->Append(CEE_LDC_I8, (uint64_t)_function->GetFunctionId());
-            if (_isCoreClr)
-            {
-                _instructions->Append(_X("box [System.Private.CoreLib]System.UInt64"));
-            }
-            else
-            {
-                _instructions->Append(_X("box [mscorlib]System.UInt64"));
-            }
+            _instructions->Append(_X("box [") + _instructions->GetCoreLibAssemblyName() + _X("]System.UInt64"));
             _instructions->Append(_X("stelem.ref"));
             // make the call to GetTracer
             InvokeMethodInfo();
@@ -263,16 +221,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
         {
             LogTrace(_function->ToString() + _X(": Generating locals for default instrumentation."));
             auto tokenizer = _function->GetTokenizer();
-            if (_isCoreClr)
-            {
-                _tracerLocalIndex = AppendToLocalsSignature(_X("class [System.Private.CoreLib]System.Object"), tokenizer, _newLocalVariablesSignature);
-                _userExceptionLocalIndex = AppendToLocalsSignature(_X("class [System.Private.CoreLib]System.Exception"), tokenizer, _newLocalVariablesSignature);
-            }
-            else
-            {
-                _tracerLocalIndex = AppendToLocalsSignature(_X("class [mscorlib]System.Object"), tokenizer, _newLocalVariablesSignature);
-                _userExceptionLocalIndex = AppendToLocalsSignature(_X("class [mscorlib]System.Exception"), tokenizer, _newLocalVariablesSignature);
-            }
+            _tracerLocalIndex = AppendToLocalsSignature(_X("class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Object"), tokenizer, _newLocalVariablesSignature);
+            _userExceptionLocalIndex = AppendToLocalsSignature(_X("class [") + _instructions->GetCoreLibAssemblyName() + _X("]System.Exception"), tokenizer, _newLocalVariablesSignature);
             
             if (_methodSignature->_returnType->_kind != SignatureParser::ReturnType::Kind::VOID_RETURN_TYPE)
                 _resultLocalIndex = AppendReturnTypeLocal(_newLocalVariablesSignature, _methodSignature);

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -272,7 +272,7 @@ namespace NewRelic { namespace Profiler {
             ModuleInjector::IModulePtr module;
             try
             {
-                module = std::make_shared<Module>(_corProfilerInfo4, moduleId);
+                module = std::make_shared<Module>(_corProfilerInfo4, moduleId, _isCoreClr);
             }
             catch (const NewRelic::Profiler::MessageException& exception)
             {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
@@ -20,13 +20,6 @@ namespace NewRelic { namespace Profiler
     class CorTokenizer : public sicily::codegen::ITokenizer
     {
     public:
-        CorTokenizer(CComPtr<IMetaDataAssemblyEmit> metaDataAssemblyEmit, CComPtr<IMetaDataEmit2> metaDataEmit, CComPtr<IMetaDataImport2> metaDataImport, CComPtr<IMetaDataAssemblyImport> metaDataAssemblyImport) :
-            metaDataEmit(metaDataEmit),
-            metaDataAssemblyEmit(metaDataAssemblyEmit),
-            metaDataImport(metaDataImport),
-            metaDataAssemblyImport(metaDataAssemblyImport)
-        { }
-
         virtual uint32_t GetAssemblyRefToken(const xstring_t& assemblyName) override
         {
             HCORENUM enumerator = nullptr;
@@ -132,7 +125,15 @@ namespace NewRelic { namespace Profiler
         }
 
     protected:
+        CorTokenizer(CComPtr<IMetaDataAssemblyEmit> metaDataAssemblyEmit, CComPtr<IMetaDataEmit2> metaDataEmit, CComPtr<IMetaDataImport2> metaDataImport, CComPtr<IMetaDataAssemblyImport> metaDataAssemblyImport) :
+            metaDataEmit(metaDataEmit),
+            metaDataAssemblyEmit(metaDataAssemblyEmit),
+            metaDataImport(metaDataImport),
+            metaDataAssemblyImport(metaDataAssemblyImport)
+        { }
+
         CComPtr<IMetaDataAssemblyEmit> metaDataAssemblyEmit;
+
     private:
         CComPtr<IMetaDataEmit2> metaDataEmit;
         CComPtr<IMetaDataImport2> metaDataImport;

--- a/src/Agent/NewRelic/Profiler/Profiler/Module.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Module.h
@@ -15,9 +15,10 @@ namespace NewRelic { namespace Profiler
     class Module : public ModuleInjector::IModule
     {
     public:
-        Module(CComPtr<ICorProfilerInfo4> profilerInfo, const ModuleID& moduleId) :
+        Module(CComPtr<ICorProfilerInfo4> profilerInfo, const ModuleID& moduleId, bool isCoreClr) :
             _profilerInfo(profilerInfo),
-            _moduleId(moduleId)
+            _moduleId(moduleId),
+            _isCoreClr(isCoreClr)
         {
             // get the module's name
             ULONG moduleNameLength = 0;
@@ -50,7 +51,7 @@ namespace NewRelic { namespace Profiler
             CheckIfThisIsAFrameworkAssembly();
             IdentifyFrameworkAssemblyReferences();
 
-            _tokenizer.reset(new CorTokenizer(_metaDataAssemblyEmit, _metaDataEmit, _metaDataImport, _metaDataAssemblyImport));
+            _tokenizer = CreateCorTokenizer(_metaDataAssemblyEmit, _metaDataEmit, _metaDataImport, _metaDataAssemblyImport, _isCoreClr);
         }
 
         virtual xstring_t GetModuleName() override { return _moduleName; }
@@ -140,6 +141,7 @@ namespace NewRelic { namespace Profiler
         xstring_t _moduleName;
         mdAssemblyRef _mscorlibAssemblyRefToken;
         mdAssemblyRef _systemPrivateCoreLibAssemblyRefToken;
+        const bool _isCoreClr;
         bool _hasRefMscorlib;
         bool _hasRefSysRuntime;
         bool _hasRefNetStandard;


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Reduces the number of times we need to check the isCoreClr flag to determine which assembly to reference in an instruction.

This also includes a fix to ensure that the correct tokenizer is always used.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
