### PR TITLE
ci: consolidate test secrets

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -453,7 +453,7 @@ jobs:
 
       - name: Set up secrets
         env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
+          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
         run: |
           "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
         shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Set up secrets
         env:
-          INTEGRATION_TEST_SECRETS: ${{ secrets.UNBOUNDED_TEST_SECRETS }}
+          INTEGRATION_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
         run: |
           "$Env:INTEGRATION_TEST_SECRETS" | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
         shell: pwsh #this doesn't work with normal powershell due to UTF-8 BOM handling


### PR DESCRIPTION
Use the same secrets in both kinds of integration tests.

Test run: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/7993740794