### PR TITLE
chore: Add `.ConfigureAwait(false)` to all async method invocations.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -322,10 +322,10 @@ namespace NewRelic.Agent.Core
             if (rumBytes == null)
             {
                 transaction.LogFinest("Skipping RUM Injection: No script was available.");
-                await baseStream.WriteAsync(buffer, 0, buffer.Length);
+                await baseStream.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
             }
             else
-                await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, rumBytes, transaction);
+                await BrowserScriptInjectionHelper.InjectBrowserScriptAsync(buffer, baseStream, rumBytes, transaction).ConfigureAwait(false);
         }
 
         private string TryGetRUMScriptInternal(string contentType, string requestPath)

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             {
                 // not found, can't inject anything
                 transaction?.LogFinest("Skipping RUM Injection: No suitable location found to inject script.");
-                await baseStream.WriteAsync(buffer, 0, buffer.Length);
+                await baseStream.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                 return;
             }
 
@@ -34,13 +34,13 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             if (index < buffer.Length) // validate index is less than buffer length
             {
                 // Write everything up to the insertion index
-                await baseStream.WriteAsync(buffer, 0, index);
+                await baseStream.WriteAsync(buffer, 0, index).ConfigureAwait(false);
 
                 // Write the RUM script
-                await baseStream.WriteAsync(rumBytes, 0, rumBytes.Length);
+                await baseStream.WriteAsync(rumBytes, 0, rumBytes.Length).ConfigureAwait(false);
 
                 // Write the rest of the doc, starting after the insertion index
-                await baseStream.WriteAsync(buffer, index, buffer.Length - index);
+                await baseStream.WriteAsync(buffer, index, buffer.Length - index).ConfigureAwait(false) ;
             }
             else
                 transaction?.LogFinest($"Skipping RUM Injection: Insertion index was invalid.");

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                     wc.DownloadString(testAddress);
                 }
 #else
-                _lazyHttpClient.Value.GetAsync(testAddress).GetAwaiter().GetResult();
+                _lazyHttpClient.Value.GetAsync(testAddress).ConfigureAwait(false).GetAwaiter().GetResult();
 #endif
                 Log.Info("Connection test to \"{0}\" succeeded", testAddress);
             }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
         public async Task<IHttpResponseMessageWrapper> SendAsync(HttpRequestMessage message)
         {
             var cts = new CancellationTokenSource(_timeoutMilliseconds);
-            return new HttpResponseMessageWrapper(await _httpClient.SendAsync(message, cts.Token));
+            return new HttpResponseMessageWrapper(await _httpClient.SendAsync(message, cts.Token).ConfigureAwait(false));
         }
 
         public TimeSpan Timeout

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpResponse.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                     return Constants.EmptyResponseBody;
                 }
 
-                var responseStream = await _httpResponseMessageWrapper.Content.ReadAsStreamAsync();
+                var responseStream = await _httpResponseMessageWrapper.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
                 var contentTypeEncoding = _httpResponseMessageWrapper.Content.Headers.ContentEncoding;
                 if (contentTypeEncoding.Contains("gzip"))
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 using (responseStream)
                 using (var reader = new StreamReader(responseStream, Encoding.UTF8))
                 {
-                    var responseBody = await reader.ReadLineAsync();
+                    var responseBody = await reader.ReadLineAsync().ConfigureAwait(false);
 
                     if (responseBody != null)
                     {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                     req.Content.Headers.Add(contentHeader.Key, contentHeader.Value);
                 }
 
-                var response = await _httpClientWrapper.SendAsync(req);
+                var response = await _httpClientWrapper.SendAsync(req).ConfigureAwait(false);
 
                 var httpResponse = new HttpResponse(request.RequestGuid, response);
                 return httpResponse;

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/DataStreamingService.cs
@@ -50,7 +50,7 @@ namespace NewRelic.Agent.Core.DataTransport
             var success = false;
             try
             {
-                success = await _responseStream.MoveNext(_streamCancellationToken);
+                success = await _responseStream.MoveNext(_streamCancellationToken).ConfigureAwait(false);
             }
             catch (RpcException rpcEx)
             {
@@ -774,7 +774,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 // Wait until there are both no spans to be sent and no workers pending. Performance ?????
                 while (_collection?.Count > 0 || _workCounter?.Value > 0)
                 {
-                    await Task.Delay(100);
+                    await Task.Delay(100).ConfigureAwait(false);
                 }
             });
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -46,7 +46,7 @@ namespace NewRelic.Agent.Core.DataTransport
             {
 
                 var httpClient = _httpClientFactory.CreateClient(connectionInfo.Proxy, _configuration);
-
+                
                 request = new HttpRequest(_configuration)
                 {
                     Endpoint = method,
@@ -62,9 +62,9 @@ namespace NewRelic.Agent.Core.DataTransport
                 foreach (var header in _requestHeadersMap)
                     request.Headers.Add(header.Key, header.Value);
 
-                using var response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                using var response = httpClient.SendAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
 
-                var responseContent = response.GetContentAsync().GetAwaiter().GetResult();
+                var responseContent = response.GetContentAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
             {
                 _agent.Logger.Log(Agent.Extensions.Logging.Level.Finest, "Skipping instrumenting incoming OPTIONS request.");
 
-                await _next(context);
+                await _next(context).ConfigureAwait(false);
                 return;
             }
 
@@ -72,7 +72,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
 
             try
             {
-                await _next(context);
+                await _next(context).ConfigureAwait(false);
                 EndTransaction(segment, transaction, context, null);
             }
             catch (Exception ex)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectingStreamWrapper.cs
@@ -77,7 +77,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                     // Set a flag on the context to indicate we're in the middle of injecting - prevents multiple recursions when response compression is in use
                     StartInjecting();
                     _agent.TryInjectBrowserScriptAsync(_context.Response.ContentType, _context.Request.Path.Value, buffer, _baseStream)
-                        .GetAwaiter().GetResult();
+                        .ConfigureAwait(false).GetAwaiter().GetResult();
                 }
                 finally
                 {
@@ -102,7 +102,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                 {
                     // Set a flag on the context to indicate we're in the middle of injecting - prevents multiple recursions when response compression is in use
                     StartInjecting();
-                    await _agent.TryInjectBrowserScriptAsync(_context.Response.ContentType, _context.Request.Path.Value, buffer.ToArray(), _baseStream);
+                    await _agent.TryInjectBrowserScriptAsync(_context.Response.ContentType, _context.Request.Path.Value, buffer.ToArray(), _baseStream).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -113,7 +113,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
             }
 
             if (_baseStream != null)
-                await _baseStream.WriteAsync(buffer, cancellationToken);
+                await _baseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private const string InjectingRUM = "InjectingRUM";
@@ -126,7 +126,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
         {
             _context = null;
 
-            await _baseStream.DisposeAsync();
+            await _baseStream.DisposeAsync().ConfigureAwait(false);
             _baseStream = null;
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
             {
                 _agent.Logger.Log(Agent.Extensions.Logging.Level.Finest, "Not instrumenting incoming OPTIONS request.");
 
-                await _next(context);
+                await _next(context).ConfigureAwait(false);
                 return;
             }
 
@@ -72,7 +72,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
 
             try
             {
-                await _next(context);
+                await _next(context).ConfigureAwait(false);
                 EndTransaction(segment, transaction, context, null);
             }
             catch (Exception ex)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/NewRelicFilter.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransit/NewRelicFilter.cs
@@ -54,7 +54,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
 
             var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
             transaction.End();
 
@@ -92,7 +92,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
             InsertDistributedTraceHeaders(context.Headers, transaction);
             var segment = transaction.StartMessageBrokerSegment(mc, queueData.DestinationType, MessageBrokerAction.Produce, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
         }
 
@@ -109,7 +109,7 @@ namespace NewRelic.Providers.Wrapper.MassTransit
             InsertDistributedTraceHeaders(context.Headers, transaction);
             var segment = transaction.StartMessageBrokerSegment(mc, queueData.DestinationType, MessageBrokerAction.Produce, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/NewRelicFilter.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MassTransitLegacy/NewRelicFilter.cs
@@ -55,7 +55,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
 
             var segment = transaction.StartMessageBrokerSegment(mc, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
             transaction.End();
 
@@ -93,7 +93,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
             InsertDistributedTraceHeaders(context.Headers, transaction);
             var segment = transaction.StartMessageBrokerSegment(mc, queueData.DestinationType, MessageBrokerAction.Produce, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
         }
 
@@ -110,7 +110,7 @@ namespace NewRelic.Providers.Wrapper.MassTransitLegacy
             InsertDistributedTraceHeaders(context.Headers, transaction);
             var segment = transaction.StartMessageBrokerSegment(mc, queueData.DestinationType, MessageBrokerAction.Produce, MessageBrokerVendorName, queueData.QueueName);
 
-            await next.Send(context);
+            await next.Send(context).ConfigureAwait(false);
             segment.End();
         }
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
@@ -56,7 +56,7 @@ namespace NewRelic.Providers.Wrapper.Owin
 
             try
             {
-                await _next.Invoke(context);
+                await _next.Invoke(context).ConfigureAwait(false);
                 EndTransaction(segment, transaction, context, null);
             }
             catch (Exception ex)


### PR DESCRIPTION
Updates all async method invocations to add `.ConfigureAwait(false)` which may help prevent deadlocks in certain cases - in particular, we've seen reports of the agent apparently hanging on startup in some instances which may be related to our use of `HttpClient.SendAsync()`. Changes are, at worst, harmless and are based on [guidance for "library" code from Stephen Toub](https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse). 

Note that unit and integration tests were not updated, as those are "application" code which (generally) shouldn't use `.ConfigureAwait(false)`. 