### PR TITLE
fix: Use original regex to get container id from cgroup v1 in fallback case

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.Core.Utilization
         private const string ValidateMetadataRegex = @"^[a-zA-Z0-9-_. /]*$";
 #if NETSTANDARD2_0
         private const string ContainerIdV1Regex = @".*:cpu:/docker/([0-9a-f]{64}).*";
-        private const string ContainerIdV1FallbackRegex = @"([0-9a-f]{64})"; // This is the old regex that just looks for any 64-char alphanumeric string
+        private const string ContainerIdV1FallbackRegex = @"([0-9a-f]{64})"; // This is the old regex that just looks for any 64-char hexadecimal string
         private const string ContainerIdV2Regex = ".*/docker/containers/([0-9a-f]{64})/.*";
 #endif
 

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -25,6 +25,7 @@ namespace NewRelic.Agent.Core.Utilization
         private const string ValidateMetadataRegex = @"^[a-zA-Z0-9-_. /]*$";
 #if NETSTANDARD2_0
         private const string ContainerIdV1Regex = @".*:cpu:/docker/([0-9a-f]{64}).*";
+        private const string ContainerIdV1FallbackRegex = @"([0-9a-f]{64})"; // This is the old regex that just looks for any 64-char alphanumeric string
         private const string ContainerIdV2Regex = ".*/docker/containers/([0-9a-f]{64})/.*";
 #endif
 
@@ -314,18 +315,33 @@ namespace NewRelic.Agent.Core.Utilization
 
         private IVendorModel TryGetDockerCGroupV1(string fileContent)
         {
-            string id = null;
+            string id;
             var matches = Regex.Matches(fileContent, ContainerIdV1Regex);
+            if (TryGetIdFromRegexMatch(matches, out id))
+            {
+                return new DockerVendorModel(id);
+            }
+            matches = Regex.Matches(fileContent, ContainerIdV1FallbackRegex);
+            if (TryGetIdFromRegexMatch(matches, out id))
+            {
+                return new DockerVendorModel(id);
+            }
+            return null;
+        }
+
+        private bool TryGetIdFromRegexMatch(MatchCollection matches, out string id)
+        {
+            id = null;
             if (matches.Count > 0)
             {
                 var firstMatch = matches[0];
                 if (firstMatch.Success && firstMatch.Groups.Count > 1 && firstMatch.Groups[1].Success)
                 {
                     id = firstMatch.Groups[1].Value;
+                    return true;
                 }
             }
-
-            return id == null ? null : new DockerVendorModel(id);
+            return false;
         }
 
         private IVendorModel TryGetDockerCGroupV2(string fileContent)


### PR DESCRIPTION
Fixes #2256 by adding additional logic to try and parse the container ID out of cgroup v1 data if the newer regex fails to find anything.  Includes a new unit test to verify the intended result.

