### PR TITLE
fix: When audit logging is enabled, no logs are written to the audit log file.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -12,7 +12,7 @@ namespace NewRelic.Agent.Core.Logging
         // a lazy ILogger instance that injects an "Audit" property
         private static Lazy<ILogger> _lazyAuditLogger = LazyAuditLogger();
 
-        public static bool IsAuditLogEnabled { get; set; } //setter is public only for unit tests, not expected to be use anywhere else
+        public static bool IsAuditLogEnabled { get; set; } 
 
         // for unit tests only
         public static void ResetLazyLogger()
@@ -38,8 +38,6 @@ namespace NewRelic.Agent.Core.Logging
 
         public static LoggerConfiguration IncludeOnlyAuditLog(this LoggerConfiguration loggerConfiguration)
         {
-            IsAuditLogEnabled = true; // set a flag so Log() can short-circuit when audit log is not enabled
-
             return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is not null");
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/AuditLog.cs
@@ -45,8 +45,6 @@ namespace NewRelic.Agent.Core.Logging
 
         public static LoggerConfiguration ExcludeAuditLog(this LoggerConfiguration loggerConfiguration)
         {
-            IsAuditLogEnabled = false; // set a flag so Log() can short-circuit when audit log is not enabled
-
             return loggerConfiguration.Filter.ByIncludingOnly($"{LogLevelExtensions.AuditLevel} is null");
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -57,6 +57,8 @@ namespace NewRelic.Agent.Core
         {
             SetupLogLevel(config);
 
+            AuditLog.IsAuditLogEnabled = config.IsAuditLogEnabled;
+
             var loggerConfig = new LoggerConfiguration()
                 .MinimumLevel.ControlledBy(_loggingLevelSwitch)
                 .ConfigureAuditLogSink(config)

--- a/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Logging/AuditLogTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using NUnit.Framework;
@@ -28,26 +28,6 @@ namespace NewRelic.Agent.Core.Logging.Tests
         public void TearDown()
         {
             AuditLog.ResetLazyLogger();
-        }
-
-        [Test]
-        public void IncludeOnlyAuditLog_EnablesAuditLog()
-        {
-            Assert.False(AuditLog.IsAuditLogEnabled);
-
-            var _ = new LoggerConfiguration().IncludeOnlyAuditLog();
-
-            Assert.True(AuditLog.IsAuditLogEnabled);
-        }
-
-        [Test]
-        public void ExcludeAuditLog_DisablesAuditLog()
-        {
-            AuditLog.IsAuditLogEnabled = true;
-
-            var _ = new LoggerConfiguration().ExcludeAuditLog();
-
-            Assert.False(AuditLog.IsAuditLogEnabled);
         }
 
         [TestCase(true)]


### PR DESCRIPTION
Fixes an issue where audit logging wasn't correctly enabled at runtime.

Resolves #2028 