### PR TITLE
chore: Minor verbiage change for the release notes builder

### DIFF
--- a/build/ReleaseNotesBuilder/data.yml
+++ b/build/ReleaseNotesBuilder/data.yml
@@ -11,7 +11,7 @@ preamble:
 # This will appear immediately after the checksums section and will be the last portion of the file.
 # Can be empty.
 epilogue: |
-  ### Updating
+  ### Updating your agent
 
   * Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
   * If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
Makes a very minor change to the release notes builder to use wording that the docs team seems to want, based on a change to our most recent release notes PR. 
![image](https://github.com/newrelic/newrelic-dotnet-agent/assets/120425148/3e77fae3-5be7-44f2-b69c-accc8ded367a)
