### PR TITLE
ci: Configure CodeQL Workflow, Unify <langVersion>

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,11 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        config: |
+          paths: 
+            - src/Agent/NewRelic
+            - src/Agent/NewRelic.Api.Agent
+            - src/NewRelic.Core
 
     - name: Build .NET Agent Solution
       if: ${{ matrix.language == 'csharp' }}
@@ -51,6 +56,12 @@ jobs:
         Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
         dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
       shell: powershell
+
+    - name: Install Windows SDK for Profiler build
+      if: ${{ matrix.language == 'c-cpp' }}
+      uses: GuillaumeFalourd/setup-windows10-sdk-action@cce3ecf1101850047239b3dea39a835e10ffa9d1  #v 1.12
+      with:
+        sdk-version: 18362
 
     - name: Add msbuild to PATH for Profiler build
       if: ${{ matrix.language == 'c-cpp' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
         Write-Host "List NuGet Sources"
         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
         Write-Host "MSBuild.exe -restore -m -p:Platform=x64 ${{ env.profiler_solution_path }}"
-        MSBuild.exe -restore -m -p:Platform=x64 - ${{ env.profiler_solution_path }}
+        MSBuild.exe -restore -m -p:Platform=x64 ${{ env.profiler_solution_path }}
       shell: powershell
    
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,7 +76,6 @@ jobs:
         MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
       shell: powershell
    
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,19 +3,14 @@ name: "CodeQL"
 on:
   push:
     # comment out for testing branches: [ "main",  ]
-  pull_request:
-    branches: [ "main", "feature/*"]
+  #pull_request:
+  #  branches: [ "main", "feature/*"]
   schedule:
-    - cron: '20 3 * * 6'
+    - cron: '20 3 * * 1'
 
 jobs:
   analyze:
     name: Analyze
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners
-    # Consider using larger runners for possible analysis time improvements.
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:
@@ -26,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c-cpp', 'csharp' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: [ 'csharp' ]
+        #language: [ 'c-cpp', 'csharp' ] # until we can figure out how to build the Profiler on Windows 2022 (and VS2022)
 
     env:
         profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
@@ -39,16 +34,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        config: |
-          paths: 
-            - src/Agent/NewRelic
-            - src/Agent/NewRelic.Api.Agent
-            - src/NewRelic.Core
 
     - name: Build .NET Agent Solution
       if: ${{ matrix.language == 'csharp' }}
@@ -56,12 +45,6 @@ jobs:
         Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
         dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
       shell: powershell
-
-    - name: Install Windows SDK for Profiler build
-      if: ${{ matrix.language == 'c-cpp' }}
-      uses: GuillaumeFalourd/setup-windows10-sdk-action@cce3ecf1101850047239b3dea39a835e10ffa9d1  #v 1.12
-      with:
-        sdk-version: 18362
 
     - name: Add msbuild to PATH for Profiler build
       if: ${{ matrix.language == 'c-cpp' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '20 3 * * 1'
 
+# only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   analyze-dotnet:
     name: Analyze .NET

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        debug: true
 
     - name: Build .NET Agent Solution
       if: ${{ matrix.language == 'csharp' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,7 @@ jobs:
     - name: Build .NET Agent Solution
       if: ${{ matrix.language == 'csharp' }}
       run: |
-        Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
-        dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
+        dotnet build ${{ env.fullagent_solution_path }}
       shell: powershell
 
     - name: Add msbuild to PATH for Profiler build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   analyze-dotnet:
     name: Analyze .NET
@@ -41,7 +41,6 @@ jobs:
         languages: csharp
 
     - name: Build .NET Agent Solution
-      if: ${{ matrix.language == 'csharp' }}
       run: |
         dotnet build ${{ env.fullagent_solution_path }}
       shell: powershell

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,15 +2,15 @@ name: "CodeQL"
 
 on:
   push:
-    # comment out for testing branches: [ "main",  ]
-  #pull_request:
-  #  branches: [ "main", "feature/*"]
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main", "feature/*"]
   schedule:
     - cron: '20 3 * * 1'
 
 jobs:
-  analyze:
-    name: Analyze
+  analyze-dotnet:
+    name: Analyze .NET
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:
@@ -20,12 +20,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'csharp' ]
-        #language: [ 'c-cpp', 'csharp' ] # until we can figure out how to build the Profiler on Windows 2022 (and VS2022)
 
     env:
-        profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
         fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln
 
     steps:
@@ -37,29 +33,54 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: ${{ matrix.language }}
-        debug: true
+        languages: csharp
 
     - name: Build .NET Agent Solution
       if: ${{ matrix.language == 'csharp' }}
       run: |
         dotnet build ${{ env.fullagent_solution_path }}
       shell: powershell
+   
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:csharp"
+
+  analyze-cpp:
+    name: Analyze C++
+    runs-on: windows-2019
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    env:
+        profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: c-cpp
 
     - name: Add msbuild to PATH for Profiler build
-      if: ${{ matrix.language == 'c-cpp' }}
       uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
 
-    - name: Build .NET Profiler
-      if: ${{ matrix.language == 'c-cpp' }}
+    - name: Build Profiler
       run: |
         Write-Host "List NuGet Sources"
         dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
-        Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
-        MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
+        Write-Host "MSBuild.exe -restore -m -p:Platform=x64 ${{ env.profiler_solution_path }}"
+        MSBuild.exe -restore -m -p:Platform=x64 - ${{ env.profiler_solution_path }}
       shell: powershell
    
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:c-cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: "CodeQL"
+
+on:
+  push:
+    # comment out for testing branches: [ "main",  ]
+  pull_request:
+    branches: [ "main", "feature/*"]
+  schedule:
+    - cron: '20 3 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners
+    # Consider using larger runners for possible analysis time improvements.
+    runs-on: windows-latest
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'c-cpp', 'csharp' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    env:
+        profiler_solution_path: ${{ github.workspace }}\src\Agent\NewRelic\Profiler\NewRelic.Profiler.sln
+        fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Build .NET Agent Solution
+      if: ${{ matrix.language == 'csharp' }}
+      run: |
+        Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
+        dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}
+      shell: powershell
+
+    - name: Add msbuild to PATH for Profiler build
+      if: ${{ matrix.language == 'c-cpp' }}
+      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
+
+    - name: Build .NET Profiler
+      if: ${{ matrix.language == 'c-cpp' }}
+      run: |
+        Write-Host "List NuGet Sources"
+        dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
+        Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
+        MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
+      shell: powershell
+   
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>default</LangVersion>
     <RootProjectDirectory>$(MSBuildThisFileDirectory)</RootProjectDirectory>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>
       VSTHRD200, <!-- Use `Async` suffix for async methods -->
       VSTHRD105, <!-- Avoid method overloads that assume `TaskScheduler.Current` -->

--- a/build/ArtifactBuilder/ArtifactBuilder.csproj
+++ b/build/ArtifactBuilder/ArtifactBuilder.csproj
@@ -5,14 +5,6 @@
     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/build/NugetValidator/NugetValidator.csproj
+++ b/build/NugetValidator/NugetValidator.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+++ b/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
+++ b/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/build/S3Validator/S3Validator.csproj
+++ b/build/S3Validator/S3Validator.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Agent/NewRelic.Api.Agent/Directory.Build.props
+++ b/src/Agent/NewRelic.Api.Agent/Directory.Build.props
@@ -2,7 +2,5 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'FullAgent.sln'))\build\StyleCop.props" />
     <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/Agent/NewRelic/Agent/Directory.Build.props
+++ b/src/Agent/NewRelic/Agent/Directory.Build.props
@@ -1,8 +1,4 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'FullAgent.sln'))\build\StyleCop.props" />
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
 </Project>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/AspNetCore6Plus.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/AspNetCore6Plus.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>NewRelic.Providers.Wrapper.AspNetCore6Plus</AssemblyName>
     <RootNamespace>NewRelic.Providers.Wrapper.AspNetCore6Plus</RootNamespace>
     <Description>ASP.NET Core 6+ Wrapper Provider for New Relic .NET Agent</Description>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,4 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
   <Import Project="$(MSBuildThisFileDirectory)..\build\Common.src.props" />
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/Applications/AspNetCoreFeatures/AspNetCoreFeatures.csproj
+++ b/tests/Agent/IntegrationTests/Applications/AspNetCoreFeatures/AspNetCoreFeatures.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/BasicAspNetCoreRazorApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicAspNetCoreRazorApplication/BasicAspNetCoreRazorApplication.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -30,7 +30,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,7 +38,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/KafkaTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/KafkaTestApp.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/SmokeTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/SmokeTestApp.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net7.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
@@ -4,7 +4,6 @@
     <RootNamespace>NewRelic.Agent.ContainerIntegrationTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.ContainerIntegrationTests</AssemblyName>
     <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <Import Project="Test.targets" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -5,7 +5,6 @@
     
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
  
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationCore/ConsoleMultiFunctionApplicationCore.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>NewRelic.Agent.UnboundedIntegrationTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.UnboundedIntegrationTests</AssemblyName>
     <TargetFrameworks>net462</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -7,7 +7,6 @@
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net7.0'">
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
+++ b/tests/AwsLambda/UnitTests/AwsLambdaWrapperTests/AwsLambdaWrapperTests.csproj
@@ -8,7 +8,6 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR introduces a new workflow to run CodeQL, superseding the "default" configuration that was recently enabled for all repos in the New Relic org. 

~~For the time being, we will only scan C# projects, as we can (apparently) have only a single CodeQL workflow per repo, and our C++ projects have to build on Windows 2019, while our C# projects have to build on Windows 2022.~~
I was able to get the scan to run on both C# and C++. Yay! 
Results for the analysis on this PR are at: https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning?query=tool%3ACodeQL+pr%3A2159 -- there doesn't seem to be anything for C++, so I guess that code is solid. The other items reported for C# are either used in tests or false positives.

The other (somewhat huge) set of changes in this PR is to eliminate explicit use of `<langVersion>` attributes in .csproj files (which specified wildly different versions), in favor of a single, unified `<langVersion>default</langVersion>` in the base `Directory.Build.props` file. Aside from ensuring that all projects build with the correct language version (based on the tfm), this also helps alleviate some issues with the CodeQL scanning tool, as it was unhappy about using certain hard-coded language versions. 