### PR TITLE
feat: Update configuration.xsd to allow ignored instrumentation to appear in any order.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -1407,7 +1407,7 @@ namespace NewRelic.Agent.Core.Config
     public partial class configurationInstrumentation
     {
         
-        private List<configurationInstrumentationIgnore> ignoreField;
+        private List<configurationInstrumentationIgnore> rulesField;
         
         private List<configurationInstrumentationApplication> applicationsField;
         
@@ -1419,20 +1419,20 @@ namespace NewRelic.Agent.Core.Config
         public configurationInstrumentation()
         {
             this.applicationsField = new List<configurationInstrumentationApplication>();
-            this.ignoreField = new List<configurationInstrumentationIgnore>();
+            this.rulesField = new List<configurationInstrumentationIgnore>();
             this.logField = false;
         }
         
-        [System.Xml.Serialization.XmlElementAttribute("ignore")]
-        public List<configurationInstrumentationIgnore> ignore
+        [System.Xml.Serialization.XmlArrayItemAttribute("ignore", IsNullable=false)]
+        public List<configurationInstrumentationIgnore> rules
         {
             get
             {
-                return this.ignoreField;
+                return this.rulesField;
             }
             set
             {
-                this.ignoreField = value;
+                this.rulesField = value;
             }
         }
         

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -373,30 +373,45 @@
                     </xs:annotation>
 
                     <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded">
-                                <xs:annotation>
-                                    <xs:documentation>
-                                        Disables instrumentation for a given assembly or class.
-                                    </xs:documentation>
-                                </xs:annotation>
+                        <xs:all>
+
+                            <xs:element name="rules" minOccurs="0" maxOccurs="1">
                                 <xs:complexType>
-                                    <xs:attribute name="assemblyName" type="xs:string" use="required">
-                                        <xs:annotation>
-                                            <xs:documentation>
-                                                The assembly name to not instrument.
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:attribute>
-                                    <xs:attribute name="className" type="xs:string" use="optional">
-                                        <xs:annotation>
-                                            <xs:documentation>
-                                                The class name to not instrument. If blank, no classes in the given assembly will be instrumented.
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                    </xs:attribute>
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            A list of rules that can affect the behavior of instrumentation.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+
+                                        <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    Disables instrumentation for a given assembly or class.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="assemblyName" type="xs:string" use="required">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The assembly name to not instrument.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="className" type="xs:string" use="optional">
+                                                    <xs:annotation>
+                                                        <xs:documentation>
+                                                            The class name to not instrument. If blank, no classes in the given assembly will be instrumented.
+                                                        </xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+
+                                    </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
+
                             <xs:element name="applications" minOccurs="0" maxOccurs="1">
                                 <xs:annotation>
                                     <xs:documentation>
@@ -420,7 +435,7 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
-                        </xs:sequence>
+                        </xs:all>
 
                         <xs:attribute name="log" type="xs:boolean" default="false">
                             <xs:annotation>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2032,7 +2032,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (_ignoredInstrumentation == null)
                 {
-                    _ignoredInstrumentation =_localConfiguration.instrumentation.ignore
+                    _ignoredInstrumentation =_localConfiguration.instrumentation.rules
                         .Select(i => new ReadOnlyDictionary<string, string>(
                                 new Dictionary<string, string>
                                 {

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.30"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.33"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -331,7 +331,11 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
 
         void SetInstrumentationIgnoreList(rapidxml::xml_node<xchar_t>* instrumentationNode)
         {
-            for (auto ignoreNode = instrumentationNode->first_node(_X("ignore"), 0, false); ignoreNode; ignoreNode = ignoreNode->next_sibling(_X("ignore"), 0, false)) {
+            auto rulesNode = instrumentationNode->first_node(_X("rules"), 0, false);
+            if (rulesNode == nullptr)
+                return;
+
+            for (auto ignoreNode = rulesNode->first_node(_X("ignore"), 0, false); ignoreNode; ignoreNode = ignoreNode->next_sibling(_X("ignore"), 0, false)) {
                 auto assemblyName = ignoreNode->first_attribute(_X("assemblyname"), 0, false);
 
                 if (assemblyName == nullptr)

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/IgnoreInstrumentationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/IgnoreInstrumentationTest.cpp
@@ -22,7 +22,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 <?xml version=\"1.0\"?>\
                 <configuration>\
                     <instrumentation>\
-                        <ignore assemblyName='MyAssembly' className='MyNamespace.MyClass'/>\
+                        <rules>\
+                            <ignore assemblyName='MyAssembly' className='MyNamespace.MyClass'/>\
+                        </rules>\
                     </instrumentation>\
                 </configuration>\
                 ");
@@ -54,7 +56,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 <?xml version=\"1.0\"?>\
                 <configuration>\
                     <instrumentation>\
-                        <ignore assemblyName='MyAssembly' />\
+                        <rules>\
+                            <ignore assemblyName='MyAssembly' />\
+                        </rules>\
                     </instrumentation>\
                 </configuration>\
                 ");
@@ -84,7 +88,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 <?xml version=\"1.0\"?>\
                 <configuration>\
                     <instrumentation>\
-                        <ignore className='MyNamespace.MyClass' />\
+                        <rules>\
+                            <ignore className='MyNamespace.MyClass' />\
+                        </rules>\
                     </instrumentation>\
                 </configuration>\
                 ");
@@ -110,9 +116,11 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
                 <?xml version=\"1.0\"?>\
                 <configuration>\
                     <instrumentation>\
-                        <ignore assemblyName='MyAssembly' className='MyNamespace.MyClass'/>\
-                        <ignore assemblyName='alpha' />\
-                        <ignore assemblyName='foo' className='bar'/>\
+                        <rules>\
+                            <ignore assemblyName='MyAssembly' className='MyNamespace.MyClass'/>\
+                            <ignore assemblyName='alpha' />\
+                            <ignore assemblyName='foo' className='bar'/>\
+                        </rules>\
                     </instrumentation>\
                 </configuration>\
                 ");

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/CommonUtils.cs
@@ -220,6 +220,13 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 configurationNode.AppendChild(instrumentationNode);
             }
 
+            var rulesNode = instrumentationNode.SelectSingleNode("nr:rules", namespaceManager);
+            if (rulesNode == null)
+            {
+                rulesNode = document.CreateElement("rules", nrNamespace);
+                instrumentationNode.AppendChild(rulesNode);
+            }
+
             var ignoreElement = document.CreateElement("ignore", nrNamespace);
             ignoreElement.SetAttribute("assemblyName", assemblyName);
             if (!string.IsNullOrWhiteSpace(className))
@@ -227,7 +234,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 ignoreElement.SetAttribute("className", className);
             }
 
-            instrumentationNode.AppendChild(ignoreElement);
+            rulesNode.AppendChild(ignoreElement);
 
             document.Save(filePath);
         }
@@ -252,9 +259,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 throw new InvalidOperationException($"Invalid configuration file. Missing <configuration> element. File: {filePath}");
             }
 
-            var instrumentationNode = configurationNode.SelectSingleNode("nr:instrumentation", namespaceManager);
+            var rulesNode = configurationNode.SelectSingleNode("nr:instrumentation/nr:rules", namespaceManager);
 
-            if (instrumentationNode == null || !instrumentationNode.HasChildNodes)
+            if (rulesNode == null || !rulesNode.HasChildNodes)
             {
                 // There is nothing to remove
                 return;
@@ -266,13 +273,13 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 xpathQuery = $"nr:ignore[@assemblyName='{assemblyName}' and @className='{className}']";
             }
 
-            var childToRemove = instrumentationNode.SelectSingleNode(xpathQuery, namespaceManager);
+            var childToRemove = rulesNode.SelectSingleNode(xpathQuery, namespaceManager);
             if (childToRemove == null)
             {
                 return;
             }
 
-            instrumentationNode.RemoveChild(childToRemove);
+            rulesNode.RemoveChild(childToRemove);
             document.Save(filePath);
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -3650,7 +3650,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 }
             };
 
-            _localConfig.instrumentation.ignore.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1" });
+            _localConfig.instrumentation.rules.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1" });
 
             Assert.That(_defaultConfig.IgnoredInstrumentation, Is.EquivalentTo(expectedList));
         }
@@ -3667,7 +3667,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 }
             };
 
-            _localConfig.instrumentation.ignore.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1", className = "Class1" });
+            _localConfig.instrumentation.rules.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1", className = "Class1" });
 
             Assert.That(_defaultConfig.IgnoredInstrumentation, Is.EquivalentTo(expectedList));
         }
@@ -3689,8 +3689,8 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 }
             };
 
-            _localConfig.instrumentation.ignore.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1" });
-            _localConfig.instrumentation.ignore.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly2", className = "Class2" });
+            _localConfig.instrumentation.rules.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly1" });
+            _localConfig.instrumentation.rules.Add(new configurationInstrumentationIgnore { assemblyName = "Assembly2", className = "Class2" });
 
             Assert.That(_defaultConfig.IgnoredInstrumentation, Is.EquivalentTo(expectedList));
         }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the the ignored instrumentation configuration to appear either before or after the applications element in the instrumentation element. This will prevent the managed agent from reporting a configuration error if the ordering isn't what we expect. The code already did not care what order the elements appeared in.

The different xml layouts were tested manually.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
