### PR TITLE
ci: Deploy workflow fixes and other goodies

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -776,7 +776,6 @@ jobs:
           name: deploy-artifacts
           path: |
             ${{ github.workspace }}\build\BuildArtifacts
-            ${{ github.workspace }}\deploy
           if-no-files-found: error
 
   # This job is necessary in order for us to have a branch protection rule for tests with a matrix

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -76,13 +76,6 @@ jobs:
           path: ${{ github.workspace }}/build/BuildArtifacts
           if-no-files-found: error
 
-      # - name: Upload Deploy Tooling Locally
-      #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-      #   with:
-      #     name: deploy-tooling
-      #     path: ${{ github.workspace }}/deploy/
-      #     if-no-files-found: error
-
   deploy-downloadsite:
     needs: get-external-artifacts
     if: ${{ github.event.inputs.downloadsite == 'true' }}
@@ -273,12 +266,6 @@ jobs:
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}/
-
-      # - name: Download Deploy Tooling
-      #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      #   with:
-      #     name: deploy-tooling
-      #     path: ${{ github.workspace }}/deploy
 
       - name: Get GPG Key
         id: write_gpgkey

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -262,17 +262,17 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y dos2unix
         shell: bash
-      
-      - name: Download Deploy Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: deploy-artifacts
-          path: ${{ github.workspace }}/
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+
+      - name: Download Deploy Artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: deploy-artifacts
+          path: ${{ github.workspace }}/
 
       # - name: Download Deploy Tooling
       #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -262,18 +262,23 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y dos2unix
         shell: bash
-        
+      
       - name: Download Deploy Artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}/
 
-      - name: Download Deploy Tooling
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          name: deploy-tooling
-          path: ${{ github.workspace }}/deploy
+          fetch-depth: 0
+
+      # - name: Download Deploy Tooling
+      #   uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      #   with:
+      #     name: deploy-tooling
+      #     path: ${{ github.workspace }}/deploy
 
       - name: Get GPG Key
         id: write_gpgkey

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -76,12 +76,12 @@ jobs:
           path: ${{ github.workspace }}/build/BuildArtifacts
           if-no-files-found: error
 
-      - name: Upload Deploy Tooling Locally
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: deploy-tooling
-          path: ${{ github.workspace }}/deploy/
-          if-no-files-found: error
+      # - name: Upload Deploy Tooling Locally
+      #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      #   with:
+      #     name: deploy-tooling
+      #     path: ${{ github.workspace }}/deploy/
+      #     if-no-files-found: error
 
   deploy-downloadsite:
     needs: get-external-artifacts

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -7,17 +7,17 @@ on:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-      external_call:
-        type: boolean
-        default: true
-        required: false
   workflow_call:
     inputs:
       agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-
+      external_call:
+        type: boolean
+        default: true
+        required: false
+  
 permissions:
   contents: read
   packages: read
@@ -37,7 +37,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.event.inputs.external_call }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event.inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -31,35 +31,7 @@ env:
 
 jobs:
 
-  get-external-artifacts:
-    name: Get and Publish Deploy Artifacts Locally
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
-        with:
-          disable-sudo: true
-          egress-policy: audit
-
-      - name: Download Deploy Artifacts
-        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
-          name: deploy-artifacts
-          path: ${{ github.workspace }}
-          repo: ${{ github.repository }}
-      
-      - name: Upload Deploy Artifacts Locally
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: deploy-artifacts
-          path: ${{ github.workspace }}/build/BuildArtifacts
-          if-no-files-found: error
-
   publish-release-notes:
-    needs: get-external-artifacts
     name: Create and Publish Release Notes
     runs-on: ubuntu-latest
     steps:
@@ -74,10 +46,14 @@ jobs:
           fetch-depth: 0
       
       - name: Download Deploy Artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2.28.0
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: all_solutions.yml
+          run_id: ${{ github.event.inputs.run_id }}
           name: deploy-artifacts
-          path: ${{ github.workspace }}/artifacts
+          path: ${{ github.workspace }}/deploy-artifacts
+          repo: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
         run: |
@@ -97,7 +73,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
           RUN_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/bin/Release/net7.0/
           CHANGELOG: ${{ github.workspace }}/src/Agent/CHANGELOG.md
-          CHECKSUMS: ${{ github.workspace }}/artifacts/DownloadSite/SHA256/checksums.md
+          CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/build/BuildArtifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}
 
       - name: Create branch

--- a/deploy/linux/deploy.bash
+++ b/deploy/linux/deploy.bash
@@ -24,6 +24,8 @@ fi
 AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 AWS_DEFAULT_OUTPUT=${AWS_DEFAULT_OUTPUT:-text}
 
+# a magic incantation that somehow prevents aws cli failures when running in Github. See https://github.com/aws/aws-cli/issues/5623
+AWS_EC2_METADATA_DISABLED=true
 
 ## Actions
 # 'release' => release new packages

--- a/deploy/linux/deploy.bash
+++ b/deploy/linux/deploy.bash
@@ -25,7 +25,7 @@ AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-west-2}
 AWS_DEFAULT_OUTPUT=${AWS_DEFAULT_OUTPUT:-text}
 
 # a magic incantation that somehow prevents aws cli failures when running in Github. See https://github.com/aws/aws-cli/issues/5623
-AWS_EC2_METADATA_DISABLED=true
+export AWS_EC2_METADATA_DISABLED=true
 
 ## Actions
 # 'release' => release new packages


### PR DESCRIPTION
* Modifies `deploy.bash` to export a magic environment variable that keeps the aws cli from failing when running on a github hosted runner. Resolves #2140 
* Modifies the `deploy_agent` workflow so that it checks out the repo and uses the files in the deploy folder rather than downloading those files from the build artifact uploaded from the `all_solutions` workflow. This was necessary to allow for testing changes to the linux deploy Dockerfile and scripts.
* Removes the `deploy` folder from `deploy-artifacts` in the `all_solutions` workflow.
* Attempts (yet again) to fix a bug in the `post_deploy_agent` workflow where we want the workflow to delay 5 minutes when called from another workflow but not when invoked manually.
* Removes the (unnecessary) `get-external-artifacts` job from the `publish_release_notes` workflow and refactors the primary job to download the artifacts instead.