### PR TITLE
fix: improve handling of .NET environments and settings from appsettings.*.json files

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -41,7 +41,8 @@ namespace NewRelic.Agent.Core.Configuration
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(applicationDirectory)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                .AddJsonFile("appsettings.Production.json", optional: true, reloadOnChange: false);
 
             // Determine if there might be an environment-specific appsettings file
             var env = new SystemInterfaces.Environment();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
             _connectData = _connectData ?? _fixture.AgentLog.GetConnectData();
 
             var nrConfig = _connectData?.Environment?.GetPropertyString("Initial NewRelic Config");
-            var appConfig = _connectData?.Environment?.GetPropertyString("Application Config");
+            var appConfig = _connectData?.Environment?.GetPropertyString("Application Config").Split(',')[0];
 
             NrAssert.Multiple(
                 () => Assert.NotNull(nrConfig),


### PR DESCRIPTION
## Description

Fixes #2081 by adding `appsettings.Production.json` to the list of files to search by default for New Relic config settings.  In addition, the agent will now look at `DOTNET_ENVIRONMENT` in addition to `ASPNETCORE_ENVIRONMENT` to determine the specific environment configured for the agent.
