### PR TITLE
chore: Change debug type to "embedded" instead of "PDB"

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -45,10 +45,7 @@
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="ILRepack" Version="2.0.27">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="ILRepack" Version="2.0.16" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -12,6 +12,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration'=='Debug'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
     <DefineConstants>TRACE;LEGACY_GRPC</DefineConstants>
   </PropertyGroup>
@@ -45,7 +49,10 @@
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="ILRepack" Version="2.0.18" />
+    <PackageReference Include="ILRepack" Version="2.0.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
@@ -65,7 +72,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- .NET Core can use the modern gRPC library -->
-    <PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[2.0.0]" />

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="ILRepack" Version="2.0.16" />
+    <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
@@ -65,7 +65,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- .NET Core can use the modern gRPC library -->
-    <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[2.0.0]" />

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -6,6 +6,11 @@
     <Description>Extensions for the New Relic .NET Agent</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration'=='Debug'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>

--- a/src/Agent/NewRelic/Agent/Parsing/Parsing.csproj
+++ b/src/Agent/NewRelic/Agent/Parsing/Parsing.csproj
@@ -5,6 +5,11 @@
     <RootNamespace>NewRelic.Parsing</RootNamespace>
     <Description>Parsing library for New Relic .NET Agent</Description>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration'=='Debug'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -13,6 +18,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Extensions\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
     <ProjectReference Include="$(RootProjectDirectory)\src\NewRelic.Core\NewRelic.Core.csproj" />

--- a/src/NewRelic.Core/NewRelic.Core.csproj
+++ b/src/NewRelic.Core/NewRelic.Core.csproj
@@ -1,51 +1,57 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="VersionByGitTag">
-    <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-        <AssemblyName>NewRelic.Core</AssemblyName>
-        <RootNamespace>NewRelic.Core</RootNamespace>
-        <Description>New Relic Common Library</Description>
-        <GitTagPrefix>v</GitTagPrefix>
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <IntermediateOutputPath>$(MSBuildThisFileDirectory)\..\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</IntermediateOutputPath>
-        <OutputPath>$(MSBuildThisFileDirectory)\..\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</OutputPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <PackageReference Include="ILRepack" Version="2.0.27">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-        <Reference Include="System" />
-        <Reference Include="System.configuration" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Web" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-  
+  <PropertyGroup>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <AssemblyName>NewRelic.Core</AssemblyName>
+    <RootNamespace>NewRelic.Core</RootNamespace>
+    <Description>New Relic Common Library</Description>
+    <GitTagPrefix>v</GitTagPrefix>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <IntermediateOutputPath>$(MSBuildThisFileDirectory)\..\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</IntermediateOutputPath>
+    <OutputPath>$(MSBuildThisFileDirectory)\..\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration'=='Debug'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ILRepack" Version="2.0.27">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <Reference Include="System" />
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+
   <Target Name="ILRepack" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
     <ItemGroup>
       <PossibleRefsForILRepack Include="$(OutputPath)*.dll" />
     </ItemGroup>
-    
-	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
     </ItemGroup>
-	
+
     <PropertyGroup>
       <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">1</ILRepackIncludeCount>
       <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">1</ILRepackIncludeCount>
     </PropertyGroup>
-    
+
     <Error Text="ILRepack of $(AssemblyName) ($(TargetFramework)) failed. A dependency is missing. Expected $(ILRepackIncludeCount) dependencies but found @(ILRepackInclude-&gt;Count())." Condition="@(ILRepackInclude-&gt;Count()) != $(ILRepackIncludeCount)" />
 
     <ItemGroup>
@@ -66,5 +72,5 @@
     <Message Importance="High" Text="Executing ILRepack.exe for $(TargetFramework) build: $(ILRepackCommand)" />
     <Exec Command="$(ILRepackCommand)" />
   </Target>
-  
+
 </Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/SharedApplicationHelpers/ReflectionHelpers/ReflectionUtil.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/SharedApplicationHelpers/ReflectionHelpers/ReflectionUtil.cs
@@ -79,7 +79,18 @@ namespace NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers
 
             foreach (var assembly in assemblies)
             {
-                foreach (var type in assembly.GetTypes())
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Exception calling .GetTypes on assembly {assembly.FullName}");
+                    throw;
+                }
+
+                foreach (var type in types)
                 {
                     if (type.IsDefined(attribType, true))
                     {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/SharedApplicationHelpers/ReflectionHelpers/ReflectionUtil.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/SharedApplicationHelpers/ReflectionHelpers/ReflectionUtil.cs
@@ -84,7 +84,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers
                 {
                     types = assembly.GetTypes();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     Console.WriteLine($"Exception calling .GetTypes on assembly {assembly.FullName}");
                     throw;


### PR DESCRIPTION
This change is to enabled embedded PDBs in our debug builds of ILRepacked assemblies, to facilitate local debugging. 

This is intended to be a temporary change, pending resolution of an [issue where the DLL is written with an incorrect path to the .PDB file](https://github.com/gluck/il-repack/issues/352). 

There is no change to the release build at all.