### PR TITLE
test: Update nlog to 5.2.7

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -241,12 +241,12 @@
 
   <ItemGroup> <!-- Versions below 4.5 did not support netstandard 2.0 -->
     <PackageReference Include="NLog" Version="4.5.9" Condition="'$(TargetFramework)' == 'net6.0'" />
-	  <PackageReference Include="NLog" Version="5.2.6" Condition="'$(TargetFramework)' == 'net7.0'" />
+	  <PackageReference Include="NLog" Version="5.2.7" Condition="'$(TargetFramework)' == 'net7.0'" />
 
     <PackageReference Include="NLog" Version="4.3.11" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NLog" Version="4.1.2" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NLog" Version="4.5.11" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="NLog" Version="5.2.6" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog" Version="5.2.7" Condition="'$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates integration tests for nlog to use v5.2.7

Resolves #2102 