### PR TITLE
chore: Fix MetricName conflict in MetricWireModel.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -733,7 +733,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 
             if (_publishMetricDelegate == null)
             {
-                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricName.Name);
+                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricNameModel.Name);
                 return;
             }
 

--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/MetricWireModelJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/MetricWireModelJsonConverter.cs
@@ -19,9 +19,9 @@ namespace NewRelic.Agent.Core.JsonConverters
         {
             jsonWriter.WriteStartArray();
 
-            MetricNameWireModelJsonConverter.WriteJsonImpl(jsonWriter, value.MetricName, serializer);
+            MetricNameWireModelJsonConverter.WriteJsonImpl(jsonWriter, value.MetricNameModel, serializer);
 
-            MetricDataWireModelJsonConverter.WriteJsonImpl(jsonWriter, value.Data, serializer);
+            MetricDataWireModelJsonConverter.WriteJsonImpl(jsonWriter, value.DataModel, serializer);
 
             jsonWriter.WriteEndArray();
         }

--- a/src/Agent/NewRelic/Agent/Core/Metrics/ApiSupportabilityMetricCounters.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/ApiSupportabilityMetricCounters.cs
@@ -106,7 +106,7 @@ namespace NewRelic.Agent.Core.Metrics
 
             if (_publishMetricDelegate == null)
             {
-                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricName.Name);
+                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricNameModel.Name);
                 return;
             }
 

--- a/src/Agent/NewRelic/Agent/Core/Metrics/CATSupportabilityMetricCounters.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/CATSupportabilityMetricCounters.cs
@@ -71,7 +71,7 @@ namespace NewRelic.Agent.Core.Metrics
 
             if (_publishMetricDelegate == null)
             {
-                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricName.Name);
+                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricNameModel.Name);
                 return;
             }
 

--- a/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/MetricWireModel.cs
@@ -15,20 +15,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using InternalMetricName = NewRelic.Agent.Core.Metrics.MetricName;
 
 namespace NewRelic.Agent.Core.WireModels
 {
     [JsonConverter(typeof(MetricWireModelJsonConverter))]
     public class MetricWireModel : IAllMetricStatsCollection
     {
-        public readonly MetricNameWireModel MetricName;
-        public readonly MetricDataWireModel Data;
+        public readonly MetricNameWireModel MetricNameModel;
+        public readonly MetricDataWireModel DataModel;
 
-        private MetricWireModel(MetricNameWireModel metricName, MetricDataWireModel data)
+        private MetricWireModel(MetricNameWireModel metricNameModel, MetricDataWireModel dataModel)
         {
-            MetricName = metricName;
-            Data = data;
+            MetricNameModel = metricNameModel;
+            DataModel = dataModel;
         }
 
         /// <summary>
@@ -55,13 +54,13 @@ namespace NewRelic.Agent.Core.WireModels
                 throw new Exception("At least one metric must be passed in");
             }
 
-            var metricName = metrics.First().MetricName;
-            if (metrics.Any(metric => !metric.MetricName.Equals(metricName)))
+            var metricName = metrics.First().MetricNameModel;
+            if (metrics.Any(metric => !metric.MetricNameModel.Equals(metricName)))
             {
                 throw new Exception("Cannot merge metrics with different names");
             }
 
-            var inputData = metrics.Select(metric => metric.Data);
+            var inputData = metrics.Select(metric => metric.DataModel);
             var mergedData = MetricDataWireModel.BuildAggregateData(inputData);
             return new MetricWireModel(metricName, mergedData);
         }
@@ -81,18 +80,18 @@ namespace NewRelic.Agent.Core.WireModels
 
         public override string ToString()
         {
-            return MetricName + Data.ToString();
+            return MetricNameModel + DataModel.ToString();
         }
 
         public void AddMetricsToCollection(MetricStatsCollection collection)
         {
-            if (string.IsNullOrEmpty(MetricName.Scope))
+            if (string.IsNullOrEmpty(MetricNameModel.Scope))
             {
-                collection.MergeUnscopedStats(MetricName.Name, Data);
+                collection.MergeUnscopedStats(MetricNameModel.Name, DataModel);
             }
             else
             {
-                collection.MergeScopedStats(MetricName.Scope, MetricName.Name, Data);
+                collection.MergeScopedStats(MetricNameModel.Scope, MetricNameModel.Name, DataModel);
             }
         }
 
@@ -105,7 +104,7 @@ namespace NewRelic.Agent.Core.WireModels
 
             if (obj is MetricWireModel other)
             {
-                return other.MetricName.Equals(this.MetricName) && other.Data.Equals(this.Data);
+                return other.MetricNameModel.Equals(this.MetricNameModel) && other.DataModel.Equals(this.DataModel);
             }
 
             return false;
@@ -114,8 +113,8 @@ namespace NewRelic.Agent.Core.WireModels
         public override int GetHashCode()
         {
             var hashCode = 2074576463;
-            hashCode = hashCode * -1521134295 + EqualityComparer<MetricNameWireModel>.Default.GetHashCode(MetricName);
-            hashCode = hashCode * -1521134295 + EqualityComparer<MetricDataWireModel>.Default.GetHashCode(Data);
+            hashCode = hashCode * -1521134295 + EqualityComparer<MetricNameWireModel>.Default.GetHashCode(MetricNameModel);
+            hashCode = hashCode * -1521134295 + EqualityComparer<MetricDataWireModel>.Default.GetHashCode(DataModel);
             return hashCode;
         }
 
@@ -138,7 +137,7 @@ namespace NewRelic.Agent.Core.WireModels
                     ? MetricNames.WebTransactionAll
                     : MetricNames.OtherTransactionAll;
                 txStats.MergeUnscopedStats(proposedName, data);
-                txStats.MergeUnscopedStats(InternalMetricName.Create(txStats.GetTransactionName().PrefixedName), data);
+                txStats.MergeUnscopedStats(MetricName.Create(txStats.GetTransactionName().PrefixedName), data);
 
                 // "HttpDispacher" is a metric that is used to populate the APM response time chart.
                 if (isWebTransaction)
@@ -247,7 +246,7 @@ namespace NewRelic.Agent.Core.WireModels
                 TimeSpan apdexT, TransactionMetricStatsCollection txStats)
             {
                 var data = MetricDataWireModel.BuildApdexData(responseTime, apdexT);
-                txStats.MergeUnscopedStats(InternalMetricName.Create(transactionApdexName), data);
+                txStats.MergeUnscopedStats(MetricName.Create(transactionApdexName), data);
                 txStats.MergeUnscopedStats(MetricNames.ApdexAll, data);
                 var proposedName = isWebTransaction
                     ? MetricNames.ApdexAllWeb
@@ -264,7 +263,7 @@ namespace NewRelic.Agent.Core.WireModels
                     ? MetricNames.ApdexAllWeb
                     : MetricNames.ApdexAllOther;
                 txStats.MergeUnscopedStats(proposedName, data);
-                txStats.MergeUnscopedStats(InternalMetricName.Create(txApdexName), data);
+                txStats.MergeUnscopedStats(MetricName.Create(txApdexName), data);
             }
 
             #endregion Transaction apdex builders
@@ -444,7 +443,7 @@ namespace NewRelic.Agent.Core.WireModels
             public static void TryBuildDatastoreStatementMetric(DatastoreVendor vendor, ParsedSqlStatement sqlStatement,
                 TimeSpan totalTime, TimeSpan exclusiveDuration, TransactionMetricStatsCollection txStats)
             {
-                var proposedName = InternalMetricName.Create(sqlStatement.DatastoreStatementMetricName);
+                var proposedName = MetricName.Create(sqlStatement.DatastoreStatementMetricName);
                 var data = MetricDataWireModel.BuildTimingData(totalTime, exclusiveDuration);
                 txStats.MergeUnscopedStats(proposedName, data);
                 txStats.MergeScopedStats(proposedName, data);

--- a/tests/Agent/UnitTests/CompositeTests/Assertions.cs
+++ b/tests/Agent/UnitTests/CompositeTests/Assertions.cs
@@ -32,18 +32,18 @@ namespace CompositeTests
                     continue;
                 }
 
-                if ((expectedMetric.Value0 != null && matchedMetric.Data.Value0 != expectedMetric.Value0) ||
-                    (expectedMetric.Value1 != null && matchedMetric.Data.Value1 != expectedMetric.Value1) ||
-                    (expectedMetric.Value2 != null && matchedMetric.Data.Value2 != expectedMetric.Value2) ||
-                    (expectedMetric.Value3 != null && matchedMetric.Data.Value3 != expectedMetric.Value3) ||
-                    (expectedMetric.Value4 != null && matchedMetric.Data.Value4 != expectedMetric.Value4) ||
-                    (expectedMetric.Value5 != null && matchedMetric.Data.Value5 != expectedMetric.Value5))
+                if ((expectedMetric.Value0 != null && matchedMetric.DataModel.Value0 != expectedMetric.Value0) ||
+                    (expectedMetric.Value1 != null && matchedMetric.DataModel.Value1 != expectedMetric.Value1) ||
+                    (expectedMetric.Value2 != null && matchedMetric.DataModel.Value2 != expectedMetric.Value2) ||
+                    (expectedMetric.Value3 != null && matchedMetric.DataModel.Value3 != expectedMetric.Value3) ||
+                    (expectedMetric.Value4 != null && matchedMetric.DataModel.Value4 != expectedMetric.Value4) ||
+                    (expectedMetric.Value5 != null && matchedMetric.DataModel.Value5 != expectedMetric.Value5))
                 {
-                    builder.AppendFormat("Metric named {0} scoped to {1} was found in the metric payload, but had unexpected stats.", matchedMetric.MetricName.Name, matchedMetric.MetricName.Scope ?? "nothing");
+                    builder.AppendFormat("Metric named {0} scoped to {1} was found in the metric payload, but had unexpected stats.", matchedMetric.MetricNameModel.Name, matchedMetric.MetricNameModel.Scope ?? "nothing");
                     builder.AppendLine();
                     builder.AppendFormat("Expected: {0}, {1}, {2}, {3}, {4}, {5}", expectedMetric.Value0, expectedMetric.Value1, expectedMetric.Value2, expectedMetric.Value3, expectedMetric.Value4, expectedMetric.Value5);
                     builder.AppendLine();
-                    builder.AppendFormat("Actual: {0}, {1}, {2}, {3}, {4}, {5}", matchedMetric.Data.Value0, matchedMetric.Data.Value1, matchedMetric.Data.Value2, matchedMetric.Data.Value3, matchedMetric.Data.Value4, matchedMetric.Data.Value5);
+                    builder.AppendFormat("Actual: {0}, {1}, {2}, {3}, {4}, {5}", matchedMetric.DataModel.Value0, matchedMetric.DataModel.Value1, matchedMetric.DataModel.Value2, matchedMetric.DataModel.Value3, matchedMetric.DataModel.Value4, matchedMetric.DataModel.Value5);
                     builder.AppendLine();
                     succeeded = false;
                 }
@@ -62,7 +62,7 @@ namespace CompositeTests
 
                 if (matchedMetric != null)
                 {
-                    builder.AppendFormat("Metric named {0} scoped to {1} was found in the metric payload.", matchedMetric.MetricName.Name, matchedMetric.MetricName.Scope ?? "nothing");
+                    builder.AppendFormat("Metric named {0} scoped to {1} was found in the metric payload.", matchedMetric.MetricNameModel.Name, matchedMetric.MetricNameModel.Scope ?? "nothing");
                     builder.AppendLine();
                     succeeded = false;
                 }
@@ -75,11 +75,11 @@ namespace CompositeTests
         {
             foreach (var actualMetric in actualMetrics)
             {
-                if (expectedMetric.IsRegexName && !Regex.IsMatch(actualMetric.MetricName.Name, expectedMetric.Name))
+                if (expectedMetric.IsRegexName && !Regex.IsMatch(actualMetric.MetricNameModel.Name, expectedMetric.Name))
                     continue;
-                if (!expectedMetric.IsRegexName && expectedMetric.Name != actualMetric.MetricName.Name)
+                if (!expectedMetric.IsRegexName && expectedMetric.Name != actualMetric.MetricNameModel.Name)
                     continue;
-                if (expectedMetric.Scope != actualMetric.MetricName.Scope)
+                if (expectedMetric.Scope != actualMetric.MetricNameModel.Scope)
                     continue;
 
                 return actualMetric;

--- a/tests/Agent/UnitTests/CompositeTests/AsyncLocalStorageContextTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/AsyncLocalStorageContextTests.cs
@@ -63,8 +63,8 @@ namespace CompositeTests
             Assert.AreEqual(1, transactionEvents.Count);
             Assert.AreEqual("foregroundExternal", transactionEvents.First().AgentAttributes()["request.uri"]);
             CollectionAssert.IsEmpty(errors);
-            CollectionAssert.IsEmpty(metrics.Where(x => x.MetricName.Name.Contains("backgroundExternal")));
-            CollectionAssert.IsNotEmpty(metrics.Where(x => x.MetricName.Name.Contains("foregroundExternal")));
+            CollectionAssert.IsEmpty(metrics.Where(x => x.MetricNameModel.Name.Contains("backgroundExternal")));
+            CollectionAssert.IsNotEmpty(metrics.Where(x => x.MetricNameModel.Name.Contains("foregroundExternal")));
 
             void InstrumentationThatStartsATransaction()
             {

--- a/tests/Agent/UnitTests/CompositeTests/StackExchangeRedisSessionCacheTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/StackExchangeRedisSessionCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -366,11 +366,11 @@ namespace CompositeTests
             const int maxLoops = 30;
             var loops = 0;
             _compositeTestAgent.Harvest();
-            var cleanupCount = _compositeTestAgent.Metrics.FirstOrDefault(m => m.MetricName.Name == "Supportability/Dotnet/RedisSessionCacheCleanup/Count");
+            var cleanupCount = _compositeTestAgent.Metrics.FirstOrDefault(m => m.MetricNameModel.Name == "Supportability/Dotnet/RedisSessionCacheCleanup/Count");
             while (cleanupCount == null && loops < maxLoops)
             {
                 _compositeTestAgent.Harvest();
-                cleanupCount = _compositeTestAgent.Metrics.FirstOrDefault(m => m.MetricName.Name == "Supportability/Dotnet/RedisSessionCacheCleanup/Count");
+                cleanupCount = _compositeTestAgent.Metrics.FirstOrDefault(m => m.MetricNameModel.Name == "Supportability/Dotnet/RedisSessionCacheCleanup/Count");
                 loops++;
                 Thread.Sleep(100);
             }

--- a/tests/Agent/UnitTests/CompositeTests/TransactionTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/TransactionTests.cs
@@ -485,7 +485,7 @@ namespace CompositeTests
             segment.End();
             transaction.End();
             _compositeTestAgent.Harvest();
-            var metrics = _compositeTestAgent.Metrics.Where(x => x.MetricName.Name.Contains("AgentTiming"));
+            var metrics = _compositeTestAgent.Metrics.Where(x => x.MetricNameModel.Name.Contains("AgentTiming"));
             Assert.IsEmpty(metrics);
         }
 
@@ -503,7 +503,7 @@ namespace CompositeTests
             segment.End();
             transaction.End();
             _compositeTestAgent.Harvest();
-            var metrics = _compositeTestAgent.Metrics.Where(x => x.MetricName.Name.Contains("AgentTiming"));
+            var metrics = _compositeTestAgent.Metrics.Where(x => x.MetricNameModel.Name.Contains("AgentTiming"));
             Assert.IsNotEmpty(metrics);
         }
 
@@ -528,10 +528,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the WebTransaction metric which should contain the response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "WebTransaction");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "WebTransaction");
             NrAssert.Multiple(
-                    () => Assert.GreaterOrEqual(timingMetric.Data.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
-                    () => Assert.LessOrEqual(timingMetric.Data.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
+                    () => Assert.GreaterOrEqual(timingMetric.DataModel.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
+                    () => Assert.LessOrEqual(timingMetric.DataModel.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
                 );
         }
 
@@ -556,10 +556,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the OtherTransaction/all metric which should contain the duration instead of response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "OtherTransaction/all");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "OtherTransaction/all");
             NrAssert.Multiple(
-                    () => Assert.GreaterOrEqual(timingMetric.Data.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
-                    () => Assert.LessOrEqual(timingMetric.Data.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
+                    () => Assert.GreaterOrEqual(timingMetric.DataModel.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
+                    () => Assert.LessOrEqual(timingMetric.DataModel.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
                 );
         }
 
@@ -587,8 +587,8 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the WebTransaction metric which should contain the response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "WebTransaction");
-            Assert.LessOrEqual(timingMetric.Data.Value1, expectedResponseTimeUpperBound);
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "WebTransaction");
+            Assert.LessOrEqual(timingMetric.DataModel.Value1, expectedResponseTimeUpperBound);
         }
 
         [Test]
@@ -616,10 +616,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the OtherTransaction/all metric which should contain the duration instead of response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "OtherTransaction/all");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "OtherTransaction/all");
             NrAssert.Multiple(
-                    () => Assert.Greater(timingMetric.Data.Value1, expectedResponseTimeUpperBound),
-                    () => Assert.LessOrEqual(timingMetric.Data.Value1, expectedDurationUpperBound)
+                    () => Assert.Greater(timingMetric.DataModel.Value1, expectedResponseTimeUpperBound),
+                    () => Assert.LessOrEqual(timingMetric.DataModel.Value1, expectedDurationUpperBound)
                 );
         }
 
@@ -647,10 +647,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the WebTransaction metric which should contain the response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "WebTransaction");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "WebTransaction");
             NrAssert.Multiple(
-                    () => Assert.GreaterOrEqual(timingMetric.Data.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
-                    () => Assert.LessOrEqual(timingMetric.Data.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
+                    () => Assert.GreaterOrEqual(timingMetric.DataModel.Value1, lowerBoundStopWatch.Elapsed.TotalSeconds),
+                    () => Assert.LessOrEqual(timingMetric.DataModel.Value1, upperBoundStopWatch.Elapsed.TotalSeconds)
                 );
         }
 
@@ -674,8 +674,8 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the WebTransaction metric which should contain the response time
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "WebTransaction");
-            Assert.LessOrEqual(timingMetric.Data.Value1, upperBoundStopWatch.Elapsed.TotalSeconds);
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "WebTransaction");
+            Assert.LessOrEqual(timingMetric.DataModel.Value1, upperBoundStopWatch.Elapsed.TotalSeconds);
         }
 
         [Test]
@@ -701,10 +701,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the OtherTransaction/all metric to confirm that the transaction was transformed and harvested
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "OtherTransaction/all");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "OtherTransaction/all");
             NrAssert.Multiple(
                     () => Assert.IsFalse(transactionAfterCallToEnd.IsValid, "The current transaction should be the NoOpTransaction."),
-                    () => Assert.AreEqual(1.0, timingMetric.Data.Value0, "The transaction should be harvested.")
+                    () => Assert.AreEqual(1.0, timingMetric.DataModel.Value0, "The transaction should be harvested.")
                 );
         }
 
@@ -731,10 +731,10 @@ namespace CompositeTests
             _compositeTestAgent.Harvest();
 
             //Use the OtherTransaction/all metric to confirm that the transaction was transformed and harvested
-            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricName.Name == "OtherTransaction/all");
+            var timingMetric = _compositeTestAgent.Metrics.First(x => x.MetricNameModel.Name == "OtherTransaction/all");
             NrAssert.Multiple(
                     () => Assert.IsTrue(transactionAfterCallToEnd.IsValid, "The current transaction should not be the NoOpTransaction."),
-                    () => Assert.AreEqual(1.0, timingMetric.Data.Value0, "The transaction should be harvested.")
+                    () => Assert.AreEqual(1.0, timingMetric.DataModel.Value0, "The transaction should be harvested.")
                 );
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
@@ -66,14 +66,14 @@ namespace NewRelic.Agent.Core.AgentHealth
             Assert.AreEqual(1, _publishedMetrics.Count);
             var metric1 = _publishedMetrics.ElementAt(0);
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/AgentVersion/1.0", metric1.MetricName.Name),
-                () => Assert.AreEqual(null, metric1.MetricName.Scope),
-                () => Assert.AreEqual(1, metric1.Data.Value0),
-                () => Assert.AreEqual(0, metric1.Data.Value1),
-                () => Assert.AreEqual(0, metric1.Data.Value2),
-                () => Assert.AreEqual(0, metric1.Data.Value3),
-                () => Assert.AreEqual(0, metric1.Data.Value4),
-                () => Assert.AreEqual(0, metric1.Data.Value5)
+                () => Assert.AreEqual("Supportability/AgentVersion/1.0", metric1.MetricNameModel.Name),
+                () => Assert.AreEqual(null, metric1.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, metric1.DataModel.Value0),
+                () => Assert.AreEqual(0, metric1.DataModel.Value1),
+                () => Assert.AreEqual(0, metric1.DataModel.Value2),
+                () => Assert.AreEqual(0, metric1.DataModel.Value3),
+                () => Assert.AreEqual(0, metric1.DataModel.Value4),
+                () => Assert.AreEqual(0, metric1.DataModel.Value5)
                 );
         }
 
@@ -85,9 +85,9 @@ namespace NewRelic.Agent.Core.AgentHealth
             var metric0 = _publishedMetrics.ElementAt(0);
             var metric1 = _publishedMetrics.ElementAt(1);
             var metric2 = _publishedMetrics.ElementAt(2);
-            Assert.AreEqual("Supportability/WrapperShutdown/all", metric0.MetricName.Name);
-            Assert.AreEqual("Supportability/WrapperShutdown/Castle.Proxies.IWrapperProxy/all", metric1.MetricName.Name);
-            Assert.AreEqual("Supportability/WrapperShutdown/Castle.Proxies.IWrapperProxy/String.FooMethod", metric2.MetricName.Name);
+            Assert.AreEqual("Supportability/WrapperShutdown/all", metric0.MetricNameModel.Name);
+            Assert.AreEqual("Supportability/WrapperShutdown/Castle.Proxies.IWrapperProxy/all", metric1.MetricNameModel.Name);
+            Assert.AreEqual("Supportability/WrapperShutdown/Castle.Proxies.IWrapperProxy/String.FooMethod", metric2.MetricNameModel.Name);
         }
 
         [Test]
@@ -96,11 +96,11 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportSupportabilityCollectorErrorException("test_method_endpoint", TimeSpan.FromMilliseconds(1500), HttpStatusCode.InternalServerError);
             Assert.AreEqual(2, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Agent/Collector/HTTPError/500", _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(1, _publishedMetrics[0].Data.Value0),
-                () => Assert.AreEqual("Supportability/Agent/Collector/test_method_endpoint/Duration", _publishedMetrics[1].MetricName.Name),
-                () => Assert.AreEqual(1, _publishedMetrics[1].Data.Value0),
-                () => Assert.AreEqual(1.5, _publishedMetrics[1].Data.Value1)
+                () => Assert.AreEqual("Supportability/Agent/Collector/HTTPError/500", _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(1, _publishedMetrics[0].DataModel.Value0),
+                () => Assert.AreEqual("Supportability/Agent/Collector/test_method_endpoint/Duration", _publishedMetrics[1].MetricNameModel.Name),
+                () => Assert.AreEqual(1, _publishedMetrics[1].DataModel.Value0),
+                () => Assert.AreEqual(1.5, _publishedMetrics[1].DataModel.Value1)
             );
         }
 
@@ -110,9 +110,9 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportSupportabilityCollectorErrorException("test_method_endpoint", TimeSpan.FromMilliseconds(1500), statusCode: null);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Agent/Collector/test_method_endpoint/Duration", _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(1, _publishedMetrics[0].Data.Value0),
-                () => Assert.AreEqual(1.5, _publishedMetrics[0].Data.Value1)
+                () => Assert.AreEqual("Supportability/Agent/Collector/test_method_endpoint/Duration", _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(1, _publishedMetrics[0].DataModel.Value0),
+                () => Assert.AreEqual(1.5, _publishedMetrics[0].DataModel.Value1)
             );
         }
 
@@ -123,8 +123,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportSupportabilityCountMetric(MetricName);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual($"Supportability/{MetricName}", _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(1, _publishedMetrics[0].Data.Value0)
+                () => Assert.AreEqual($"Supportability/{MetricName}", _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(1, _publishedMetrics[0].DataModel.Value0)
             );
         }
 
@@ -135,8 +135,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportSupportabilityCountMetric(MetricName, 2);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual($"Supportability/{MetricName}", _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(2, _publishedMetrics[0].Data.Value0)
+                () => Assert.AreEqual($"Supportability/{MetricName}", _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(2, _publishedMetrics[0].DataModel.Value0)
             );
         }
 
@@ -147,8 +147,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportCountMetric(MetricName, 2);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(2, _publishedMetrics[0].Data.Value0)
+                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(2, _publishedMetrics[0].DataModel.Value0)
             );
         }
 
@@ -160,8 +160,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportByteMetric(MetricName, totalBytes);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes), _publishedMetrics[0].Data)
+                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes), _publishedMetrics[0].DataModel)
             );
         }
 
@@ -174,8 +174,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportByteMetric(MetricName, totalBytes, exclusiveBytes);
             Assert.AreEqual(1, _publishedMetrics.Count);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes, exclusiveBytes), _publishedMetrics[0].Data)
+                () => Assert.AreEqual(MetricName, _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes, exclusiveBytes), _publishedMetrics[0].DataModel)
             );
         }
 
@@ -185,8 +185,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             var agentVersion = AgentInstallConfiguration.AgentVersion;
             _agentHealthReporter.CollectMetrics();
             NrAssert.Multiple(
-                () => Assert.AreEqual($"Supportability/AgentVersion/{agentVersion}", _publishedMetrics[0].MetricName.Name),
-                () => Assert.AreEqual(1, _publishedMetrics[0].Data.Value0)
+                () => Assert.AreEqual($"Supportability/AgentVersion/{agentVersion}", _publishedMetrics[0].MetricNameModel.Name),
+                () => Assert.AreEqual(1, _publishedMetrics[0].DataModel.Value0)
             );
         }
 
@@ -215,7 +215,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 { "Supportability/InfiniteTracing/Span/Sent", 13 },
                 { "Supportability/InfiniteTracing/Span/Received", 1 }
             };
-            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
 
             CollectionAssert.IsSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
         }
@@ -229,11 +229,11 @@ namespace NewRelic.Agent.Core.AgentHealth
             };
 
             _agentHealthReporter.CollectMetrics();
-            var firstCollectionMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            var firstCollectionMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
             CollectionAssert.IsSubsetOf(expectedOneTimeMetrics, firstCollectionMetricNamesAndValues);
 
             _agentHealthReporter.CollectMetrics();
-            var secondCollectionMetricNames = _publishedMetrics.Select(x => x.MetricName);
+            var secondCollectionMetricNames = _publishedMetrics.Select(x => x.MetricNameModel);
             CollectionAssert.IsNotSubsetOf(expectedOneTimeMetrics.Keys, secondCollectionMetricNames);
         }
 
@@ -249,53 +249,53 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.CollectMetrics();
 
             // Verify that top level Unspecified destination metric exists with expected rolled up values
-            var perDestinationUnspecifiedMetric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/UnspecifiedDestination/Output/Bytes").ToArray();
+            var perDestinationUnspecifiedMetric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/UnspecifiedDestination/Output/Bytes").ToArray();
             Assert.AreEqual(1, perDestinationUnspecifiedMetric.Length);
-            Assert.AreEqual(1, perDestinationUnspecifiedMetric[0].Data.Value0); // call count
-            Assert.AreEqual(100, perDestinationUnspecifiedMetric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(100, perDestinationUnspecifiedMetric[0].Data.Value2); // bytes received
+            Assert.AreEqual(1, perDestinationUnspecifiedMetric[0].DataModel.Value0); // call count
+            Assert.AreEqual(100, perDestinationUnspecifiedMetric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(100, perDestinationUnspecifiedMetric[0].DataModel.Value2); // bytes received
 
             // Verify that subarea metric exists for Collector data with unspecified api area
-            var unspecifiedDestinationAndAreaMetric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/UnspecifiedDestination/Output/Bytes").ToArray();
+            var unspecifiedDestinationAndAreaMetric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/UnspecifiedDestination/Output/Bytes").ToArray();
             Assert.AreEqual(1, unspecifiedDestinationAndAreaMetric.Length);
-            Assert.AreEqual(1, unspecifiedDestinationAndAreaMetric[0].Data.Value0); // call count
-            Assert.AreEqual(100, unspecifiedDestinationAndAreaMetric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(100, unspecifiedDestinationAndAreaMetric[0].Data.Value2); // bytes received
+            Assert.AreEqual(1, unspecifiedDestinationAndAreaMetric[0].DataModel.Value0); // call count
+            Assert.AreEqual(100, unspecifiedDestinationAndAreaMetric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(100, unspecifiedDestinationAndAreaMetric[0].DataModel.Value2); // bytes received
 
             // Verify that top level Collector destination metric exists with expected rolled up values
-            var perDestinationCollectorMetric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/Collector/Output/Bytes").ToArray();
+            var perDestinationCollectorMetric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/Collector/Output/Bytes").ToArray();
             Assert.AreEqual(1, perDestinationCollectorMetric.Length);
-            Assert.AreEqual(5, perDestinationCollectorMetric[0].Data.Value0); // call count
-            Assert.AreEqual(1100, perDestinationCollectorMetric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(1500, perDestinationCollectorMetric[0].Data.Value2); // bytes received
+            Assert.AreEqual(5, perDestinationCollectorMetric[0].DataModel.Value0); // call count
+            Assert.AreEqual(1100, perDestinationCollectorMetric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(1500, perDestinationCollectorMetric[0].DataModel.Value2); // bytes received
 
             // Verify that subarea metric exists for Collector 'connect'
-            var connectMetric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/Collector/connect/Output/Bytes").ToArray();
+            var connectMetric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/Collector/connect/Output/Bytes").ToArray();
             Assert.AreEqual(1, connectMetric.Length);
-            Assert.AreEqual(1, connectMetric[0].Data.Value0, 1); // call count
-            Assert.AreEqual(100, connectMetric[0].Data.Value1, 100); // bytes sent
-            Assert.AreEqual(200, connectMetric[0].Data.Value2, 200); // bytes received
+            Assert.AreEqual(1, connectMetric[0].DataModel.Value0, 1); // call count
+            Assert.AreEqual(100, connectMetric[0].DataModel.Value1, 100); // bytes sent
+            Assert.AreEqual(200, connectMetric[0].DataModel.Value2, 200); // bytes received
 
             // Verify that subarea metric exists for Collector 'doSomething1'
-            var doSomething1Metric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/Collector/doSomething1/Output/Bytes").ToArray();
+            var doSomething1Metric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/Collector/doSomething1/Output/Bytes").ToArray();
             Assert.AreEqual(1, doSomething1Metric.Length);
-            Assert.AreEqual(2, doSomething1Metric[0].Data.Value0); // call count
-            Assert.AreEqual(500, doSomething1Metric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(700, doSomething1Metric[0].Data.Value2); // bytes received
+            Assert.AreEqual(2, doSomething1Metric[0].DataModel.Value0); // call count
+            Assert.AreEqual(500, doSomething1Metric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(700, doSomething1Metric[0].DataModel.Value2); // bytes received
 
             // Verify that subarea metric exists for Collector 'doSomething2'
-            var doSomething2Metric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/Collector/doSomething2/Output/Bytes").ToArray();
+            var doSomething2Metric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/Collector/doSomething2/Output/Bytes").ToArray();
             Assert.AreEqual(1, doSomething2Metric.Length);
-            Assert.AreEqual(1, doSomething2Metric[0].Data.Value0); // call count
-            Assert.AreEqual(400, doSomething2Metric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(500, doSomething2Metric[0].Data.Value2); // bytes received
+            Assert.AreEqual(1, doSomething2Metric[0].DataModel.Value0); // call count
+            Assert.AreEqual(400, doSomething2Metric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(500, doSomething2Metric[0].DataModel.Value2); // bytes received
 
             // Verify that subarea metric exists for Collector data with unspecified api area
-            var collectorUnspecifiedMetric = _publishedMetrics.Where(x => x.MetricName.Name == "Supportability/DotNET/Collector/UnspecifiedDestinationArea/Output/Bytes").ToArray();
+            var collectorUnspecifiedMetric = _publishedMetrics.Where(x => x.MetricNameModel.Name == "Supportability/DotNET/Collector/UnspecifiedDestinationArea/Output/Bytes").ToArray();
             Assert.AreEqual(1, collectorUnspecifiedMetric.Length);
-            Assert.AreEqual(1, collectorUnspecifiedMetric[0].Data.Value0); // call count
-            Assert.AreEqual(100, collectorUnspecifiedMetric[0].Data.Value1); // bytes sent
-            Assert.AreEqual(100, collectorUnspecifiedMetric[0].Data.Value2); // bytes received
+            Assert.AreEqual(1, collectorUnspecifiedMetric[0].DataModel.Value0); // call count
+            Assert.AreEqual(100, collectorUnspecifiedMetric[0].DataModel.Value1); // bytes sent
+            Assert.AreEqual(100, collectorUnspecifiedMetric[0].DataModel.Value2); // bytes received
         }
 
         [Test]
@@ -312,40 +312,40 @@ namespace NewRelic.Agent.Core.AgentHealth
 
             _agentHealthReporter.CollectLoggingMetrics();
 
-            var infoLevelLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/lines/INFO");
-            var debugLevelLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/lines/DEBUG");
-            var finestLevelLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/lines/FINEST");
-            var missingLevelLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/lines/MISSING_LEVEL");
-            var allLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/lines");
+            var infoLevelLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/lines/INFO");
+            var debugLevelLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/lines/DEBUG");
+            var finestLevelLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/lines/FINEST");
+            var missingLevelLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/lines/MISSING_LEVEL");
+            var allLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/lines");
 
-            var infoLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/denied/INFO");
-            var debugLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/denied/DEBUG");
-            var finestLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/denied/FINEST");
-            var missingLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/denied/MISSING_LEVEL");
-            var allDeniedLines = _publishedMetrics.First(metric => metric.MetricName.Name == "Logging/denied");
+            var infoLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/denied/INFO");
+            var debugLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/denied/DEBUG");
+            var finestLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/denied/FINEST");
+            var missingLevelDeniedLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/denied/MISSING_LEVEL");
+            var allDeniedLines = _publishedMetrics.First(metric => metric.MetricNameModel.Name == "Logging/denied");
 
             NrAssert.Multiple(
                 () => Assert.AreEqual(10, _publishedMetrics.Count),
-                () => Assert.AreEqual($"Logging/lines/INFO", infoLevelLines.MetricName.Name),
-                () => Assert.AreEqual(1, infoLevelLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/lines/DEBUG", debugLevelLines.MetricName.Name),
-                () => Assert.AreEqual(1, debugLevelLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/lines/FINEST", finestLevelLines.MetricName.Name),
-                () => Assert.AreEqual(1, finestLevelLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/lines/MISSING_LEVEL", missingLevelLines.MetricName.Name),
-                () => Assert.AreEqual(1, missingLevelLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/lines", allLines.MetricName.Name),
-                () => Assert.AreEqual(4, allLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/denied/INFO", infoLevelDeniedLines.MetricName.Name),
-                () => Assert.AreEqual(1, infoLevelDeniedLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/denied/DEBUG", debugLevelDeniedLines.MetricName.Name),
-                () => Assert.AreEqual(1, debugLevelDeniedLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/denied/FINEST", finestLevelDeniedLines.MetricName.Name),
-                () => Assert.AreEqual(1, finestLevelDeniedLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/denied/MISSING_LEVEL", missingLevelDeniedLines.MetricName.Name),
-                () => Assert.AreEqual(1, missingLevelDeniedLines.Data.Value0),
-                () => Assert.AreEqual($"Logging/denied", allDeniedLines.MetricName.Name),
-                () => Assert.AreEqual(4, allDeniedLines.Data.Value0)
+                () => Assert.AreEqual($"Logging/lines/INFO", infoLevelLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, infoLevelLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/lines/DEBUG", debugLevelLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, debugLevelLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/lines/FINEST", finestLevelLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, finestLevelLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/lines/MISSING_LEVEL", missingLevelLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, missingLevelLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/lines", allLines.MetricNameModel.Name),
+                () => Assert.AreEqual(4, allLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/denied/INFO", infoLevelDeniedLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, infoLevelDeniedLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/denied/DEBUG", debugLevelDeniedLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, debugLevelDeniedLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/denied/FINEST", finestLevelDeniedLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, finestLevelDeniedLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/denied/MISSING_LEVEL", missingLevelDeniedLines.MetricNameModel.Name),
+                () => Assert.AreEqual(1, missingLevelDeniedLines.DataModel.Value0),
+                () => Assert.AreEqual($"Logging/denied", allDeniedLines.MetricNameModel.Name),
+                () => Assert.AreEqual(4, allDeniedLines.DataModel.Value0)
                 );
         }
 
@@ -377,7 +377,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 { "Supportability/Logging/Forwarding/DotNET/Framework1/enabled", 1},
                 { "Supportability/Logging/Forwarding/DotNET/Framework2/enabled", 1}
             };
-            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
 
             CollectionAssert.IsSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
         }
@@ -389,8 +389,8 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportLogForwardingEnabledWithFramework("log4net");
             _agentHealthReporter.CollectMetrics();
 
-            Assert.True(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/DotNET/log4net/enabled"));
-            Assert.True(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/Forwarding/DotNET/log4net/enabled"));
+            Assert.True(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/DotNET/log4net/enabled"));
+            Assert.True(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/Forwarding/DotNET/log4net/enabled"));
 
             // Clear out captured metrics, and recollect
             _publishedMetrics = new List<MetricWireModel>();
@@ -400,10 +400,10 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthReporter.ReportLogForwardingEnabledWithFramework("serilog");
             _agentHealthReporter.CollectMetrics();
 
-            Assert.True(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/DotNET/serilog/enabled"));
-            Assert.False(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/DotNET/log4net/enabled"));
-            Assert.True(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/Forwarding/DotNET/serilog/enabled"));
-            Assert.False(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/Logging/Forwarding/DotNET/log4net/enabled"));
+            Assert.True(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/DotNET/serilog/enabled"));
+            Assert.False(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/DotNET/log4net/enabled"));
+            Assert.True(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/Forwarding/DotNET/serilog/enabled"));
+            Assert.False(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Logging/Forwarding/DotNET/log4net/enabled"));
         }
 
         [Test]
@@ -418,7 +418,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 { "Supportability/Logging/LocalDecorating/DotNET/enabled", 1 },
             };
 
-            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
 
             CollectionAssert.IsSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
 
@@ -426,7 +426,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             _publishedMetrics = new List<MetricWireModel>();
             _agentHealthReporter.CollectMetrics();
 
-            actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
             CollectionAssert.IsNotSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
         }
 
@@ -442,7 +442,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 { "Supportability/DotNET/AgentLogging/Disabled", 1 },
                 { "Supportability/DotNET/AgentLogging/DisabledDueToError", 1 },
             };
-            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricName.Name, x.Data.Value0));
+            var actualMetricNamesAndValues = _publishedMetrics.Select(x => new KeyValuePair<string, long>(x.MetricNameModel.Name, x.DataModel.Value0));
 
             CollectionAssert.IsSubsetOf(expectedMetricNamesAndValues, actualMetricNamesAndValues);
 
@@ -460,8 +460,8 @@ namespace NewRelic.Agent.Core.AgentHealth
                 { "Supportability/DotNET/AgentLogging/Disabled", 1 },
                 { "Supportability/DotNET/AgentLogging/DisabledDueToError", 1 },
             };
-            Assert.False(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/DotNET/AgentLogging/Disabled"));
-            Assert.False(_publishedMetrics.Any(x => x.MetricName.Name == "Supportability/DotNET/AgentLogging/DisabledDueToError"));
+            Assert.False(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/DotNET/AgentLogging/Disabled"));
+            Assert.False(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/DotNET/AgentLogging/DisabledDueToError"));
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricAggregatorTests.cs
@@ -105,14 +105,14 @@ namespace NewRelic.Agent.Core.Aggregators
             Assert.AreEqual(1, sentMetrics.Count());
             var sentMetric = sentMetrics.ElementAt(0);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric.MetricName.Name),
-                () => Assert.AreEqual(null, sentMetric.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric.Data.Value0),
-                () => Assert.AreEqual(0, sentMetric.Data.Value1),
-                () => Assert.AreEqual(0, sentMetric.Data.Value2),
-                () => Assert.AreEqual(0, sentMetric.Data.Value3),
-                () => Assert.AreEqual(0, sentMetric.Data.Value4),
-                () => Assert.AreEqual(0, sentMetric.Data.Value5)
+                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(null, sentMetric.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric.DataModel.Value0),
+                () => Assert.AreEqual(0, sentMetric.DataModel.Value1),
+                () => Assert.AreEqual(0, sentMetric.DataModel.Value2),
+                () => Assert.AreEqual(0, sentMetric.DataModel.Value3),
+                () => Assert.AreEqual(0, sentMetric.DataModel.Value4),
+                () => Assert.AreEqual(0, sentMetric.DataModel.Value5)
                 );
         }
 
@@ -184,7 +184,7 @@ namespace NewRelic.Agent.Core.Aggregators
             string[] names = new string[] { "Supportability/MetricHarvest/transmit", "DotNet/test_metric" };
             foreach (MetricWireModel current in sentMetrics)
             {
-                Assert.IsTrue(names.Contains(current.MetricName.Name), "Name is not present: " + current.MetricName.Name);
+                Assert.IsTrue(names.Contains(current.MetricNameModel.Name), "Name is not present: " + current.MetricNameModel.Name);
             }
         }
 
@@ -208,51 +208,51 @@ namespace NewRelic.Agent.Core.Aggregators
 
             foreach (MetricWireModel metric in sentMetrics)
             {
-                if ("DotNet/metric1".Equals(metric.MetricName.Name))
+                if ("DotNet/metric1".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric1 = metric;
                 }
-                else if ("DotNet/metric2".Equals(metric.MetricName.Name))
+                else if ("DotNet/metric2".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric2 = metric;
                 }
-                else if ("Supportability/MetricHarvest/transmit".Equals(metric.MetricName.Name))
+                else if ("Supportability/MetricHarvest/transmit".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric3 = metric;
                 }
                 else
                 {
-                    Assert.Fail("Unexpected metric name " + metric.MetricName.Name);
+                    Assert.Fail("Unexpected metric name " + metric.MetricNameModel.Name);
                 }
             }
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/metric1", sentMetric1.MetricName.Name),
-                () => Assert.AreEqual(null, sentMetric1.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric1.Data.Value0),
-                () => Assert.AreEqual(3, sentMetric1.Data.Value1),
-                () => Assert.AreEqual(1, sentMetric1.Data.Value2),
-                () => Assert.AreEqual(3, sentMetric1.Data.Value3),
-                () => Assert.AreEqual(3, sentMetric1.Data.Value4),
-                () => Assert.AreEqual(9, sentMetric1.Data.Value5),
+                () => Assert.AreEqual("DotNet/metric1", sentMetric1.MetricNameModel.Name),
+                () => Assert.AreEqual(null, sentMetric1.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric1.DataModel.Value0),
+                () => Assert.AreEqual(3, sentMetric1.DataModel.Value1),
+                () => Assert.AreEqual(1, sentMetric1.DataModel.Value2),
+                () => Assert.AreEqual(3, sentMetric1.DataModel.Value3),
+                () => Assert.AreEqual(3, sentMetric1.DataModel.Value4),
+                () => Assert.AreEqual(9, sentMetric1.DataModel.Value5),
 
-                () => Assert.AreEqual("DotNet/metric2", sentMetric2.MetricName.Name),
-                () => Assert.AreEqual("scope2", sentMetric2.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric2.Data.Value0),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value1),
-                () => Assert.AreEqual(5, sentMetric2.Data.Value2),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value3),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value4),
-                () => Assert.AreEqual(49, sentMetric2.Data.Value5),
+                () => Assert.AreEqual("DotNet/metric2", sentMetric2.MetricNameModel.Name),
+                () => Assert.AreEqual("scope2", sentMetric2.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric2.DataModel.Value0),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value1),
+                () => Assert.AreEqual(5, sentMetric2.DataModel.Value2),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value3),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value4),
+                () => Assert.AreEqual(49, sentMetric2.DataModel.Value5),
 
-                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric3.MetricName.Name),
-                () => Assert.AreEqual(null, sentMetric3.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric3.Data.Value0),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value1),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value2),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value3),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value4),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value5)
+                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric3.MetricNameModel.Name),
+                () => Assert.AreEqual(null, sentMetric3.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric3.DataModel.Value0),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value1),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value2),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value3),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value4),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value5)
             );
         }
 
@@ -277,51 +277,51 @@ namespace NewRelic.Agent.Core.Aggregators
 
             foreach (MetricWireModel metric in sentMetrics)
             {
-                if ("DotNet/metric1".Equals(metric.MetricName.Name))
+                if ("DotNet/metric1".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric1 = metric;
                 }
-                else if ("DotNet/metric2".Equals(metric.MetricName.Name))
+                else if ("DotNet/metric2".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric2 = metric;
                 }
-                else if ("Supportability/MetricHarvest/transmit".Equals(metric.MetricName.Name))
+                else if ("Supportability/MetricHarvest/transmit".Equals(metric.MetricNameModel.Name))
                 {
                     sentMetric3 = metric;
                 }
                 else
                 {
-                    Assert.Fail("Unexpected metric name " + metric.MetricName.Name);
+                    Assert.Fail("Unexpected metric name " + metric.MetricNameModel.Name);
                 }
             }
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/metric1", sentMetric1.MetricName.Name),
-                () => Assert.AreEqual(null, sentMetric1.MetricName.Scope),
-                () => Assert.AreEqual(2, sentMetric1.Data.Value0),
-                () => Assert.AreEqual(10, sentMetric1.Data.Value1),
-                () => Assert.AreEqual(6, sentMetric1.Data.Value2),
-                () => Assert.AreEqual(3, sentMetric1.Data.Value3),
-                () => Assert.AreEqual(7, sentMetric1.Data.Value4),
-                () => Assert.AreEqual(58, sentMetric1.Data.Value5),
+                () => Assert.AreEqual("DotNet/metric1", sentMetric1.MetricNameModel.Name),
+                () => Assert.AreEqual(null, sentMetric1.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, sentMetric1.DataModel.Value0),
+                () => Assert.AreEqual(10, sentMetric1.DataModel.Value1),
+                () => Assert.AreEqual(6, sentMetric1.DataModel.Value2),
+                () => Assert.AreEqual(3, sentMetric1.DataModel.Value3),
+                () => Assert.AreEqual(7, sentMetric1.DataModel.Value4),
+                () => Assert.AreEqual(58, sentMetric1.DataModel.Value5),
 
-                () => Assert.AreEqual("DotNet/metric2", sentMetric2.MetricName.Name),
-                () => Assert.AreEqual("scope2", sentMetric2.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric2.Data.Value0),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value1),
-                () => Assert.AreEqual(5, sentMetric2.Data.Value2),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value3),
-                () => Assert.AreEqual(7, sentMetric2.Data.Value4),
-                () => Assert.AreEqual(49, sentMetric2.Data.Value5),
+                () => Assert.AreEqual("DotNet/metric2", sentMetric2.MetricNameModel.Name),
+                () => Assert.AreEqual("scope2", sentMetric2.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric2.DataModel.Value0),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value1),
+                () => Assert.AreEqual(5, sentMetric2.DataModel.Value2),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value3),
+                () => Assert.AreEqual(7, sentMetric2.DataModel.Value4),
+                () => Assert.AreEqual(49, sentMetric2.DataModel.Value5),
 
-                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric3.MetricName.Name),
-                () => Assert.AreEqual(null, sentMetric3.MetricName.Scope),
-                () => Assert.AreEqual(1, sentMetric3.Data.Value0),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value1),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value2),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value3),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value4),
-                () => Assert.AreEqual(0, sentMetric3.Data.Value5)
+                () => Assert.AreEqual(MetricNames.SupportabilityMetricHarvestTransmit, sentMetric3.MetricNameModel.Name),
+                () => Assert.AreEqual(null, sentMetric3.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, sentMetric3.DataModel.Value0),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value1),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value2),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value3),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value4),
+                () => Assert.AreEqual(0, sentMetric3.DataModel.Value5)
             );
         }
 
@@ -352,9 +352,9 @@ namespace NewRelic.Agent.Core.Aggregators
 
             // Assert
             Assert.AreEqual(3, unsentMetrics.Count()); // include "DotNet/metric1", "DotNet/metric2" and "Supportability/MetricHarvest/transmit" metrics
-            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricName.Name == "DotNet/metric1" && _.Data.Value0 == 1));
-            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricName.Name == "DotNet/metric2" && _.Data.Value0 == 1));
-            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricName.Name == "Supportability/MetricHarvest/transmit" && _.Data.Value0 == 2));
+            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricNameModel.Name == "DotNet/metric1" && _.DataModel.Value0 == 1));
+            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricNameModel.Name == "DotNet/metric2" && _.DataModel.Value0 == 1));
+            Assert.IsTrue(unsentMetrics.Any(_ => _.MetricNameModel.Name == "Supportability/MetricHarvest/transmit" && _.DataModel.Value0 == 2));
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Aggregators/MetricStatsCollectionTests.cs
@@ -33,18 +33,18 @@ namespace NewRelic.Agent.Core.Aggregators
             Mock.Arrange(() => mNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => "IAmRenamed");
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(mNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("IAmRenamed", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("IAmRenamed", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -57,18 +57,18 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -81,19 +81,19 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
             var scopedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
-            scopedStats[metric1.MetricName.Name] = metric1.Data;
-            collection.MergeScopedStats(metric1.MetricName.Scope, scopedStats);
+            scopedStats[metric1.MetricNameModel.Name] = metric1.DataModel;
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, scopedStats);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(mNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("IAmRenamed", current.MetricName.Name);
-                Assert.AreEqual("myscope", current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("IAmRenamed", current.MetricNameModel.Name);
+                Assert.AreEqual("myscope", current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -103,18 +103,18 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -124,25 +124,25 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(2, current.Data.Value0);
-                Assert.AreEqual(6, current.Data.Value1);
-                Assert.AreEqual(4, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                Assert.AreEqual(2, current.DataModel.Value0);
+                Assert.AreEqual(6, current.DataModel.Value1);
+                Assert.AreEqual(4, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
 
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "name", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(4)));
-            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
-            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
+            collection.MergeUnscopedStats(metric2.MetricNameModel.Name, metric2.DataModel);
+            collection.MergeUnscopedStats(metric2.MetricNameModel.Name, metric2.DataModel);
             stats = collection.ConvertToJsonForSending(_metricNameService);
 
             count = 0;
@@ -150,11 +150,11 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                Assert.AreEqual(4, current.Data.Value0);
-                Assert.AreEqual(16, current.Data.Value1);
-                Assert.AreEqual(12, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                Assert.AreEqual(4, current.DataModel.Value0);
+                Assert.AreEqual(16, current.DataModel.Value1);
+                Assert.AreEqual(12, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -166,31 +166,31 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", null, MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
             var collection = new MetricStatsCollection();
-            collection.MergeUnscopedStats(metric1.MetricName.Name, metric1.Data);
-            collection.MergeUnscopedStats(metric2.MetricName.Name, metric2.Data);
+            collection.MergeUnscopedStats(metric1.MetricNameModel.Name, metric1.DataModel);
+            collection.MergeUnscopedStats(metric2.MetricNameModel.Name, metric2.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                if (current.MetricName.Name.Equals("DotNet/name"))
+                if (current.MetricNameModel.Name.Equals("DotNet/name"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(5, current.Data.Value1);
-                    Assert.AreEqual(4, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(5, current.DataModel.Value1);
+                    Assert.AreEqual(4, current.DataModel.Value2);
                 }
-                else if (current.MetricName.Name.Equals("DotNet/another"))
+                else if (current.MetricNameModel.Name.Equals("DotNet/another"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(3, current.Data.Value1);
-                    Assert.AreEqual(2, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(3, current.DataModel.Value1);
+                    Assert.AreEqual(2, current.DataModel.Value2);
                 }
                 else
                 {
-                    Assert.Fail("Unexpected Metric: " + current.MetricName.Name);
+                    Assert.Fail("Unexpected Metric: " + current.MetricNameModel.Name);
                 }
-                Assert.AreEqual(null, current.MetricName.Scope);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
 
             }
             Assert.AreEqual(2, count);
@@ -205,18 +205,18 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("DotNet/name", current.MetricName.Name);
-                Assert.AreEqual("myScope", current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("DotNet/name", current.MetricNameModel.Name);
+                Assert.AreEqual("myScope", current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -226,8 +226,8 @@ namespace NewRelic.Agent.Core.Aggregators
         {
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
-            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
-            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -235,11 +235,11 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual(metric1.MetricName.Name, current.MetricName.Name);
-                Assert.AreEqual(metric1.MetricName.Scope, current.MetricName.Scope);
-                Assert.AreEqual(2, current.Data.Value0);
-                Assert.AreEqual(6, current.Data.Value1);
-                Assert.AreEqual(4, current.Data.Value2);
+                Assert.AreEqual(metric1.MetricNameModel.Name, current.MetricNameModel.Name);
+                Assert.AreEqual(metric1.MetricNameModel.Scope, current.MetricNameModel.Scope);
+                Assert.AreEqual(2, current.DataModel.Value0);
+                Assert.AreEqual(6, current.DataModel.Value1);
+                Assert.AreEqual(4, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -251,8 +251,8 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric2 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/another", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
 
             var collection = new MetricStatsCollection();
-            collection.MergeScopedStats(metric1.MetricName.Scope, metric1.MetricName.Name, metric1.Data);
-            collection.MergeScopedStats(metric2.MetricName.Scope, metric2.MetricName.Name, metric2.Data);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, metric1.MetricNameModel.Name, metric1.DataModel);
+            collection.MergeScopedStats(metric2.MetricNameModel.Scope, metric2.MetricNameModel.Name, metric2.DataModel);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -260,23 +260,23 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                if (current.MetricName.Name.Equals("DotNet/name"))
+                if (current.MetricNameModel.Name.Equals("DotNet/name"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(7, current.Data.Value1);
-                    Assert.AreEqual(5, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(7, current.DataModel.Value1);
+                    Assert.AreEqual(5, current.DataModel.Value2);
                 }
-                else if (current.MetricName.Name.Equals("DotNet/another"))
+                else if (current.MetricNameModel.Name.Equals("DotNet/another"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(3, current.Data.Value1);
-                    Assert.AreEqual(2, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(3, current.DataModel.Value1);
+                    Assert.AreEqual(2, current.DataModel.Value2);
                 }
                 else
                 {
-                    Assert.Fail("Unexpected metric: " + current.MetricName.Name);
+                    Assert.Fail("Unexpected metric: " + current.MetricNameModel.Name);
                 }
-                Assert.AreEqual(metric1.MetricName.Scope, current.MetricName.Scope);
+                Assert.AreEqual(metric1.MetricNameModel.Scope, current.MetricNameModel.Scope);
 
             }
             Assert.AreEqual(2, count);
@@ -292,19 +292,19 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myScope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            collection.MergeScopedStats(metric1.MetricName.Scope, txStats);
+            txStats.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, txStats);
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
 
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual("myScope", current.MetricName.Scope);
-                Assert.AreEqual(1, current.Data.Value0);
-                Assert.AreEqual(3, current.Data.Value1);
-                Assert.AreEqual(2, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual("myScope", current.MetricNameModel.Scope);
+                Assert.AreEqual(1, current.DataModel.Value0);
+                Assert.AreEqual(3, current.DataModel.Value1);
+                Assert.AreEqual(2, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -315,9 +315,9 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "myscope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            txStats.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            collection.MergeScopedStats(metric1.MetricName.Scope, txStats);
+            txStats.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
+            txStats.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, txStats);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -325,11 +325,11 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual("myscope", current.MetricName.Scope);
-                Assert.AreEqual(2, current.Data.Value0);
-                Assert.AreEqual(6, current.Data.Value1);
-                Assert.AreEqual(4, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual("myscope", current.MetricNameModel.Scope);
+                Assert.AreEqual(2, current.DataModel.Value0);
+                Assert.AreEqual(6, current.DataModel.Value1);
+                Assert.AreEqual(4, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -340,11 +340,11 @@ namespace NewRelic.Agent.Core.Aggregators
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "name", "scope", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
+            txStats1.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats2.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
-            collection.MergeScopedStats(metric1.MetricName.Scope, txStats1);
-            collection.MergeScopedStats(metric1.MetricName.Scope, txStats2);
+            txStats2.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, txStats1);
+            collection.MergeScopedStats(metric1.MetricNameModel.Scope, txStats2);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -352,11 +352,11 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                Assert.AreEqual("name", current.MetricName.Name);
-                Assert.AreEqual("scope", current.MetricName.Scope);
-                Assert.AreEqual(2, current.Data.Value0);
-                Assert.AreEqual(6, current.Data.Value1);
-                Assert.AreEqual(4, current.Data.Value2);
+                Assert.AreEqual("name", current.MetricNameModel.Name);
+                Assert.AreEqual("scope", current.MetricNameModel.Scope);
+                Assert.AreEqual(2, current.DataModel.Value0);
+                Assert.AreEqual(6, current.DataModel.Value1);
+                Assert.AreEqual(4, current.DataModel.Value2);
             }
             Assert.AreEqual(1, count);
         }
@@ -369,11 +369,11 @@ namespace NewRelic.Agent.Core.Aggregators
 
             var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
+            txStats1.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats2.Merge(metric2.MetricName.Name, metric2.Data, MetricDataWireModel.BuildAggregateData);
-            collection.MergeScopedStats(metric2.MetricName.Scope, txStats1);
-            collection.MergeScopedStats(metric2.MetricName.Scope, txStats2);
+            txStats2.Merge(metric2.MetricNameModel.Name, metric2.DataModel, MetricDataWireModel.BuildAggregateData);
+            collection.MergeScopedStats(metric2.MetricNameModel.Scope, txStats1);
+            collection.MergeScopedStats(metric2.MetricNameModel.Scope, txStats2);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -381,23 +381,23 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                if (current.MetricName.Name.Equals("DotNet/name"))
+                if (current.MetricNameModel.Name.Equals("DotNet/name"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(2, current.Data.Value1);
-                    Assert.AreEqual(1, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(2, current.DataModel.Value1);
+                    Assert.AreEqual(1, current.DataModel.Value2);
                 }
-                else if (current.MetricName.Name.Equals("DotNet/another"))
+                else if (current.MetricNameModel.Name.Equals("DotNet/another"))
                 {
-                    Assert.AreEqual(1, current.Data.Value0);
-                    Assert.AreEqual(3, current.Data.Value1);
-                    Assert.AreEqual(2, current.Data.Value2);
+                    Assert.AreEqual(1, current.DataModel.Value0);
+                    Assert.AreEqual(3, current.DataModel.Value1);
+                    Assert.AreEqual(2, current.DataModel.Value2);
                 }
                 else
                 {
-                    Assert.Fail("Unexpected metric: " + current.MetricName.Name);
+                    Assert.Fail("Unexpected metric: " + current.MetricNameModel.Name);
                 }
-                Assert.AreEqual("scope", current.MetricName.Scope);
+                Assert.AreEqual("scope", current.MetricNameModel.Scope);
             }
             Assert.AreEqual(2, count);
         }
@@ -413,18 +413,18 @@ namespace NewRelic.Agent.Core.Aggregators
 
             var collection = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> txStats1 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats1.Merge(metric1.MetricName.Name, metric1.Data, MetricDataWireModel.BuildAggregateData);
+            txStats1.Merge(metric1.MetricNameModel.Name, metric1.DataModel, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats2 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats2.Merge(metric2.MetricName.Name, metric2.Data, MetricDataWireModel.BuildAggregateData);
+            txStats2.Merge(metric2.MetricNameModel.Name, metric2.DataModel, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats3 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats3.Merge(metric3.MetricName.Name, metric3.Data, MetricDataWireModel.BuildAggregateData);
+            txStats3.Merge(metric3.MetricNameModel.Name, metric3.DataModel, MetricDataWireModel.BuildAggregateData);
             MetricStatsDictionary<string, MetricDataWireModel> txStats4 = new MetricStatsDictionary<string, MetricDataWireModel>();
-            txStats4.Merge(metric4.MetricName.Name, metric4.Data, MetricDataWireModel.BuildAggregateData);
+            txStats4.Merge(metric4.MetricNameModel.Name, metric4.DataModel, MetricDataWireModel.BuildAggregateData);
 
-            collection.MergeScopedStats(metric2.MetricName.Scope, txStats1);
-            collection.MergeScopedStats(metric2.MetricName.Scope, txStats2);
-            collection.MergeScopedStats(metric3.MetricName.Scope, txStats3);
-            collection.MergeScopedStats(metric4.MetricName.Scope, txStats4);
+            collection.MergeScopedStats(metric2.MetricNameModel.Scope, txStats1);
+            collection.MergeScopedStats(metric2.MetricNameModel.Scope, txStats2);
+            collection.MergeScopedStats(metric3.MetricNameModel.Scope, txStats3);
+            collection.MergeScopedStats(metric4.MetricNameModel.Scope, txStats4);
 
             IEnumerable<MetricWireModel> stats = collection.ConvertToJsonForSending(_metricNameService);
             var count = 0;
@@ -432,41 +432,41 @@ namespace NewRelic.Agent.Core.Aggregators
             foreach (MetricWireModel current in stats)
             {
                 count++;
-                if (current.MetricName.Name.Equals("DotNet/name"))
+                if (current.MetricNameModel.Name.Equals("DotNet/name"))
                 {
-                    if (current.MetricName.Scope.Equals("scope"))
+                    if (current.MetricNameModel.Scope.Equals("scope"))
                     {
-                        Assert.AreEqual(1, current.Data.Value0);
-                        Assert.AreEqual(2, current.Data.Value1);
-                        Assert.AreEqual(1, current.Data.Value2);
+                        Assert.AreEqual(1, current.DataModel.Value0);
+                        Assert.AreEqual(2, current.DataModel.Value1);
+                        Assert.AreEqual(1, current.DataModel.Value2);
                     }
                     else
                     {
-                        Assert.AreEqual("myotherscope", current.MetricName.Scope);
-                        Assert.AreEqual(1, current.Data.Value0);
-                        Assert.AreEqual(5, current.Data.Value1);
-                        Assert.AreEqual(4, current.Data.Value2);
+                        Assert.AreEqual("myotherscope", current.MetricNameModel.Scope);
+                        Assert.AreEqual(1, current.DataModel.Value0);
+                        Assert.AreEqual(5, current.DataModel.Value1);
+                        Assert.AreEqual(4, current.DataModel.Value2);
                     }
                 }
-                else if (current.MetricName.Name.Equals("DotNet/another"))
+                else if (current.MetricNameModel.Name.Equals("DotNet/another"))
                 {
-                    if (current.MetricName.Scope.Equals("scope"))
+                    if (current.MetricNameModel.Scope.Equals("scope"))
                     {
-                        Assert.AreEqual(1, current.Data.Value0);
-                        Assert.AreEqual(3, current.Data.Value1);
-                        Assert.AreEqual(2, current.Data.Value2);
+                        Assert.AreEqual(1, current.DataModel.Value0);
+                        Assert.AreEqual(3, current.DataModel.Value1);
+                        Assert.AreEqual(2, current.DataModel.Value2);
                     }
                     else
                     {
-                        Assert.AreEqual("myotherscope", current.MetricName.Scope);
-                        Assert.AreEqual(1, current.Data.Value0);
-                        Assert.AreEqual(7, current.Data.Value1);
-                        Assert.AreEqual(6, current.Data.Value2);
+                        Assert.AreEqual("myotherscope", current.MetricNameModel.Scope);
+                        Assert.AreEqual(1, current.DataModel.Value0);
+                        Assert.AreEqual(7, current.DataModel.Value1);
+                        Assert.AreEqual(6, current.DataModel.Value2);
                     }
                 }
                 else
                 {
-                    Assert.Fail("Unexpected metric: " + current.MetricName.Name);
+                    Assert.Fail("Unexpected metric: " + current.MetricNameModel.Name);
                 }
 
             }
@@ -487,14 +487,14 @@ namespace NewRelic.Agent.Core.Aggregators
             MetricStatsDictionary<string, MetricDataWireModel> scoped1 = new MetricStatsDictionary<string, MetricDataWireModel>();
             scoped1.Merge("DotNet/name1", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1)), MetricDataWireModel.BuildAggregateData);
             scoped1.Merge("DotNet/name2", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)), MetricDataWireModel.BuildAggregateData);
-            collection1.MergeUnscopedStats(metric5.MetricName.Name, metric5.Data);
+            collection1.MergeUnscopedStats(metric5.MetricNameModel.Name, metric5.DataModel);
             collection1.MergeScopedStats("collection1scope", scoped1);
 
             var collection2 = new MetricStatsCollection();
             MetricStatsDictionary<string, MetricDataWireModel> scoped2 = new MetricStatsDictionary<string, MetricDataWireModel>();
             scoped2.Merge("DotNet/name3", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(1)), MetricDataWireModel.BuildAggregateData);
             scoped2.Merge("DotNet/name4", MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)), MetricDataWireModel.BuildAggregateData);
-            collection1.MergeUnscopedStats(metric6.MetricName.Name, metric6.Data);
+            collection1.MergeUnscopedStats(metric6.MetricNameModel.Name, metric6.DataModel);
             collection1.MergeScopedStats("collection2scope", scoped1);
 
             var collection3 = new MetricStatsCollection();

--- a/tests/Agent/UnitTests/Core.UnitTest/Metrics/ApiSupportabilityMetricCountersTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Metrics/ApiSupportabilityMetricCountersTests.cs
@@ -45,8 +45,8 @@ namespace NewRelic.Agent.Core.Metrics
             _apiSupportabilityMetricCounters.Record(apiMethod);
             _apiSupportabilityMetricCounters.CollectMetrics();
             var metric = _publishedMetrics.Single();
-            Assert.AreEqual(SupportabilityPrefix + apiMethod, metric.MetricName.Name);
-            Assert.AreEqual(1, metric.Data.Value0);
+            Assert.AreEqual(SupportabilityPrefix + apiMethod, metric.MetricNameModel.Name);
+            Assert.AreEqual(1, metric.DataModel.Value0);
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.Metrics
             }
 
             _apiSupportabilityMetricCounters.CollectMetrics();
-            var actualMetricNames = _publishedMetrics.Select(metric => metric.MetricName.Name).ToList();
+            var actualMetricNames = _publishedMetrics.Select(metric => metric.MetricNameModel.Name).ToList();
             var expectedMetricNames = ApiMethods.Select(x => SupportabilityPrefix + x.ToString()).ToList();
 
             CollectionAssert.AreEquivalent(expectedMetricNames, actualMetricNames);
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Metrics
             }
             _apiSupportabilityMetricCounters.CollectMetrics();
             var metric = _publishedMetrics.Single();
-            Assert.AreEqual(recordCount, metric.Data.Value0);
+            Assert.AreEqual(recordCount, metric.DataModel.Value0);
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Metrics/CATSupportabilityMetricCounterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Metrics/CATSupportabilityMetricCounterTests.cs
@@ -53,11 +53,11 @@ namespace NewRelic.Agent.Core.Metrics
                 var expectedName = MetricNames.GetSupportabilityCATConditionMetricName(enumVal);
 
                 //Ensure that we can find out metric
-                assertions.Add(() => Assert.IsNotNull(_metrics.FirstOrDefault(x => x.MetricName.Name == expectedName),
+                assertions.Add(() => Assert.IsNotNull(_metrics.FirstOrDefault(x => x.MetricNameModel.Name == expectedName),
                     $"Unable to find metric '{expectedName}'"));
 
                 //Ensure its count matches the number of times the supportability metric was called
-                assertions.Add(() => Assert.AreEqual(countHits, _metrics.FirstOrDefault(x => x.MetricName.Name == MetricNames.GetSupportabilityCATConditionMetricName(enumVal)).Data.Value0));
+                assertions.Add(() => Assert.AreEqual(countHits, _metrics.FirstOrDefault(x => x.MetricNameModel.Name == MetricNames.GetSupportabilityCATConditionMetricName(enumVal)).DataModel.Value0));
             }
 
             //Act

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/GCStatsSampleTransformerTests.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.Transformers
             //Collect metrics that are generated from sample data
             var generatedMetrics = new Dictionary<string, MetricWireModel>();
             Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>()))
-                .DoInstead<MetricWireModel>((metric) => { generatedMetrics.Add(metric.MetricName.Name, metric); });
+                .DoInstead<MetricWireModel>((metric) => { generatedMetrics.Add(metric.MetricNameModel.Name, metric); });
 
             //Act
             _transformer.Transform(_sampleData);
@@ -66,7 +66,7 @@ namespace NewRelic.Agent.Core.Transformers
             //Assert
             Assert.AreEqual(_sampleTypesCount, generatedMetrics.Count, $"{_sampleTypesCount} metrics should have been generated, but {generatedMetrics.Count} were.");
             Assert.IsFalse(generatedMetrics.Any(x => x.Value == null));
-            Assert.IsFalse(generatedMetrics.Any(x => x.Value.Data == null));
+            Assert.IsFalse(generatedMetrics.Any(x => x.Value.DataModel == null));
         }
 
         /// <summary>
@@ -155,12 +155,12 @@ namespace NewRelic.Agent.Core.Transformers
             //Collect metrics that are generated from sample data
             var generatedMetrics = new Dictionary<string, MetricWireModel>();
             Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>()))
-                .DoInstead<MetricWireModel>((metric) => { generatedMetrics.Add(metric.MetricName.Name, metric); });
+                .DoInstead<MetricWireModel>((metric) => { generatedMetrics.Add(metric.MetricNameModel.Name, metric); });
 
             //Act
             _transformer.Transform(_sampleData);
 
-            Assert.IsFalse(generatedMetrics.Any(x => x.Value.Data.Value0 < 0));
+            Assert.IsFalse(generatedMetrics.Any(x => x.Value.DataModel.Value0 < 0));
         }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/MemorySampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/MemorySampleTransformerTests.cs
@@ -54,7 +54,7 @@ namespace NewRelic.Agent.Core.Transformers
             long expectedMemoryWorkingSetValue = 42445745745L;
             float expectedMemoryWorkingSetValueAsFloat = expectedMemoryWorkingSetValue / BytesPerMb;
 
-            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricName.Name, m.Data));
+            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricNameModel.Name, m.DataModel));
 
             var sample = new ImmutableMemorySample(expectedMemoryPhysicalValue, expectedMemoryWorkingSetValue);
             Transform(sample);
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Transformers
             long expectedMemoryPhysicalValue = 0L;
             long expectedMemoryWorkingSetValue = 0L;
 
-            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricName.Name, m.Data));
+            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricNameModel.Name, m.DataModel));
 
             var sample = new ImmutableMemorySample(expectedMemoryPhysicalValue, expectedMemoryWorkingSetValue);
             Transform(sample);
@@ -88,7 +88,7 @@ namespace NewRelic.Agent.Core.Transformers
         {
             var generatedMetrics = new Dictionary<string, MetricDataWireModel>();
 
-            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricName.Name, m.Data));
+            Mock.Arrange(() => _metricAggregator.Collect(Arg.IsAny<MetricWireModel>())).DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricNameModel.Name, m.DataModel));
 
             var sample = new ImmutableMemorySample(PrivateBytesTestValue, WorkingSetTestValue);
             Transform(sample, isWindows);

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/ThreadStatsSampleTransformerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/ThreadStatsSampleTransformerTests.cs
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.Core.Transformers
 
             Mock.Arrange(() => _metricAggregator
                 .Collect(Arg.IsAny<MetricWireModel>()))
-                .DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricName.Name, m.Data));
+                .DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricNameModel.Name, m.DataModel));
 
             var sample = new ThreadpoolUsageStatsSample(countWorkerThreadsRemaining + countWorkerThreadsInUse, countWorkerThreadsRemaining, countCompletionThreadsRemaining + countCompletionThreadsInUse, countCompletionThreadsRemaining);
 
@@ -70,7 +70,7 @@ namespace NewRelic.Agent.Core.Transformers
 
             Mock.Arrange(() => _metricAggregator
                 .Collect(Arg.IsAny<MetricWireModel>()))
-                .DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricName.Name, m.Data));
+                .DoInstead<MetricWireModel>(m => generatedMetrics.Add(m.MetricNameModel.Name, m.DataModel));
 
             var sample = new ThreadpoolThroughputEventsSample(countThreadRequestsQueued, countThreadRequestsDequeued, countThreadRequestQueueLength);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricBuilderTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricBuilderTests.cs
@@ -29,8 +29,8 @@ namespace NewRelic.Agent.Core.WireModels
             const int RawBytes = 1024;
             var actualMetric = _metricBuilder.TryBuildMemoryPhysicalMetric(RawBytes);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.MemoryPhysical, actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawBytes), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.MemoryPhysical, actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawBytes), actualMetric.DataModel)
             );
         }
 
@@ -40,8 +40,8 @@ namespace NewRelic.Agent.Core.WireModels
             const int RawBytes = 1536;
             var actualMetric = _metricBuilder.TryBuildMemoryWorkingSetMetric(RawBytes);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.MemoryWorkingSet, actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawBytes), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.MemoryWorkingSet, actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawBytes), actualMetric.DataModel)
             );
         }
 
@@ -53,8 +53,8 @@ namespace NewRelic.Agent.Core.WireModels
             var threadStatus = Samplers.ThreadStatus.Available;
             var actualMetric = _metricBuilder.TryBuildThreadpoolUsageStatsMetric(threadType, threadStatus, RawValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetThreadpoolUsageStatsName(threadType, threadStatus), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetThreadpoolUsageStatsName(threadType, threadStatus), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.DataModel)
             );
         }
 
@@ -65,8 +65,8 @@ namespace NewRelic.Agent.Core.WireModels
             var throughputStatsType = Samplers.ThreadpoolThroughputStatsType.Started;
             var actualMetric = _metricBuilder.TryBuildThreadpoolThroughputStatsMetric(throughputStatsType, RawValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetThreadpoolThroughputStatsName(throughputStatsType), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetThreadpoolThroughputStatsName(throughputStatsType), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.DataModel)
             );
         }
 
@@ -77,8 +77,8 @@ namespace NewRelic.Agent.Core.WireModels
             var gcSampleType = Samplers.GCSampleType.Gen0Size;
             var actualMetric = _metricBuilder.TryBuildGCBytesMetric(gcSampleType, RawByteValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawByteValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(RawByteValue), actualMetric.DataModel)
             );
         }
 
@@ -89,8 +89,8 @@ namespace NewRelic.Agent.Core.WireModels
             var gcSampleType = Samplers.GCSampleType.Gen0CollectionCount;
             var actualMetric = _metricBuilder.TryBuildGCCountMetric(gcSampleType, RawCountValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(RawCountValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(RawCountValue), actualMetric.DataModel)
             );
         }
 
@@ -101,8 +101,8 @@ namespace NewRelic.Agent.Core.WireModels
             var gcSampleType = Samplers.GCSampleType.PercentTimeInGc;
             var actualMetric = _metricBuilder.TryBuildGCPercentMetric(gcSampleType, RawPercentageValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildPercentageData(RawPercentageValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildPercentageData(RawPercentageValue), actualMetric.DataModel)
             );
         }
 
@@ -113,8 +113,8 @@ namespace NewRelic.Agent.Core.WireModels
             var gcSampleType = Samplers.GCSampleType.HandlesCount;
             var actualMetric = _metricBuilder.TryBuildGCGaugeMetric(gcSampleType, RawValue);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetGCMetricName(gcSampleType), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildGaugeValue(RawValue), actualMetric.DataModel)
             );
         }
 
@@ -124,8 +124,8 @@ namespace NewRelic.Agent.Core.WireModels
             const string MetricName = "WCFClient/BindingType/BasicHttpBinding";
             var actualMetric = _metricBuilder.TryBuildSupportabilityCountMetric(MetricName);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetSupportabilityName(MetricName), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(1), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetSupportabilityName(MetricName), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(1), actualMetric.DataModel)
             );
         }
 
@@ -135,8 +135,8 @@ namespace NewRelic.Agent.Core.WireModels
             const string MetricName = "WCFClient/BindingType/BasicHttpBinding";
             var actualMetric = _metricBuilder.TryBuildSupportabilityCountMetric(MetricName, 2);
             NrAssert.Multiple(
-                () => Assert.AreEqual(MetricNames.GetSupportabilityName(MetricName), actualMetric.MetricName.Name),
-                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(2), actualMetric.Data)
+                () => Assert.AreEqual(MetricNames.GetSupportabilityName(MetricName), actualMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(MetricDataWireModel.BuildCountData(2), actualMetric.DataModel)
             );
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/MetricWireModelTests.cs
@@ -100,7 +100,7 @@ namespace NewRelic.Agent.Core.WireModels
             var metric1 = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "scope",
                 MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             Assert.That(metric1, Is.Not.Null);
-            var data = metric1.Data;
+            var data = metric1.DataModel;
             Assert.NotNull(data);
             Assert.AreEqual(1, data.Value0);
             Assert.AreEqual(3, data.Value1);
@@ -117,16 +117,16 @@ namespace NewRelic.Agent.Core.WireModels
             MetricDataWireModel scopedData = null;
             foreach (var current in actual)
             {
-                if (current.MetricName.Scope == null)
+                if (current.MetricNameModel.Scope == null)
                 {
                     unscopedCount++;
                 }
                 else
                 {
                     scopedCount++;
-                    theScope = current.MetricName.Scope;
-                    metricName = current.MetricName.Name;
-                    scopedData = current.Data;
+                    theScope = current.MetricNameModel.Scope;
+                    metricName = current.MetricNameModel.Name;
+                    scopedData = current.DataModel;
                 }
             }
 
@@ -148,7 +148,7 @@ namespace NewRelic.Agent.Core.WireModels
                 MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2)));
             Assert.That(metric1, Is.Not.Null);
 
-            var data = metric1.Data;
+            var data = metric1.DataModel;
             Assert.NotNull(data);
             Assert.AreEqual(1, data.Value0);
             Assert.AreEqual(3, data.Value1);
@@ -161,9 +161,9 @@ namespace NewRelic.Agent.Core.WireModels
 
             foreach (var current in stats)
             {
-                Assert.AreEqual("DotNet/name", current.MetricName.Name);
-                Assert.AreEqual(null, current.MetricName.Scope);
-                var myData = current.Data;
+                Assert.AreEqual("DotNet/name", current.MetricNameModel.Name);
+                Assert.AreEqual(null, current.MetricNameModel.Scope);
+                var myData = current.DataModel;
                 Assert.AreEqual(1, myData.Value0);
                 Assert.AreEqual(3, myData.Value1);
                 Assert.AreEqual(2, myData.Value2);
@@ -182,13 +182,13 @@ namespace NewRelic.Agent.Core.WireModels
             var mergedMetric = MetricWireModel.Merge(new[] { metric1 });
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricName.Name),
-                () => Assert.AreEqual(1, mergedMetric.Data.Value0),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value1),
-                () => Assert.AreEqual(1, mergedMetric.Data.Value2),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value3),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value4),
-                () => Assert.AreEqual(9, mergedMetric.Data.Value5)
+                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(1, mergedMetric.DataModel.Value0),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value1),
+                () => Assert.AreEqual(1, mergedMetric.DataModel.Value2),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value3),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value4),
+                () => Assert.AreEqual(9, mergedMetric.DataModel.Value5)
             );
         }
 
@@ -203,13 +203,13 @@ namespace NewRelic.Agent.Core.WireModels
             var mergedMetric = MetricWireModel.Merge(metric1, metric2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricName.Name),
-                () => Assert.AreEqual(2, mergedMetric.Data.Value0),
-                () => Assert.AreEqual(10, mergedMetric.Data.Value1),
-                () => Assert.AreEqual(6, mergedMetric.Data.Value2),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value3),
-                () => Assert.AreEqual(7, mergedMetric.Data.Value4),
-                () => Assert.AreEqual(58, mergedMetric.Data.Value5)
+                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(2, mergedMetric.DataModel.Value0),
+                () => Assert.AreEqual(10, mergedMetric.DataModel.Value1),
+                () => Assert.AreEqual(6, mergedMetric.DataModel.Value2),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value3),
+                () => Assert.AreEqual(7, mergedMetric.DataModel.Value4),
+                () => Assert.AreEqual(58, mergedMetric.DataModel.Value5)
             );
         }
 
@@ -226,13 +226,13 @@ namespace NewRelic.Agent.Core.WireModels
             var mergedMetric = MetricWireModel.Merge(new[] { metric1, metric2, metric3 });
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricName.Name),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value0),
-                () => Assert.AreEqual(23, mergedMetric.Data.Value1),
-                () => Assert.AreEqual(17, mergedMetric.Data.Value2),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value3),
-                () => Assert.AreEqual(13, mergedMetric.Data.Value4),
-                () => Assert.AreEqual(227, mergedMetric.Data.Value5)
+                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value0),
+                () => Assert.AreEqual(23, mergedMetric.DataModel.Value1),
+                () => Assert.AreEqual(17, mergedMetric.DataModel.Value2),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value3),
+                () => Assert.AreEqual(13, mergedMetric.DataModel.Value4),
+                () => Assert.AreEqual(227, mergedMetric.DataModel.Value5)
             );
         }
 
@@ -250,13 +250,13 @@ namespace NewRelic.Agent.Core.WireModels
             mergedMetric = MetricWireModel.Merge(new[] { mergedMetric, metric3 });
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricName.Name),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value0),
-                () => Assert.AreEqual(23, mergedMetric.Data.Value1),
-                () => Assert.AreEqual(17, mergedMetric.Data.Value2),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value3),
-                () => Assert.AreEqual(13, mergedMetric.Data.Value4),
-                () => Assert.AreEqual(227, mergedMetric.Data.Value5)
+                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value0),
+                () => Assert.AreEqual(23, mergedMetric.DataModel.Value1),
+                () => Assert.AreEqual(17, mergedMetric.DataModel.Value2),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value3),
+                () => Assert.AreEqual(13, mergedMetric.DataModel.Value4),
+                () => Assert.AreEqual(227, mergedMetric.DataModel.Value5)
             );
         }
 
@@ -269,13 +269,13 @@ namespace NewRelic.Agent.Core.WireModels
             var mergedMetric = MetricWireModel.Merge(new[] { null, metric1, null });
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricName.Name),
-                () => Assert.AreEqual(1, mergedMetric.Data.Value0),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value1),
-                () => Assert.AreEqual(1, mergedMetric.Data.Value2),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value3),
-                () => Assert.AreEqual(3, mergedMetric.Data.Value4),
-                () => Assert.AreEqual(9, mergedMetric.Data.Value5)
+                () => Assert.AreEqual("DotNet/name", mergedMetric.MetricNameModel.Name),
+                () => Assert.AreEqual(1, mergedMetric.DataModel.Value0),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value1),
+                () => Assert.AreEqual(1, mergedMetric.DataModel.Value2),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value3),
+                () => Assert.AreEqual(3, mergedMetric.DataModel.Value4),
+                () => Assert.AreEqual(9, mergedMetric.DataModel.Value5)
             );
         }
 
@@ -354,7 +354,7 @@ namespace NewRelic.Agent.Core.WireModels
         public void BuildMetricWireModelUsesOriginalName()
         {
             var actual = MetricWireModel.BuildMetric(_metricNameService, "originalName", null, null);
-            Assert.AreEqual("originalName", actual.MetricName.Name);
+            Assert.AreEqual("originalName", actual.MetricNameModel.Name);
         }
 
         [Test]
@@ -442,9 +442,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildCpuTimeRollupMetric(isWebTransaction, TimeSpan.FromSeconds(2));
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(expectedMetricName, actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value1)
+                () => Assert.AreEqual(expectedMetricName, actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value1)
             );
         }
 
@@ -456,9 +456,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildCpuTimeMetric(transactionMetricName, TimeSpan.FromSeconds(2));
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(expectedMetricName, actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value1)
+                () => Assert.AreEqual(expectedMetricName, actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value1)
             );
         }
 
@@ -468,9 +468,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildSupportabilityGaugeMetric("metricName", 2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/metricName", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value1)
+                () => Assert.AreEqual("Supportability/metricName", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value1)
             );
         }
 
@@ -480,9 +480,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildDotnetCoreVersionMetric(DotnetCoreVersion.Other);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Dotnet/NetCore/Other", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Dotnet/NetCore/Other", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -492,9 +492,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildAgentVersionByHostMetric("hostName", "10.0.0.0");
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/AgentVersion/hostName/10.0.0.0", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/AgentVersion/hostName/10.0.0.0", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -504,9 +504,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildMetricHarvestAttemptMetric();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/MetricHarvest/transmit", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/MetricHarvest/transmit", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -516,9 +516,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildTransactionEventReservoirResizedMetric();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/AnalyticsEvents/TryResizeReservoir", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/AnalyticsEvents/TryResizeReservoir", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -528,9 +528,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildTransactionEventsRecollectedMetric(2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/AnalyticsEvents/TotalEventsRecollected", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/AnalyticsEvents/TotalEventsRecollected", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -540,9 +540,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildCustomEventReservoirResizedMetric();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Events/Customer/TryResizeReservoir", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Events/Customer/TryResizeReservoir", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -552,9 +552,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildCustomEventsRecollectedMetric(2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Events/Customer/TotalEventsRecollected", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Events/Customer/TotalEventsRecollected", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -564,9 +564,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildErrorTracesRecollectedMetric(2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Errors/TotalErrorsRecollected", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Errors/TotalErrorsRecollected", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -576,9 +576,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildSqlTracesRecollectedMetric(2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/SqlTraces/TotalSqlTracesRecollected", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/SqlTraces/TotalSqlTracesRecollected", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -588,9 +588,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildFeatureEnabledMetric("featureName");
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/FeatureEnabled/featureName", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/FeatureEnabled/featureName", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -601,9 +601,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildLinuxOsMetric(isLinux);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/OS/Linux", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(expectedCount, actual.Data.Value1)
+                () => Assert.AreEqual("Supportability/OS/Linux", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(expectedCount, actual.DataModel.Value1)
             );
         }
 
@@ -613,9 +613,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildBootIdError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/boot_id/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/boot_id/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -625,9 +625,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildKubernetesUsabilityError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/kubernetes/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/kubernetes/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -637,9 +637,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildAwsUsabilityError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/aws/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/aws/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -649,9 +649,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildAzureUsabilityError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/azure/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/azure/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -661,9 +661,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildPcfUsabilityError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/pcf/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/pcf/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -673,9 +673,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildGcpUsabilityError();
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/utilization/gcp/error", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/utilization/gcp/error", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -685,9 +685,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildSupportabilityEndpointMethodErrorAttempts("endpoint");
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Agent/Collector/endpoint/Attempts", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(1, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Agent/Collector/endpoint/Attempts", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(1, actual.DataModel.Value0)
             );
         }
 
@@ -697,9 +697,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimit("endpoint", 2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/DotNet/Collector/MaxPayloadSizeLimit/endpoint", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/DotNet/Collector/MaxPayloadSizeLimit/endpoint", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -709,9 +709,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(2);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual("Supportability/Logging/Forwarding/Dropped", actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(2, actual.Data.Value0)
+                () => Assert.AreEqual("Supportability/Logging/Forwarding/Dropped", actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(2, actual.DataModel.Value0)
             );
         }
 
@@ -724,9 +724,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildCountMetric(metricName, count);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(metricName, actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(count, actual.Data.Value0)
+                () => Assert.AreEqual(metricName, actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(count, actual.DataModel.Value0)
             );
         }
 
@@ -739,9 +739,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildByteMetric(metricName, byteCount);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(metricName, actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(byteCount), actual.Data)
+                () => Assert.AreEqual(metricName, actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(byteCount), actual.DataModel)
             );
         }
 
@@ -755,9 +755,9 @@ namespace NewRelic.Agent.Core.WireModels
             var actual = _metricBuilder.TryBuildByteMetric(metricName, totalBytes, exclusiveBytes);
 
             NrAssert.Multiple(
-                () => Assert.AreEqual(metricName, actual.MetricName.Name),
-                () => Assert.IsNull(actual.MetricName.Scope),
-                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes, exclusiveBytes), actual.Data)
+                () => Assert.AreEqual(metricName, actual.MetricNameModel.Name),
+                () => Assert.IsNull(actual.MetricNameModel.Scope),
+                () => Assert.AreEqual(MetricDataWireModel.BuildByteData(totalBytes, exclusiveBytes), actual.DataModel)
             );
         }
 
@@ -805,13 +805,13 @@ namespace NewRelic.Agent.Core.WireModels
             var wireModel = obj as MetricWireModel;
             Assert.That(wireModel, Is.Not.Null);
 
-            Assert.That(wireModel.MetricName.Name, Is.EqualTo(name));
-            Assert.That(wireModel.Data.Value0, Is.EqualTo(1));
-            Assert.That(wireModel.Data.Value1, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value2, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value3, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value4, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value5, Is.EqualTo(0));
+            Assert.That(wireModel.MetricNameModel.Name, Is.EqualTo(name));
+            Assert.That(wireModel.DataModel.Value0, Is.EqualTo(1));
+            Assert.That(wireModel.DataModel.Value1, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value2, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value3, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value4, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value5, Is.EqualTo(0));
         }
 
         [Test]
@@ -828,13 +828,13 @@ namespace NewRelic.Agent.Core.WireModels
             var wireModel = obj as MetricWireModel;
             Assert.That(wireModel, Is.Not.Null);
 
-            Assert.That(wireModel.MetricName.Name, Is.EqualTo(name));
-            Assert.That(wireModel.Data.Value0, Is.EqualTo(2));
-            Assert.That(wireModel.Data.Value1, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value2, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value3, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value4, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value5, Is.EqualTo(0));
+            Assert.That(wireModel.MetricNameModel.Name, Is.EqualTo(name));
+            Assert.That(wireModel.DataModel.Value0, Is.EqualTo(2));
+            Assert.That(wireModel.DataModel.Value1, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value2, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value3, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value4, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value5, Is.EqualTo(0));
         }
 
 
@@ -846,13 +846,13 @@ namespace NewRelic.Agent.Core.WireModels
             var wireModel = _metricBuilder.TryBuildAcceptPayloadIgnoredUntrustedAccount();
             Assert.That(wireModel, Is.Not.Null);
 
-            Assert.That(wireModel.MetricName.Name, Is.EqualTo(name));
-            Assert.That(wireModel.Data.Value0, Is.EqualTo(1));
-            Assert.That(wireModel.Data.Value1, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value2, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value3, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value4, Is.EqualTo(0));
-            Assert.That(wireModel.Data.Value5, Is.EqualTo(0));
+            Assert.That(wireModel.MetricNameModel.Name, Is.EqualTo(name));
+            Assert.That(wireModel.DataModel.Value0, Is.EqualTo(1));
+            Assert.That(wireModel.DataModel.Value1, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value2, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value3, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value4, Is.EqualTo(0));
+            Assert.That(wireModel.DataModel.Value5, Is.EqualTo(0));
         }
 
         #endregion DistributedTracing
@@ -867,10 +867,10 @@ namespace NewRelic.Agent.Core.WireModels
             var wireModel = _metricBuilder.TryBuildSupportabilityDataUsageMetric(name, 1, 2, 3);
             Assert.That(wireModel, Is.Not.Null);
 
-            Assert.That(wireModel.MetricName.Name, Is.EqualTo(name));
-            Assert.That(wireModel.Data.Value0, Is.EqualTo(1));
-            Assert.That(wireModel.Data.Value1, Is.EqualTo(2));
-            Assert.That(wireModel.Data.Value2, Is.EqualTo(3));
+            Assert.That(wireModel.MetricNameModel.Name, Is.EqualTo(name));
+            Assert.That(wireModel.DataModel.Value0, Is.EqualTo(1));
+            Assert.That(wireModel.DataModel.Value1, Is.EqualTo(2));
+            Assert.That(wireModel.DataModel.Value2, Is.EqualTo(3));
         }
 
         #endregion DataUsageMetrics


### PR DESCRIPTION
Resolves a naming conflict in `MetricWireModel` by renaming a couple of public properties and refactoring references to those properties as needed.

Resolves #1900