### PR TITLE
test: Fix a .NET 8 integration test flicker in EnvironmentTests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/EnvironmentTests.cs
@@ -23,6 +23,14 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
             _fixture.TestLogger = output;
             _fixture.Actions
             (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+
+                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+
+                },
                 exerciseApplication: ExerciseApplication
             );
             _fixture.Initialize();


### PR DESCRIPTION
Found another test that fails intermittently with `Internal CLR Error` https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/8087172617/job/22098992766?pr=2289#step:9:84