### PR TITLE
test: make browser agent injection tests break when they should

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Views/Default/Index.cshtml
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Views/Default/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits System.Web.Mvc.WebViewPage
+@inherits System.Web.Mvc.WebViewPage
 
 @{
     Layout = null;
@@ -8,6 +8,7 @@
 
 <html>
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width" />
     <title></title>
 </head>


### PR DESCRIPTION
We have some integration tests that verify whether browser agent auto-injection is working as it should.  I found that these tests were still passing in a scenario where I would expect them to fail (browser agent version 1.219.0, with a .NET agent version older than 10.2.0).  The reason the tests were not failing as expected is because there was no `<meta http-equiv="X-UA-Compatible" content="IE=edge" />` tag in the webpage being tested for automatic browser agent injection.  This PR adds the tag.  I verified that the tests failed as expected in the scenario I was testing after making this change.