### PR TITLE
fix: During browser agent injection, don't set ContentLength if headers have already been sent. (#2051)

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
@@ -39,7 +39,8 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
         {
             if (!Disabled && !_isContentLengthSet && IsHtmlResponse())
             {
-                _context.Response.ContentLength = null;
+                if (!_context.Response.HasStarted)  // can't set headers if response has already started
+                    _context.Response.ContentLength = null;
                 _isContentLengthSet = true;
             }
 
@@ -154,7 +155,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                 // * text/html response
                 // * UTF-8 formatted (either explicitly or no charset defined)
                 _isHtmlResponse =
-                    _context.Response.ContentType != null && 
+                    _context.Response.ContentType != null &&
                     _context.Response.ContentType.Contains("text/html", StringComparison.OrdinalIgnoreCase) &&
                     (_context.Response.ContentType.Contains("utf-8", StringComparison.OrdinalIgnoreCase) ||
                      !_context.Response.ContentType.Contains("charset=", StringComparison.OrdinalIgnoreCase));
@@ -170,7 +171,8 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                 // and fail when it doesn't match if (_isHtmlResponse.Value)
                 if (!_isContentLengthSet && _context.Response.ContentLength != null)
                 {
-                    _context.Response.ContentLength = null;
+                    if (!_context.Response.HasStarted) // can't set headers if response has already started
+                        _context.Response.ContentLength = null;
                     _isContentLengthSet = true;
                 }
             }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Adds a check during browser agent injection for ASP.NET Core 6+ to determine if response headers have already been sent and only sets `Response.ContentLength` if headers have *not* been sent. 

Resolves #2051 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
