### PR TITLE
fix: Revert RabbitMQ HandleBasicDeliver instrumentation change from #1972. Resolves #2047

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/Instrumentation.xml
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <!-- Consume  Push / Event / Subscribe -->
 		<tracerFactory name="HandleBasicDeliverWrapper">
-      <match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Impl.ModelBase">
+      <match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Events.EventingBasicConsumer">
         <exactMethodMatcher methodName="HandleBasicDeliver" />
       </match>
 		</tracerFactory>


### PR DESCRIPTION


Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Reverts a change to the `HandleBasicDeliver` instrumentation point that was made in #1972, but which caused issues as reported in #2047.

We would have to make this change eventually in any case, as the instrumented class appears to have been removed in the most recent (presently unrelease) [Rabbit MQ .NET Client codebase](https://github.com/rabbitmq/rabbitmq-dotnet-client).

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
