### PR TITLE
*DRAFT** ci: Revert linux deploy changes

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -776,7 +776,6 @@ jobs:
           name: deploy-artifacts
           path: |
             ${{ github.workspace }}\build\BuildArtifacts
-            ${{ github.workspace }}\deploy
           if-no-files-found: error
 
   # This job is necessary in order for us to have a branch protection rule for tests with a matrix

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -76,13 +76,6 @@ jobs:
           path: ${{ github.workspace }}/build/BuildArtifacts
           if-no-files-found: error
 
-      # - name: Upload Deploy Tooling Locally
-      #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-      #   with:
-      #     name: deploy-tooling
-      #     path: ${{ github.workspace }}/deploy/
-      #     if-no-files-found: error
-
   deploy-downloadsite:
     needs: get-external-artifacts
     if: ${{ github.event.inputs.downloadsite == 'true' }}
@@ -273,12 +266,6 @@ jobs:
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}/
-
-      # - name: Download Deploy Tooling
-      #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      #   with:
-      #     name: deploy-tooling
-      #     path: ${{ github.workspace }}/deploy
 
       - name: Get GPG Key
         id: write_gpgkey

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -76,12 +76,12 @@ jobs:
           path: ${{ github.workspace }}/build/BuildArtifacts
           if-no-files-found: error
 
-      - name: Upload Deploy Tooling Locally
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: deploy-tooling
-          path: ${{ github.workspace }}/deploy/
-          if-no-files-found: error
+      # - name: Upload Deploy Tooling Locally
+      #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      #   with:
+      #     name: deploy-tooling
+      #     path: ${{ github.workspace }}/deploy/
+      #     if-no-files-found: error
 
   deploy-downloadsite:
     needs: get-external-artifacts
@@ -262,18 +262,23 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y dos2unix
         shell: bash
-        
+
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
       - name: Download Deploy Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}/
 
-      - name: Download Deploy Tooling
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: deploy-tooling
-          path: ${{ github.workspace }}/deploy
+      # - name: Download Deploy Tooling
+      #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      #   with:
+      #     name: deploy-tooling
+      #     path: ${{ github.workspace }}/deploy
 
       - name: Get GPG Key
         id: write_gpgkey

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -7,17 +7,17 @@ on:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-      external_call:
-        type: boolean
-        default: true
-        required: false
   workflow_call:
     inputs:
       agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-
+      external_call:
+        type: boolean
+        default: true
+        required: false
+  
 permissions:
   contents: read
   packages: read
@@ -37,7 +37,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call == 'true'}} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -30,36 +30,7 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-
-  get-external-artifacts:
-    name: Get and Publish Deploy Artifacts Locally
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
-        with:
-          disable-sudo: true
-          egress-policy: audit
-
-      - name: Download Deploy Artifacts
-        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
-          name: deploy-artifacts
-          path: ${{ github.workspace }}
-          repo: ${{ github.repository }}
-      
-      - name: Upload Deploy Artifacts Locally
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: deploy-artifacts
-          path: ${{ github.workspace }}/build/BuildArtifacts
-          if-no-files-found: error
-
   publish-release-notes:
-    needs: get-external-artifacts
     name: Create and Publish Release Notes
     runs-on: ubuntu-latest
     steps:
@@ -74,10 +45,14 @@ jobs:
           fetch-depth: 0
       
       - name: Download Deploy Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: all_solutions.yml
+          run_id: ${{ github.event.inputs.run_id }}
           name: deploy-artifacts
           path: ${{ github.workspace }}/artifacts
+          repo: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
         run: |

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -51,7 +51,7 @@ jobs:
           workflow: all_solutions.yml
           run_id: ${{ github.event.inputs.run_id }}
           name: deploy-artifacts
-          path: ${{ github.workspace }}/artifacts
+          path: ${{ github.workspace }}/deploy-artifacts
           repo: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
@@ -72,7 +72,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
           RUN_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/bin/Release/net7.0/
           CHANGELOG: ${{ github.workspace }}/src/Agent/CHANGELOG.md
-          CHECKSUMS: ${{ github.workspace }}/artifacts/DownloadSite/SHA256/checksums.md
+          CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/build/BuildArtifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}
 
       - name: Create branch

--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:stable-20231120@sha256:6a798ffaa39776765d80c63afffc5920d09f8003b1b7d6a24026527d826c8de7
+FROM debian:buster-20230703-slim@sha256:cddb688e1263b9752275b064171ef6ac9c70ae21a77c774339aecfb53690b9a1
 
 RUN apt-get update && apt-get install -y \
     apt-utils \
     dpkg-dev \
-    createrepo-c \
+    createrepo \
     awscli \
     curl \
     dos2unix \

--- a/deploy/linux/deploy_scripts/deploy-packages.bash
+++ b/deploy/linux/deploy_scripts/deploy-packages.bash
@@ -165,7 +165,7 @@ fi
 export TARGET='production' # this is just a string used in local paths for repository data pulled down from S3 and then pushed back up
 
 # Make sure we have all the external tools we need
-for CMD in apt-ftparchive gpg createrepo_c curl rsync; do
+for CMD in apt-ftparchive gpg createrepo curl rsync; do
   if ! command -v $CMD > /dev/null; then
     die 'command not found:' $CMD
   fi

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -110,7 +110,7 @@ rebuild_yum() {
 
     printf \\n
     if [[ -d "$REPO_DIR" ]]; then
-      createrepo_c --update --checksum sha "$REPO_DIR"
+      createrepo --update --checksum sha "$REPO_DIR"
     fi
   done
 }

--- a/deploy/linux/deploy_scripts/puppet/manifests/site.pp
+++ b/deploy/linux/deploy_scripts/puppet/manifests/site.pp
@@ -12,7 +12,7 @@ package { "apt-utils":
 }
 
 # YUM repo mgmt
-package { "createrepo-c":
+package { "createrepo":
   ensure => installed
 }
 


### PR DESCRIPTION
* Reverts the changes made in #2113, as we discovered that there is some sort of conflict with the aws cli when running on `debian:stable` in a container on a Github runner. 
* Modifies the `deploy_agent` workflow so that it checks out the repo and uses the files in the `deploy` folder rather than downloading those files from the build artifact uploaded from the `all_solutions` workflow. This was necessary to allow for testing changes to the linux deploy Dockerfile and scripts. 
* Removes the `deploy` folder from `deploy-artifacts`  in the `all_solutions` workflow.
* Attempts (yet again) to fix a bug in the `post_deploy_agent` workflow where we want the workflow to delay 5 minutes when called from another workflow but not when invoked manually.
* Removes the (unnecessary) `get-external-artifacts` job from the `publish_release_notes` workflow and refactors the primary job to download the artifacts instead.