### PR TITLE
test: Use a pre-built Amazon Linux image with ASP.NET Core already installed

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/Dockerfile.AmazonBaseImage
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/Dockerfile.AmazonBaseImage
@@ -1,0 +1,15 @@
+FROM amazonlinux:latest AS base
+
+# configure dnf and upgrade all packages
+RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
+RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf
+RUN dnf update --refresh -y
+RUN dnf upgrade-minimal -y
+
+# install the asp.netcore runtime. Based on https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual
+ARG DOTNET_VERSION
+RUN dnf install -y wget tar findutils gzip libicu
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+RUN chmod +x ./dotnet-install.sh
+RUN ./dotnet-install.sh --channel ${DOTNET_VERSION} --runtime aspnetcore
+ENV PATH="${PATH}:/root/.dotnet:/root/.dotnet/tools"

--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/Dockerfile.FedoraBaseImage
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/Dockerfile.FedoraBaseImage
@@ -1,0 +1,15 @@
+FROM fedora:latest AS base
+
+# configure dnf and upgrade all packages
+RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
+RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf
+RUN dnf update --refresh -y
+RUN dnf upgrade-minimal -y
+
+# install the asp.netcore runtime. Based on https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual
+ARG DOTNET_VERSION
+RUN dnf install -y wget tar findutils gzip libicu
+RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+RUN chmod +x ./dotnet-install.sh
+RUN ./dotnet-install.sh --channel ${DOTNET_VERSION} --runtime aspnetcore
+ENV PATH="${PATH}:/root/.dotnet:/root/.dotnet/tools"

--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -1,0 +1,48 @@
+# Building  Custom Base Images for the Container Integration Tests
+Instructions for building a set of custom base images, used by the Container Integration Tests solution. The images have the ASP.NET Core runtime pre-installed, which considerably reduces the time required to execute the container tests. 
+
+*Note that this process only builds Amazon Linux and Fedora base images; the base images for the other Linux distros we test are available with ASP.NET Core runtime already installed.*
+
+### References: 
+https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
+https://docs.docker.com/engine/reference/commandline/buildx_build/
+
+### Prerequisites:
+* [Azure CLI (32 bit)](https://aka.ms/installazurecliwindows)
+
+## Azure login
+1. Open a Powershell command prompt
+2. Run `az login <your_azure_login_email` and follow the authentication instructions
+
+## Azure container registry login via Docker
+From a Powershell command prompt in the same folder as this README file:
+1. Log in to the DotNetReg container repository
+`docker login -u dotnet-agent-token -p {insert password here} dotnetreg.azurecr.io`
+2. Configure buildx in Docker Desktop
+`docker buildx create --use`
+3. Build the base images. The images will be pushed to the DotNetReg container registry with tags per .NET version
+
+```
+docker buildx  build --build-arg DOTNET_VERSION="6.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:6.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="7.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:7.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
+
+docker buildx  build --build-arg DOTNET_VERSION="6.0" -f Dockerfile.FedoraBaseImage --tag fedora-aspnet:6.0 --platform linux/amd64,linux/arm64/v8 -push .
+docker buildx  build --build-arg DOTNET_VERSION="7.0" -f Dockerfile.FedoraBaseImage --tag fedora-aspnet:7.0 --platform linux/amd64,linux/arm64/v8 -push .
+docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseImage --tag fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 -push .
+```
+
+4. Disable buildx in Docker Desktop
+`docker buildx rm`
+
+5. Log out of the DotNetReg container repository
+`docker logout dotnetreg.azurecr.io`
+
+### Azure Container Registry Changes:
+The DotNetReg container registry was originally created on the Basic SKU. The only way to enable anonymous pull from the container registry is to upgrade to the Standard SKU. For reference, this is the process that was followed:
+
+From a Powershell window, after authenticating to Azure:
+```
+  az acr update --name dotnetreg --sku Standard  # sku was Basic
+  az acr update --name dotnetreg --anonymous-pull-enabled
+```

--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -7,12 +7,6 @@ Instructions for building a set of custom base images, used by the Container Int
 https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
 https://docs.docker.com/engine/reference/commandline/buildx_build/
 
-### Prerequisites:
-* [Azure CLI (32 bit)](https://aka.ms/installazurecliwindows)
-
-## Azure login
-1. Open a Powershell command prompt
-2. Run `az login <your_azure_login_email` and follow the authentication instructions
 
 ## Azure container registry login via Docker
 From a Powershell command prompt in the same folder as this README file:
@@ -41,7 +35,13 @@ docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseIm
 ### Azure Container Registry Changes:
 The DotNetReg container registry was originally created on the Basic SKU. The only way to enable anonymous pull from the container registry is to upgrade to the Standard SKU. For reference, this is the process that was followed:
 
-From a Powershell window, after authenticating to Azure:
+#### Prerequisites:
+* [Azure CLI (32 bit)](https://aka.ms/installazurecliwindows)
+
+#### Azure login
+1. Open a Powershell command prompt
+2. Run `az login <your_azure_login_email` and follow the authentication instructions
+3. Run the following:
 ```
   az acr update --name dotnetreg --sku Standard  # sku was Basic
   az acr update --name dotnetreg --anonymous-pull-enabled

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.amazon
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.amazon
@@ -1,6 +1,8 @@
 ARG DOTNET_VERSION
 ARG TARGET_ARCH
-FROM --platform=${TARGET_ARCH} amazonlinux:latest AS base
+# Uses a custom-built Amazon Linux image with ASP.NET Core pre-installed, served from a private
+# container repository under the .NET Team Sandbox Azure subscription
+FROM --platform=${TARGET_ARCH} dotnetreg.azurecr.io/amazonlinux-aspnet:${DOTNET_VERSION} AS base
 WORKDIR /app
 EXPOSE 80
 
@@ -19,16 +21,6 @@ FROM build AS publish
 RUN dotnet publish "SmokeTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false --os linux -a ${TARGET_ARCH}
 
 FROM base AS final
-ARG DOTNET_VERSION
-# install asp.netcore the *really* hard way...
-# other methods don't seem to work or take forever
-RUN echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
-RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf
-RUN dnf install -y wget tar findutils gzip libicu
-RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
-RUN chmod +x ./dotnet-install.sh
-RUN ./dotnet-install.sh --channel ${DOTNET_VERSION} --runtime aspnetcore
-ENV PATH="${PATH}:/root/.dotnet:/root/.dotnet/tools"
 
 # Enable the agent
 ARG NEW_RELIC_HOST


### PR DESCRIPTION
Updates `Dockerfile.amazon` to use a pre-built Amazon Linux image that has ASP.NET Core already installed, served from the DotNetReg private Azure container registry under our .NET Team Sandbox Azure subscription. This will significantly reduce the execution time for the Amazon container integration tests, specifically the arm64 version of that test.

Also includes instructions and a couple of new Dockerfiles to allow rebuilding the custom images.

