### PR TITLE
test: Reduce APM service name proliferation in container tests

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
@@ -66,7 +66,9 @@ public class ContainerApplication : RemoteApplication
         }
     }
 
-    public override string AppName => $"ContainerTestApp_{_dotnetVersion}-{_distroTag}_{_targetArch}_{_randomId}";
+    public string NRAppName =>$"ContainerTestApp_{_dotnetVersion}-{_distroTag}_{_targetArch}";
+
+    public override string AppName => $"{NRAppName}_{_randomId}";
 
     private string ContainerName => AppName.ToLower().Replace(".", "_"); // must be lowercase, can't have any periods in it
 
@@ -123,7 +125,7 @@ public class ContainerApplication : RemoteApplication
         var testConfiguration = IntegrationTestConfiguration.GetIntegrationTestConfiguration("Default");
 
         startInfo.EnvironmentVariables.Add("TEST_DOCKERFILE", _dockerfile);
-        startInfo.EnvironmentVariables.Add("NEW_RELIC_APP_NAME", AppName);
+        startInfo.EnvironmentVariables.Add("NEW_RELIC_APP_NAME", NRAppName);
         startInfo.EnvironmentVariables.Add("DOTNET_VERSION", _dotnetVersion);
         startInfo.EnvironmentVariables.Add("APP_DOTNET_VERSION", _dotnetVersion);
         startInfo.EnvironmentVariables.Add("DISTRO_TAG", _distroTag);


### PR DESCRIPTION
The `NEW_RELIC_APP_NAME` value we're currently using in our container integration tests is causing a ridiculous proliferation of APM services in the staging environment since every run of every container includes a random id at the end of the name. This change removes the random id from the service name and should result in only a handful of distinct APM services in staging.