### PR TITLE
chore: update linux smoke tests to only remove networks in debug build

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -83,7 +83,7 @@ services:
         extends:
             service: smoketestapp
         depends_on:
-            - kafka-broker
+            - kafka-broker1
         environment:
             - NEW_RELIC_KAFKA_TOPIC=${NEW_RELIC_KAFKA_TOPIC}
             - NEW_RELIC_KAFKA_CONTAINER_NAME=${NEW_RELIC_KAFKA_CONTAINER_NAME}
@@ -92,12 +92,32 @@ services:
         extends:
             service: smoketestapp
         depends_on:
-            - kafka-broker
+            - kafka-broker2
         environment:
             - NEW_RELIC_KAFKA_TOPIC=${NEW_RELIC_KAFKA_TOPIC}
             - NEW_RELIC_KAFKA_CONTAINER_NAME=${NEW_RELIC_KAFKA_CONTAINER_NAME}
 
-    kafka-broker:
+    kafka-broker1:
+        image: confluentinc/cp-kafka:7.5.0
+        container_name: ${NEW_RELIC_KAFKA_CONTAINER_NAME}
+        environment:
+          KAFKA_BROKER_ID: 1
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29092,PLAINTEXT_HOST://${NEW_RELIC_KAFKA_CONTAINER_NAME}:9092
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+          KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_NODE_ID: 1
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@${NEW_RELIC_KAFKA_CONTAINER_NAME}:29093
+          KAFKA_LISTENERS: PLAINTEXT://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29092,CONTROLLER://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29093,PLAINTEXT_HOST://:9092
+          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+          CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
+    kafka-broker2:
         image: confluentinc/cp-kafka:7.5.0
         container_name: ${NEW_RELIC_KAFKA_CONTAINER_NAME}
         environment:

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -83,7 +83,7 @@ services:
         extends:
             service: smoketestapp
         depends_on:
-            - kafka-broker1
+            - kafka-broker
         environment:
             - NEW_RELIC_KAFKA_TOPIC=${NEW_RELIC_KAFKA_TOPIC}
             - NEW_RELIC_KAFKA_CONTAINER_NAME=${NEW_RELIC_KAFKA_CONTAINER_NAME}
@@ -92,32 +92,12 @@ services:
         extends:
             service: smoketestapp
         depends_on:
-            - kafka-broker2
+            - kafka-broker
         environment:
             - NEW_RELIC_KAFKA_TOPIC=${NEW_RELIC_KAFKA_TOPIC}
             - NEW_RELIC_KAFKA_CONTAINER_NAME=${NEW_RELIC_KAFKA_CONTAINER_NAME}
 
-    kafka-broker1:
-        image: confluentinc/cp-kafka:7.5.0
-        container_name: ${NEW_RELIC_KAFKA_CONTAINER_NAME}
-        environment:
-          KAFKA_BROKER_ID: 1
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29092,PLAINTEXT_HOST://${NEW_RELIC_KAFKA_CONTAINER_NAME}:9092
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-          KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-          KAFKA_PROCESS_ROLES: broker,controller
-          KAFKA_NODE_ID: 1
-          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@${NEW_RELIC_KAFKA_CONTAINER_NAME}:29093
-          KAFKA_LISTENERS: PLAINTEXT://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29092,CONTROLLER://${NEW_RELIC_KAFKA_CONTAINER_NAME}:29093,PLAINTEXT_HOST://:9092
-          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-          KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
-          CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
-
-    kafka-broker2:
+    kafka-broker:
         image: confluentinc/cp-kafka:7.5.0
         container_name: ${NEW_RELIC_KAFKA_CONTAINER_NAME}
         environment:

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
@@ -201,8 +201,10 @@ public class ContainerApplication : RemoteApplication
             }
         }
 
+#if DEBUG
         // Cleanup the networks with no attached containers. Mainly for testings on dev laptops - they can build up and block runs.
         Process.Start("docker", "network prune -f");
+#endif
     }
 
     protected virtual void WaitForAppServerToStartListening(Process process, bool captureStandardOutput)

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
@@ -189,6 +189,7 @@ public class ContainerApplication : RemoteApplication
     private void CleanupContainer()
     {
         Console.WriteLine($"[{AppName} {DateTime.Now}] Cleaning up container and images related to {ContainerName} container.");
+        TestLogger?.WriteLine($"[{AppName}] Cleaning up container and images related to {ContainerName} container.");
         // ensure there's no stray containers or images laying around
         Process.Start("docker", $"container rm --force {ContainerName}");
         Process.Start("docker", $"image rm --force {ContainerName}");
@@ -197,6 +198,8 @@ public class ContainerApplication : RemoteApplication
         {
             foreach (var dep in DockerDependencies)
             {
+                Console.WriteLine($"[{AppName} {DateTime.Now}] Removing dependent container: {dep}.");
+                TestLogger?.WriteLine($"[{AppName}] Removing dependent container: {dep}.");
                 Process.Start("docker", $"container rm --force {dep}");
             }
         }


### PR DESCRIPTION
Updated linux smoke tests so that we don't try to prune the networks at the end of every container execution -- it looks like there are occasional concurrency issues where a network gets deleted out from under a container that's firing up. 