### PR TITLE
fix: Prevent null reference exceptions while serializing LoadedModuleWireModelCollection. (#2185)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LoadedModuleWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LoadedModuleWireModelCollectionJsonConverter.cs
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.Core.JsonConverters
                 foreach (var item in loadedModule.Data)
                 {
                     jsonWriter.WritePropertyName(item.Key);
-                    jsonWriter.WriteValue(item.Value.ToString());
+                    jsonWriter.WriteValue(item.Value?.ToString() ?? " ");
                 }
 
                 jsonWriter.WriteEndObject();

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -82,12 +82,7 @@ namespace NewRelic.Agent.Core.WireModels
                     assemblyName = Path.GetFileName(assembly.Location);
                 }
 
-                if (string.IsNullOrWhiteSpace(assemblyName))
-                {
-                    return false;
-                }
-
-                return true;
+                return !string.IsNullOrWhiteSpace(assemblyName);
             }
             catch
             {
@@ -101,12 +96,7 @@ namespace NewRelic.Agent.Core.WireModels
             try
             {
                 publicKey = BitConverter.ToString(assemblyDetails.GetPublicKeyToken()).Replace("-", "");
-                if (string.IsNullOrWhiteSpace(publicKey))
-                {
-                    return false;
-                }
-
-                return true;
+                return !string.IsNullOrWhiteSpace(publicKey);
             }
             catch
             {
@@ -154,7 +144,7 @@ namespace NewRelic.Agent.Core.WireModels
                     sha512.Dispose();
                 }
 
-                return true;
+                return !string.IsNullOrWhiteSpace(sha1FileHash) && !string.IsNullOrWhiteSpace(sha512FileHash);
             }
             catch
             {
@@ -169,7 +159,7 @@ namespace NewRelic.Agent.Core.WireModels
             try
             {
                 assemblyHashCode = assembly.GetHashCode().ToString();
-                return true;
+                return !string.IsNullOrWhiteSpace(assemblyHashCode);
             }
             catch
             {
@@ -190,7 +180,7 @@ namespace NewRelic.Agent.Core.WireModels
                 }
 
                 companyName = ((AssemblyCompanyAttribute)attributes[0]).Company;
-                return true;
+                return !string.IsNullOrWhiteSpace(companyName);
             }
             catch
             {
@@ -211,7 +201,7 @@ namespace NewRelic.Agent.Core.WireModels
                 }
 
                 copyright = ((AssemblyCopyrightAttribute)attributes[0]).Copyright;
-                return true;
+                return !string.IsNullOrWhiteSpace(copyright);
             }
             catch
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
@@ -37,6 +37,7 @@ namespace NewRelic.Agent.Core.Utilities
             baseTestAssembly.SetAssemblyName = baseAssemblyName;
             baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
+            baseTestAssembly.SetLocation = BaseAssemblyPath;
             baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
             baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
 

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
@@ -37,12 +37,36 @@ namespace NewRelic.Agent.Core.Utilities
             baseTestAssembly.SetAssemblyName = baseAssemblyName;
             baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
-            baseTestAssembly.SetLocation = BaseAssemblyPath;
             baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
             baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
 
             var assemblies = new List<Assembly>();
             assemblies.Add(baseTestAssembly);
+            var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+
+            var serialized = JsonConvert.SerializeObject(new[] { loadedModules }, Formatting.None);
+            Assert.AreEqual(expected, serialized);
+        }
+
+        [Test]
+        public void LoadedModuleWireModelCollectionHandlesNulls()
+        {
+            var expected = @"[""Jars"",[[""MyTestAssembly"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42""}]]]";
+
+            var baseAssemblyName = new AssemblyName();
+            baseAssemblyName.Name = BaseAssemblyName;
+            baseAssemblyName.Version = new Version(BaseAssemblyVersion);
+            baseAssemblyName.SetPublicKeyToken(Encoding.ASCII.GetBytes(BasePublicKeyToken));
+
+            var baseTestAssembly = new TestAssembly();
+            baseTestAssembly.SetAssemblyName = baseAssemblyName;
+            baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won't have one.
+            baseTestAssembly.SetHashCode = BaseHashCode;
+            baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(null));
+            baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(null));
+
+            var assemblies = new List<Assembly> { baseTestAssembly };
+
             var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
 
             var serialized = JsonConvert.SerializeObject(new[] { loadedModules }, Formatting.None);

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using NUnit.Framework;
+using static Google.Protobuf.Reflection.SourceCodeInfo.Types;
 
 namespace NewRelic.Agent.Core.WireModels
 {
@@ -15,6 +16,7 @@ namespace NewRelic.Agent.Core.WireModels
         private const string BaseAssemblyName = "MyTestAssembly";
 
         private string BaseAssemblyVersion;
+        private string BaseAssemblyPath;
         private string BaseCompanyName;
         private string BaseCopyrightValue;
         private int    BaseHashCode;
@@ -29,6 +31,7 @@ namespace NewRelic.Agent.Core.WireModels
         {
             
             BaseAssemblyVersion = "1.0.0";
+            BaseAssemblyPath = @"C:\path\to\assembly\MyTestAssembly.dll";
             BaseCompanyName = "MyCompany";
             BaseCopyrightValue = "Copyright 2008";
             BaseHashCode = 42;
@@ -44,6 +47,7 @@ namespace NewRelic.Agent.Core.WireModels
             _baseTestAssembly.SetAssemblyName = _baseAssemblyName;
             _baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
             _baseTestAssembly.SetHashCode = BaseHashCode;
+            _baseTestAssembly.SetLocation = BaseAssemblyPath;
             _baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
             _baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
         }
@@ -61,7 +65,10 @@ namespace NewRelic.Agent.Core.WireModels
         public int TryGetAssemblyName_UsingCollectionCount(string assemblyName, bool isDynamic)
         {
             _baseAssemblyName.Name = assemblyName;
-
+            if (string.IsNullOrWhiteSpace(assemblyName))
+            {
+                _baseTestAssembly.SetLocation = null;
+            }
             _baseTestAssembly.SetAssemblyName = _baseAssemblyName;
             _baseTestAssembly.SetDynamic = isDynamic;
             
@@ -255,6 +262,8 @@ namespace NewRelic.Agent.Core.WireModels
 
         private int _hashCode;
 
+        private string _location;
+
         private List<object> _customAttributes = new List<object>();
 
         public AssemblyName SetAssemblyName
@@ -284,6 +293,12 @@ namespace NewRelic.Agent.Core.WireModels
             return _hashCode;
         }
 
+        public string SetLocation
+        {
+            set { _location = value; }
+        }
+
+        public override string Location => _location;
         public void AddCustomAttribute(object attribute)
         {
             _customAttributes.Add(attribute);
@@ -347,6 +362,19 @@ namespace NewRelic.Agent.Core.WireModels
             }
 
             throw new Exception();
+        }
+
+        public override string Location
+        {
+            get
+            {
+                if (ItemToTest != "Location")
+                {
+                    return _assembly.Location;
+                }
+
+                throw new Exception();
+            }
         }
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
@@ -196,7 +196,7 @@ namespace NewRelic.Agent.Core.WireModels
         {
             _baseTestAssembly = new TestAssembly();
             _baseTestAssembly.SetAssemblyName = _baseAssemblyName;
-            _baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
+            _baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won't have one.
             _baseTestAssembly.SetHashCode = BaseHashCode;
 
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Adds defensive coding to prevent null reference exceptions while serializing `LoadedModuleWireModelCollection`. Improves unit tests to check for null values.

Fixes #2185 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
