### PR TITLE
Enables configuration of the profiler method caching strategy.

### DIFF
--- a/src/Agent/NewRelic/Profiler/MethodRewriter/AgentCallStyle.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/AgentCallStyle.h
@@ -1,0 +1,60 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include "../Common/xplat.h"
+#ifdef PAL_STDCPP_COMPAT
+#include "../Profiler/UnixSystemCalls.h"
+#else
+#include "../Profiler/SystemCalls.h"
+#endif
+
+namespace NewRelic { namespace Profiler { namespace MethodRewriter
+{
+    class AgentCallStyle
+    {
+    public:
+        enum class Strategy
+        {
+            Reflection,
+            AppDomainCache,
+            InAgentCache
+        };
+
+        AgentCallStyle(std::shared_ptr<ISystemCalls> systemCalls) : _systemCalls(systemCalls) {}
+
+        const Strategy GetConfiguredCallingStrategy()
+        {
+            if (_systemCalls->GetIsAppDomainCachingDisabled())
+            {
+                return Strategy::Reflection;
+            }
+
+            if (_systemCalls->GetIsLegacyCachingEnabled())
+            {
+                return Strategy::AppDomainCache;
+            }
+
+            return Strategy::InAgentCache;
+        }
+
+        static const xstring_t ToString(const Strategy agentCallStrategy)
+        {
+            if (agentCallStrategy == Strategy::InAgentCache)
+            {
+                return _X("In Agent Cache");
+            }
+
+            if (agentCallStrategy == Strategy::AppDomainCache)
+            {
+                return _X("AppDomain Cache");
+            }
+
+            return _X("Reflection");
+        }
+
+    private:
+        std::shared_ptr<ISystemCalls> _systemCalls;
+    };
+}}}

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ApiFunctionManipulator.h
@@ -14,8 +14,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     class ApiFunctionManipulator : FunctionManipulator
     {
     public:
-        ApiFunctionManipulator(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) :
-            FunctionManipulator(function, isCoreClr),
+        ApiFunctionManipulator(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) :
+            FunctionManipulator(function, isCoreClr, agentCallStrategy),
             _instrumentationSettings(instrumentationSettings)
         {
             Initialize();
@@ -46,7 +46,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 [&]()
                 {
                     // delegate = System.CannotUnloadAppDomainException.GetMethodFromAppDomainStorageOrReflectionOrThrow("NewRelic_Delegate_API_<function name><function signature>", "C:\path\to\NewRelic.Agent.Core", "NewRelic.Core.AgentApi", "<function name>", new object[] { <method parameter types> })
-                    LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentApi"), _function->GetFunctionName(), _function->GetFunctionId(), GetArrayOfTypeParametersLamdba(), true);
+                    LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentApi"), _function->GetFunctionName(), _function->GetFunctionId(), GetArrayOfTypeParametersLamdba());
                     
                     _instructions->Append(_X("ldnull"));
                     BuildObjectArrayOfParameters();

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/HelperFunctionManipulator.h
@@ -13,8 +13,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     class HelperFunctionManipulator : FunctionManipulator
     {
     public:
-        HelperFunctionManipulator(IFunctionPtr function, const bool isCoreClr) : 
-            FunctionManipulator(function, isCoreClr)
+        HelperFunctionManipulator(IFunctionPtr function, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) :
+            FunctionManipulator(function, isCoreClr, agentCallStrategy)
         {
             Initialize();
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <set>
 #include "../Common/xplat.h"
+#include "../Common/Strings.h"
 #include "../Logging/DefaultFileLogLocation.h"
 
 namespace NewRelic { namespace Profiler { namespace MethodRewriter {
@@ -47,21 +48,14 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
             return TryGetEnvironmentVariable(_X("NEWRELIC_FORCE_PROFILING")) != nullptr;
         }
 
+        virtual bool GetIsLegacyCachingEnabled()
+        {
+            return TryGetBooleanEnvironmentVariable(_X("NEW_RELIC_ENABLE_LEGACY_CACHING"));
+        }
+
         virtual bool GetIsAppDomainCachingDisabled()
         {
-            auto value = TryGetEnvironmentVariable(_X("NEW_RELIC_DISABLE_APPDOMAIN_CACHING"));
-
-            if (value == nullptr)
-            {
-                return false;
-            }
-
-            if(Strings::AreEqualCaseInsensitive(*value, _X("true")) || Strings::AreEqualCaseInsensitive(*value, _X("1")))
-            {
-                return true;
-            }
-
-            return false;
+            return TryGetBooleanEnvironmentVariable(_X("NEW_RELIC_DISABLE_APPDOMAIN_CACHING"));
         }
 
         virtual std::unique_ptr<xstring_t> GetProfilerDelay()
@@ -91,6 +85,23 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
 
     private:
         bool _isCoreClr = false;
+
+        bool TryGetBooleanEnvironmentVariable(const xstring_t& variableName)
+        {
+            auto value = TryGetEnvironmentVariable(variableName);
+
+            if (value == nullptr)
+            {
+                return false;
+            }
+
+            if (Strings::AreEqualCaseInsensitive(*value, _X("true")) || Strings::AreEqualCaseInsensitive(*value, _X("1")))
+            {
+                return true;
+            }
+
+            return false;
+        }
     };
     typedef std::shared_ptr<ISystemCalls> ISystemCallsPtr;
     typedef std::set<xstring_t> FilePaths;

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -14,9 +14,12 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     class InstrumentFunctionManipulator : FunctionManipulator
     {
     public:
-        InstrumentFunctionManipulator(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) : 
-            FunctionManipulator(function, isCoreClr), 
-            _instrumentationSettings(instrumentationSettings)
+        InstrumentFunctionManipulator(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) :
+            FunctionManipulator(function, isCoreClr, agentCallStrategy),
+            _instrumentationSettings(instrumentationSettings),
+            _tracerLocalIndex(0),
+            _resultLocalIndex(0),
+            _userExceptionLocalIndex(0)
         {
             if (_function->Preprocess()) {
                 Initialize();
@@ -153,7 +156,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
         void CallGetTracer(NewRelic::Profiler::Configuration::InstrumentationPointPtr instrumentationPoint)
         {
-            LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), 0, nullptr, true);
+            LoadMethodInfo(_instrumentationSettings->GetCorePath(), _X("NewRelic.Agent.Core.AgentShim"), _X("GetFinishTracerDelegate"), 0, nullptr);
               
             // tracer = delegates[0].Invoke(null, new object[] { tracerFactoryName, tracerFactoryArgs, metricName, assemblyName, type, typeName, functionName, argumentSignatureString, this, new object[], functionId });
             _instructions->Append(_X("ldnull"));

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -7,6 +7,7 @@
 #include "../Logging/Logger.h"
 #include "../Common/Strings.h"
 #include "IFunction.h"
+#include "AgentCallStyle.h"
 #include "FunctionManipulator.h"
 #include "ApiFunctionManipulator.h"
 #include "HelperFunctionManipulator.h"
@@ -21,13 +22,13 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     // Interface for different classes that can all instrument a function
     struct IInstrumentor
     {
-        virtual bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) = 0;
+        virtual bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) = 0;
     };
 
     // The default instrumentor, injects our usual set of bytes into the user's function
     struct DefaultInstrumentor : public IInstrumentor
     {
-        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) override
+        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) override
         {
             auto instrumentationPoint = instrumentationSettings->GetInstrumentationConfiguration()->TryGetInstrumentationPoint(function);
             if (instrumentationPoint == nullptr)
@@ -72,7 +73,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
             LogInfo(L"Instrumenting method: ", function->ToString());
 
-            InstrumentFunctionManipulator manipulator(function, instrumentationSettings, isCoreClr);
+            InstrumentFunctionManipulator manipulator(function, instrumentationSettings, isCoreClr, agentCallStrategy);
             if (!function->IsValid()) {
                 // we might have mucked the method up trying to re-write multiple RETs
                 LogInfo(L"Skipping invalid method: ", function->ToString());
@@ -90,7 +91,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     // An instrumentor for the New Relic API functions
     struct ApiInstrumentor : public IInstrumentor
     {
-        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) override
+        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) override
         {
             if (function->GetTypeName() == _X("NewRelic.Api.Agent.NewRelic"))
             {
@@ -101,7 +102,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 }
 
                 LogInfo(L"Instrumenting API method: ", function->ToString());
-                ApiFunctionManipulator manipulator(function, instrumentationSettings, isCoreClr);
+                ApiFunctionManipulator manipulator(function, instrumentationSettings, isCoreClr, agentCallStrategy);
                 manipulator.InstrumentApi();
                 return true;
             }
@@ -116,7 +117,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     // An instrumentor for the methods we inject into mscorlib
     struct HelperInstrumentor : public IInstrumentor
     {
-        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr) override
+        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings, const bool isCoreClr, const AgentCallStyle::Strategy agentCallStrategy) override
         {
             const auto expectedHelperAssemblyName = isCoreClr ? _X("System.Private.CoreLib.dll") : _X("mscorlib.dll");
             if (!Strings::EndsWith(function->GetModuleName(), expectedHelperAssemblyName))
@@ -141,7 +142,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
                 return false;
 
             LogInfo(L"Instrumenting helper method: ", function->ToString());
-            HelperFunctionManipulator manipulator(function, isCoreClr);
+            HelperFunctionManipulator manipulator(function, isCoreClr, agentCallStrategy);
             manipulator.InstrumentHelper();
             return false;
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
@@ -103,13 +103,13 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
         }
 
         // instrument the provided method (if necessary)
-        void Instrument(IFunctionPtr function)
+        void Instrument(IFunctionPtr function, const AgentCallStyle::Strategy agentCallStrategy)
         {
             LogTrace("Possibly instrumenting: ", function->ToString());
 
             InstrumentationSettingsPtr instrumentationSettings = std::make_shared<InstrumentationSettings>(_instrumentationConfiguration, _corePath);
 
-            if (_helperInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr) || _apiInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr) || _defaultInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr)) {
+            if (_helperInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr, agentCallStrategy) || _apiInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr, agentCallStrategy) || _defaultInstrumentor->Instrument(function, instrumentationSettings, _isCoreClr, agentCallStrategy)) {
             }
         }
 

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.vcxproj
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.vcxproj
@@ -152,6 +152,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="AgentCallStyle.h" />
     <ClInclude Include="ApiFunctionManipulator.h" />
     <ClInclude Include="CustomInstrumentation.h" />
     <ClInclude Include="ExceptionHandlerManipulator.h" />

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/AgentCallStyleTests.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/AgentCallStyleTests.cpp
@@ -1,0 +1,85 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <memory>
+#include <exception>
+#include <functional>
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include "MockSystemCalls.h"
+#include "../MethodRewriter/AgentCallStyle.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace NewRelic { namespace Profiler { namespace MethodRewriter{ namespace Test
+{
+    TEST_CLASS(AgentCallStyleTest)
+    {
+    public:
+        TEST_METHOD(AgentCallStrategy_LegacyCaching_false_DisableAppDomainCaching_false_Expected_InAgent)
+        {
+            RunTest(_X("false"), _X("false"), AgentCallStyle::Strategy::InAgentCache);
+        }
+
+        TEST_METHOD(AgentCallStrategy_LegacyCaching_false_DisableAppDomainCaching_true_Expected_Reflection)
+        {
+            RunTest(_X("false"), _X("true"), AgentCallStyle::Strategy::Reflection);
+        }
+
+        TEST_METHOD(AgentCallStrategy__LegacyCaching_true_DisableAppDomainCaching_false_Expected_AppDomain)
+        {
+            RunTest(_X("true"), _X("false"), AgentCallStyle::Strategy::AppDomainCache);
+        }
+
+        TEST_METHOD(AgentCallStrategy_LegacyCaching_true_DisableAppDomainCaching_true_Expected_Relfection)
+        {
+            RunTest(_X("true"), _X("true"), AgentCallStyle::Strategy::Reflection);
+        }
+
+        TEST_METHOD(AgentCallStrategy_ToString_InAgentCache)
+        {
+            const xstring_t expectedValue = _X("In Agent Cache");
+            Assert::AreEqual(expectedValue, AgentCallStyle::ToString(AgentCallStyle::Strategy::InAgentCache));
+        }
+
+        TEST_METHOD(AgentCallStrategy_ToString_AppDomainCache)
+        {
+            const xstring_t expectedValue = _X("AppDomain Cache");
+            Assert::AreEqual(expectedValue, AgentCallStyle::ToString(AgentCallStyle::Strategy::AppDomainCache));
+        }
+
+        TEST_METHOD(AgentCallStrategy_ToString_Reflection)
+        {
+            const xstring_t expectedValue = _X("Reflection");
+            Assert::AreEqual(expectedValue, AgentCallStyle::ToString(AgentCallStyle::Strategy::Reflection));
+        }
+
+    private:
+        void RunTest(const xstring_t& legacyCachingEnabled, const xstring_t& disableAppDomainCache, const AgentCallStyle::Strategy expectedStrategy)
+        {
+            auto systemCalls = std::make_shared<MockSystemCalls>();
+            systemCalls->EnvironmentVariableResult = [&legacyCachingEnabled, &disableAppDomainCache](const xstring_t& variableName)
+            {
+                if (variableName == _X("NEW_RELIC_ENABLE_LEGACY_CACHING"))
+                {
+                    return std::make_unique<xstring_t>(legacyCachingEnabled);
+                }
+                else if (variableName == _X("NEW_RELIC_DISABLE_APPDOMAIN_CACHING"))
+                {
+                    return std::make_unique<xstring_t>(disableAppDomainCache);
+                }
+                else
+                {
+                    return std::make_unique<xstring_t>(_X(""));
+                }
+            };
+
+            AgentCallStyle agentCallStyle(systemCalls);
+
+            const auto callStrategy = agentCallStyle.GetConfiguredCallingStrategy();
+
+            Assert::AreEqual(static_cast<int>(expectedStrategy), static_cast<int>(callStrategy));
+        }
+    };
+}}}}

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/FunctionManipulatorTest.cpp
@@ -22,13 +22,13 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
         TEST_METHOD(construction)
         {
             auto function = std::make_shared<MockFunction>();
-            FunctionManipulator manipulator(function, false);
+            FunctionManipulator manipulator(function, false, AgentCallStyle::Strategy::InAgentCache);
         }
 
         TEST_METHOD(instrument_minimal_method)
         {
             auto function = std::make_shared<MockFunction>();
-            InstrumentFunctionManipulator manipulator(function, std::make_shared<InstrumentationSettings>(nullptr, L""), false);
+            InstrumentFunctionManipulator manipulator(function, std::make_shared<InstrumentationSettings>(nullptr, L""), false, AgentCallStyle::Strategy::InAgentCache);
 
             auto instrumentationPoint = CreateInstrumentationPointThatMatchesFunction(function);
             manipulator.InstrumentDefault(instrumentationPoint);

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.cpp
@@ -76,8 +76,8 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
         };
 
         // ACT
-        methodRewriter->Instrument(overload1);
-        methodRewriter->Instrument(overload2);
+        methodRewriter->Instrument(overload1, AgentCallStyle::Strategy::InAgentCache);
+        methodRewriter->Instrument(overload2, AgentCallStyle::Strategy::InAgentCache);
 
         // ASSERT
         Assert::AreEqual((uint8_t)1, overload1CallCount, L"Function should have been instrumented 1 time!");

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MethodRewriterTest.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="UnreferencedFunctions.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AgentCallStyleTests.cpp" />
     <ClCompile Include="CustomInstrumentationTest.cpp" />
     <ClCompile Include="ExceptionHandlerManipulatorTest.cpp" />
     <ClCompile Include="InstantiatedGenericTypeTest.cpp" />

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/MockSystemCalls.h
@@ -20,7 +20,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             };
         }
 
-        virtual std::unique_ptr<std::wstring> TryGetEnvironmentVariable(const std::wstring& variableName)
+        virtual std::unique_ptr<std::wstring> TryGetEnvironmentVariable(const std::wstring& variableName) override
         {
             return EnvironmentVariableResult(variableName);
         }
@@ -29,5 +29,17 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
         {
             return true;
         }
+
+        virtual uint32_t GetCurrentProcessId() override { return 0; }
+        virtual std::shared_ptr<std::wostream> OpenFile(const xstring_t&, std::ios_base::openmode) override { return nullptr; }
+        virtual void CloseFile(std::shared_ptr<std::wostream>) override { }
+        virtual bool DirectoryExists(const xstring_t&) override { return false; }
+        virtual void DirectoryCreate(const xstring_t&) override { }
+        virtual xstring_t GetCommonAppDataFolderPath() override { return _X(""); }
+
+        virtual std::unique_ptr<xstring_t> GetNewRelicHomePath() override { return nullptr; }
+        virtual std::unique_ptr<xstring_t> GetNewRelicProfilerLogDirectory() override { return nullptr; }
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogDirectory() override { return nullptr; }
+        virtual std::unique_ptr<xstring_t> GetNewRelicLogLevel() override { return nullptr; }
     };
 }}}}

--- a/src/Agent/NewRelic/Profiler/Profiler/Module.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Module.h
@@ -117,7 +117,7 @@ namespace NewRelic { namespace Profiler
             GetOrCreateMemberReferenceToken(typeReferenceOrDefinitionToken, methodName, signature);
         }
 
-        virtual bool InjectReferenceToCoreLib()
+        virtual bool InjectReferenceToCoreLib() override
         {
             const auto coreLibName = _isCoreClr ? SYSTEM_PRIVATE_CORELIB_ASSEMBLYNAME : MSCORLIB_ASSEMBLYNAME;
             constexpr const BYTE pubTokenCoreClr[] = { 0x7C, 0xEC, 0x85, 0xD7, 0xBE, 0xA7, 0x79, 0x8E };

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -65,13 +65,13 @@ namespace NewRelic { namespace Profiler
             return std::unique_ptr<xstring_t>(new xstring_t(valueString.get()));
         }
 
-        virtual xstring_t GetProgramCommandLine()
+        static xstring_t GetProgramCommandLine()
         {
             auto commandLine = GetCommandLineW();
             return commandLine;
         }
 
-        virtual xstring_t GetProcessPath()
+        static xstring_t GetProcessPath()
         {
             const int MAX_PROCESS_PATH = 1024;
             wchar_t moduleName[MAX_PROCESS_PATH];
@@ -86,7 +86,7 @@ namespace NewRelic { namespace Profiler
             return moduleName;
         }
 
-        virtual xstring_t GetParentProcessPath()
+        static xstring_t GetParentProcessPath()
         {
             const int MAX_PROCESS_PATH = 1024;
             wchar_t moduleName[MAX_PROCESS_PATH] = L"";
@@ -128,10 +128,10 @@ namespace NewRelic { namespace Profiler
             return moduleName;
         }
 
-        virtual uint32_t GetParentProcessId()
+        static uint32_t GetParentProcessId()
         {
             uint32_t ppid = 0;
-            const uint32_t pid = GetCurrentProcessId();
+            const uint32_t pid = ::GetCurrentProcessId();
             const HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 
             if (hSnapshot == INVALID_HANDLE_VALUE)
@@ -164,7 +164,7 @@ namespace NewRelic { namespace Profiler
         }
 
 
-        virtual xstring_t GetProcessDirectoryPath()
+        static xstring_t GetProcessDirectoryPath()
         {
             const int MAX_PROCESS_PATH = 1024;
             wchar_t path[MAX_PROCESS_PATH];

--- a/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/UnixSystemCalls.h
@@ -64,7 +64,7 @@ namespace NewRelic { namespace Profiler
             return inputDoesNotContainSpaces ? arg : "'" + arg + "'";
         }
 
-        virtual xstring_t GetProgramCommandLine()
+        static xstring_t GetProgramCommandLine()
         {
             try
             {
@@ -94,7 +94,7 @@ namespace NewRelic { namespace Profiler
             }
         }
 
-        virtual xstring_t GetProcessPath()
+        static xstring_t GetProcessPath()
         {
             /*
             char *argv[] = {};
@@ -124,12 +124,12 @@ namespace NewRelic { namespace Profiler
             return _X(".");
         }
 
-        virtual xstring_t GetParentProcessPath()
+        static xstring_t GetParentProcessPath()
         {
             return _X(".");
         }
 
-        virtual xstring_t GetProcessDirectoryPath()
+        static xstring_t GetProcessDirectoryPath()
         {
             return _X(".");
         }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Adds a new environment variable `NEW_RELIC_ENABLE_LEGACY_CACHING` in addition to the existing `NEW_RELIC_DISABLE_APPDOMAIN_CACHING` environment variable that allows someone to control which caching strategy is used.

If `NEW_RELIC_DISABLE_APPDOMAIN_CACHING` is set to `true` reflection without any caching will be used. This will happen even if the other environment variable is set to `true`.
If `NEW_RELIC_ENABLE_LEGACY_CACHING` is set to `true` (and the other variable is not set to `true`) AppDomain caching will be used.

The new In Agent cache will be enabled by default.

.Net Framework applications that want to enable the previous caching behavior should set `NEW_RELIC_ENABLE_LEGACY_CACHING` to `true`.

.Net / .Net Core applications that want to enable the previous caching behavior should set `NEW_RELIC_DISABLE_APPDOMAIN_CACHING` to `true` (AppDomain caching was not previously supported for .Net / .Net Core applications).

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
