### PR TITLE
feat: Allow profiler to respond to log level changes.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationTracker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationTracker.cs
@@ -21,8 +21,11 @@ namespace NewRelic.Agent.Core.Config
 
         private DateTime _lastWriteTime;
 
-        public ConfigurationTracker(IConfigurationService configurationService)
+        private readonly INativeMethods _nativeMethods;
+
+        public ConfigurationTracker(IConfigurationService configurationService, INativeMethods nativeMethods)
         {
+            _nativeMethods = nativeMethods;
             var fileName = configurationService.Configuration.NewRelicConfigFilePath;
             if (fileName == null)
                 return;
@@ -39,6 +42,7 @@ namespace NewRelic.Agent.Core.Config
                     Log.Debug("newrelic.config file changed, reloading.");
                     ConfigurationLoader.Initialize(fileName);
                     _lastWriteTime = lastWriteTime;
+                    _nativeMethods.ReloadConfiguration();
                 }
             }, TimeSpan.FromMinutes(1));
         }

--- a/src/Agent/NewRelic/Agent/Core/INativeMethods.cs
+++ b/src/Agent/NewRelic/Agent/Core/INativeMethods.cs
@@ -14,6 +14,7 @@ namespace NewRelic.Agent.Core
         void ShutdownNativeThreadProfiler();
 
         int InstrumentationRefresh();
+        int ReloadConfiguration();
         int AddCustomInstrumentation(string fileName, string xml);
         int ApplyCustomInstrumentation();
     }

--- a/src/Agent/NewRelic/Agent/Core/NativeMethods.cs
+++ b/src/Agent/NewRelic/Agent/Core/NativeMethods.cs
@@ -15,6 +15,9 @@ namespace NewRelic.Agent.Core
         [DllImport(DllName, EntryPoint = "InstrumentationRefresh", CallingConvention = CallingConvention.Cdecl)]
         private static extern int ExternInstrumentationRefresh();
 
+        [DllImport(DllName, EntryPoint = "ReloadConfiguration", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int ExternReloadConfiguration();
+
         [DllImport(DllName, EntryPoint = "AddCustomInstrumentation", CallingConvention = CallingConvention.Cdecl)]
         private static extern int ExternAddCustomInstrumentation(string fileName, string xml);
 
@@ -30,6 +33,19 @@ namespace NewRelic.Agent.Core
             catch (Exception ex)
             {
                 Log.Error(ex, "LinuxNativeMethods.InstrumentationRefresh() exception");
+                return -1;
+            }
+        }
+
+        public int ReloadConfiguration()
+        {
+            try
+            {
+                return ExternReloadConfiguration();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "LinuxNativeMethods.ReloadConfiguration() exception");
                 return -1;
             }
         }
@@ -84,6 +100,9 @@ namespace NewRelic.Agent.Core
         [DllImport(DllName, EntryPoint = "InstrumentationRefresh", CallingConvention = CallingConvention.Cdecl)]
         private static extern int ExternInstrumentationRefresh();
 
+        [DllImport(DllName, EntryPoint = "ReloadConfiguration", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int ExternReloadConfiguration();
+
         [DllImport(DllName, EntryPoint = "AddCustomInstrumentation", CallingConvention = CallingConvention.Cdecl)]
         private static extern int ExternAddCustomInstrumentation(string fileName, string xml);
 
@@ -99,6 +118,19 @@ namespace NewRelic.Agent.Core
             catch (Exception ex)
             {
                 Log.Error(ex, "WindowsNativeMethods.InstrumentationRefresh() exception");
+                return -1;
+            }
+        }
+
+        public int ReloadConfiguration()
+        {
+            try
+            {
+                return ExternReloadConfiguration();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "WindowsNativeMethods.ReloadConfiguration() exception");
                 return -1;
             }
         }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the managed agent to notify the profiler if the newrelic.config files changes. Updates the profiler so that it includes a method invoked by the managed agent so that it can reload the newrelic config, and update some of the logging settings. These changes allow the profiler log level to change without restarting the application.

This code was testing manually, with and without an updated profiler. Without an updated profiler, the agent logs an error stating that it couldn't notify the profiler about the configuration changing. With an updated profiler, the profiler log level was successfully changed and messaged began logging at the newer level.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
