### PR TITLE
Deploy workflow fixes

### DIFF
--- a/.github/workflows/awslambda_release.yml
+++ b/.github/workflows/awslambda_release.yml
@@ -132,5 +132,5 @@ jobs:
         with:
           name: deploy-artifacts
           path: |
-            ${{ github.workspace }}\build\BuildArtifacts
+            ${{ github.workspace }}
           if-no-files-found: error

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -173,7 +173,7 @@ jobs:
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: deploy-artifacts
-          path: ${{ github.workspace }}/build/BuildArtifacts
+          path: ${{ github.workspace }}
           if-no-files-found: error
 
   deploy-downloadsite:

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -440,7 +440,7 @@ jobs:
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@main
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
-      run_id: ${{ github.event.inputs.run_id }}
+      run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
     secrets: inherit
 
   post-deploy:

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -72,7 +72,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
           RUN_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/bin/Release/net7.0/
           CHANGELOG: ${{ github.workspace }}/src/Agent/CHANGELOG.md
-          CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/build/BuildArtifacts/DownloadSite/SHA256/checksums.md
+          CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}
 
       - name: Create branch

--- a/.github/workflows/siteextension_release.yml
+++ b/.github/workflows/siteextension_release.yml
@@ -59,5 +59,5 @@ jobs:
         with:
           name: deploy-artifacts
           path: |
-            ${{ github.workspace }}\build\BuildArtifacts
+            ${{ github.workspace }}
           if-no-files-found: error


### PR DESCRIPTION
The pathing for some of our build artifacts changed due to some recent workflow changes. This is the branch I ran the Deploy workflow from, so it should be good to go.