### PR TITLE
Don't register IConnectionHandler or IConnectionManager in Serverless mode.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -149,8 +149,13 @@ namespace NewRelic.Agent.Core
             var agentApi = _container.Resolve<IAgentApi>();
             _wrapperService = _container.Resolve<IWrapperService>();
 
-            //We need to attempt to auto start the agent once all services have resolved
-            _container.Resolve<IConnectionManager>().AttemptAutoStart();
+            // Attempt to auto start the agent once all services have resolved, except in serverless mode
+            if (!config.ServerlessModeEnabled)
+                _container.Resolve<IConnectionManager>().AttemptAutoStart();
+            else
+            {
+                Log.Info("The New Relic agent is operating in serverless mode.");
+            }
 
             AgentServices.StartServices(_container, config.ServerlessModeEnabled);
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionManager.cs
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.Core.DataTransport
         {
             _connectionHandler = connectionHandler;
             _scheduler = scheduler;
-            
+
             _subscriptions.Add<StartAgentEvent>(OnStartAgent);
             _subscriptions.Add<RestartAgentEvent>(OnRestartAgent);
 
@@ -74,17 +74,10 @@ namespace NewRelic.Agent.Core.DataTransport
                 if (_started)
                     return;
 
-                if (!_configuration.ServerlessModeEnabled)
-                {
-                    if (_configuration.CollectorSyncStartup || _configuration.CollectorSendDataOnExit)
-                        Connect();
-                    else
-                        _scheduler.ExecuteOnce(Connect, TimeSpan.Zero);
-                }
+                if (_configuration.CollectorSyncStartup || _configuration.CollectorSendDataOnExit)
+                    Connect();
                 else
-                {
-                    Log.Info("The Agent is operating in Serverless mode.");
-                }
+                    _scheduler.ExecuteOnce(Connect, TimeSpan.Zero);
 
                 _started = true;
             }

--- a/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
+++ b/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
@@ -109,13 +109,15 @@ namespace NewRelic.Agent.Core.DependencyInjection
             container.Register<Environment, Environment>();
 
             if (!serverlessModeEnabled)
-                container.Register<IDataTransportService, DataTransportService>();
-            else
             {
+                // Register the connection manager and handler only if serverless mode is not enabled
                 container.Register<IConnectionHandler, ConnectionHandler>();
                 container.Register<IConnectionManager, ConnectionManager>();
-                container.Register<IDataTransportService, IServerlessModeDataTransportService, ServerlessModeDataTransportService>();
+                // Register the data transport service only if serverless mode is not enabled
+                container.Register<IDataTransportService, DataTransportService>();
             }
+            else
+                container.Register<IDataTransportService, IServerlessModeDataTransportService, ServerlessModeDataTransportService>();
 
             container.Register<IScheduler, Scheduler>();
             container.Register<ISystemInfo, SystemInfo>();

--- a/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
+++ b/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
@@ -107,13 +107,15 @@ namespace NewRelic.Agent.Core.DependencyInjection
             container.Register<ISerializer, JsonSerializer>();
             container.Register<ICollectorWireFactory, HttpCollectorWireFactory>();
             container.Register<Environment, Environment>();
-            container.Register<IConnectionHandler, ConnectionHandler>();
-            container.Register<IConnectionManager, ConnectionManager>();
 
             if (!serverlessModeEnabled)
                 container.Register<IDataTransportService, DataTransportService>();
             else
+            {
+                container.Register<IConnectionHandler, ConnectionHandler>();
+                container.Register<IConnectionManager, ConnectionManager>();
                 container.Register<IDataTransportService, IServerlessModeDataTransportService, ServerlessModeDataTransportService>();
+            }
 
             container.Register<IScheduler, Scheduler>();
             container.Register<ISystemInfo, SystemInfo>();


### PR DESCRIPTION
Remove Autofac registration of `IConnectionManager` and `IConnectionHandler` when in Serverless mode. This ensures that there is no way to attempt to connect or reconnect to the collector. 