### PR TITLE
chore: Disable ASP.NET Core 6+ browser injection by default.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2103,7 +2103,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 return _enableAspNetCore6PlusBrowserInjection.HasValue
                     ? _enableAspNetCore6PlusBrowserInjection.Value
-                    : (_enableAspNetCore6PlusBrowserInjection = TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", true)).Value;
+                    : (_enableAspNetCore6PlusBrowserInjection = TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", false)).Value;
             }
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -3241,8 +3241,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return defaultConfig.ForceSynchronousTimingCalculationHttpClient;
         }
 
-        [TestCase(null, ExpectedResult = true)]
-        [TestCase("not a bool", ExpectedResult = true)]
+        [TestCase(null, ExpectedResult = false)]
+        [TestCase("not a bool", ExpectedResult = false)]
         [TestCase("false", ExpectedResult = false)]
         [TestCase("true", ExpectedResult = true)]
         public bool AspNetCore6PlusBrowserInjectionTests(string localConfigValue)


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Toggles the default vale for the `EnableAspNetCore6PlusBrowserInjection` setting to `false`. This will disable browser injection unless explicitly enabled in `newrelic.config`.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
