### PR TITLE
Fix issue #2261

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftLoggingWrapper.cs
@@ -81,14 +81,13 @@ namespace NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging
                 var getLoggersArrayFunc = _getLoggersArray ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<dynamic>(logger.GetType(), "ScopeLoggers");
                 var loggers = getLoggersArrayFunc(logger);
 
-                // Get the first ScopeLogger in the array (logger.ScopeLoggers[0])
-                // If there is more than one scope logger, they've all received the same data, so the first
-                // one should be fine
-                object firstLogger = loggers.GetValue(0);
+                // Get the last ScopeLogger in the array (logger.ScopeLoggers[loggers.Length-1])
+                // If there is more than one scope logger, the last logger is the one with the ExternalScopeProvider set
+                object lastLogger = loggers.GetValue(loggers.Length-1);
 
-                // Get the scope provider from that logger (logger.ScopeLoggers[0].ExternalScopeProvider)
-                var scopeProviderPI = _scopeProviderPropertyInfo ??= firstLogger.GetType().GetProperty("ExternalScopeProvider");
-                var scopeProvider = scopeProviderPI.GetValue(firstLogger) as IExternalScopeProvider;
+                // Get the scope provider from that logger (logger.ScopeLoggers[loggers.Length-1].ExternalScopeProvider)
+                var scopeProviderPI = _scopeProviderPropertyInfo ??= lastLogger.GetType().GetProperty("ExternalScopeProvider");
+                var scopeProvider = scopeProviderPI.GetValue(lastLogger) as IExternalScopeProvider;
 
                 // Get the context data
                 var harvestedKvps = new Dictionary<string, object>();


### PR DESCRIPTION
## Description

Fixing issue #2261.  When there are multiple logging providers registered, only the last provider will have the ExternalScopeProvider set to a non-null value.  Because of this, new relic's logic to pull the first ScopeLogger from the array causes context data to be missed.  The simple fix is to simply grab the last value in the array.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
