### PR TITLE
ci: Update to artifacts v4

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -502,7 +502,7 @@ jobs:
           path: src/Agent
 
       - name: Download Unbounded Integration Test Artifacts
-        uses: actions/download-artifact/@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: unboundedintegrationtests
           # Should not need a path because the integration test artifacts are archived with the full directory structure

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -364,19 +364,19 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts-${{ matrix.namespace }}
+          name: integration-test-working-directory-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
           if-no-files-found: error
 
-      # - name: Archive Test Artifacts
-      #   if: ${{ always() }}
-      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-      #   with:
-      #     name: integration-test-artifacts
-      #     path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-      #     if-no-files-found: error
+      - name: Archive Test Artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        with:
+          name: integration-test-results-${{ matrix.namespace }}
+          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+          if-no-files-found: error
 
   run-integration-tests-linux-arm64:
     needs: build-fullagent-msi
@@ -441,17 +441,17 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts-linux-arm64
+          name: integration-test-working-directory-linux-arm64
           path: ${{ env.test_path }}/**/*
           if-no-files-found: error
 
-      # - name: Archive Test Artifacts
-      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-      #   if: ${{ always() }}
-      #   with:
-      #     name: integration-test-artifacts-linux-arm64
-      #     path: ${{ env.test_path }}/*.trx
-      #     if-no-files-found: error
+      - name: Archive Test Results on failure
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        if: ${{ failure() }}
+        with:
+          name: integration-test-results-linux-arm64
+          path: ${{ env.test_path }}/*.trx
+          if-no-files-found: error
 
   run-unbounded-tests:
     needs: [build-unbounded-tests]
@@ -576,19 +576,19 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: unbounded-test-artifacts-${{ matrix.namespace }}
+          name: unbounded-test-working-directory-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
           if-no-files-found: error
 
-      # - name: Archive Test Artifacts
-      #   if: ${{ always() }}
-      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-      #   with:
-      #     name: integration-test-artifacts
-      #     path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-      #     if-no-files-found: error
+      - name: Archive Test Results on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        with:
+          name: unbounded-test-results-${{ matrix.namespace }}
+          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+          if-no-files-found: error
 
   create-package-rpm:
     needs: build-fullagent-msi

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -364,19 +364,19 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: integration-test-artifacts-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
           if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: integration-test-artifacts
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-          if-no-files-found: error
+      # - name: Archive Test Artifacts
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      #   with:
+      #     name: integration-test-artifacts
+      #     path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+      #     if-no-files-found: error
 
   run-integration-tests-linux-arm64:
     needs: build-fullagent-msi
@@ -445,13 +445,13 @@ jobs:
           path: ${{ env.test_path }}/**/*
           if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        if: ${{ always() }}
-        with:
-          name: integration-test-artifacts-linux-arm64
-          path: ${{ env.test_path }}/*.trx
-          if-no-files-found: error
+      # - name: Archive Test Artifacts
+      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      #   if: ${{ always() }}
+      #   with:
+      #     name: integration-test-artifacts-linux-arm64
+      #     path: ${{ env.test_path }}/*.trx
+      #     if-no-files-found: error
 
   run-unbounded-tests:
     needs: [build-unbounded-tests]
@@ -576,19 +576,19 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: unbounded-test-artifacts-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
           if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: integration-test-artifacts
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
-          if-no-files-found: error
+      # - name: Archive Test Artifacts
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      #   with:
+      #     name: integration-test-artifacts
+      #     path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+      #     if-no-files-found: error
 
   create-package-rpm:
     needs: build-fullagent-msi

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -360,22 +360,15 @@ jobs:
           }
         shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: integration-test-working-directory-${{ matrix.namespace }}
-          path: |
-            C:\IntegrationTestWorkingDirectory\**\*.log
-            C:\IntegrationTestWorkingDirectory\**\*.config
-          if-no-files-found: error
-
-      - name: Archive Test Artifacts
+      - name: Archive integration test results on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: integration-test-results-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+          path: |
+            C:\IntegrationTestWorkingDirectory\**\*.log
+            C:\IntegrationTestWorkingDirectory\**\*.config
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
   run-integration-tests-linux-arm64:
@@ -437,20 +430,14 @@ jobs:
             echo $test_secrets | dotnet user-secrets set --project "../Shared"
             dotnet test -f netcoreapp3.1 -c Release -l "trx" --filter "FullyQualifiedName~ApiCallsTestsCore|FullyQualifiedName~InfiniteTracingNetCoreLatestTests"
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
+      - name: Archive integration test results on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: integration-test-working-directory-linux-arm64
-          path: ${{ env.test_path }}/**/*
-          if-no-files-found: error
-
-      - name: Archive Test Results on failure
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        if: ${{ failure() }}
         with:
           name: integration-test-results-linux-arm64
-          path: ${{ env.test_path }}/*.trx
+          path: |
+            ${{ env.test_path }}/**/*
+            ${{ env.test_path }}/*.trx
           if-no-files-found: error
 
   run-unbounded-tests:
@@ -572,7 +559,7 @@ jobs:
           }
         shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
+      - name: Archive unbounded test results on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
@@ -580,14 +567,7 @@ jobs:
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
-          if-no-files-found: error
-
-      - name: Archive Test Results on failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: unbounded-test-results-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
   create-package-rpm:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -131,21 +131,23 @@ jobs:
         shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling
 
       - name: Download Agent Home Folders
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
           repo: ${{ github.repository }}
       
       - name: Download Integration Tests
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ github.event.inputs.run_id }}
           name: integrationtests
           path: ${{ github.workspace }}
           repo: ${{ github.repository }}
@@ -194,18 +196,18 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: integration-test-working-directory-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
             C:\IntegrationTestWorkingDirectory\**\appsettings.json
           if-no-files-found: error
 
-      - name: Archive Test Artifacts
-        if: ${{ always() }}
+      - name: Archive Test Artifacts on failure
+        if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: integration-test-results-${{ matrix.namespace }}
           path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
@@ -233,21 +235,23 @@ jobs:
           fetch-depth: 0
 
       - name: Download Agent Home Folders
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+        #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
           repo: ${{ github.repository }}
       
       - name: Download Integration Tests
-        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: all_solutions.yml
-          run_id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ github.event.inputs.run_id }}
           name: unboundedintegrationtests
           path: ${{ github.workspace }}
           repo: ${{ github.repository }}
@@ -326,7 +330,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: unbounded-test-working-directory-${{ matrix.namespace }}
           path: |
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
@@ -334,10 +338,10 @@ jobs:
           if-no-files-found: error
 
       - name: Archive Test Artifacts
-        if: ${{ always() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: integration-test-artifacts
+          name: unbounded-test-results-${{ matrix.namespace }}
           path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -15,11 +15,11 @@ on:
         - UnboundedIntegrationTests
         - Both
       integration-test-namespaces:
-        description: 'A comma-separated, single-quoted list of integration test namespaces to run (e.g. "''AgentFeatures'', ''BasicInstrumentation''").  If not specified, all integration tests will be run.'
+        description: 'A comma-separated, single-quoted list of integration test namespaces to run (e.g. "''AgentFeatures'', ''BasicInstrumentation''").  If set to ALL, all integration tests will be run.'
         required: true
         default: 'ALL'
       unbounded-test-namespaces:
-        description: 'A comma-separated, single-quoted list of unbounded integration test namespaces to run (e.g. "''MsSql'', ''Couchbase''").  If not specified, all unbounded tests will be run.'
+        description: 'A comma-separated, single-quoted list of unbounded integration test namespaces to run (e.g. "''MsSql'', ''Couchbase''").  If set to ALL, all unbounded tests will be run.'
         required: true
         default: 'ALL'
       parallelize:
@@ -134,23 +134,23 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
-          repo: ${{ github.repository }}
+          repository: ${{ github.repository }}
       
       - name: Download Integration Tests
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
       #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: integrationtests
           path: ${{ github.workspace }}
-          repo: ${{ github.repository }}
+          repository: ${{ github.repository }}
 
       - name: Install dependencies
         run: |
@@ -238,23 +238,23 @@ jobs:
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
-          repo: ${{ github.repository }}
+          repository: ${{ github.repository }}
       
       - name: Download Integration Tests
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
       #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: all_solutions.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: unboundedintegrationtests
           path: ${{ github.workspace }}
-          repo: ${{ github.repository }}
+          repository: ${{ github.repository }}
       
       - name: Disable TLS 1.3
         run: |

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -132,10 +132,8 @@ jobs:
 
       - name: Download Agent Home Folders
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-        #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
@@ -143,10 +141,8 @@ jobs:
       
       - name: Download Integration Tests
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: integrationtests
           path: ${{ github.workspace }}
@@ -192,7 +188,7 @@ jobs:
           }
         shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
+      - name: Archive integration test results on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
@@ -201,14 +197,7 @@ jobs:
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
             C:\IntegrationTestWorkingDirectory\**\appsettings.json
-          if-no-files-found: error
-
-      - name: Archive Test Artifacts on failure
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: integration-test-results-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
   run-unbounded-tests:
@@ -236,10 +225,8 @@ jobs:
 
       - name: Download Agent Home Folders
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-        #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
@@ -247,10 +234,8 @@ jobs:
       
       - name: Download Integration Tests
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-      #uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          #workflow: all_solutions.yml
           run-id: ${{ github.event.inputs.run_id }}
           name: unboundedintegrationtests
           path: ${{ github.workspace }}
@@ -326,7 +311,7 @@ jobs:
           }
         shell: powershell
 
-      - name: Archive IntegrationTestWorkingDirectory on Failure
+      - name: Archive unbounded test results on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
@@ -335,14 +320,7 @@ jobs:
             C:\IntegrationTestWorkingDirectory\**\*.log
             C:\IntegrationTestWorkingDirectory\**\*.config
             C:\IntegrationTestWorkingDirectory\**\appsettings.json
-          if-no-files-found: error
-
-      - name: Archive Test Artifacts
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: unbounded-test-results-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
+            C:\IntegrationTestWorkingDirectory\TestResults\**\*TestResults.trx
           if-no-files-found: error
 
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -255,7 +255,7 @@ First, a few caveats:
 * Only tests with the `[NetCoreTest]` attribute (which sets an XUnit trait named `RuntimeFramework` to `NetCore`) can run on Linux.
 * The agent solution still needs to be built on Windows in Visual Studio, or from the command line using the [build.ps1](../build/build.ps1) script (which uses Visual Studio tooling).
 
-We recommend using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) to install an Ubuntu 20.04+ VM on your Windows 10 development system.
+We recommend using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) to install an Ubuntu 20.04+ VM on your Windows 10+ development system.
 
 ### Linux system setup
 


### PR DESCRIPTION
## Description

Fix the main agent CI workflow after merging breaking artifacts changes (v3->v4) in Dependabot PRs.  The main issue is that you can't upload multiple artifacts to the same artifact name.  This is only really a problem for the matrixed integration test jobs.  The fix is to use a unique artifact name based on the matrix namespace value.  Additionally, the workflow is modified to only archive the test results on failure since it's highly unlikely anybody wants to look at them if everything passes.

An additional breaking change from artifacts v3->v4 is a limit on the number of artifacts that can be uploaded per job (10).  This means that if more than ten namespaces have integration tests failures, we would have failures uploading some of the test working directories and results files.  However, nothing downstream of the integration test jobs need those artifacts, and if more than ten namespaces are failing we probably have bigger problems to deal with.

As a side note, these changes do seem to improve the speed of the workflow by a significant amount.

