### PR TITLE
fix: obfuscate logged appSettings values

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -4,6 +4,7 @@
 using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Core;
+using NewRelic.Agent.Core.Configuration;
 using NewRelic.Core.Logging;
 using NewRelic.SystemInterfaces;
 using System;
@@ -15,7 +16,6 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 #if NETSTANDARD2_0
 using System.Reflection;
-using NewRelic.Agent.Core.Configuration;
 #endif
 
 namespace NewRelic.Agent.Core.Config
@@ -139,7 +139,7 @@ namespace NewRelic.Agent.Core.Config
             if (fileName != null)
                 return fileName;
 
-            throw new Exception(string.Format("Could not find {0} in NewRelic.ConfigFile path, application root, New Relic home directory, or working directory.", NewRelicConfigFileName));
+            throw new Exception(string.Format("Could not find {0} in {1} path, application root, New Relic home directory, or working directory.", NewRelicConfigFileName, Constants.AppSettingsConfigFile));
         }
 
         private static string TryGetAgentConfigFileFromAppConfig()
@@ -149,13 +149,13 @@ namespace NewRelic.Agent.Core.Config
 
 			try
 			{
-				var fileName = AppSettingsConfigResolveWhenUsed.GetAppSetting("NewRelic.ConfigFile");
+				var fileName = AppSettingsConfigResolveWhenUsed.GetAppSetting(Constants.AppSettingsConfigFile);
 				if (!File.Exists(fileName))
 				{
 					return null;
 				}
 
-				Log.Info("Configuration file found in path pointed to by NewRelic.ConfigFile appSetting: {0}", fileName);
+				Log.Info("Configuration file found in path pointed to by {0} appSetting: {1}", Constants.AppSettingsConfigFile, fileName);
 				return fileName;
 			}
 			catch (Exception)
@@ -166,13 +166,13 @@ namespace NewRelic.Agent.Core.Config
 #else
             try
             {
-                var fileName = GetConfigSetting("NewRelic.ConfigFile").Value;
+                var fileName = GetConfigSetting(Constants.AppSettingsConfigFile).Value;
                 if (!FileExists(fileName))
                 {
                     return null;
                 }
 
-                Log.Info("Configuration file found in path pointed to by NewRelic.ConfigFile appSetting of app/web config: {0}", fileName);
+                Log.Info("Configuration file found in path pointed to by {0} appSetting of app/web config: {1}", Constants.AppSettingsConfigFile, fileName);
                 return fileName;
             }
             catch (Exception)
@@ -674,7 +674,7 @@ namespace NewRelic.Agent.Core.Config
 
             try
             {
-                var enabledProvenance = ConfigurationLoader.GetConfigSetting("NewRelic.AgentEnabled");
+                var enabledProvenance = ConfigurationLoader.GetConfigSetting(Constants.AppSettingsAgentEnabled);
                 if (enabledProvenance != null && enabledProvenance.Value != null && bool.Parse(enabledProvenance.Value) == false)
                 {
                     agentEnabled = false;
@@ -683,7 +683,7 @@ namespace NewRelic.Agent.Core.Config
             }
             catch
             {
-                Log.Error("Failed to read NewRelic.AgentEnabled from local config.");
+                Log.Error($"Failed to read {Constants.AppSettingsAgentEnabled} from local config.");
             }
 
             return this;

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
+using NewRelic.Core;
 using NewRelic.Core.Logging;
 
 namespace NewRelic.Agent.Core.Configuration
@@ -79,6 +80,10 @@ namespace NewRelic.Agent.Core.Configuration
                 }
                 else
                 {
+                    if (key.Equals("NewRelic.LicenseKey"))
+                    {
+                        value = Strings.ObfuscateLicenseKey(value);
+                    }
                     Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={value}'");
                 }
             }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -80,7 +80,7 @@ namespace NewRelic.Agent.Core.Configuration
                 }
                 else
                 {
-                    if (key.Equals("NewRelic.LicenseKey"))
+                    if (key.Equals(Constants.AppSettingsLicenseKey))
                     {
                         value = Strings.ObfuscateLicenseKey(value);
                     }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/Constants.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/Constants.cs
@@ -1,0 +1,15 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Core.Configuration
+{
+    public static class Constants
+    {
+        public const string AppSettingsLicenseKey = "NewRelic.LicenseKey";
+        public const string AppSettingsAgentEnabled = "NewRelic.AgentEnabled";
+        public const string AppSettingsAppName = "NewRelic.AppName";
+        public const string AppSettingsLabels = "NewRelic.Labels";
+        public const string AppSettingsConfigFile = "NewRelic.ConfigFile";
+
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -198,7 +198,7 @@ namespace NewRelic.Agent.Core.Configuration
                 {
                     lock (_lockObj)
                     {
-                        _agentEnabledAppSettingParsed ??= bool.TryParse(_configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"),
+                        _agentEnabledAppSettingParsed ??= bool.TryParse(_configurationManagerStatic.GetAppSetting(Constants.AppSettingsAgentEnabled),
                             out _appSettingAgentEnabled);
                     }
                 }
@@ -216,7 +216,7 @@ namespace NewRelic.Agent.Core.Configuration
                 if (_agentLicenseKey != null)
                     return _agentLicenseKey;
 
-                _agentLicenseKey = _configurationManagerStatic.GetAppSetting("NewRelic.LicenseKey")
+                _agentLicenseKey = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLicenseKey)
                     ?? EnvironmentOverrides(_localConfiguration.service.licenseKey, "NEW_RELIC_LICENSE_KEY", "NEWRELIC_LICENSEKEY");
 
                 if (_agentLicenseKey != null)
@@ -243,7 +243,7 @@ namespace NewRelic.Agent.Core.Configuration
                 return runtimeAppNames;
             }
 
-            var appName = _configurationManagerStatic.GetAppSetting("NewRelic.AppName");
+            var appName = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName);
             if (appName != null)
             {
                 Log.Info("Application name from web.config or app.config.");
@@ -1361,7 +1361,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (!_labelsChecked)
                 {
-                    var labels = _configurationManagerStatic.GetAppSetting("NewRelic.Labels");
+                    var labels = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLabels);
                     if (labels != null)
                     {
                         Log.Info("Application labels from web.config, app.config, or appsettings.json.");

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTestAgent.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTestAgent.cs
@@ -141,7 +141,7 @@ namespace CompositeTests
                 .DoInstead<WaitCallback>(callback => { lock (_queuedCallbacksLockObject) { _queuedCallbacks.Add(callback); } });
 
             var configurationManagerStatic = Mock.Create<IConfigurationManagerStatic>();
-            Mock.Arrange(() => configurationManagerStatic.GetAppSetting("NewRelic.LicenseKey"))
+            Mock.Arrange(() => configurationManagerStatic.GetAppSetting(NewRelic.Agent.Core.Configuration.Constants.AppSettingsLicenseKey))
                 .Returns("Composite test license key");
 
             // Construct services

--- a/tests/Agent/UnitTests/Core.UnitTest/Config/ConfigurationLoaderTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Config/ConfigurationLoaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using NewRelic.Agent.Core.Configuration;
 using NUnit.Framework;
 
 namespace NewRelic.Agent.Core.Config
@@ -119,7 +120,7 @@ namespace NewRelic.Agent.Core.Config
             {
                 const string expectedFileName = "filenameFromAppConfig";
                 var testWebConfiguration = ConfigurationManager.OpenExeConfiguration(null);
-                testWebConfiguration.AppSettings.Settings.Add("NewRelic.ConfigFile", expectedFileName);
+                testWebConfiguration.AppSettings.Settings.Add(Constants.AppSettingsConfigFile, expectedFileName);
 
                 staticMocks.UseAppDomainAppIdFunc(() => "testAppId");
                 staticMocks.UseAppDomainAppVirtualPathFunc(() => "testVirtualPath");
@@ -138,7 +139,7 @@ namespace NewRelic.Agent.Core.Config
             {
                 const string expectedFileName = "filenameFromAppConfig";
                 var testWebConfiguration = ConfigurationManager.OpenExeConfiguration(null);
-                testWebConfiguration.AppSettings.Settings.Add("NewRelic.ConfigFile", expectedFileName);
+                testWebConfiguration.AppSettings.Settings.Add(Constants.AppSettingsConfigFile, expectedFileName);
 
                 staticMocks.UseAppDomainAppIdFunc(() => "testAppId");
                 staticMocks.UseAppDomainAppVirtualPathFunc(() => "testVirtualPath");
@@ -157,7 +158,7 @@ namespace NewRelic.Agent.Core.Config
             {
                 const string expectedFileName = "filenameFromAppConfig";
                 var testWebConfiguration = ConfigurationManager.OpenExeConfiguration(null);
-                testWebConfiguration.AppSettings.Settings.Add("NewRelic.ConfigFile", expectedFileName);
+                testWebConfiguration.AppSettings.Settings.Add(Constants.AppSettingsConfigFile, expectedFileName);
 
                 staticMocks.UseAppDomainAppIdFunc(() => "testAppId");
                 staticMocks.UseAppDomainAppVirtualPathFunc(() => "testVirtualPath");

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Serialization;
 using NewRelic.Agent.Core.Config;
+using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.SystemInterfaces;
 using NewRelic.SystemInterfaces.Web;
@@ -75,18 +76,18 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         [Test]
         public void AgentEnabledShouldUseCachedAppSetting()
         {
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled")).Returns("false");
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAgentEnabled)).Returns("false");
 
             Assert.IsFalse(_defaultConfig.AgentEnabled);
             Assert.IsFalse(_defaultConfig.AgentEnabled);
 
-            Mock.Assert(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled"), Occurs.Once());
+            Mock.Assert(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAgentEnabled), Occurs.Once());
         }
 
         [Test]
         public void AgentEnabledShouldPreferAppSettingOverLocalConfig()
         {
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AgentEnabled")).Returns("false");
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAgentEnabled)).Returns("false");
 
             _localConfig.agentEnabled = true;
 
@@ -1384,7 +1385,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public string LabelsAreOverriddenProperlyAndAreCached(string appConfigValue, string environment, string local)
         {
             _localConfig.labels = local;
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.Labels")).Returns(appConfigValue);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLabels)).Returns(appConfigValue);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_LABELS")).Returns(environment);
 
             // call Labels accessor multiple times to verify caching behavior
@@ -1395,7 +1396,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             }
 
             // Checking that the underlying abstractions are only ever called once verifies caching behavior
-            Mock.Assert(() => _configurationManagerStatic.GetAppSetting("NewRelic.Labels"), Occurs.AtMost(1));
+            Mock.Assert(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLabels), Occurs.AtMost(1));
             Mock.Assert(() => _environment.GetEnvironmentVariable("NEW_RELIC_LABELS"), Occurs.AtMost(1));
 
             return result;
@@ -1434,7 +1435,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _localConfig.service.licenseKey = local;
             Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_LICENSE_KEY")).Returns(newEnvironmentName);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("NEWRELIC_LICENSEKEY")).Returns(legacyEnvironmentName);
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.LicenseKey")).Returns(appSettingEnvironmentName);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLicenseKey)).Returns(appSettingEnvironmentName);
 
             return _defaultConfig.AgentLicenseKey;
         }
@@ -1764,7 +1765,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string>();
 
@@ -1778,8 +1779,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationNamesPullsNamesFromRuntimeConfig()
         {
             _runTimeConfig.ApplicationNames = new List<string> { "MyAppName1", "MyAppName2" };
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns((string)null);
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns((string)null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns((string)null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns((string)null);
             _localConfig.application.name = new List<string>();
@@ -1799,7 +1799,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationNamesPullsSingleNameFromAppSettings()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns("MyAppName");
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns("MyAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("OtherAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
@@ -1818,7 +1818,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationNamesPullsMultipleNamesFromAppSettings()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns("MyAppName1,MyAppName2");
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns("MyAppName1,MyAppName2");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("OtherAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
@@ -1838,7 +1838,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationNamesPullsSingleNameFromIisExpressSitenameEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns((string)null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("MyAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
@@ -1857,7 +1857,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         public void ApplicationNamesPullsMultipleNamesFromIisExpressSitenameEnvironmentVariaible()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns((string)null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("MyAppName1,MyAppName2");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
@@ -1881,7 +1881,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("MyAppName");
             _localConfig.application.name = new List<string>();
@@ -1904,7 +1904,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("MyAppName1,MyAppName2");
             _localConfig.application.name = new List<string>();
@@ -1928,7 +1928,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string> { "MyAppName1", "MyAppName2" };
             Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
@@ -1951,7 +1951,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns((string)null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
 
             _localConfig.application.name = new List<string>();
             Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("MyAppName");
@@ -1973,7 +1973,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string>();
             Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("MyAppName1,MyAppName2");
@@ -2001,7 +2001,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string>();
             Mock.Arrange(() => _environment.GetCommandLineArgs()).Returns(commandLine.Split(new[] { ' ' }));
@@ -2022,7 +2022,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.AppName")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string>();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/DataTransport/CollectorHostNameTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/DataTransport/CollectorHostNameTests.cs
@@ -69,7 +69,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.DataTransport
         [TestCaseSource("CollectorHostnameTestData")]
         public void RunCrossAgentCollectorHostnameTests(string configFileKey, string envKey, string configOverrideHost, string envOverrideHost, string hostname)
         {
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting("NewRelic.LicenseKey")).Returns<string>(null);
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLicenseKey)).Returns<string>(null);
 
             if (envKey != null)
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
@@ -95,7 +95,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.RumTests
             _localConfig.crossApplicationTracingEnabled = true;
             _localConfig.attributes.enabled = true;
             _localConfig.service.licenseKey = testCase.LicenseKey;
-            _localConfig.appSettings.Add(new configurationAdd() { key = "NewRelic.LicenseKey", value = testCase.LicenseKey });
+            _localConfig.appSettings.Add(new configurationAdd() { key = Constants.AppSettingsLicenseKey, value = testCase.LicenseKey });
             _serverConfig.RumSettingsJavaScriptAgentLoader = "JSAGENT";
             _serverConfig.RumSettingsJavaScriptAgentFile = testCase.ConnectReply.JsAgentFile;
             _serverConfig.RumSettingsBeacon = testCase.ConnectReply.Beacon;


### PR DESCRIPTION
## Description

Apply the same obfuscation from https://github.com/newrelic/newrelic-dotnet-agent/pull/1542 to the debug-level logging of values read from appSettings.

This PR also makes the names of keys being read by the agent from appsettings constants. 🏕️ 

# Author Checklist
- [X] Unit tests, ~Integration tests, and Unbounded tests~ completed
- [ ] ~Performance testing completed with satisfactory results (if required)~

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
