### PR TITLE
ci: Update linux deploy to run debian:stable

### DIFF
--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:buster-20230703-slim@sha256:cddb688e1263b9752275b064171ef6ac9c70ae21a77c774339aecfb53690b9a1
+FROM debian:stable@sha256:6a798ffaa39776765d80c63afffc5920d09f8003b1b7d6a24026527d826c8de7
 
 RUN apt-get update && apt-get install -y \
     apt-utils \
     dpkg-dev \
-    createrepo \
+    createrepo-c \
     awscli \
     curl \
     dos2unix \

--- a/deploy/linux/deploy_scripts/deploy-packages.bash
+++ b/deploy/linux/deploy_scripts/deploy-packages.bash
@@ -165,7 +165,7 @@ fi
 export TARGET='production' # this is just a string used in local paths for repository data pulled down from S3 and then pushed back up
 
 # Make sure we have all the external tools we need
-for CMD in apt-ftparchive gpg createrepo curl rsync; do
+for CMD in apt-ftparchive gpg createrepo_c curl rsync; do
   if ! command -v $CMD > /dev/null; then
     die 'command not found:' $CMD
   fi

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -110,7 +110,7 @@ rebuild_yum() {
 
     printf \\n
     if [[ -d "$REPO_DIR" ]]; then
-      createrepo --update --checksum sha "$REPO_DIR"
+      createrepo_c --update --checksum sha "$REPO_DIR"
     fi
   done
 }

--- a/deploy/linux/deploy_scripts/puppet/manifests/site.pp
+++ b/deploy/linux/deploy_scripts/puppet/manifests/site.pp
@@ -12,7 +12,7 @@ package { "apt-utils":
 }
 
 # YUM repo mgmt
-package { "createrepo":
+package { "createrepo-c":
   ensure => installed
 }
 


### PR DESCRIPTION
Updates the linux package deploy `Dockerfile` to use the latest `debian:stable` base image. This change required migrating from using the `createrepo` package to the `createrepo-c` package, the former being dead and unmaintained. 

Tested locally by running the docker-compose file and publishing to the test repo, then installing from the test repo to my local Ubuntu WSL instance. All worked as expected.