### PR TITLE
Implemented error handling for Bedrock

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Llm/LlmErrorData.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Llm/LlmErrorData.cs
@@ -1,0 +1,13 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Extensions.Llm
+{
+    public class LlmErrorData
+    {
+        public string ErrorMessage { get; set; }
+        public string ErrorCode { get; set; }
+        public string ErrorParam { get; set; }
+        public string HttpStatusCode { get; set; }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -61,6 +61,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                 if (responseTask.IsFaulted)
                 {
                     HandleError(segment, invokeModelRequest, responseTask, agent);
+                    segment.End();
                     return;
                 }
 


### PR DESCRIPTION
Error handling for Bedrock, based on requirements in the spec. Generates error events similar to 

```
["BW7NK7CFbFXrAAQqrgglOVll6NSgAAQBIQArJQEAAFys5SnXZAIECBONVAMACjEwLjIxLjAuMzQACU5SREQ1WlZUMwAVQUkgTW9uaXRvcmluZyBTaWduYWxS", {
        "reservoir_size": 8,
        "events_seen": 1
    }, [[{
                "duration": 19.778362,
                "error.class": "Custom Error",
                "error.message": "You don't have access to the model with the specified model ID.",
                "externalCallCount": 1.0,
                "externalDuration": 0.6889039874076843,
                "guid": "3b38fb9cbda92a6d",
                "priority": 1.2292109727859497,
                "sampled": true,
                "spanId": "81f43eaa26391287",
                "timestamp": 1709757514125,
                "traceId": "930d051d14fe639dba54c70ec91025a8",
                "transactionName": "WebTransaction/ASP/chathub",
                "type": "TransactionError"
            }, {
                "completion_id": "2c606da9-4262-4dca-bc75-ed8ffc0937e0",
                "error.code": "AccessDeniedException",
                "http.statusCode": "403",
                "llm.conversation_id": "a9028608-c5f6-4c78-ab16-7e653361c721",
                "llm.SomethingAwesome": 42,
                "NotAwesome": 13
            }, {
                "host.displayName": "NRDD5ZVT3",
                "http.statusCode": 101,
                "request.headers.accept-encoding": "gzip, deflate, br, zstd",
                "request.headers.accept-language": "en-US,en;q=0.9",
                "request.headers.cache-control": "no-cache",
                "request.headers.connection": "Upgrade",
                "request.headers.host": "localhost:5001",
                "request.headers.origin": "https://localhost:5001",
                "request.headers.pragma": "no-cache",
                "request.headers.sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
                "request.headers.sec-websocket-key": "c70e2PolE06sEaSaDwx7yg==",
                "request.headers.sec-websocket-version": "13",
                "request.headers.upgrade": "websocket",
                "request.headers.user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
                "request.method": "GET",
                "request.uri": "/chathub",
                "response.status": "101"
            }
        ]]]
```

Closes  #2295 