### PR TITLE
fix: Fix a crash that can occur when the profiler logs certain characters. (#1982)

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -408,7 +408,7 @@ jobs:
           path: src/Agent
 
       - name: Run test commands
-        uses: uraimo/run-on-arch-action@4ed76f16f09d12e83abd8a49e1ac1e5bf08784d4 # v2.5.1
+        uses: uraimo/run-on-arch-action@4803fad82c266c7860218e93d3024b5810c7866a # v2.6.0
         with:
           arch: aarch64
           distro: ubuntu18.04

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -246,7 +246,7 @@ jobs:
           rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
         shell: bash
 
-      - uses: uraimo/run-on-arch-action@4ed76f16f09d12e83abd8a49e1ac1e5bf08784d4 # v2.5.1
+      - uses: uraimo/run-on-arch-action@4803fad82c266c7860218e93d3024b5810c7866a # v2.6.0
         name: Run commands
         id: runcmd
         with:

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.18.0.15"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.0.8"/>
   </ItemGroup>
 
 </Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Controllers/WeatherForecastController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Controllers/WeatherForecastController.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using NewRelic.Api.Agent;
 
 namespace ContainerizedAspNetCoreApp.Controllers;
 
@@ -28,6 +31,9 @@ public class WeatherForecastController : ControllerBase
     [HttpGet]
     public IEnumerable<WeatherForecast> Get()
     {
+        // This name of this method call contains characters outside of the ascii
+        // range of characters.
+        MethodWithSpecialCharacter\u0435();
         return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
@@ -35,5 +41,18 @@ public class WeatherForecastController : ControllerBase
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
+    }
+
+    /// <summary>
+    /// The е in Mеthod is not a normal e character, it is char code \u0435.
+    /// This method is used to validate that we support instrumenting methods
+    /// with these types of names, and that the profiler does not crash.
+    /// </summary>
+    [Trace]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    private void MethodWithSpecialCharacter\u0435()
+    {
+        // This just similates doing a blocking external call
+        Thread.Sleep(100);
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/SmokeTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/SmokeTestApp.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.2" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.20.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -67,6 +67,10 @@ services:
             service: smoketestapp
         build:
             dockerfile: SmokeTestApp/Dockerfile.centos
+    LinuxUnicodeLogFileApp:
+        extends:
+            file: docker-compose-smoketestapp.yml
+            service: smoketestapp
            
 networks:
     default:

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/LinuxUnicodeLogFileTestFixture.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerFixtures/LinuxUnicodeLogFileTestFixture.cs
@@ -1,0 +1,15 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.ContainerIntegrationTests.ContainerFixtures
+{
+    public class LinuxUnicodeLogFileTestFixture : LinuxSmokeTestFixtureBase
+    {
+        private static readonly string Dockerfile = "SmokeTestApp/Dockerfile";
+        private static readonly string ApplicationDirectoryName = "LinuxUnicodeLogfileTestApp";
+        private static readonly ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
+        private static readonly string DistroTag = "jammy";
+
+        public LinuxUnicodeLogFileTestFixture() : base(ApplicationDirectoryName, DistroTag, Architecture, Dockerfile) { }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/LinuxUnicodeLogFileTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/LinuxUnicodeLogFileTest.cs
@@ -1,0 +1,59 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.IntegrationTestHelpers;
+using Xunit.Abstractions;
+using Xunit;
+using NewRelic.Agent.ContainerIntegrationTests.ContainerFixtures;
+using System;
+
+namespace ContainerIntegrationTests
+{
+    /// <summary>
+    /// This test is meant to prevent any regressions from occurring when profiler log lines containing
+    /// character codes outside of the ascii range are written to log files. Older profiler versions
+    /// could trigger an error or crash when this happened. Before the profiler change, no transactions
+    /// would be created by the test application, with the profiler change, the test transaction should be
+    /// created successfully.
+    /// </summary>
+    public class LinuxUnicodeLogFileTest : NewRelicIntegrationTest<DebianX64SmokeTestFixture>
+    {
+        private readonly DebianX64SmokeTestFixture _fixture;
+
+        public LinuxUnicodeLogFileTest(DebianX64SmokeTestFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+
+            _fixture.Actions(setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                // The original problem only seemed to occur with some of the finest level log lines
+                // and it did not occur with console logs.
+                configModifier.SetLogLevel("finest");
+            },
+                exerciseApplication: () =>
+                {
+                    _fixture.ExerciseApplication();
+
+                    _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+
+                    // shut down the container and wait for the agent log to see it
+                    _fixture.ShutdownRemoteApplication();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromSeconds(10));
+                });
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var actualMetrics = _fixture.AgentLog.GetMetrics();
+
+            Assert.Contains(actualMetrics, m => m.MetricSpec.Name.Equals("WebTransaction/MVC/WeatherForecast/Get"));
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the profiler log file initialization to imbue a locale with a codecvt facet so that character codes can be mapped more appropriately. 

This change was tested locally on Windows and Linux. For Linux this was manually tested using the same distros and architectures used by our Linux smoke tests.

Fixes #1982 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
