### PR TITLE
test: Timing adjustment in ExpectedErrorTests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
-                    configModifier.ConfigureFasterErrorTracesHarvestCycle(10);
+                    configModifier.ConfigureFasterErrorTracesHarvestCycle(12); // long enough to ensure metric harvest runs before error traces
                     configModifier.SetOrDeleteDistributedTraceEnabled(true);
                     configModifier.AddExpectedStatusCodes("410-450")
                     .AddExpectedErrorMessages("System.Exception", new List<string> { "test exception"})


### PR DESCRIPTION
Minor tweak in `ExpectedErrorTests` to help eliminate a flicker. An overnight CI run failed because metric and error harvest happened at the same time. 