### PR TITLE
test: Fixes an issue with the Selenium web driver usage in BasicAspWebServiceFixture.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -42,7 +42,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Selenium.Support" Version="4.17.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
-    <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="120.0.2210.144" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.6.6" />

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebServiceFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/BasicAspWebServiceFixture.cs
@@ -6,25 +6,25 @@
 using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using OpenQA.Selenium.Edge;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
 
 namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 {
     public class BasicAspWebServiceFixture : RemoteApplicationFixture
     {
-        private EdgeDriver _driver;
+        private IWebDriver _driver;
         public BasicAspWebServiceFixture() : base(new RemoteWebApplication("BasicAspWebService", ApplicationType.Bounded))
         {
-            var driverService = EdgeDriverService.CreateDefaultService();
-            driverService.HideCommandPromptWindow = true;
-            driverService.SuppressInitialDiagnosticInformation = true;
-            driverService.InitializationTimeout = TimeSpan.FromMinutes(2);
-            driverService.Port = RandomPortGenerator.NextPort();
+            var chromeDriverService = ChromeDriverService.CreateDefaultService();
+            chromeDriverService.HideCommandPromptWindow = true;
+            chromeDriverService.SuppressInitialDiagnosticInformation = true;
+            chromeDriverService.Port = RandomPortGenerator.NextPort();
 
-            var options = new EdgeOptions();
-            options.AddArgument("headless");
+            var chromeOptions = new ChromeOptions();
+            chromeOptions.AddArgument("headless");
 
-            _driver = new EdgeDriver(driverService, options, TimeSpan.FromMinutes(2));
+            _driver = new ChromeDriver(chromeDriverService, chromeOptions, TimeSpan.FromMinutes(2));
         }
 
         public void InvokeAsyncCall()


### PR DESCRIPTION
Removes a third-party Selenium driver package that is no longer needed, as Selenium will now download the required web driver and browser as needed for testing. Code was updated to use the Chromium web driver instead of Edge.