### PR TITLE
ci: Use actual release version for release notes branch

### DIFF
--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set Docs PR Branch Name
         run: |
-          cleaned_branch=$(echo "10.13.0" | sed 's/\./-/g')
+          cleaned_branch=$(echo "${{ github.event.inputs.agent_version }}"" | sed 's/\./-/g')
           echo "branch_name=dotnet-release-$cleaned_branch"
           echo "branch_name=dotnet-release-$cleaned_branch" >> $GITHUB_ENV
         shell: bash


### PR DESCRIPTION
Fix a minor issue with the workflow that generates the release notes PR for the docs website; it was using a hardcoded version string of 10.13.0 to create the branch instead of the actual release version.

