### PR TITLE
fix: Certain Profiler log messages did not print correctly when running under Linux. (#2200)

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.1.27"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.9"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -189,7 +189,7 @@ namespace NewRelic { namespace Profiler {
                 HRESULT corProfilerInfoInitResult = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo4), (void**)&_corProfilerInfo4);
                 if (FAILED(corProfilerInfoInitResult)) {
                     // Since MinimumDotnetVersionCheck already queried for minimum required interface, this check is just for safety
-                    LogError(_X("Error initializing CLR profiler info: "), corProfilerInfoInitResult);
+                    LogError(L"Error initializing CLR profiler info: ", corProfilerInfoInitResult);
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
 
@@ -199,12 +199,12 @@ namespace NewRelic { namespace Profiler {
                     &runtimeInfo->runtimeType, &runtimeInfo->majorVersion, &runtimeInfo->minorVersion, nullptr, nullptr, 0, nullptr, nullptr);
 
                 if (FAILED(runtimeInfoResult)) {
-                    LogError(_X("Error retrieving runtime information: "), runtimeInfoResult);
+                    LogError(L"Error retrieving runtime information: ", runtimeInfoResult);
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
 
                 if (!SetClrType(runtimeInfo)) {
-                    LogError(_X("Unknown Runtime Type found: "), runtimeInfo->runtimeType);
+                    LogError(L"Unknown Runtime Type found: ", runtimeInfo->runtimeType);
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
 
@@ -411,7 +411,7 @@ namespace NewRelic { namespace Profiler {
                 CComPtr<ICorProfilerInfo8> temp;
                 HRESULT result = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo11), (void**)&temp);
                 if (FAILED(result)) {
-                    LogError(_X(".NET Core 3.1 or greater required. Profiler not attaching."));
+                    LogError(L".NET Core 3.1 or greater required. Profiler not attaching.");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
                 return S_OK;
@@ -421,7 +421,7 @@ namespace NewRelic { namespace Profiler {
                 CComPtr<ICorProfilerInfo4> temp;
                 HRESULT interfaceCheckResult = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo7), (void**)&temp);
                 if (FAILED(interfaceCheckResult)) {
-                    LogError(_X(".NET Framework 4.6.1 is required.  Detaching New Relic profiler."));
+                    LogError(L".NET Framework 4.6.1 is required.  Detaching New Relic profiler.");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
 


### PR DESCRIPTION
This PR fixes an issue with certain Profiler log messages that used the `_X()` macro to convert a string. On Linux platforms, those messages would print out as an address (like `0x7fc4e6afc77c`) rather than the string content. Modifying the log messages to use the `L` prefix instead results in the messages printing correctly as expected. 

There may be a deeper issue, but there were only a handful of log messages using `_X()` and I've changed the ones that might get emitted on Linux to `L` instead.

I also confirmed that this isn't an issue related to an old .NET Core version or an old Linux distro -- the test app I used to reproduce this issue behaved the same when built on the latest .NET SDK and Runtime. 

Fixes #2200