### PR TITLE
ci: Update `wait_for_apt_and_yum` default value to true on workflow_dispatch

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -9,7 +9,7 @@ on:
         type: string
       wait_for_apt_and_yum:
         type: boolean
-        default: false
+        default: true
         required: false
   workflow_call:
     inputs:


### PR DESCRIPTION
This should resolve the issue where the workflow didn't delay to wait for apt/yum to update, when called from an external workflow.