### PR TITLE
fix: Prevent multiple SessionCache instances from being created. (#2180)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -28,8 +28,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Mime;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,7 +63,6 @@ namespace NewRelic.Agent.Core
         private readonly ILogEventAggregator _logEventAggregator;
         private readonly ILogContextDataFilter _logContextDataFilter;
         private Extensions.Logging.ILogger _logger;
-        private volatile IStackExchangeRedisCache _stackExchangeRedisCache;
         private readonly ISimpleSchedulingService _simpleSchedulingService;
 
         public Agent(ITransactionService transactionService, ITransactionTransformer transactionTransformer,
@@ -419,11 +416,7 @@ namespace NewRelic.Agent.Core
             get { return _simpleSchedulingService; }
         }
 
-        public IStackExchangeRedisCache StackExchangeRedisCache
-        {
-            get { return _stackExchangeRedisCache; }
-            set { _stackExchangeRedisCache = value; }
-        }
+        public IStackExchangeRedisCache StackExchangeRedisCache { get; set; }
 
         public void RecordSupportabilityMetric(string metricName, long count = 1)
         {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -10,6 +10,7 @@ using NewRelic.Agent.Api.Experimental;
 using NewRelic.Agent.Extensions.Helpers;
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Core.Logging;
 using NewRelic.Parsing.ConnectionString;
 using StackExchange.Redis.Profiling;
 
@@ -81,10 +82,10 @@ namespace NewRelic.Providers.Wrapper.StackExchangeRedis2Plus
 
         private void CleanUp()
         {
-            var cleanedSessions = 0;
-
             try
             {
+                var cleanedSessions = 0;
+
                 foreach (var pair in _sessionCache)
                 {
                     // This can happen outside the lock since the object transaction was garbage collected.
@@ -107,10 +108,11 @@ namespace NewRelic.Providers.Wrapper.StackExchangeRedis2Plus
                         }
                     }
                 }
+
+                Log.Finest($"SessionCache.Cleanup() removed {cleanedSessions}");
+                _agent.RecordSupportabilityMetric(SessionCacheCleanupSupportabilityMetricName, cleanedSessions);
             }
             catch { } // Don't want to log here, just want to prevent collection problems from breaking things.
-
-            _agent.RecordSupportabilityMetric(SessionCacheCleanupSupportabilityMetricName, cleanedSessions);
         }
 
         private ConnectionInfo GetConnectionInfo(EndPoint endpoint)


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description
Prevents an edge case where multiple `SessionCache` instances could get created if `StackExchange.Redis.ConnectionMultiplexer.CreateMultiplexer()` is called multiple times. 

Improves resiliency in `SessionCache.Cleanup()` and adds logging.

Fixes #2180 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
