### PR TITLE
test: Disable EventListenerSamplers in ApiCalls tests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -55,6 +55,7 @@ namespace NewRelic.Agent.IntegrationTests.Api
                     var configModifier = new NewRelicConfigModifier(Fixture.DestinationNewRelicConfigFilePath);
                     configModifier.SetOrDeleteDistributedTraceEnabled(true);
                     configModifier.SetLogLevel("finest");
+                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
                 }
             );
 


### PR DESCRIPTION
Disabling EventListenerSamplers in another integration test to eliminate .NET 8 test failure/flickers. 

Ref: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/7105662195/job/19344415498#step:9:153