### PR TITLE
chore: Add Install Type to environment variables that BMDS can capture.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -67,7 +67,6 @@ namespace NewRelic.Agent.Core.AgentHealth
             {
                 Log.Debug(logMessage);
             }
-
             List<string> events = new List<string>();
             foreach (var counter in _agentHealthEventCounters)
             {
@@ -341,7 +340,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         #region TraceContext
 
-        /// <summary>Incremented when the agent successfuly proceses inbound tracestate and traceparent headers</summary>
+        /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
         public void ReportSupportabilityTraceContextAcceptSuccess()
         {
             _traceContextAcceptSuccessCounter.Increment();

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -67,7 +67,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             {
                 Log.Debug(logMessage);
             }
-            
+
             List<string> events = new List<string>();
             foreach (var counter in _agentHealthEventCounters)
             {
@@ -226,20 +226,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public void ReportAgentInfo()
         {
-            if (AgentInstallConfiguration.AgentInfo == null)
-            {
-                TrySend(_metricBuilder.TryBuildInstallTypeMetric("Unknown"));
-                return;
-            }
-
-            if (AgentInstallConfiguration.AgentInfo.AzureSiteExtension)
-            {
-                TrySend(_metricBuilder.TryBuildInstallTypeMetric((AgentInstallConfiguration.AgentInfo.InstallType ?? "Unknown") + "SiteExtension"));
-            }
-            else
-            {
-                TrySend(_metricBuilder.TryBuildInstallTypeMetric(AgentInstallConfiguration.AgentInfo.InstallType ?? "Unknown"));
-            }
+            TrySend(_metricBuilder.TryBuildInstallTypeMetric(AgentInstallConfiguration.AgentInfo?.ToString() ?? "Unknown"));
         }
 
         public void ReportTransactionGarbageCollected(TransactionMetricName transactionMetricName, string lastStartedSegmentName, string lastFinishedSegmentName)
@@ -354,7 +341,7 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         #region TraceContext
 
-        /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
+        /// <summary>Incremented when the agent successfuly proceses inbound tracestate and traceparent headers</summary>
         public void ReportSupportabilityTraceContextAcceptSuccess()
         {
             _traceContextAcceptSuccessCounter.Increment();
@@ -661,7 +648,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             _agentHealthEventCounters[AgentHealthEvent.Log]?.Add(count);
         }
 
-        public void ReportLoggingEventsDropped(int droppedCount)=> TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(droppedCount));
+        public void ReportLoggingEventsDropped(int droppedCount) => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(droppedCount));
 
         public void ReportIfAppDomainCachingDisabled()
         {
@@ -678,7 +665,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogDecoratingConfiguredName(_configuration.LogDecoratorEnabled));
         }
 
-#endregion
+        #endregion
 
         public void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint)
         {

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentInfo.cs
@@ -12,5 +12,10 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         [JsonProperty(PropertyName = "azure_site_extension", NullValueHandling = NullValueHandling.Ignore)]
         public bool AzureSiteExtension { get; set; }
+
+        public override string ToString()
+        {
+            return $"{InstallType ?? "Unknown"}{(AzureSiteExtension ? "SiteExtension" : "")}";
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -198,7 +198,7 @@ namespace NewRelic.Agent.Core
             return System.Environment.GetEnvironmentVariable(NewRelicLogLevelEnvironmentVariable);
         }
 
-        private static AgentInfo GetAgentInfo()
+        public static AgentInfo GetAgentInfo()
         {
             var agentInfoPath = $@"{NewRelicHome}\agentinfo.json";
             if (File.Exists(agentInfoPath))

--- a/src/Agent/NewRelic/Agent/Core/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Environment.cs
@@ -125,7 +125,10 @@ namespace NewRelic.Agent.Core
                     AddVariable("Physical Processors", () => managementObject["NumberOfProcessors"]);
                     AddVariable("Logical Processors", () => managementObject["NumberOfLogicalProcessors"]);
                 }
+
 #endif
+
+                AddVariable("Install Type", () => AgentInstallConfiguration.GetAgentInfo()?.ToString() ?? "Unknown");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Adds an `Install Type` environment variable that reports agent install type (from `agentinfo.json`). This info is currently only available as a supportability metric, queryable via Angler. 

A corresponding BMDS PR will also be created to capture that variable and make it available in the DotnetMetadataSummary.