### PR TITLE
chore(deps): Bump System.Reflection.Emit.Lightweight from 4.3.0 to 4.7.0 and bump Microsoft.CSharp from 4.5.0 to 4.7.0.

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />


### PR DESCRIPTION
Applying changes from two current Dependabot PRs so that we can validate the full solution build and test.

 See #2205 and #2206 for reference.