### PR TITLE
fix: Path to agentinfo.json was built incorrectly, leading to file not found errors when running on Linux. (#2156)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -217,11 +217,11 @@ namespace NewRelic.Agent.Core
                 catch (Exception e)
                 {
                     Log.Debug(e, $"Could not deserialize agent info from {agentInfoPath}.");
-                    return null;
                 }
             }
+            else
+                Log.Debug($"Could not get agent info from {agentInfoPath}. File does not exist.");
 
-            Log.Debug($"Could not get agent info from {agentInfoPath}. File does not exist.");
             return null;
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -217,6 +217,7 @@ namespace NewRelic.Agent.Core
                 catch (Exception e)
                 {
                     Log.Debug(e, $"Could not deserialize agent info from {agentInfoPath}.");
+                    return null;
                 }
             }
 

--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -200,6 +200,12 @@ namespace NewRelic.Agent.Core
 
         public static AgentInfo GetAgentInfo()
         {
+            if (string.IsNullOrEmpty(NewRelicHome))
+            {
+                Log.Debug($"Could not get agent info. NewRelicHome is null or empty.");
+                return null;
+            }
+
             var agentInfoPath = Path.Combine(NewRelicHome, "agentinfo.json");
 
             if (File.Exists(agentInfoPath))

--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -200,19 +200,21 @@ namespace NewRelic.Agent.Core
 
         public static AgentInfo GetAgentInfo()
         {
-            var agentInfoPath = $@"{NewRelicHome}\agentinfo.json";
+            var agentInfoPath = Path.Combine(NewRelicHome, "agentinfo.json");
+
             if (File.Exists(agentInfoPath))
             {
                 try
                 {
                     return JsonConvert.DeserializeObject<AgentInfo>(File.ReadAllText(agentInfoPath));
                 }
-                catch
+                catch (Exception e)
                 {
-                    // Fail silently
+                    Log.Debug(e, $"Could not get agent info from {agentInfoPath}.");
                 }
             }
 
+            Log.Debug($"Could not get agent info from {agentInfoPath}. File does not exist.");
             return null;
         }
     }


### PR DESCRIPTION
Update the hard-coded pathing in `GetAgentInfo()` to use `Path.Combine()` instead for Linux compatibility. 

Fixes #2156.

