### PR TITLE
ci: Add support for running unit tests on feature branches

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main # runs after a completed PR to main
+      - feature/* # runs after a completed PR to a feature branch
   pull_request: # runs on a PR to any branch
   workflow_dispatch: # allows for manual trigger
 


### PR DESCRIPTION
Modifies the unit test workflow to run on a push to any `feature/*` branch. This will ensure that we have code coverage reports for the feature branch, which will make it easier to see the code coverage changes during PRs to the feature branch.