### PR TITLE
ci: Update run and config paths for NugetVersionDeprecator to net8.0

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -181,5 +181,5 @@ jobs:
         shell: bash
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
-          RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/
-          CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net7.0/config.yml
+          RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net8.0/
+          CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net8.0/config.yml


### PR DESCRIPTION
I should have remembered to do this when I updated the TFM for NugetVersionDeprecator to net8.0 in this PR: https://github.com/newrelic/newrelic-dotnet-agent/pull/2280