### PR TITLE
test: Eliminate firewall pop-ups when running integration tests locally

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreBasicWebApiApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreBasicWebApiApplication/Program.cs
@@ -38,7 +38,7 @@ namespace AspNetCoreBasicWebApiApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreDistTracingApplication/Program.cs
@@ -32,7 +32,7 @@ namespace AspNetCoreDistTracingApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls(string.Format(@"http://localhost:{0}/", _port))
+                .UseUrls(string.Format(@"http://127.0.0.1:{0}/", _port))
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreFeatures/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreFeatures/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreFeatures
                 {
                     webBuilder
                         .UseStartup<Startup>()
-                        .UseUrls($@"http://localhost:{_port}/");
+                        .UseUrls($@"http://127.0.0.1:{_port}/");
                 });
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcAsyncApplication/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreMvcAsyncApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcBasicRequestsApplication/Program.cs
@@ -35,7 +35,7 @@ namespace AspNetCoreMvcBasicRequestsApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         /// <summary>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcCoreFrameworkApplication/Program.cs
@@ -31,7 +31,7 @@ namespace AspNetCoreMvcCoreFrameworkApplication
         public static IWebHost BuildWebHost(string[] args, string port) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{port}/")
+                .UseUrls($@"http://127.0.0.1:{port}/")
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkApplication/Program.cs
@@ -73,7 +73,7 @@ namespace AspNetCoreMvcFrameworkApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcFrameworkAsyncApplication/Program.cs
@@ -55,7 +55,7 @@ namespace AspNetCoreMvcFrameworkAsyncApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
         private static void CreatePidFile()

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreMvcRejitApplication/Program.cs
@@ -32,7 +32,7 @@ namespace AspNetCoreMvcRejitApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreWebApiCustomAttributesApplication/Program.cs
@@ -34,7 +34,7 @@ namespace AspNetCoreWebApiCustomAttributesApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls(string.Format(@"http://localhost:{0}/", _port))
+                .UseUrls(string.Format(@"http://127.0.0.1:{0}/", _port))
                 .Build();
     }
 }

--- a/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/Program.cs
@@ -61,8 +61,7 @@ namespace BasicAspNetCoreRazorApplication
                     }));
             });
 
-
-            app.Urls.Add($"http://*:{_port}");
+            app.Urls.Add($"http://127.0.0.1:{_port}");
 
             var task = app.RunAsync(ct.Token);
 

--- a/tests/Agent/IntegrationTests/Applications/CustomAttributesWebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/CustomAttributesWebApi/Program.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests.Applications.CustomAttributesWebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 using (var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset,

--- a/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin2WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin2WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 using (var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset,

--- a/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin3WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin3WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 using (var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset,

--- a/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Program.cs
@@ -31,7 +31,7 @@ namespace Owin4WebApi
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset, "app_server_wait_for_all_request_done_" + Port.ToString());

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Controllers/RemoteController.cs
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Controllers/RemoteController.cs
@@ -14,14 +14,14 @@ namespace OwinRemotingClient.Controllers
         [Route("GetObjectTcp")]
         public string GetObjectTcp()
         {
-            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "tcp://localhost:7878/GetObject");
+            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "tcp://127.0.0.1:7878/GetObject");
             return GetObject(myMarshalByRefClassObj);
         }
 
         [Route("GetObjectHttp")]
         public string GetObjectHttp()
         {
-            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "http://localhost:7879/GetObject");
+            var myMarshalByRefClassObj = (MyMarshalByRefClass)Activator.GetObject(typeof(MyMarshalByRefClass), "http://127.0.0.1:7879/GetObject");
             return GetObject(myMarshalByRefClassObj);
         }
 

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingClient/Program.cs
@@ -31,7 +31,7 @@ namespace OwinRemotingClient
 
         private void RealMain()
         {
-            var baseAddress = string.Format(@"http://*:{0}/", Port);
+            var baseAddress = string.Format(@"http://127.0.0.1:{0}/", Port);
             using (WebApp.Start<Startup>(baseAddress))
             {
                 using (var eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset,

--- a/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/OwinRemotingServer/Program.cs
@@ -34,20 +34,16 @@ namespace OwinRemotingServer
 
         private void RealMain()
         {
-            var serverProviderTcp = new BinaryServerFormatterSinkProvider();
-            serverProviderTcp.TypeFilterLevel = System.Runtime.Serialization.Formatters.TypeFilterLevel.Full;
+            var serverProviderTcp = new BinaryServerFormatterSinkProvider { TypeFilterLevel = System.Runtime.Serialization.Formatters.TypeFilterLevel.Full };
             var clientProviderTcp = new BinaryClientFormatterSinkProvider();
-            var propertiesTcp = new System.Collections.Hashtable();
-            propertiesTcp["port"] = 7878;
+            var propertiesTcp = new System.Collections.Hashtable { ["port"] = 7878, ["bindTo"] = "127.0.0.1" };
 
             var tcpChannel = new TcpChannel(propertiesTcp, clientProviderTcp, serverProviderTcp);
             ChannelServices.RegisterChannel(tcpChannel, false);
 
-            var serverProviderHttp = new SoapServerFormatterSinkProvider();
-            serverProviderHttp.TypeFilterLevel = System.Runtime.Serialization.Formatters.TypeFilterLevel.Full;
+            var serverProviderHttp = new SoapServerFormatterSinkProvider { TypeFilterLevel = System.Runtime.Serialization.Formatters.TypeFilterLevel.Full };
             var clientProviderHttp = new SoapClientFormatterSinkProvider();
-            var propertiesHttp = new System.Collections.Hashtable();
-            propertiesHttp["port"] = 7879;
+            var propertiesHttp = new System.Collections.Hashtable { ["port"] = 7879, ["bindTo"] = "127.0.0.1" };
 
             var httpChannel = new HttpChannel(propertiesHttp, clientProviderHttp, serverProviderHttp);
             ChannelServices.RegisterChannel(httpChannel, false);

--- a/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/SerilogSumologicApplication/Program.cs
@@ -38,7 +38,7 @@ namespace SerilogSumologicApplication
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseUrls($@"http://localhost:{_port}/")
+                .UseUrls($@"http://127.0.0.1:{_port}/")
                 .Build();
 
     }

--- a/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/AppHost.cs
+++ b/tests/Agent/IntegrationTests/Applications/ServiceStackApplication/AppHost.cs
@@ -27,7 +27,7 @@ namespace ServiceStackApplication
             // This plugin attempts to serialize everything in HttpContext using ServiceStack.Text
             // It tests that we do not reintroduce a StackOverflow issue that can crash apps.
             // We don't formally take responsibility over this but we do our best to do no harm.
-            Plugins.Add(new SeqRequestLogsFeature { SeqUrl = "http://localhost:5341" });
+            Plugins.Add(new SeqRequestLogsFeature { SeqUrl = "http://127.0.0.1:5341" });
         }
     }
 }

--- a/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
+++ b/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
+					<binding protocol="http" bindingInformation="*:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>

--- a/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
+++ b/tests/Agent/IntegrationTests/HostedWebCore/applicationHost.config
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="*:80:" />
+					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -214,7 +214,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
         public int Port => _port ?? (_port = RandomPortGenerator.NextPort()).Value;
 
-        public readonly string DestinationServerName = Dns.GetHostName().ToLower();
+        public static readonly string DestinationServerName = "127.0.0.1";
 
         private NewRelicConfigModifier _newRelicConfigModifier;
         public NewRelicConfigModifier NewRelicConfig => _newRelicConfigModifier ?? (_newRelicConfigModifier = new NewRelicConfigModifier(DestinationNewRelicConfigFilePath));

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteWebApplication.cs
@@ -184,7 +184,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             };
             var attributes = new[]
             {
-                new KeyValuePair<string, string>("bindingInformation", string.Format(@"*:{0}:", Port)),
+                new KeyValuePair<string, string>("bindingInformation", string.Format(@"127.0.0.1:{0}:", Port)),
             };
             XmlUtils.ModifyOrCreateXmlAttributes(DestinationApplicationHostConfigFilePath, string.Empty, nodes, attributes);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatDisabledChainedRequestsWebRequest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatDisabledChainedRequestsWebRequest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.CatInbound;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -62,15 +63,15 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
             {
                 new Assertions.ExpectedMetric { metricName = @"External/all", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"External/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest", callCount = 1 }
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest", callCount = 1 }
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index" },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest" },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index" },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest" },
                 new Assertions.ExpectedMetric { metricName = @"ClientApplication/[^/]+/all", IsRegexName = true }
             };
             var expectedCallerTraceSegmentRegexes = new List<string>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedAsyncAwaitRestSharp.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedAsyncAwaitRestSharp.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -75,7 +76,7 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
 				// This scoped metric should be superceded by the ExternalTransaction metric above
-				new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/AsyncAwaitClient" }
+				new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/AsyncAwaitClient" }
             };
 
             // Note: we are checking the attributes attached to the *Callee's* transaction, not the caller's transaction. The attributes attached to the caller's transaction are already fully vetted in the CatInbound tests.

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsHttpClient.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsHttpClient.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -67,17 +68,17 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
             {
                 new Assertions.ExpectedMetric { metricName = @"External/all", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"External/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedHttpClient", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedHttpClient", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"ClientApplication/[^/]+/all", IsRegexName = true }
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
 				// This scoped metric should be superceded by the ExternalTransaction metric above
-				new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedHttpClient" }
+				new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedHttpClient" }
             };
             // Note: we are checking the attributes attached to the *Callee's* transaction, not the caller's transaction. The attributes attached to the caller's transaction are already fully vetted in the CatInbound tests.
             var expectedTransactionEventIntrinsicAttributes1 = new List<string>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsWebRequest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedRequestsWebRequest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -69,17 +70,17 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
             {
                 new Assertions.ExpectedMetric { metricName = @"External/all", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"External/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{_fixture.RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalApp/{RemoteApplication.DestinationServerName}/{crossProcessId}/all", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"ExternalTransaction/{RemoteApplication.DestinationServerName}/{crossProcessId}/WebTransaction/MVC/DefaultController/Index", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = @"ClientApplication/[^/]+/all", IsRegexName = true }
             };
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
 				// This scoped metric should be superceded by the ExternalTransaction metric above
-				new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest" }
+				new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/DefaultController/ChainedWebRequest" }
             };
             // Note: we are checking the attributes attached to the *Callee's* transaction, not the caller's transaction. The attributes attached to the caller's transaction are already fully vetted in the CatInbound tests.
             var expectedTransactionEventIntrinsicAttributes1 = new List<string>

--- a/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedTaskResultRestSharp.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CatOutbound/CatEnabledChainedTaskResultRestSharp.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -78,7 +79,7 @@ namespace NewRelic.Agent.IntegrationTests.CatOutbound
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
 				// This scoped metric should be superceded by the ExternalTransaction metric above
-				new Assertions.ExpectedMetric { metricName = $@"External/{_fixture.RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient" }
+				new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/RestSharpController/TaskResultClient" }
             };
 
             // Note: we are checking the attributes attached to the *Callee's* transaction, not the caller's transaction. The attributes attached to the caller's transaction are already fully vetted in the CatInbound tests.

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
@@ -363,10 +363,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 
@@ -408,10 +408,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/localhost/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/AspNetCoreDistTraceRequestChainTests.cs
@@ -363,10 +363,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/FirstCallController/CallNext", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/FirstCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 
@@ -408,10 +408,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing
                 new Assertions.ExpectedMetric { metricName = @"WebTransactionTotalTime/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", CallCountAllHarvests = ExpectedTransactionCount },
 
                 new Assertions.ExpectedMetric { metricName = @"DotNet/SecondCallController/CallNext", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
-                new Assertions.ExpectedMetric { metricName = @"External/127.0.0.1/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
+                new Assertions.ExpectedMetric { metricName = $@"External/{RemoteApplication.DestinationServerName}/Stream/GET", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
                 new Assertions.ExpectedMetric { metricName = @"DotNet/Middleware Pipeline", metricScope = @"WebTransaction/MVC/SecondCall/CallNext/{nextUrl}", CallCountAllHarvests = ExpectedTransactionCount },
             };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingSender/CallNext").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingReceiver/CallEnd").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 
 namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationTests
 {
@@ -39,7 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingSender/CallNext").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/DistributedTracingReceiver/CallEnd").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
@@ -90,10 +90,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/CallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/CallNext/{nextUrl}").FirstOrDefault();
-            var receiverExternalSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var receiverExternalSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var lastRootSpanEvent = lastCallAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/LastCall/CallEnd").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpClientW3CTestsNetCore.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -90,10 +91,10 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/CallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/CallNext/{nextUrl}").FirstOrDefault();
-            var receiverExternalSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
+            var receiverExternalSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var lastRootSpanEvent = lastCallAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/LastCall/CallEnd").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/DefaultController/ChainedWebRequest").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{_fixture.SenderApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/DefaultController/Index").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
@@ -78,7 +79,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/HttpWebRequestW3CTestsNetCore.cs
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
             }
 
             var senderRootSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/FirstCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = receiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/SecondCall/WebRequestCallNext/{nextUrl}").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -37,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/DistributedTracingController/MakeExternalCallUsingRestClient").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/127.0.0.1/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/RestAPI/Get").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/RestSharpW3CTests.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
         public override void RootSpanAttributes()
         {
             var senderRootSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/MVC/DistributedTracingController/MakeExternalCallUsingRestClient").FirstOrDefault();
-            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/localhost/Stream/GET").FirstOrDefault();
+            var externalSpanEvent = SenderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/127.0.0.1/Stream/GET").FirstOrDefault();
 
             var receiverRootSpanEvent = ReceiverAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "WebTransaction/WebAPI/RestAPI/Get").FirstOrDefault();
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -71,7 +71,7 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
                     _fixture.AddCommand("ProcessRunner AddArgument -m unittest");
                     _fixture.AddCommand("ProcessRunner AddSwitch -v");
                     _fixture.AddCommand($@"ProcessRunner WorkingDirectory {Path.Combine(_fixture.RemoteApplication.DestinationApplicationDirectoryPath, "trace-context", "test")}"); // python W3C tests are in test dir
-                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT {_fixture.DestinationServerName}:{_fixture.RemoteApplication.Port}/test");
+                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT http://{_fixture.DestinationServerName}:{_fixture.RemoteApplication.Port}/test");
                     _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable STRICT_LEVEL 1");
                     _fixture.AddCommand("ProcessRunner Start");
                     _fixture.AddCommand("ProcessRunner WaitforExit 30000");

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/W3CInstrumentationTests/W3CValidation.cs
@@ -64,14 +64,14 @@ namespace NewRelic.Agent.IntegrationTests.DistributedTracing.W3CInstrumentationT
                     _fixture.RemoteApplication.NewRelicConfig.SetRequestTimeout(TimeSpan.FromSeconds(10));
                     _fixture.RemoteApplication.NewRelicConfig.ForceTransactionTraces();
 
-                    _fixture.AddCommand($"W3CTestService StartService {_fixture.RemoteApplication.Port}");
+                    _fixture.AddCommand($"W3CTestService StartService {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
                     _fixture.AddCommand($@"GitCommand Clone https://github.com/w3c/trace-context.git {Path.Combine(_fixture.RemoteApplication.DestinationApplicationDirectoryPath, "trace-context")}");
                     _fixture.AddCommand($@"GitCommand Checkout { Path.Combine(_fixture.RemoteApplication.DestinationApplicationDirectoryPath, "trace-context")} 98f210efd89c63593dce90e2bae0a1bdcb986f51");
                     _fixture.AddCommand("ProcessRunner ProcessName python.exe");
                     _fixture.AddCommand("ProcessRunner AddArgument -m unittest");
                     _fixture.AddCommand("ProcessRunner AddSwitch -v");
                     _fixture.AddCommand($@"ProcessRunner WorkingDirectory {Path.Combine(_fixture.RemoteApplication.DestinationApplicationDirectoryPath, "trace-context", "test")}"); // python W3C tests are in test dir
-                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT http://localhost:{_fixture.RemoteApplication.Port}/test");
+                    _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable SERVICE_ENDPOINT {_fixture.DestinationServerName}:{_fixture.RemoteApplication.Port}/test");
                     _fixture.AddCommand($"ProcessRunner AddEnvironmentVariable STRICT_LEVEL 1");
                     _fixture.AddCommand("ProcessRunner Start");
                     _fixture.AddCommand("ProcessRunner WaitforExit 30000");

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
@@ -61,7 +61,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
             var senderAppSpanEvents = _fixture.AgentLog.GetSpanEvents();
             var receiverAppSpanEvents = _fixture.ReceiverApplication.AgentLog.GetSpanEvents();
 
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/localhost/Stream/GET")
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET")
                 .FirstOrDefault();
             Assert.Equal(externalSpanEvent.IntrinsicAttributes["guid"], receiverAppTxEvent.IntrinsicAttributes["parentSpanId"]);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinDTChainTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 using Xunit.Abstractions;
 using NewRelic.Agent.IntegrationTestHelpers;
 using System.Collections.Generic;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 
 namespace NewRelic.Agent.IntegrationTests.Owin
@@ -61,7 +62,7 @@ namespace NewRelic.Agent.IntegrationTests.Owin
             var senderAppSpanEvents = _fixture.AgentLog.GetSpanEvents();
             var receiverAppSpanEvents = _fixture.ReceiverApplication.AgentLog.GetSpanEvents();
 
-            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == "External/127.0.0.1/Stream/GET")
+            var externalSpanEvent = senderAppSpanEvents.Where(@event => @event?.IntrinsicAttributes?["name"]?.ToString() == $"External/{RemoteApplication.DestinationServerName}/Stream/GET")
                 .FirstOrDefault();
             Assert.Equal(externalSpanEvent.IntrinsicAttributes["guid"], receiverAppTxEvent.IntrinsicAttributes["parentSpanId"]);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreBasicWebApiApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreBasicWebApiApplicationFixture.cs
@@ -16,13 +16,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void MakeExternalCallUsingHttpClient(string baseAddress, string path)
         {
-            var address = $"http://localhost:{Port}/api/default/MakeExternalCallUsingHttpClient?baseAddress={baseAddress}&path={path}";
+            var address = $"http://{DestinationServerName}:{Port}/api/default/MakeExternalCallUsingHttpClient?baseAddress={baseAddress}&path={path}";
             GetStringAndAssertContains(address, "Worked");
         }
 
         public string GetTraceId()
         {
-            var address = $"http://localhost:{Port}/api/default/GetTraceId";
+            var address = $"http://{DestinationServerName}:{Port}/api/default/GetTraceId";
             return GetStringAndAssertIsNotNull(address);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
@@ -41,9 +41,9 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ExecuteTraceRequestChain(string firstAppAction, string secondAppAction, string thirdAppAction, IEnumerable<KeyValuePair<string, string>> headers = null)
         {
-            var firstCallBaseUrl = $"http://localhost:{FirstCallApplication.Port}/FirstCall";
-            var secondCallBaseUrl = $"http://localhost:{SecondCallApplication.Port}/SecondCall";
-            var lastCallBaseUrl = $"http://localhost:{RemoteApplication.Port}/LastCall";
+            var firstCallBaseUrl = $"http://{DestinationServerName}:{FirstCallApplication.Port}/FirstCall";
+            var secondCallBaseUrl = $"http://{DestinationServerName}:{SecondCallApplication.Port}/SecondCall";
+            var lastCallBaseUrl = $"http://{DestinationServerName}:{RemoteApplication.Port}/LastCall";
 
             var lastCallUrl = $"{lastCallBaseUrl}/{thirdAppAction}";
             var secondCallUrl = $"{secondCallBaseUrl}/{secondAppAction}?nextUrl={lastCallUrl}";

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreFeaturesFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreFeaturesFixture.cs
@@ -17,37 +17,37 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://{DestinationServerName}:{Port}/";
             GetStringAndAssertContains(address, "<html>");
         }
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://{DestinationServerName}:{Port}/Home/ThrowException";
             GetAndAssertStatusCode(address, HttpStatusCode.InternalServerError);
         }
 
         public void AccessCollectible()
         {
-            var address = $"http://localhost:{Port}/Collectible/AccessCollectible";
+            var address = $"http://{DestinationServerName}:{Port}/Collectible/AccessCollectible";
             _httpClient.GetStringAsync(address).Wait();
         }
 
         public void AsyncStream()
         {
-            var address = $"http://localhost:{Port}/api/AsyncStream";
+            var address = $"http://{DestinationServerName}:{Port}/api/AsyncStream";
             GetStringAndAssertContains(address, "45");
         }
 
         public void InterfaceDefaultsGetWithAttributes()
         {
-            var address = $"http://localhost:{Port}/InterfaceDefaults/GetWithAttributes";
+            var address = $"http://{DestinationServerName}:{Port}/InterfaceDefaults/GetWithAttributes";
             GetStringAndAssertContains(address, "Done");
         }
 
         public void InterfaceDefaultsGetWithoutAttributes()
         {
-            var address = $"http://localhost:{Port}/InterfaceDefaults/GetWithoutAttributes";
+            var address = $"http://{DestinationServerName}:{Port}/InterfaceDefaults/GetWithoutAttributes";
             GetStringAndAssertContains(address, "Done");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcAsyncTestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcAsyncTestsFixture.cs
@@ -17,43 +17,43 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetIoBoundConfigureAwaitFalseAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskRunBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/NewThreadStartBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcBasicRequestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcBasicRequestsFixture.cs
@@ -23,12 +23,12 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://{DestinationServerName}:{Port}/";
             GetStringAndAssertContains(address, "<html>");
         }
         public void GetCORSPreflight()
         {
-            var address = $"http://localhost:{Port}/Home/About";
+            var address = $"http://{DestinationServerName}:{Port}/Home/About";
 
             using (var request = new HttpRequestMessage(HttpMethod.Options, address))
             {
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void MakePostRequestWithCustomRequestHeader(Dictionary<string, string> customHeadersToAdd)
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://{DestinationServerName}:{Port}/";
 
             using (var request = new HttpRequestMessage(HttpMethod.Options, address))
             {
@@ -79,61 +79,61 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://{DestinationServerName}:{Port}/Home/ThrowException";
             GetAndAssertStatusCode(address, HttpStatusCode.InternalServerError);
         }
 
         public void ThrowExceptionWithMessage(string exceptionMessage)
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ThrowExceptionWithMessage?exceptionMessage={exceptionMessage}";
+            var address = $"http://{DestinationServerName}:{Port}/ExpectedErrorTest/ThrowExceptionWithMessage?exceptionMessage={exceptionMessage}";
             GetAndAssertStatusCode(address, HttpStatusCode.InternalServerError);
         }
 
         public void ReturnADesiredStatusCode(int statusCode)
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ReturnADesiredStatusCode?statusCode={statusCode}";
+            var address = $"http://{DestinationServerName}:{Port}/ExpectedErrorTest/ReturnADesiredStatusCode?statusCode={statusCode}";
             GetAndAssertStatusCode(address, (HttpStatusCode)statusCode);
         }
 
         public void ThrowCustomException()
         {
-            var address = $"http://localhost:{Port}/ExpectedErrorTest/ThrowCustomException";
+            var address = $"http://{DestinationServerName}:{Port}/ExpectedErrorTest/ThrowCustomException";
             GetAndAssertStatusCode(address, HttpStatusCode.InternalServerError);
         }
 
         public void GetWithData(string requestParameter)
         {
-            var address = $"http://localhost:{Port}/Home/Query?data={requestParameter}";
+            var address = $"http://{DestinationServerName}:{Port}/Home/Query?data={requestParameter}";
             GetStringAndAssertContains(address, "<html>");
         }
 
         public void GetHttpClient()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClient";
+            var address = $"http://{DestinationServerName}:{Port}/Home/HttpClient";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetHttpClientTaskCancelled()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClientTaskCancelled";
+            var address = $"http://{DestinationServerName}:{Port}/Home/HttpClientTaskCancelled";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetHttpClientFactory()
         {
-            var address = $"http://localhost:{Port}/Home/HttpClientFactory";
+            var address = $"http://{DestinationServerName}:{Port}/Home/HttpClientFactory";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetTypedHttpClient()
         {
-            var address = $"http://localhost:{Port}/Home/TypedHttpClient";
+            var address = $"http://{DestinationServerName}:{Port}/Home/TypedHttpClient";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCallAsyncExternal()
         {
-            var address = $"http://localhost:{Port}/DetachWrapper/CallAsyncExternal";
+            var address = $"http://{DestinationServerName}:{Port}/DetachWrapper/CallAsyncExternal";
             GetStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcCoreFrameworkFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcCoreFrameworkFixture.cs
@@ -18,7 +18,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/api/values";
+            var address = $"http://{DestinationServerName}:{Port}/api/values";
             GetStringAndAssertContains(address, "value1");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkAsyncTestsFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkAsyncTestsFixture.cs
@@ -19,43 +19,43 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/IoBoundNoSpecialAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/CustomMiddlewareIoBoundNoSpecialAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetIoBoundConfigureAwaitFalseAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/IoBoundConfigureAwaitFalseAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwaitTest/CpuBoundTasksAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskRunBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/NewThreadStartBlocked";
             GetStringAndAssertEqual(address, "Worked");
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreMvcFrameworkFixture.cs
@@ -21,13 +21,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/";
+            var address = $"http://{DestinationServerName}:{Port}/";
             GetStringAndAssertContains(address, "<html>");
         }
 
         public void GetCORSPreflight()
         {
-            var address = $"http://localhost:{Port}/Home/About";
+            var address = $"http://{DestinationServerName}:{Port}/Home/About";
 
             using (var request = new HttpRequestMessage(HttpMethod.Options, address))
             {
@@ -44,19 +44,19 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ThrowException()
         {
-            var address = $"http://localhost:{Port}/Home/ThrowException";
+            var address = $"http://{DestinationServerName}:{Port}/Home/ThrowException";
             GetAndAssertStatusCode(address, HttpStatusCode.InternalServerError);
         }
 
         public void GetWithData(string requestParameter)
         {
-            var address = $"http://localhost:{Port}/Home/Query?data={requestParameter}";
+            var address = $"http://{DestinationServerName}:{Port}/Home/Query?data={requestParameter}";
             GetStringAndAssertContains(address, "<html>");
         }
 
         public void GetCallAsyncExternal()
         {
-            var address = $"http://localhost:{Port}/DetachWrapper/CallAsyncExternal";
+            var address = $"http://{DestinationServerName}:{Port}/DetachWrapper/CallAsyncExternal";
             GetStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiCustomAttributesFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiCustomAttributesFixture.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = string.Format("http://localhost:{0}/api/CustomAttributes", Port);
+            var address = $"http://{DestinationServerName}:{Port}/api/CustomAttributes";
             GetStringAndAssertEqual(address, "success");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiWithCollectorFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreWebApiWithCollectorFixture.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get()
         {
-            var address = $"http://localhost:{Port}/api/default/AwesomeName";
+            var address = $"http://{DestinationServerName}:{Port}/api/default/AwesomeName";
             GetStringAndAssertContains(address, "Chuck Norris");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebService.cs
@@ -37,6 +37,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             _driver.Navigate().GoToUrl(address);
         }
 
+        public override string DestinationServerName { get; } = "localhost";
+
         public override void Dispose()
         {
             if (_driver != null)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/DTBasicMVCApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/DTBasicMVCApplicationFixture.cs
@@ -20,14 +20,14 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Initiate()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/Initiate";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/Initiate";
 
             GetStringAndIgnoreResult(address);
         }
 
         public void ReceiveDTPayload()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/ReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/ReceivePayload";
 
             //string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
             string payload =
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateMajorVersionMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityReceivePayload";
 
             // Version: [9999,1]
             string payload = "eyJ2IjpbOTk5OSwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiOTEyMyIsImFwIjoiNTE0MjQiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjE0ODI5NTk1MjU1NzciLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNTI5NDI0MTMwNjAzLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYifX0=";
@@ -54,7 +54,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateIgnoredNullMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = null;
 
             var headers = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>(DTHeaderName, payload) };
@@ -63,7 +63,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateParsePayloadMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImZvbyI6ImJhciIsYWMiOiI5MTIzIiwiYXAiOiI1MTQyNCIsImlkIjoiMjc4NTZmNzBkM2QzMTRiNyIsInRyIjoiMTQ4Mjk1OTUyNTU3NyIsInByIjowLjEyMzQsInNhIjpmYWxzZSwidGkiOjE1Mjk0MjQxMzA2MDMsInBhIjoiNWZhM2MwMTQ5OGUyNDRhNiJ9fQ==";
 
             var headers = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>(DTHeaderName, payload) };
@@ -72,7 +72,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateAcceptSuccessMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityReceivePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
 
             var headers = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>(DTHeaderName, payload) };
@@ -81,7 +81,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateUntrustedAccountMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityReceivePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityReceivePayload";
 
             //{"v":[0,1],"d":{"ty":"App","ac":"8675309","ap":"51424","pa":"5fa3c01498e244a6","id":"27856f70d3d314b7","tr":"3221bf09aa0bcf0d","pr":0.1234,"sa":false,"ti":1482959525577}}
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiODY3NTMwOSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
@@ -92,7 +92,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GenerateCreateSuccessMetric()
         {
-            var address = $"http://localhost:{Port}/DistributedTracing/SupportabilityCreatePayload";
+            var address = $"http://{DestinationServerName}:{Port}/DistributedTracing/SupportabilityCreatePayload";
             string payload = "eyJ2IjpbMCwxXSwiZCI6eyJ0eSI6IkFwcCIsImFjIjoiMSIsImFwIjoiNTE0MjQiLCJwYSI6IjVmYTNjMDE0OThlMjQ0YTYiLCJpZCI6IjI3ODU2ZjcwZDNkMzE0YjciLCJ0ciI6IjMyMjFiZjA5YWEwYmNmMGQiLCJwciI6MC4xMjM0LCJzYSI6ZmFsc2UsInRpIjoxNDgyOTU5NTI1NTc3fX0=";
 
             var headers = new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>(DTHeaderName, payload) };

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MvcAsyncFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MvcAsyncFixture.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwait/CpuBoundTasksAsync";
             GetStringAndAssertEqual(address, "Worked");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinWebApiFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinWebApiFixture.cs
@@ -136,43 +136,43 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         }
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwait/CpuBoundTasksAsync";
             GetJsonAndAssertEqual(address, "Worked");
         }
         public void GetCustomMiddlewareIoBoundNoSpecialAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CustomMiddlewareIoBoundNoSpecialAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwait/CustomMiddlewareIoBoundNoSpecialAsync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void ErrorResponse()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/ErrorResponse";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwait/ErrorResponse";
 
             GetAndAssertSuccessStatus(address, false, GetHeaders());
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskRunBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/NewThreadStartBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetBogusPath(string bogusPath)
         {
-            var address = string.Format(@"http://{0}:{1}/{2}", DestinationServerName, Port, bogusPath);
+            var address = $@"http://{DestinationServerName}:{Port}/{bogusPath}";
             GetAndAssertStatusCode(address, HttpStatusCode.NotFound, GetHeaders());
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/SerilogSumologicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/SerilogSumologicFixture.cs
@@ -16,13 +16,13 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void SyncControllerMethod()
         {
-            var address = $"http://localhost:{Port}/Home/SyncControllerMethod";
+            var address = $"http://{DestinationServerName}:{Port}/Home/SyncControllerMethod";
             GetStringAndAssertContains(address, "<html>");
         }
 
         public void AsyncControllerMethod()
         {
-            var address = $"http://localhost:{Port}/Home/AsyncControllerMethod";
+            var address = $"http://{DestinationServerName}:{Port}/Home/AsyncControllerMethod";
             GetStringAndAssertContains(address, "<html>");
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
@@ -109,7 +109,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         public HttpResponseHeaders ExecuteTraceRequestChainHttpWebRequest(IEnumerable<KeyValuePair<string, string>> headers)
         {
             const string action = "Index";
-            var queryString = $"?chainedServerName={ReceiverApplication.DestinationServerName}&chainedPortNumber={ReceiverApplication.Port}&chainedAction={action}";
+            var queryString = $"?chainedServerName={DestinationServerName}&chainedPortNumber={ReceiverApplication.Port}&chainedAction={action}";
 
             var address = $"http://{DestinationServerName}:{Port}/Default/ChainedWebRequest{queryString}";
 
@@ -130,8 +130,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         public void ExecuteTraceRequestChainHttpClient(IEnumerable<KeyValuePair<string, string>> headers = null)
         {
             // the test calls the senderUrl, passing in the receiverUrl as a parameter
-            var senderBaseUrl = $"http://localhost:{RemoteApplication.Port}";
-            var receiverBaseUrl = $"http://localhost:{ReceiverApplication.Port}";
+            var senderBaseUrl = $"http://{DestinationServerName}:{RemoteApplication.Port}";
+            var receiverBaseUrl = $"http://{DestinationServerName}:{ReceiverApplication.Port}";
 
             var receiverUrl = $"{receiverBaseUrl}/api/CallEnd";
             var senderUrl = $"{senderBaseUrl}/api/CallNext?nextUrl={receiverUrl}";
@@ -143,8 +143,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void ExecuteTraceRequestChainRestSharp(IEnumerable<KeyValuePair<string, string>> headers)
         {
-            var secondCallUrl = $"http://localhost:{ReceiverApplication.Port}/api/RestAPI";
-            var firstCallUrl = $"http://localhost:{SenderApplication.Port}/DistributedTracing/MakeExternalCallUsingRestClient?externalCallUrl={secondCallUrl}";
+            var secondCallUrl = $"http://{DestinationServerName}:{ReceiverApplication.Port}/api/RestAPI";
+            var firstCallUrl = $"http://{DestinationServerName}:{SenderApplication.Port}/DistributedTracing/MakeExternalCallUsingRestClient?externalCallUrl={secondCallUrl}";
 
             GetStringAndAssertEqual(firstCallUrl, "Worked", headers);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/WebApiAsyncFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/WebApiAsyncFixture.cs
@@ -30,73 +30,73 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void GetCpuBoundTasksAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncAwait/CpuBoundTasksAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncAwait/CpuBoundTasksAsync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskRunBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskRunBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskRunBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualTaskFactoryStartNewBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/TaskFactoryStartNewBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetManualNewThreadStartBlocked()
         {
-            var address = $"http://localhost:{Port}/ManualAsync/NewThreadStartBlocked";
+            var address = $"http://{DestinationServerName}:{Port}/ManualAsync/NewThreadStartBlocked";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_AwaitedAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_AwaitedAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Async_AwaitedAsync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_FireAndForget()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_FireAndForget";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Async_FireAndForget";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetAsync_Sync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Async_Sync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Async_Sync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_AwaitedAsync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_AwaitedAsync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Sync_AwaitedAsync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_FireAndForget()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_FireAndForget";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Sync_FireAndForget";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void GetSync_Sync()
         {
-            var address = $"http://localhost:{Port}/AsyncFireAndForget/Sync_Sync";
+            var address = $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Sync_Sync";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public void ExecuteResponseTimeTestOperation(int delayDurationSeconds)
         {
-            var address = $"http://localhost:{Port}/ResponseTime/CallsOtherMethod/{delayDurationSeconds}";
+            var address = $"http://{DestinationServerName}:{Port}/ResponseTime/CallsOtherMethod/{delayDurationSeconds}";
             GetJsonAndAssertEqual(address, "Worked");
         }
 
         public string Request(HttpMethod method)
         {
-            using (var requestMessage = new HttpRequestMessage(method, $"http://localhost:{Port}/AsyncFireAndForget/Sync_Sync"))
+            using (var requestMessage = new HttpRequestMessage(method, $"http://{DestinationServerName}:{Port}/AsyncFireAndForget/Sync_Sync"))
             {
                 var result = _httpClient.SendAsync(requestMessage).Result;
                 return result.Content.ReadAsStringAsync().Result;
@@ -105,7 +105,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public void Get404(string Path = "DoesNotExist")
         {
-            GetAndAssertStatusCode($"http://localhost:{Port}/{Path}", HttpStatusCode.NotFound);
+            GetAndAssertStatusCode($"http://{DestinationServerName}:{Port}/{Path}", HttpStatusCode.NotFound);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"{RemoteApplication.DestinationServerName}:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
         };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersDisabledTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"{RemoteApplication.DestinationServerName}:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
         };
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -28,7 +28,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"{RemoteApplication.DestinationServerName}:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
             { "request.headers.foo", "bar" },
             { "request.headers.dashes-are-valid", "true" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/WCF/AllowAllHeadersEnabledTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
@@ -28,7 +28,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.WCF
             { "request.headers.referer", "http://example.com/" },
             { "request.headers.accept", "text/html" },
             { "request.headers.content-length", GetExpectedContentLength() },
-            { "request.headers.host", $"localhost:{_fixture.RemoteApplication.Port}" },
+            { "request.headers.host", $"{RemoteApplication.DestinationServerName}:{_fixture.RemoteApplication.Port}" },
             { "request.headers.user-agent", "FakeUserAgent" },
             { "request.headers.foo", "bar" },
             { "request.headers.dashes-are-valid", "true" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationAsyncAwaitCAT.cs
@@ -24,11 +24,11 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
-            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.RemoteApplication.Port} GET true true");
-            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.RemoteApplication.Port} PUT false false");
-            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.RemoteApplication.Port} POST false false");
-            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.RemoteApplication.Port} DELETE true true");
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} GET true true");
+            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} PUT false false");
+            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} POST false false");
+            _fixture.AddCommand($"RestSharpExerciser AsyncAwaitClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} DELETE true true");
             _fixture.AddCommand("RestSharpService StopService");
 
             _fixture.AddActions
@@ -49,20 +49,22 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
         [Fact]
         public void Test()
         {
+            var serverName = _fixture.DestinationServerName;
+
             var crossProcessId = _fixture.AgentLog.GetCrossProcessId();
             var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/AsyncAwaitClient";
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationCAT.cs
@@ -24,12 +24,12 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} GET false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} PUT false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} POST false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} DELETE false");
-            _fixture.AddCommand($"RestSharpExerciser RestSharpClientTaskCancelled {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} GET false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} PUT false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} POST false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} DELETE false");
+            _fixture.AddCommand($"RestSharpExerciser RestSharpClientTaskCancelled {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
             _fixture.AddCommand("RestSharpService StopService");
 
             _fixture.AddActions
@@ -55,18 +55,19 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/SyncClient";
             var cancelledTrasnsactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/RestSharpClientTaskCancelled";
 
+            var serverName = _fixture.DestinationServerName;
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 5 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", metricScope = cancelledTrasnsactionName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", callCount = 2 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", metricScope = cancelledTrasnsactionName, callCount = 1},
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationDistributedTracing.cs
@@ -26,12 +26,12 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} GET false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} PUT false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} POST false");
-            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.RemoteApplication.Port} DELETE false");
-            _fixture.AddCommand($"RestSharpExerciser RestSharpClientTaskCancelled {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} GET false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} PUT false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} POST false");
+            _fixture.AddCommand($"RestSharpExerciser SyncClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} DELETE false");
+            _fixture.AddCommand($"RestSharpExerciser RestSharpClientTaskCancelled {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
             _fixture.AddCommand("RestSharpService StopService");
 
             _fixture.AddActions
@@ -55,18 +55,20 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/SyncClient";
             var cancelledTrasnsactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/RestSharpClientTaskCancelled";
 
+            var serverName = _fixture.DestinationServerName;
+
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 5 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", metricScope = cancelledTrasnsactionName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", callCount = 2 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", metricScope = cancelledTrasnsactionName, callCount = 1},
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/PUT", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/POST", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/DELETE", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RestSharp/RestSharpClientInstrumentationTaskResultCAT.cs
@@ -24,11 +24,11 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
             _fixture.TestLogger = output;
 
-            _fixture.AddCommand($"RestSharpService StartService {_fixture.RemoteApplication.Port}");
-            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} GET true true");
-            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} PUT false false");
-            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} POST false false");
-            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.RemoteApplication.Port} DELETE true true");
+            _fixture.AddCommand($"RestSharpService StartService {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port}");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} GET true true");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} PUT false false");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} POST false false");
+            _fixture.AddCommand($"RestSharpExerciser TaskResultClient {_fixture.DestinationServerName} {_fixture.RemoteApplication.Port} DELETE true true");
             _fixture.AddCommand("RestSharpService StopService");
 
             _fixture.AddActions
@@ -52,17 +52,19 @@ namespace NewRelic.Agent.IntegrationTests.RestSharp
             var crossProcessId = _fixture.AgentLog.GetCrossProcessId();
             var callerTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp.RestSharpExerciser/TaskResultClient";
 
+            var serverName = _fixture.DestinationServerName;
+            ;
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric { metricName = "External/all", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/GET", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/PUT", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/POST", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"External/localhost/Stream/DELETE", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/localhost/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/GET", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/PUT", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/POST", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"External/{serverName}/Stream/DELETE", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Get", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Put", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Post", metricScope = callerTransactionName, callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $"ExternalTransaction/{serverName}/{crossProcessId}/WebTransaction/WebAPI/RestAPI/Delete", metricScope = callerTransactionName, callCount = 1 },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
         [Fact]
         public override void Metrics()
         {
-            var serverName = "localhost"; //_fixture.DestinationServerName;
+            var serverName = _bindingToTest == WCFBindingType.NetTcp ? "127.0.0.1" :  "localhost";
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
@@ -140,7 +140,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
             var countExpectedCreate = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS      //1 for each WCF Client call
                                     + _countClientInvocationMethodsToTest;                         //1 for GetData's HTTP call on the service
 
-            var serverName = "localhost"; //_fixture.DestinationServerName;
+            var serverName = _bindingToTest == WCFBindingType.NetTcp ? "127.0.0.1" :  "localhost";
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
@@ -38,14 +38,16 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
         [Fact]
         public override void Metrics()
         {
+            var serverName = _fixture.DestinationServerName;
+
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException", callCount = 2 },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData", callCount = 2 /*Begin/End + Event Based Async*/  },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException", callCount = 4 /*Begin/End + Event Based Async*/ },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData" , callCount = 1 },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException", callCount = 2  },
-                new Assertions.ExpectedMetric(){ metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData", callCount = 1  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException", callCount = 2 },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData", callCount = 2 /*Begin/End + Event Based Async*/  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException", callCount = 4 /*Begin/End + Event Based Async*/ },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData" , callCount = 1 },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException", callCount = 2  },
+                new Assertions.ExpectedMetric(){ metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData", callCount = 1  },
 
                 new Assertions.ExpectedMetric(){ metricName = "DotNet/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException", callCount = _countClientInvocationMethodsToTest * 2 },
@@ -59,17 +61,17 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
 
             var catExcludedMetrics = new[]
             {
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Sync_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.Begin_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
-                new Assertions.ExpectedMetric() { metricName = $"External/localhost/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException",
+                new Assertions.ExpectedMetric() { metricName = $"External/{serverName}/Stream/{SharedWcfLibraryNamespace}.IWcfClient.TAP_SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException" },
             };
 
@@ -138,14 +140,16 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
             var countExpectedCreate = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS      //1 for each WCF Client call
                                     + _countClientInvocationMethodsToTest;                         //1 for GetData's HTTP call on the service
 
+            var serverName = _fixture.DestinationServerName;
+
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS, metricName = $"ExternalApp/localhost/{CATCrossProcessID_Service}/all" },
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData",
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS, metricName = $"ExternalApp/{serverName}/{CATCrossProcessID_Service}/all" },
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/{serverName}/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData"},
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest, metricName = $"ExternalTransaction/{serverName}/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncGetData",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/GetData"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException"},
-                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/localhost/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException",
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/{serverName}/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException"},
+                new Assertions.ExpectedMetric(){ callCount = _countClientInvocationMethodsToTest * 2, metricName = $"ExternalTransaction/{serverName}/{CATCrossProcessID_Service}/WebTransaction/WCF/{SharedWcfLibraryNamespace}.IWcfService.SyncThrowException",
                     metricScope = "OtherTransaction/Custom/ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF.WCFClient/ThrowException"},
 
                 new Assertions.ExpectedMetric(){ metricName = "Supportability/CrossApplicationTracing/Request/Create/Success" , callCount = countExpectedCreate },//16

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFClientTests.cs
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
         [Fact]
         public override void Metrics()
         {
-            var serverName = _fixture.DestinationServerName;
+            var serverName = "localhost"; //_fixture.DestinationServerName;
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
@@ -140,7 +140,7 @@ namespace NewRelic.Agent.IntegrationTests.WCF.Client
             var countExpectedCreate = _countClientInvocationMethodsToTest * COUNT_SVC_METHODS      //1 for each WCF Client call
                                     + _countClientInvocationMethodsToTest;                         //1 for GetData's HTTP call on the service
 
-            var serverName = _fixture.DestinationServerName;
+            var serverName = "localhost"; //_fixture.DestinationServerName;
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -107,7 +107,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         { 
             var logger = loggerConfig.CreateLogger();
 
-            _uriBase = "http://localhost:" + _loggingPort + "/";
+            _uriBase = "http://127.0.0.1:" + _loggingPort + "/";
             var hostTask = CreateHostBuilder(_uriBase).Build().RunAsync();
 
             Console.WriteLine("URI: " + _uriBase);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/OwinService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Owin/OwinService.cs
@@ -25,9 +25,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Owin
             _startup = startup;
         }
 
-        public void StartService(int port)
+        public void StartService(string server, int port)
         {
-            _service = WebApp.Start(url: $"http://localhost:{port}/", _startup.Configuration);
+            _service = WebApp.Start(url: $"http://{server}:{port}/", _startup.Configuration);
             Task.Delay(7000).Wait();
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharp107andBeyondExerciser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -28,9 +28,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public string SyncClient(int port, string method, bool generic)
+        public string SyncClient(string host, int port, string method, bool generic)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -68,9 +68,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task<string> AsyncAwaitClient(int port, string method, bool generic, bool cancelable)
+        public async Task<string> AsyncAwaitClient(string host, int port, string method, bool generic, bool cancelable)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -116,9 +116,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public string TaskResultClient(int port, string method, bool generic, bool cancelable)
+        public string TaskResultClient(string host, int port, string method, bool generic, bool cancelable)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -167,9 +167,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task<string> RestSharpClientTaskCancelled(int port)
+        public async Task<string> RestSharpClientTaskCancelled(string host, int port)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
 
             var endpoint = "api/RestAPI/";

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpExerciser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -28,9 +28,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public string SyncClient(int port, string method, bool generic)
+        public string SyncClient(string host, int port, string method, bool generic)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -67,9 +67,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task<string> AsyncAwaitClient(int port, string method, bool generic, bool cancelable)
+        public async Task<string> AsyncAwaitClient(string host, int port, string method, bool generic, bool cancelable)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -115,9 +115,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public string TaskResultClient(int port, string method, bool generic, bool cancelable)
+        public string TaskResultClient(string host, int port, string method, bool generic, bool cancelable)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
             var client = new RestClient($"http://{myHost}:{myPort}");
 
@@ -166,9 +166,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task<string> RestSharpClientTaskCancelled(int port)
+        public async Task<string> RestSharpClientTaskCancelled(string host, int port)
         {
-            var myHost = "localhost"; // Request.RequestUri.Host;
+            var myHost = host;
             var myPort = port;
 
             var endpoint = "api/RestAPI/";

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RestSharp/RestSharpService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -17,10 +17,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
         /// <summary>
         /// Starts the RestSharp Test Service with a specific port and path
         /// </summary>
+        /// <param name="server"></param>
         /// <param name="port"></param>
         /// <param name="relativePath"></param>
         [LibraryMethod]
-        public void StartService(int port)
+        public void StartService(string server, int port)
         {
             try
             {
@@ -33,7 +34,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.RestSharp
                     .Build();
 
                 // Start OWIN host 
-                _owinService.StartService(port);
+                _owinService.StartService(server, port);
             }
             catch (Exception ex)
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/W3C/W3CTestService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/W3C/W3CTestService.cs
@@ -16,8 +16,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.W3C
         /// <summary>
         /// Starts the W3C Test Service with a specific port and path
         /// </summary>
-        /// <param name="port"></param>
-        /// <param name="relativePath"></param>
         [LibraryMethod]
         public void StartService(string server, int port)
         {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/W3C/W3CTestService.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/W3C/W3CTestService.cs
@@ -19,7 +19,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.W3C
         /// <param name="port"></param>
         /// <param name="relativePath"></param>
         [LibraryMethod]
-        public void StartService(int port)
+        public void StartService(string server, int port)
         {
             try
             {
@@ -31,7 +31,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.W3C
                     .Build();
 
                 // Start OWIN host 
-                _owinService.StartService(port);
+                _owinService.StartService(server, port);
             }
             catch (Exception ex)
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
@@ -118,7 +118,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries
             virtualDirectoryNode.Attributes["physicalPath"].Value = HostedApplicationFolder;
 
             var bindingNode = l.SelectSingleNode("configuration/system.applicationHost/sites/site/bindings/binding");
-            bindingNode.Attributes["bindingInformation"].Value = $"127.0.0.1:{port}:";
+            bindingNode.Attributes["bindingInformation"].Value = $"*:{port}:";
 
             var appPoolName = $"HWCTest{port}-{Guid.NewGuid()}";
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/HostedWebCore.cs
@@ -118,7 +118,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries
             virtualDirectoryNode.Attributes["physicalPath"].Value = HostedApplicationFolder;
 
             var bindingNode = l.SelectSingleNode("configuration/system.applicationHost/sites/site/bindings/binding");
-            bindingNode.Attributes["bindingInformation"].Value = $"*:{port}:";
+            bindingNode.Attributes["bindingInformation"].Value = $"127.0.0.1:{port}:";
 
             var appPoolName = $"HWCTest{port}-{Guid.NewGuid()}";
 

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
@@ -25,7 +25,7 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 case WCFBindingType.CustomClass:
                     return new Uri($@"http://localhost:{port}/{relativeUrl}");
                 case WCFBindingType.NetTcp:
-                    return new Uri($@"net.tcp://localhost:{port}/{relativeUrl}");
+                    return new Uri($@"net.tcp://127.0.0.1:{port}/{relativeUrl}");
                 default:
                     throw new NotSupportedException($"Binding Type {bindingTypeEnum}");
             }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
@@ -23,9 +23,9 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 case WCFBindingType.WebHttp:
                 case WCFBindingType.Custom:
                 case WCFBindingType.CustomClass:
-                    return new Uri($@"http://localhost:{port}/{relativeUrl}");
+                    return new Uri($@"http://127.0.0.1:{port}/{relativeUrl}");
                 case WCFBindingType.NetTcp:
-                    return new Uri($@"net.tcp://localhost:{port}/{relativeUrl}");
+                    return new Uri($@"net.tcp://127.0.0.1:{port}/{relativeUrl}");
                 default:
                     throw new NotSupportedException($"Binding Type {bindingTypeEnum}");
             }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFLibraryHelpers.cs
@@ -23,9 +23,9 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
                 case WCFBindingType.WebHttp:
                 case WCFBindingType.Custom:
                 case WCFBindingType.CustomClass:
-                    return new Uri($@"http://127.0.0.1:{port}/{relativeUrl}");
+                    return new Uri($@"http://localhost:{port}/{relativeUrl}");
                 case WCFBindingType.NetTcp:
-                    return new Uri($@"net.tcp://127.0.0.1:{port}/{relativeUrl}");
+                    return new Uri($@"net.tcp://localhost:{port}/{relativeUrl}");
                 default:
                     throw new NotSupportedException($"Binding Type {bindingTypeEnum}");
             }

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceSelfHosted.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFServiceSelfHosted.cs
@@ -6,6 +6,7 @@ using MultiFunctionApplicationHelpers;
 using NewRelic.Agent.IntegrationTests.Shared.Wcf;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using System;
+using System.Diagnostics;
 using System.ServiceModel;
 using System.ServiceModel.Description;
 
@@ -24,6 +25,8 @@ namespace ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.WCF
         [LibraryMethod]
         public void StartService(string bindingType, int port, string relativePath)
         {
+            //Debugger.Launch();
+
             relativePath = relativePath.TrimStart('/');
 
             if (_wcfService_SelfHosted != null)

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
+					<binding protocol="http" bindingInformation="*:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/applicationHost.config.template
@@ -116,7 +116,7 @@
 					<virtualDirectory path="/" physicalPath="%SystemDrive%\inetpub\wwwroot" />
 				</application>
 				<bindings>
-					<binding protocol="http" bindingInformation="*:80:" />
+					<binding protocol="http" bindingInformation="127.0.0.1:80:" />
 				</bindings>
 			</site>
 			<siteDefaults>


### PR DESCRIPTION
Updates Integration tests so that the annoying firewall pop-ups don't occur when running locally. Much of that issue was caused by "wildcard" bindings in some of the test services. There were also some places where using `localhost` caused the popup, for unexplained reasons. So the goal was to globally use `127.0.0.1` everywhere - but a few odd cases caused me to fall just short of reaching that goal. 

In general, we'll use `127.0.0.1` now instead of `localhost` - but if a test is using `localhost` there's almost certainly a reason for it. 

Highlight of changes:
* Changed `RemoteApplication.DestinationServerName` to return `127.0.0.1` instead of doing a DNS lookup of the hostname of the local machine.
* Changed nearly all usages of `localhost` in the integration test applications to `127.0.0.1` instead.
* Changed nearly all usages of `localhost` in integration tests to use `RemoteApplication.DestinationServerName`
* Modified "wildcard" (`*:{port}`) bindings for several services to use a specific address (usually `127.0.0.1`) instead.
* Had to leave some tests (WCF, I'm looking at you) referencing `localhost` - though even some of the WCF tests had to reference `127.0.0.1` - it's a complex web of interdependencies...

The only test that fails consistently on my local machine is `BasicAspWebService` - but I think that test also fails locally on the current `main` branch, so maybe it's not a big deal. 

Resolves #1921 