### PR TITLE
fix: Update regex parsing for CGroup v1 to match agent spec.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -24,8 +24,7 @@ namespace NewRelic.Agent.Core.Utilization
     {
         private const string ValidateMetadataRegex = @"^[a-zA-Z0-9-_. /]*$";
 #if NETSTANDARD2_0
-        private const string ContainerIdV1Regex = @".*:cpu:/docker/([0-9a-f]{64}).*";
-        private const string ContainerIdV1FallbackRegex = @"([0-9a-f]{64})"; // This is the old regex that just looks for any 64-char hexadecimal string
+        private const string ContainerIdV1Regex = @".*cpu.*([0-9a-f]{64})";
         private const string ContainerIdV2Regex = ".*/docker/containers/([0-9a-f]{64})/.*";
 #endif
 
@@ -317,11 +316,6 @@ namespace NewRelic.Agent.Core.Utilization
         {
             string id;
             var matches = Regex.Matches(fileContent, ContainerIdV1Regex);
-            if (TryGetIdFromRegexMatch(matches, out id))
-            {
-                return new DockerVendorModel(id);
-            }
-            matches = Regex.Matches(fileContent, ContainerIdV1FallbackRegex);
             if (TryGetIdFromRegexMatch(matches, out id))
             {
                 return new DockerVendorModel(id);

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
@@ -373,8 +373,9 @@ namespace NewRelic.Agent.Core.Utilization
         }
 
         // See https://new-relic.atlassian.net/browse/NR-221128 and https://new-relic.atlassian.net/browse/NR-230908
+        // The sample files below are from a customer issue where the cgroup file was not being parsed correctly
         [Test]
-        public void GetVendors_GetDockerVendorInfo_ParsesV1_IfCpuMissing()
+        public void GetVendors_GetDockerVendorInfo_ParsesV1_ForCustomerIssue()
         {
             var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
             var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
@@ -374,7 +374,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         // See https://new-relic.atlassian.net/browse/NR-221128 and https://new-relic.atlassian.net/browse/NR-230908
         [Test]
-        public void GetVendors_GetDockerVendorInfo_ParsesV1WithFallback_IfCpuMissing()
+        public void GetVendors_GetDockerVendorInfo_ParsesV1_IfCpuMissing()
         {
             var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
             var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();


### PR DESCRIPTION
Updates our container id parsing logic for CGroup v1 to match the agent spec and removes the "fallback" lookup we recently added. The spec requires that we find a line that has `cpu` in it and contains a 64-character hexadecimal string. The container ID is the 64-character string.

The logic should find a container id of `47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2` when parsing any of the following lines in `/proc/self/cgroup`:

```
1:cpuset:/docker/47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2
2:cpu:/docker/47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2
3:cpuacct,cpu:/docker/47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2
4:memory,cpu,cpuset:/docker/47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2
5:cpu,cpuacct:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2.scope
6:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-47cbd16b77c50cbf71401c069cd2189f0e659af17d5a2daca3bddf59d8a870b2.scope
```