### PR TITLE
test: Disable event listener sampler for NetCoreAsyncTests to help stabilize ci runs.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/NetCoreAsyncTests.cs
@@ -42,6 +42,10 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", "NetCoreAsyncApplication.AsyncUseCases", "TaskRunBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "TaskRunBackgroundMethod");
                     CommonUtils.AddCustomInstrumentation(instrumentationFilePath, "NetCoreAsyncApplication", "NetCoreAsyncApplication.AsyncUseCases", "TaskFactoryStartNewBackgroundMethod", "NewRelic.Providers.Wrapper.CustomInstrumentationAsync.DefaultWrapperAsync", "TaskFactoryStartNewBackgroundMethod");
+
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
                 }
             );
             _fixture.Initialize();


### PR DESCRIPTION
Minor tweak to help prevent `Internal CLR Error` exceptions in `NetCoreAsyncTests`.