### PR TITLE
ci: Use actual container name in logging

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/ContainerApplication.cs
@@ -60,7 +60,7 @@ public class ContainerApplication : RemoteApplication
         }
     }
 
-    public override string AppName => $"ContainerApplication: {_dotnetVersion}-{_distroTag}_{_targetArch}";
+    public override string AppName => $"{_dockerComposeServiceName}_{_dotnetVersion}-{_distroTag}_{_targetArch}";
 
     private string ContainerName => $"{_dockerComposeServiceName}_{_dotnetVersion}-{_distroTag}_{_targetArch}".ToLower(); // must be lowercase
 


### PR DESCRIPTION
Minor change to log the actual container name when running container integration tests. Hoping it will help with diagnosing intermittent test failures.