### PR TITLE
Add serverless mode support to Profiler

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/Instrumentation.xml
@@ -13,13 +13,5 @@ SPDX-License-Identifier: Apache-2.0
       </match>
     </tracerFactory>
 
-    <!-- Cus4tom instrumentation approach.  Hardcoded for POC, would be added to the profiler via an environment variable in the real world-->
-    <!-- TODO: Figure out how to configure this from an environment variable at runtime -->
-    <tracerFactory name="NewRelic.Providers.Wrapper.AwsLambda.HandlerMethod">
-      <match assemblyName="LambdaFunctionTestApp" className="LambdaFunctionTestApp.Function">
-        <exactMethodMatcher methodName="FunctionHandler" />
-      </match>
-    </tracerFactory>
-
   </instrumentation>
 </extension>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.33"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.73"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Common/AssemblyVersion.h
+++ b/src/Agent/NewRelic/Profiler/Common/AssemblyVersion.h
@@ -75,7 +75,7 @@ namespace NewRelic { namespace Profiler
             {
                 return nullptr;
             }
-            auto identifiers = Configuration::Strings::Split(version, '.');
+            auto identifiers = Configuration::Strings::Split(version, _X("."));
             int major = 0;
             int minor = 0;
             int build = 0;

--- a/src/Agent/NewRelic/Profiler/Configuration/Strings.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Strings.h
@@ -13,7 +13,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
     class Strings
     {
     public:
-        static std::vector<xstring_t> Split( const xstring_t& text, wchar_t delimiter )
+        static std::vector<xstring_t> Split( const xstring_t& text, const xstring_t& delimiter )
         {
             std::vector<xstring_t> result;
 
@@ -26,7 +26,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
 
                 result.push_back( token );
 
-                start = end + 1;
+                start = end + delimiter.length();
                 end   = text.find( delimiter, start );
             }
 

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/IgnoreInstrumentationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/IgnoreInstrumentationTest.cpp
@@ -43,7 +43,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(IgnoreInstrumentation::Matches(ignoreList, _X("myassembly"), _X("M")));
 
             auto xmlSet = GetInstrumentationXmlSet();
-            InstrumentationConfiguration instrumentation(xmlSet, ignoreList);
+            InstrumentationConfiguration instrumentation(xmlSet, ignoreList, nullptr);
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             // Should fail to find the instrumentation because it's in the ignore list
@@ -74,7 +74,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(IgnoreInstrumentation::Matches(ignoreList, _X(""), _X("")));
 
             auto xmlSet = GetInstrumentationXmlSet();
-            InstrumentationConfiguration instrumentation(xmlSet, ignoreList);
+            InstrumentationConfiguration instrumentation(xmlSet, ignoreList, nullptr);
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             // Should fail to find the instrumentation because it's in the ignore list
@@ -103,7 +103,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(IgnoreInstrumentation::Matches(ignoreList, _X(""), _X("MyNamespace.MyClass")));
 
             auto xmlSet = GetInstrumentationXmlSet();
-            InstrumentationConfiguration instrumentation(xmlSet, ignoreList);
+            InstrumentationConfiguration instrumentation(xmlSet, ignoreList, nullptr);
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             // Should find the instrumentation because the ignore list is invalid
@@ -138,7 +138,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(IgnoreInstrumentation::Matches(ignoreList, _X("different"), _X("MyNamespace.MyClass")));
 
             auto xmlSet = GetInstrumentationXmlSet();
-            InstrumentationConfiguration instrumentation(xmlSet, ignoreList);
+            InstrumentationConfiguration instrumentation(xmlSet, ignoreList, nullptr);
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             // Should fail to find the instrumentation because it's in the ignore list

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
@@ -949,5 +949,43 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             Assert::IsTrue(instrumentationPoint == nullptr);
         }
+
+        TEST_METHOD(set_lambda_instrumentation_point_success)
+        {
+            InstrumentationXmlSetPtr xmlSet(new InstrumentationXmlSet());
+            xmlSet->emplace(L"filename", L"<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+
+            InstrumentationConfiguration instrumentation(xmlSet, nullptr);
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
+
+            auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
+            Assert::IsFalse(instrumentationPoint == nullptr);
+        }
+
+        TEST_METHOD(set_lambda_instrumentation_point_failure)
+        {
+            InstrumentationXmlSetPtr xmlSet(new InstrumentationXmlSet());
+            xmlSet->emplace(L"filename", L"<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+
+            InstrumentationConfiguration instrumentation(xmlSet, nullptr);
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::WrongMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyNamespace.MyClass:MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("::::::MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod::"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly:MyNamespace.MyClass:MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly/MyNamespace.MyClass/MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly_MyNamespace.MyClass_MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly MyNamespace.MyClass MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(" MyAssembly::MyNamespace.MyClass:MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
+            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace .MyClass:: MyMethod"));
+
+            auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
+            Assert::IsFalse(instrumentationPoint == nullptr);
+        }
     };
 }}}}

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -29,6 +29,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     {
         bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings) override
         {
+            instrumentationSettings->GetInstrumentationConfiguration()->CheckForEnvironmentInstrumentationPoint();
             auto instrumentationPoint = instrumentationSettings->GetInstrumentationConfiguration()->TryGetInstrumentationPoint(function);
             if (instrumentationPoint == nullptr)
             {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -643,7 +643,7 @@ namespace NewRelic { namespace Profiler {
                 newIgnoreInstrumentationList = oldIgnoreList;
             }
 
-            auto instrumentationConfiguration = std::make_shared<Configuration::InstrumentationConfiguration>(instrumentationXmls, newIgnoreInstrumentationList);
+            auto instrumentationConfiguration = std::make_shared<Configuration::InstrumentationConfiguration>(instrumentationXmls, newIgnoreInstrumentationList, _systemCalls);
             if (instrumentationConfiguration->GetInvalidFileCount() > 0) {
                 LogError(L"Unable to parse one or more instrumentation files.  Instrumentation will not be refreshed.");
                 return S_FALSE;
@@ -1163,16 +1163,11 @@ namespace NewRelic { namespace Profiler {
         std::shared_ptr<Configuration::InstrumentationConfiguration> InitializeInstrumentationConfig(NewRelic::Profiler::Configuration::IgnoreInstrumentationListPtr ignoreList)
         {
             auto instrumentationXmls = GetInstrumentationXmlsFromDisk(_systemCalls);
-            auto instrumentationConfiguration = std::make_shared<Configuration::InstrumentationConfiguration>(instrumentationXmls, ignoreList);
+            auto instrumentationConfiguration = std::make_shared<Configuration::InstrumentationConfiguration>(instrumentationXmls, ignoreList, _systemCalls);
             if (instrumentationConfiguration->GetInvalidFileCount() > 0) {
                 LogWarn(L"Unable to parse one or more instrumentation files.  Live instrumentation reloading will not work until the unparsable file(s) are corrected or removed.");
             }
             LogTrace(L"Read ", instrumentationXmls->size(), " instrumentation files");
-            auto lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("AWS_LAMBDA_FUNCTION_NAME"));
-            if (lambdaInstPoint != nullptr)
-            {
-                instrumentationConfiguration->AddInstrumentationPointToCollectionFromEnvironment(*lambdaInstPoint);
-            }
             return instrumentationConfiguration;
         }
 

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -1168,6 +1168,11 @@ namespace NewRelic { namespace Profiler {
                 LogWarn(L"Unable to parse one or more instrumentation files.  Live instrumentation reloading will not work until the unparsable file(s) are corrected or removed.");
             }
             LogTrace(L"Read ", instrumentationXmls->size(), " instrumentation files");
+            auto lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("AWS_LAMBDA_FUNCTION_NAME"));
+            if (lambdaInstPoint != nullptr)
+            {
+                instrumentationConfiguration->AddInstrumentationPointToCollectionFromEnvironment(*lambdaInstPoint);
+            }
             return instrumentationConfiguration;
         }
 


### PR DESCRIPTION
This adds the ability to add an instrumentation point to the Profiler via an environment variable, `AWS_LAMBDA_FUNCTION_NAME`, in the format `assembly::class::method`. If the variable is not in the correct format it will log a Warning but continue running. It does not attempt to verify that the method exists.

The environment variable can be added at any point during the startup sequence and the Profiler will pick it up (as long as the method hasn't been invoked yet)..

When the named method is invoked it will call the wrapper `NewRelic.Providers.Wrapper.AwsLambda.HandlerMethod` in the managed Agent.

Unit tests are included.

This also removes the hard-coded method name in the `instrumentation.xml` that was used in the POC branch.