### PR TITLE
ci: Fix bug in post deploy workflow

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -37,7 +37,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300


### PR DESCRIPTION
Fixes a bug in the post deploy workflow that was preventing the apt / yum repo validation steps from delaying for 5 minutes when called from another workflow.