### PR TITLE
ci: Fix issues in post-deploy sub-workflows

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -438,7 +438,7 @@ jobs:
     needs: [get-release-info]
     # if: true
     name: Create and Publish Release Notes
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@ci/release-workflow-issues
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
       run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
@@ -453,7 +453,7 @@ jobs:
     needs: [get-release-info]
     # if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Run Post Deploy Workflow
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@ci/release-workflow-issues
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -442,8 +442,8 @@ jobs:
     name: Create and Publish Release Notes
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@ci/release-workflow-issues
     with:
-      called_agent_version: ${{ needs.get-release-info.outputs.release_version }}
-      called_run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
+      release_agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      release_run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
     secrets: inherit
 
   post-deploy:
@@ -457,6 +457,6 @@ jobs:
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@ci/release-workflow-issues
     with:
-      called_agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      release_agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit
 

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -436,11 +436,10 @@ jobs:
         shell: bash
 
   publish-release-notes:
-    # needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    needs: [get-release-info]
-    # if: true
+    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Create and Publish Release Notes
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@ci/release-workflow-issues
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@main
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
       run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
@@ -451,11 +450,10 @@ jobs:
       issues: write
       contents: read
       packages: read
-    # needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    needs: [get-release-info]
-    # if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
+    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Run Post Deploy Workflow
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@ci/release-workflow-issues
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -434,10 +434,11 @@ jobs:
         shell: bash
 
   publish-release-notes:
-    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
+    # needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    needs: [get-release-info]
+    # if: true
     name: Create and Publish Release Notes
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@main
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
       run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
@@ -448,10 +449,11 @@ jobs:
       issues: write
       contents: read
       packages: read
-    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
+    # needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    needs: [get-release-info]
+    # if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
     name: Run Post Deploy Workflow
-    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -442,8 +442,8 @@ jobs:
     name: Create and Publish Release Notes
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@ci/release-workflow-issues
     with:
-      agent_version: ${{ needs.get-release-info.outputs.release_version }}
-      run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
+      called_agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      called_run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
     secrets: inherit
 
   post-deploy:
@@ -457,6 +457,6 @@ jobs:
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@ci/release-workflow-issues
     with:
-      agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      called_agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit
 

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -109,12 +109,12 @@ jobs:
             echo "::error::Release publish date is empty. Use manual overrides to continue."
             exit 1
           fi
-          #LAST_WEEK=$(date --date "-7days" -u +"%s")
-          #PUBLISH_DATE=$(date --date "$PUBLISHED_AT" -u +"%s")
-          #if [ $LAST_WEEK -ge $PUBLISH_DATE ]; then
-          #  echo "::error::$RELEASE_VERSION was published more than a week ago. Use manual overrides to continue."
-          #  exit 1
-          #fi
+          LAST_WEEK=$(date --date "-7days" -u +"%s")
+          PUBLISH_DATE=$(date --date "$PUBLISHED_AT" -u +"%s")
+          if [ $LAST_WEEK -ge $PUBLISH_DATE ]; then
+            echo "::error::$RELEASE_VERSION was published more than a week ago. Use manual overrides to continue."
+            exit 1
+          fi
 
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -146,8 +146,6 @@ jobs:
             echo "release_version=${{github.event.inputs.agent_version}}" >> "$GITHUB_OUTPUT"
             echo "workflow_run_id=${{github.event.inputs.run_id}}" >> "$GITHUB_OUTPUT"
           fi
-          echo "Github output file:"
-          cat "${GITHUB_OUTPUT}"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -109,12 +109,12 @@ jobs:
             echo "::error::Release publish date is empty. Use manual overrides to continue."
             exit 1
           fi
-          LAST_WEEK=$(date --date "-7days" -u +"%s")
-          PUBLISH_DATE=$(date --date "$PUBLISHED_AT" -u +"%s")
-          if [ $LAST_WEEK -ge $PUBLISH_DATE ]; then
-            echo "::error::$RELEASE_VERSION was published more than a week ago. Use manual overrides to continue."
-            exit 1
-          fi
+          #LAST_WEEK=$(date --date "-7days" -u +"%s")
+          #PUBLISH_DATE=$(date --date "$PUBLISHED_AT" -u +"%s")
+          #if [ $LAST_WEEK -ge $PUBLISH_DATE ]; then
+          #  echo "::error::$RELEASE_VERSION was published more than a week ago. Use manual overrides to continue."
+          #  exit 1
+          #fi
 
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -146,6 +146,8 @@ jobs:
             echo "release_version=${{github.event.inputs.agent_version}}" >> "$GITHUB_OUTPUT"
             echo "workflow_run_id=${{github.event.inputs.run_id}}" >> "$GITHUB_OUTPUT"
           fi
+          echo "Github output file:"
+          cat "${GITHUB_OUTPUT}"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -442,8 +442,8 @@ jobs:
     name: Create and Publish Release Notes
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@ci/release-workflow-issues
     with:
-      release_agent_version: ${{ needs.get-release-info.outputs.release_version }}
-      release_run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
+      agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
     secrets: inherit
 
   post-deploy:
@@ -457,6 +457,6 @@ jobs:
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@ci/release-workflow-issues
     with:
-      release_agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      agent_version: ${{ needs.get-release-info.outputs.release_version }}
     secrets: inherit
 

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -44,7 +44,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
+        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -3,17 +3,21 @@ name: Post Deploy for the .NET Agent
 on:
   workflow_dispatch:
     inputs:
-      release_agent_version:
+      agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
+      wait_for_apt_and_yum:
+        type: boolean
+        default: false
+        required: false
   workflow_call:
     inputs:
-      release_agent_version:
+      agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-      external_call:
+      wait_for_apt_and_yum:
         type: boolean
         default: true
         required: false
@@ -26,14 +30,6 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  print_context:
-    runs-on: ubuntu-latest
-    steps:
-      - env:
-          EVENT_NAME: ${{ toJSON(github.event_name) }}
-        run: |
-          echo $EVENT_NAME
-
   validate-apt-repo:
     name: Validate APT-based repo
     runs-on: ubuntu-latest
@@ -44,7 +40,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
+        if: ${{ inputs.wait_for_apt_and_yum == 'true' }} # only wait if requested
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -65,7 +61,7 @@ jobs:
           fi
         shell: bash
         env: 
-          AGENT_VERSION: "Version: ${{ inputs.release_agent_version }}"
+          AGENT_VERSION: "Version: ${{ inputs.agent_version }}"
 
   validate-yum-repo:
     name: Validate YUM-based repo
@@ -83,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.event_name == 'workflow_call' }} # only wait if this workflow was called by another workflow
+        if: ${{ inputs.wait_for_apt_and_yum == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300
@@ -106,7 +102,7 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.release_agent_version }}-1.x86_64"
+          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.agent_version }}-1.x86_64"
 
   validate-download-site-s3:
     name: Validate S3-hosted Download Site
@@ -132,7 +128,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/S3Validator/S3Validator.csproj
           RUN_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/
           CONFIG_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/config.yml
-          AGENT_VERSION: ${{ inputs.release_agent_version }}
+          AGENT_VERSION: ${{ inputs.agent_version }}
 
   validate-nuget-packages:
     name: Validate NuGet Package Deployment
@@ -157,7 +153,7 @@ jobs:
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
           RUN_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/
-          AGENT_VERSION: ${{ inputs.release_agent_version }}
+          AGENT_VERSION: ${{ inputs.agent_version }}
           CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
 
   # report-deprecated-nuget-packages:

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -156,30 +156,30 @@ jobs:
           AGENT_VERSION: ${{ inputs.agent_version }}
           CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
 
-  # report-deprecated-nuget-packages:
-  #   name: Report Deprecated NuGet Packages
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     issues: write
+  report-deprecated-nuget-packages:
+    name: Report Deprecated NuGet Packages
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
       
-  #   steps:
-  #     - name: Harden Runner
-  #       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-  #       with:
-  #         disable-sudo: true
-  #         egress-policy: audit
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
 
-  #     - name: Checkout
-  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
-  #     - name: Build and Run NugetDeprecator
-  #       run: |
-  #         dotnet build --configuration Release "$BUILD_PATH"
-  #         "$RUN_PATH/NugetVersionDeprecator" -c $CONFIG_PATH --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
-  #       shell: bash
-  #       env:
-  #         BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
-  #         RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/
-  #         CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/config.yml
+      - name: Build and Run NugetDeprecator
+        run: |
+          dotnet build --configuration Release "$BUILD_PATH"
+          "$RUN_PATH/NugetVersionDeprecator" -c $CONFIG_PATH --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+        shell: bash
+        env:
+          BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+          RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/
+          CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/config.yml

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+          EVENT_NAME: ${{ toJSON(github.event_name) }}
         run: |
-          echo $EVENT_CONTEXT
+          echo $EVENT_NAME
 
   validate-apt-repo:
     name: Validate APT-based repo

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -37,7 +37,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ github.event.inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
+        if: ${{ inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -58,7 +58,7 @@ jobs:
           fi
         shell: bash
         env: 
-          AGENT_VERSION: "Version: ${{ github.event.inputs.release_agent_version }}"
+          AGENT_VERSION: "Version: ${{ inputs.release_agent_version }}"
 
   validate-yum-repo:
     name: Validate YUM-based repo
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ github.event.inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
+        if: ${{ inputs.external_call == 'true' }} # only wait if this workflow was called by another workflow
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300
@@ -99,7 +99,7 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "newrelic-dotnet-agent-${{ github.event.inputs.release_agent_version }}-1.x86_64"
+          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.release_agent_version }}-1.x86_64"
 
   validate-download-site-s3:
     name: Validate S3-hosted Download Site
@@ -125,7 +125,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/S3Validator/S3Validator.csproj
           RUN_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/
           CONFIG_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/config.yml
-          AGENT_VERSION: ${{ github.event.inputs.release_agent_version }}
+          AGENT_VERSION: ${{ inputs.release_agent_version }}
 
   validate-nuget-packages:
     name: Validate NuGet Package Deployment
@@ -150,7 +150,7 @@ jobs:
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
           RUN_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/
-          AGENT_VERSION: ${{ github.event.inputs.release_agent_version }}
+          AGENT_VERSION: ${{ inputs.release_agent_version }}
           CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
 
   # report-deprecated-nuget-packages:

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -153,30 +153,30 @@ jobs:
           AGENT_VERSION: ${{ github.event.inputs.agent_version }}
           CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
 
-  report-deprecated-nuget-packages:
-    name: Report Deprecated NuGet Packages
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
+  # report-deprecated-nuget-packages:
+  #   name: Report Deprecated NuGet Packages
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     issues: write
       
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          disable-sudo: true
-          egress-policy: audit
+  #   steps:
+  #     - name: Harden Runner
+  #       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+  #       with:
+  #         disable-sudo: true
+  #         egress-policy: audit
 
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
+  #     - name: Checkout
+  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Build and Run NugetDeprecator
-        run: |
-          dotnet build --configuration Release "$BUILD_PATH"
-          "$RUN_PATH/NugetVersionDeprecator" -c $CONFIG_PATH --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
-        shell: bash
-        env:
-          BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
-          RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/
-          CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/config.yml
+  #     - name: Build and Run NugetDeprecator
+  #       run: |
+  #         dotnet build --configuration Release "$BUILD_PATH"
+  #         "$RUN_PATH/NugetVersionDeprecator" -c $CONFIG_PATH --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+  #       shell: bash
+  #       env:
+  #         BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+  #         RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/
+  #         CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/config.yml

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -26,6 +26,13 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
+  print_context:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: |
+          echo $EVENT_CONTEXT
 
   validate-apt-repo:
     name: Validate APT-based repo

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -3,13 +3,13 @@ name: Post Deploy for the .NET Agent
 on:
   workflow_dispatch:
     inputs:
-      agent_version:
+      release_agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
   workflow_call:
     inputs:
-      agent_version:
+      release_agent_version:
         description: 'Agent Version to validate.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
@@ -58,7 +58,7 @@ jobs:
           fi
         shell: bash
         env: 
-          AGENT_VERSION: "Version: ${{ github.event.inputs.agent_version }}"
+          AGENT_VERSION: "Version: ${{ github.event.inputs.release_agent_version }}"
 
   validate-yum-repo:
     name: Validate YUM-based repo
@@ -99,7 +99,7 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "newrelic-dotnet-agent-${{ github.event.inputs.agent_version }}-1.x86_64"
+          AGENT_VERSION: "newrelic-dotnet-agent-${{ github.event.inputs.release_agent_version }}-1.x86_64"
 
   validate-download-site-s3:
     name: Validate S3-hosted Download Site
@@ -125,7 +125,7 @@ jobs:
           BUILD_PATH: ${{ github.workspace }}/build/S3Validator/S3Validator.csproj
           RUN_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/
           CONFIG_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/config.yml
-          AGENT_VERSION: ${{ github.event.inputs.agent_version }}
+          AGENT_VERSION: ${{ github.event.inputs.release_agent_version }}
 
   validate-nuget-packages:
     name: Validate NuGet Package Deployment
@@ -150,7 +150,7 @@ jobs:
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
           RUN_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/
-          AGENT_VERSION: ${{ github.event.inputs.agent_version }}
+          AGENT_VERSION: ${{ github.event.inputs.release_agent_version }}
           CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
 
   # report-deprecated-nuget-packages:

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "release_run_id='${{ github.event.inputs.release_run_id }}'"
           echo "release_agent_version='${{ github.event.inputs.release_agent_version }}'"
-      shell: bash
+        shell: bash
 
   publish-release-notes:
     name: Create and Publish Release Notes

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -3,21 +3,21 @@ name: Publish .NET Agent Release Notes
 on:
   workflow_dispatch:
     inputs:
-      agent_version:
-        description: 'Agent Version to deploy.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
+      release_agent_version:
+        description: 'Agent version that was released.  Needs to match the version from the Deploy Agent workflow (deploy_agent.yml). Format: X.X.X'
         required: true
         type: string
-      run_id:
+      release_run_id:
         description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
         type: string
   workflow_call:
     inputs:
-      agent_version:
+      release_agent_version:
         description: 'Agent Version to deploy.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-      run_id:
+      release_run_id:
         description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
         type: string
@@ -37,9 +37,9 @@ jobs:
     steps:
       - name: Echo vars
         run: |
-          echo "run_id='${{ github.event.inputs.run_id }}'"
-          echo "agent_version='${{ github.event.inputs.agent_version }}'"
-        shell: bash
+          echo "release_run_id='${{ github.event.inputs.release_run_id }}'"
+          echo "release_agent_version='${{ github.event.inputs.release_agent_version }}'"
+      shell: bash
 
   publish-release-notes:
     name: Create and Publish Release Notes
@@ -59,14 +59,14 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ github.event.inputs.release_run_id }}
           name: deploy-artifacts
           path: ${{ github.workspace }}/deploy-artifacts
           repository: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
         run: |
-          cleaned_branch=$(echo "${{ github.event.inputs.agent_version }}" | sed 's/\./-/g')
+          cleaned_branch=$(echo "${{ github.event.inputs.release_agent_version }}" | sed 's/\./-/g')
           echo "branch_name=dotnet-release-$cleaned_branch"
           echo "branch_name=dotnet-release-$cleaned_branch" >> $GITHUB_ENV
         shell: bash
@@ -97,7 +97,7 @@ jobs:
       #     user_name: 'dotnet-agent-team-bot'
       #     destination_branch: 'develop'
       #     destination_branch_create: ${{env.branch_name}}
-      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ github.event.inputs.agent_version }}.'
+      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ github.event.inputs.release_agent_version }}.'
 
       # - name: Create pull request
       #   run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
@@ -105,5 +105,5 @@ jobs:
       #     GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
       #     REPO: https://github.com/newrelic/docs-website/
       #     HEAD: ${{env.branch_name}}
-      #     TITLE: ".NET Agent Release Notes for v${{ github.event.inputs.agent_version }}"
+      #     TITLE: ".NET Agent Release Notes for v${{ github.event.inputs.release_agent_version }}"
       #     BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -31,6 +31,16 @@ env:
 
 jobs:
 
+  echo_input_vars:
+    name: Echo input vars (debugging)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo vars
+        run: |
+          echo "run_id='${{ github.event.inputs.run_id }}'"
+          echo "agent_version='${{ github.event.inputs.agent_version }}'"
+        shell: bash
+
   publish-release-notes:
     name: Create and Publish Release Notes
     runs-on: ubuntu-latest
@@ -75,25 +85,25 @@ jobs:
           CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}
 
-      - name: Create branch
-        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
-        with:
-          source_file: "${{ env.notes_file }}"
-          destination_repo: 'newrelic/docs-website'
-          destination_folder: 'src/content/docs/release-notes/agent-release-notes/net-release-notes'
-          user_email: '${{ secrets.BOT_EMAIL }}'
-          user_name: 'dotnet-agent-team-bot'
-          destination_branch: 'develop'
-          destination_branch_create: ${{env.branch_name}}
-          commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ github.event.inputs.agent_version }}.'
+      # - name: Create branch
+      #   uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
+      #   with:
+      #     source_file: "${{ env.notes_file }}"
+      #     destination_repo: 'newrelic/docs-website'
+      #     destination_folder: 'src/content/docs/release-notes/agent-release-notes/net-release-notes'
+      #     user_email: '${{ secrets.BOT_EMAIL }}'
+      #     user_name: 'dotnet-agent-team-bot'
+      #     destination_branch: 'develop'
+      #     destination_branch_create: ${{env.branch_name}}
+      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ github.event.inputs.agent_version }}.'
 
-      - name: Create pull request
-        run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
-        env:
-          GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
-          REPO: https://github.com/newrelic/docs-website/
-          HEAD: ${{env.branch_name}}
-          TITLE: ".NET Agent Release Notes for v${{ github.event.inputs.agent_version }}"
-          BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."
+      # - name: Create pull request
+      #   run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
+      #   env:
+      #     GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
+      #     REPO: https://github.com/newrelic/docs-website/
+      #     HEAD: ${{env.branch_name}}
+      #     TITLE: ".NET Agent Release Notes for v${{ github.event.inputs.agent_version }}"
+      #     BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Echo vars
         run: |
-          echo "github conext='${GITHUB_CONTEXT}'"
+          echo "$GITHUB_CONTEXT"
           echo "release_run_id='${{ github.event.inputs.release_run_id }}'"
           echo "release_agent_version='${{ github.event.inputs.release_agent_version }}'"
         shell: bash

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -60,14 +60,14 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.release_run_id }}
+          run-id: ${{ inputs.release_run_id }}
           name: deploy-artifacts
           path: ${{ github.workspace }}/deploy-artifacts
           repository: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
         run: |
-          cleaned_branch=$(echo "${{ github.event.inputs.release_agent_version }}" | sed 's/\./-/g')
+          cleaned_branch=$(echo "${{ inputs.release_agent_version }}" | sed 's/\./-/g')
           echo "branch_name=dotnet-release-$cleaned_branch"
           echo "branch_name=dotnet-release-$cleaned_branch" >> $GITHUB_ENV
         shell: bash
@@ -98,7 +98,7 @@ jobs:
       #     user_name: 'dotnet-agent-team-bot'
       #     destination_branch: 'develop'
       #     destination_branch_create: ${{env.branch_name}}
-      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ github.event.inputs.release_agent_version }}.'
+      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ inputs.release_agent_version }}.'
 
       # - name: Create pull request
       #   run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
@@ -106,5 +106,5 @@ jobs:
       #     GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
       #     REPO: https://github.com/newrelic/docs-website/
       #     HEAD: ${{env.branch_name}}
-      #     TITLE: ".NET Agent Release Notes for v${{ github.event.inputs.release_agent_version }}"
+      #     TITLE: ".NET Agent Release Notes for v${{ inputs.release_agent_version }}"
       #     BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Echo vars
         run: |
           echo "$GITHUB_CONTEXT"
-          echo "release_run_id='${{ github.event.inputs.release_run_id }}'"
-          echo "release_agent_version='${{ github.event.inputs.release_agent_version }}'"
+          echo "release_run_id='${{ inputs.release_run_id }}'"
+          echo "release_agent_version='${{ inputs.release_agent_version }}'"
         shell: bash
 
   publish-release-notes:

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -3,21 +3,21 @@ name: Publish .NET Agent Release Notes
 on:
   workflow_dispatch:
     inputs:
-      release_agent_version:
+      agent_version:
         description: 'Agent version that was released.  Needs to match the version from the Deploy Agent workflow (deploy_agent.yml). Format: X.X.X'
         required: true
         type: string
-      release_run_id:
+      run_id:
         description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
         type: string
   workflow_call:
     inputs:
-      release_agent_version:
+      agent_version:
         description: 'Agent Version to deploy.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
         required: true
         type: string
-      release_run_id:
+      run_id:
         description: 'Run ID of the Release Workflow (all_solutions.yml) that was triggered by creating a Release in GitHub.  ID can be found in URL for run.'
         required: true
         type: string
@@ -38,8 +38,8 @@ jobs:
       - name: Echo vars
         run: |
           echo "$GITHUB_CONTEXT"
-          echo "release_run_id='${{ inputs.release_run_id }}'"
-          echo "release_agent_version='${{ inputs.release_agent_version }}'"
+          echo "release_run_id='${{ inputs.run_id }}'"
+          echo "release_agent_version='${{ inputs.agent_version }}'"
         shell: bash
 
   publish-release-notes:
@@ -60,14 +60,14 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.release_run_id }}
+          run-id: ${{ inputs.run_id }}
           name: deploy-artifacts
           path: ${{ github.workspace }}/deploy-artifacts
           repository: ${{ github.repository }}
 
       - name: Set Docs PR Branch Name
         run: |
-          cleaned_branch=$(echo "${{ inputs.release_agent_version }}" | sed 's/\./-/g')
+          cleaned_branch=$(echo "${{ inputs.agent_version }}" | sed 's/\./-/g')
           echo "branch_name=dotnet-release-$cleaned_branch"
           echo "branch_name=dotnet-release-$cleaned_branch" >> $GITHUB_ENV
         shell: bash
@@ -98,7 +98,7 @@ jobs:
       #     user_name: 'dotnet-agent-team-bot'
       #     destination_branch: 'develop'
       #     destination_branch_create: ${{env.branch_name}}
-      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ inputs.release_agent_version }}.'
+      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ inputs.agent_version }}.'
 
       # - name: Create pull request
       #   run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
@@ -106,5 +106,5 @@ jobs:
       #     GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
       #     REPO: https://github.com/newrelic/docs-website/
       #     HEAD: ${{env.branch_name}}
-      #     TITLE: ".NET Agent Release Notes for v${{ inputs.release_agent_version }}"
+      #     TITLE: ".NET Agent Release Notes for v${{ inputs.agent_version }}"
       #     BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - name: Echo vars
         run: |
+          echo "github conext='${GITHUB_CONTEXT}'"
           echo "release_run_id='${{ github.event.inputs.release_run_id }}'"
           echo "release_agent_version='${{ github.event.inputs.release_agent_version }}'"
         shell: bash

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -30,18 +30,6 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-
-  echo_input_vars:
-    name: Echo input vars (debugging)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo vars
-        run: |
-          echo "$GITHUB_CONTEXT"
-          echo "release_run_id='${{ inputs.run_id }}'"
-          echo "release_agent_version='${{ inputs.agent_version }}'"
-        shell: bash
-
   publish-release-notes:
     name: Create and Publish Release Notes
     runs-on: ubuntu-latest
@@ -86,25 +74,25 @@ jobs:
           CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}
 
-      # - name: Create branch
-      #   uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
-      #   with:
-      #     source_file: "${{ env.notes_file }}"
-      #     destination_repo: 'newrelic/docs-website'
-      #     destination_folder: 'src/content/docs/release-notes/agent-release-notes/net-release-notes'
-      #     user_email: '${{ secrets.BOT_EMAIL }}'
-      #     user_name: 'dotnet-agent-team-bot'
-      #     destination_branch: 'develop'
-      #     destination_branch_create: ${{env.branch_name}}
-      #     commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ inputs.agent_version }}.'
+      - name: Create branch
+        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
+        with:
+          source_file: "${{ env.notes_file }}"
+          destination_repo: 'newrelic/docs-website'
+          destination_folder: 'src/content/docs/release-notes/agent-release-notes/net-release-notes'
+          user_email: '${{ secrets.BOT_EMAIL }}'
+          user_name: 'dotnet-agent-team-bot'
+          destination_branch: 'develop'
+          destination_branch_create: ${{env.branch_name}}
+          commit_message: 'chore(.net agent): Add .NET Agent release notes for v${{ inputs.agent_version }}.'
 
-      # - name: Create pull request
-      #   run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
-      #   env:
-      #     GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
-      #     REPO: https://github.com/newrelic/docs-website/
-      #     HEAD: ${{env.branch_name}}
-      #     TITLE: ".NET Agent Release Notes for v${{ inputs.agent_version }}"
-      #     BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."
+      - name: Create pull request
+        run: gh pr create --base "develop" --repo "$REPO" --head "$HEAD" --title "$TITLE" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
+          REPO: https://github.com/newrelic/docs-website/
+          HEAD: ${{env.branch_name}}
+          TITLE: ".NET Agent Release Notes for v${{ inputs.agent_version }}"
+          BODY: "This is an automated PR generated when the .NET agent is released. Please merge as soon as possible."


### PR DESCRIPTION
Fix #2284 by using the `inputs.` input values instead of `github.event.inputs`.  See: https://docs.github.com/en/actions/learn-github-actions/contexts#example-usage-of-the-inputs-context-in-a-reusable-workflow

Apparently the "github event context" of a called workflow is that of the _caller_, not the _callee_.  That's why `github.event.inputs` was working in the sub-workflows when we ran the deploy workflow and manually specified the agent version and run id (because the agent version and run_id would be inputs to the `deploy_agent` workflow), but not when the agent version and run id were determined automatically.

TL;DR use `inputs` not `github.event.inputs` when working with reusable workflows.