### PR TITLE
ci: Profiler build workflow updates

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -124,7 +124,6 @@ jobs:
           if-no-files-found: error
 
   build-linux-x64-profiler:
-    if: ${{ inputs.deploy }}
     name: Build Linux x64 Profiler
     runs-on: ubuntu-22.04
     permissions:
@@ -175,7 +174,6 @@ jobs:
           if-no-files-found: error
 
   build-linux-arm64-profiler:
-    if: ${{ inputs.deploy }}
     name: Build Linux ARM64 Profiler
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -1,44 +1,39 @@
 name: Build and Package Profiler
 
 on:
-  # run this workflow on a push to any branch other than main or a feature branch
+  # run this workflow on a push to any branch so we can get code coverage reports
   #
   # NOTE: On a push, only the build jobs will execute; the NuGet jobs will not run. 
   #       Manually run this workflow on your branch when you want it to update the
   #       NuGet package and create a PR to update the package version reference in 
   #       Home.csproj.
   push:
-    branches-ignore:
-      - main
-      - "feature/**"
+    branches:
+       - main
+       - "feature/**"
     paths-ignore:
       - ".github/**" # skip changes to the .github branch (workflows, etc.)
-  
+
+  pull_request:
+    paths-ignore:
+      - ".github/**" # skip changes to the .github branch (workflows, etc.)
+      
   # this workflow can be called from another workflow
   workflow_call:
     inputs:
-      force-build:
-        description: 'Force a build, even if no files are changed'
-        required: true
-        type: boolean
       deploy:
-        description: 'Deploy'
+        description: 'Deploy NuGet Package'
         required: true
-        default: true
+        default: false
         type: boolean
   
   # this workflow can be invoked manually
   workflow_dispatch:
     inputs:
-      force-build:
-        description: 'Force a build, even if no files are changed'
-        required: true
-        default: true
-        type: boolean
       deploy:
-        description: 'Deploy'
+        description: 'Deploy NuGet Package'
         required: true
-        default: true
+        default: false
         type: boolean
 
 permissions:
@@ -55,43 +50,9 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  check-for-changes:
-    name: Check for Updated Profiler Files
-    runs-on: ubuntu-22.04
-
-    # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well
-    if: ${{ github.actor != 'dependabot[bot]' }}
-
-    permissions:
-      pull-requests: read
-    outputs:
-      profiler_src: ${{ steps.filter.outputs.profiler_src }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          disable-sudo: true
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-
-      - name: Look for modified files
-        uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a # v3.0.1
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            profiler_src:
-              - 'src/Agent/NewRelic/Profiler/**'
-          list-files: 'csv'
-
   build-windows-profiler:
-    needs: check-for-changes
-    if: ${{ inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true' }}
-    name: Build Windows Profiler
+    if: ${{ github.event_name == 'push' }}
+    name: Build Windows Profiler & Run Unit Tests / Code Coverage
     runs-on: windows-latest
 
     env:
@@ -164,8 +125,7 @@ jobs:
           if-no-files-found: error
 
   build-linux-x64-profiler:
-    needs: check-for-changes
-    if: ${{ inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true' }}
+    if: ${{ inputs.deploy }}
     name: Build Linux x64 Profiler
     runs-on: ubuntu-22.04
     permissions:
@@ -216,8 +176,7 @@ jobs:
           if-no-files-found: error
 
   build-linux-arm64-profiler:
-    needs: check-for-changes
-    if: ${{ inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true' }}
+    if: ${{ inputs.deploy }}
     name: Build Linux ARM64 Profiler
     runs-on: ubuntu-22.04
     permissions:
@@ -292,12 +251,11 @@ jobs:
   package-and-deploy:
     needs:
       [
-        check-for-changes,
         build-windows-profiler,
         build-linux-x64-profiler,
         build-linux-arm64-profiler,
       ]
-    if: ${{ (inputs.force-build || needs.check-for-changes.outputs.profiler_src == 'true') && inputs.deploy }}
+    if: ${{ inputs.deploy }}
     name: Package and Deploy Profiler NuGet
     runs-on: windows-2022
 

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -51,7 +51,6 @@ env:
 
 jobs:
   build-windows-profiler:
-    if: ${{ github.event_name == 'push' }}
     name: Build Windows Profiler & Run Unit Tests / Code Coverage
     runs-on: windows-latest
 


### PR DESCRIPTION
Modifies the `build_profiler` workflow to: 
* Remove the check for modified files
* Run the Windows profiler build, unit tests and code coverage, Linux amd64 and arm64 builds on a push to `main` or `feature/**`, and on every pull request. 
* Modifies the input parameters for manual calls or calls from other workflows to have only a `Deploy NuGet Package` option, defaulting to `false`. 
