### PR TITLE
ci: Update all workflows to use `inputs` instead of `github.event.inputs`.

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -67,13 +67,13 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        if: ${{ github.event.inputs.get-version-automatically == 'true' }}
+        if: ${{ inputs.get-version-automatically == 'true' }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       
       - name: Get Release Version and Run ID
-        if: ${{ github.event.inputs.get-version-automatically == 'true' }}
+        if: ${{ inputs.get-version-automatically == 'true' }}
         id: step1
         run: |
           # Get the commit sha for the most recent release
@@ -131,20 +131,20 @@ jobs:
       - name: Set Output Release Version and Build Run ID
         id: step2
         run: |
-          if [ "${{ github.event.inputs.get-version-automatically}}" = "true" ]; then
+          if [ "${{ inputs.get-version-automatically}}" = "true" ]; then
             echo "release_version=${{steps.step1.outputs.release_version}}" >> "$GITHUB_OUTPUT"
             echo "workflow_run_id=${{steps.step1.outputs.workflow_run_id}}" >> "$GITHUB_OUTPUT"
           else
-            if [[ -z "${{github.event.inputs.agent_version}}" ]]; then
+            if [[ -z "${{inputs.agent_version}}" ]]; then
               echo "::error::Agent Version not specified."
               exit 1
             fi
-            if [[ -z "${{github.event.inputs.run_id}}" ]]; then
+            if [[ -z "${{inputs.run_id}}" ]]; then
               echo "::error::Run ID not specified."
               exit 1
             fi
-            echo "release_version=${{github.event.inputs.agent_version}}" >> "$GITHUB_OUTPUT"
-            echo "workflow_run_id=${{github.event.inputs.run_id}}" >> "$GITHUB_OUTPUT"
+            echo "release_version=${{inputs.agent_version}}" >> "$GITHUB_OUTPUT"
+            echo "workflow_run_id=${{inputs.run_id}}" >> "$GITHUB_OUTPUT"
           fi
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -178,7 +178,7 @@ jobs:
 
   deploy-downloadsite:
     needs: [get-release-info, get-external-artifacts]
-    if: ${{ github.event.inputs.downloadsite == 'true' }}
+    if: ${{ inputs.downloadsite == 'true' }}
     name: Deploy MSI to Download Site
     runs-on: windows-2019
 
@@ -208,7 +208,7 @@ jobs:
           New-Item -ItemType directory -Path .\latest_release -Force
           Copy-Item .\working_dir\* .\latest_release\ -Force -Recurse
           cd .\latest_release
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/latest_release/ --include "*" --exclude ".DS_Store" --delete
           }
           else {
@@ -225,7 +225,7 @@ jobs:
           New-Item -ItemType directory -Path .\previous_releases\${{ needs.get-release-info.outputs.release_version }} -Force
           Copy-Item .\working_dir\* ".\previous_releases\${{ needs.get-release-info.outputs.release_version }}\" -Force -Recurse
           cd .\previous_releases\${{ needs.get-release-info.outputs.release_version }}
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             aws s3 sync . ${{ secrets.BUCKET_NAME }}/dot_net_agent/previous_releases/${{ needs.get-release-info.outputs.release_version }}/ --include "*" --exclude ".DS_Store" --delete
           }
           else {
@@ -237,7 +237,7 @@ jobs:
   index-download-site:
     needs: deploy-downloadsite
     name: Rebuild indexes on the download site
-    if: ${{ github.event.inputs.indexdownloadsite == 'true'}}
+    if: ${{ inputs.indexdownloadsite == 'true'}}
     uses: ./.github/workflows/build_download_site_index_files.yml
     strategy:
       matrix:
@@ -250,7 +250,7 @@ jobs:
 
   deploy-nuget:
     needs: get-external-artifacts
-    if: ${{ github.event.inputs.nuget == 'true' }}
+    if: ${{ inputs.nuget == 'true' }}
     name: Deploy Agent to NuGet
     runs-on: windows-2019
 
@@ -274,7 +274,7 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgent\NewRelic.Agent.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgent\$packageName
           $version = $packageName.TrimStart('NewRelic.Agent').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
@@ -288,7 +288,7 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgentApi\NewRelic.Agent.Api.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAgentApi\$packageName
           $version = $packageName.TrimStart('NewRelic.Agent.Api').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
@@ -302,7 +302,7 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureCloudServices\NewRelicWindowsAzure.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureCloudServices\$packageName
           $version = $packageName.TrimStart('NewRelicWindowsAzure').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
@@ -316,7 +316,7 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\NewRelic.Azure.WebSites.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x64\$packageName
           $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
@@ -330,7 +330,7 @@ jobs:
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\NewRelic.Azure.WebSites.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\working_dir\NugetAzureWebSites-x86\$packageName
           $version = $packageName.TrimStart('NewRelic.Azure.WebSites.x').TrimStart('.').TrimEnd('.nupkg')
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
@@ -341,7 +341,7 @@ jobs:
 
   deploy-linux:
     needs: [get-release-info, get-external-artifacts]
-    if: ${{ github.event.inputs.linux == 'true' }}
+    if: ${{ inputs.linux == 'true' }}
     name: Deploy Linux to APT and YUM
     runs-on: ubuntu-latest
     steps:
@@ -399,7 +399,7 @@ jobs:
           touch docker.env
           echo "AGENT_VERSION=$AGENT_VERSION" >> docker.env
           echo "ACTION=release" >> docker.env
-          if [ "${{ github.event.inputs.linux-deploy-to-production }}" == "true" ] ; then
+          if [ "${{ inputs.linux-deploy-to-production }}" == "true" ] ; then
             # We're actually deploying to production (apt.newrelic.com and yum.newrelic.com)           
             echo "S3_BUCKET=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
             echo "AWS_ACCESS_KEY_ID=${{ secrets.LINUX_AWS_ACCESS_KEY_ID }}" >> docker.env
@@ -419,7 +419,7 @@ jobs:
           find . -name "*.bash" |xargs chmod a+x
           find . -type f |xargs dos2unix
           docker-compose build
-          if [ "${{ github.event.inputs.deploy }}" == "true" ] ; then
+          if [ "${{ inputs.deploy }}" == "true" ] ; then
             docker-compose run deploy_packages
           else
             echo "Input:deploy was not true.  The following deploy command was not run:"
@@ -428,14 +428,14 @@ jobs:
         shell: bash
 
       - name: Clear Fastly cache
-        if: ${{ github.event.inputs.deploy == 'true' && success() }}
+        if: ${{ inputs.deploy == 'true' && success() }}
         run: |
           curl -i -X POST -H 'Fastly-Key:${{ secrets.FASTLY_TOKEN }}' ${{ secrets.FASTLY_URL }}
         shell: bash
 
   publish-release-notes:
     needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
+    if: ${{ inputs.deploy == 'true' && inputs.downloadsite == 'true' && inputs.nuget == 'true' && inputs.linux == 'true' && inputs.linux-deploy-to-production == 'true' }}
     name: Create and Publish Release Notes
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/publish_release_notes.yml@main
     with:
@@ -449,7 +449,7 @@ jobs:
       contents: read
       packages: read
     needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
-    if: ${{ github.event.inputs.deploy == 'true' && github.event.inputs.downloadsite == 'true' && github.event.inputs.nuget == 'true' && github.event.inputs.linux == 'true' && github.event.inputs.linux-deploy-to-production == 'true' }}
+    if: ${{ inputs.deploy == 'true' && inputs.downloadsite == 'true' && inputs.nuget == 'true' && inputs.linux == 'true' && inputs.linux-deploy-to-production == 'true' }}
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main
     with:

--- a/.github/workflows/deploy_awslambda.yml
+++ b/.github/workflows/deploy_awslambda.yml
@@ -31,7 +31,7 @@ jobs:
           uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
-            run-id: ${{ github.event.inputs.run_id }}
+            run-id: ${{ inputs.run_id }}
             name: deploy-artifacts
             path: ${{ github.workspace }}
             repository: ${{ github.repository }}
@@ -45,11 +45,11 @@ jobs:
           run: |
             $packageName = Get-ChildItem ${{ github.workspace }}\NugetAwsLambdaOpenTracer\NewRelic.OpenTracing.AmazonLambda.Tracer.*.nupkg -Name
             $packagePath = Convert-Path ${{ github.workspace }}\NugetAwsLambdaOpenTracer\$packageName
-            if ("${{ github.event.inputs.deploy }}" -eq "true") {
+            if ("${{ inputs.deploy }}" -eq "true") {
               nuget.exe push $packagePath -Source ${{ env.nuget_source }}
             }
             else {
-              Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+              Write-Host "Input:deploy was not true (${{ inputs.deploy }}).  The following deploy command was not run:"
               Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
             }
           shell: powershell

--- a/.github/workflows/deploy_siteextension.yml
+++ b/.github/workflows/deploy_siteextension.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: deploy-artifacts
           path: ${{ github.workspace }}
           repository: ${{ github.repository }}
@@ -46,11 +46,11 @@ jobs:
         run: |
           $packageName = Get-ChildItem ${{ github.workspace }}\AzureSiteExtension\NewRelic.Azure.WebSites.Extension.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}\AzureSiteExtension\$packageName
-          if ("${{ github.event.inputs.deploy }}" -eq "true") {
+          if ("${{ inputs.deploy }}" -eq "true") {
             nuget.exe push $packagePath -Source ${{ env.nuget_source }}
           }
           else {
-            Write-Host "Input:deploy was not true (${{ github.event.inputs.deploy }}).  The following deploy command was not run:"
+            Write-Host "Input:deploy was not true (${{ inputs.deploy }}).  The following deploy command was not run:"
             Write-Host "nuget.exe push $packagePath -Source ${{ env.nuget_source }}"
           }
         shell: powershell

--- a/.github/workflows/multiverse_run.yml
+++ b/.github/workflows/multiverse_run.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           cd ${{ env.multiverse_reportbuilder_path }}
           sudo chmod 777 ./ReportBuilder
-          ./ReportBuilder "${{ github.event.inputs.agentVersion }}" "${{ env.multiverse_consolescanner_path }}/reports.yml" "${{ github.workspace }}/docs/mvs"
+          ./ReportBuilder "${{ inputs.agentVersion }}" "${{ env.multiverse_consolescanner_path }}/reports.yml" "${{ github.workspace }}/docs/mvs"
         shell: bash
 
       - name: Deploy 🚀

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Check for updates to core technology packages
         run: |
-          if [ ${{ github.event.inputs.daysToSearch }} != "" ]; then
-            export DOTTY_DAYS_TO_SEARCH=${{ github.event.inputs.daysToSearch }}
+          if [ ${{ inputs.daysToSearch }} != "" ]; then
+            export DOTTY_DAYS_TO_SEARCH=${{ inputs.daysToSearch }}
           fi
-          if [ "${{ github.event.inputs.testMode }}" == "true" ]; then
+          if [ "${{ inputs.testMode }}" == "true" ]; then
             export DOTTY_TEST_MODE="True"
           fi
           cd ${{ env.scan-tool-path }}/bin/Debug/net6.0

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - id: configure_integration_tests_matrix
         run: |
-          if [ "${{ github.event.inputs.integration-test-namespaces }}" == "ALL" ] ; then
+          if [ "${{ inputs.integration-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
             namespaces="[ 'AgentFeatures', 'AgentLogs', 'AgentMetrics', 'Api', 'AppDomainCaching', 'AspNetCore', 'BasicInstrumentation', 'CatInbound', 'CatOutbound', 'CodeLevelMetrics', 'Configuration', \
           'CSP', 'CustomAttributes', 'CustomInstrumentation', 'DataTransmission', 'DistributedTracing', 'Errors', 'HttpClientInstrumentation', 'InfiniteTracing', 'Logging.ContextData', \
@@ -60,21 +60,21 @@ jobs:
           'WCF.Service.IIS.ASPDisabled', 'WCF.Service.IIS.ASPEnabled', 'WCF.Service.Self' ]"
           else
             # Just use the supplied list of namespaces
-            namespaces="[ ${{ github.event.inputs.integration-test-namespaces }} ]"
+            namespaces="[ ${{ inputs.integration-test-namespaces }} ]"
           fi
           echo "matrix=$namespaces" >> $GITHUB_OUTPUT
         shell: bash
 
       - id: configure_unbounded_tests_matrix
         run: |
-          if [ "${{ github.event.inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
+          if [ "${{ inputs.unbounded-test-namespaces }}" == "ALL" ] ; then
             # Use the full list of namespaces
             # Oracle is disabled temporarily
             #namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Oracle', 'Postgres', 'RabbitMq', 'Redis' ]"
             namespaces="[ 'CosmosDB', 'Couchbase', 'Elasticsearch', 'MongoDB', 'Msmq', 'MsSql', 'MySql', 'NServiceBus', 'NServiceBus5', 'Postgres', 'RabbitMq', 'Redis' ]"
           else
             # Just use the supplied list of namespaces
-            namespaces="[ ${{ github.event.inputs.unbounded-test-namespaces }} ]"
+            namespaces="[ ${{ inputs.unbounded-test-namespaces }} ]"
           fi
           echo "matrix=$namespaces" >> $GITHUB_OUTPUT
         shell: bash
@@ -83,7 +83,7 @@ jobs:
 
   run-integration-tests:
     needs: [setup-matrices]
-    if: github.event.inputs.solutions == 'Both' || github.event.inputs.solutions == 'IntegrationTests'
+    if: inputs.solutions == 'Both' || inputs.solutions == 'IntegrationTests'
     name: Run IntegrationTests
     runs-on: windows-2022 # TODO: make this a input so we can test different OSes?
     strategy:
@@ -134,7 +134,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
           repository: ${{ github.repository }}
@@ -143,7 +143,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: integrationtests
           path: ${{ github.workspace }}
           repository: ${{ github.repository }}
@@ -171,7 +171,7 @@ jobs:
           #   $json.parallelizeAssembly = $true
           #   $json.parallelizeTestCollections = $true
           # }
-          if ("${{ github.event.inputs.parallelize }}" -eq "true") {
+          if ("${{ inputs.parallelize }}" -eq "true") {
             $json.parallelizeAssembly = $true
             $json.parallelizeTestCollections = $true
           }
@@ -202,7 +202,7 @@ jobs:
 
   run-unbounded-tests:
     needs: [setup-matrices]
-    if: github.event.inputs.solutions == 'Both' || github.event.inputs.solutions == 'UnboundedIntegrationTests'
+    if: inputs.solutions == 'Both' || inputs.solutions == 'UnboundedIntegrationTests'
     name: Run Unbounded Tests
     runs-on: windows-2022
     strategy:
@@ -227,7 +227,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
           repository: ${{ github.repository }}
@@ -236,7 +236,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: unboundedintegrationtests
           path: ${{ github.workspace }}
           repository: ${{ github.repository }}
@@ -294,7 +294,7 @@ jobs:
           $json = Get-Content "${{ env.unbounded_tests_path }}/xunit.runner.json" | ConvertFrom-Json
           $json | Add-Member -Name "parallelizeAssembly" -Value $false -MemberType NoteProperty
           $json | Add-Member -Name "parallelizeTestCollections" -Value $false -MemberType NoteProperty
-          if ("${{ github.event.inputs.parallelize }}" -eq "true") {
+          if ("${{ inputs.parallelize }}" -eq "true") {
             $json.parallelizeAssembly = $true
             $json.parallelizeTestCollections = $true
           }

--- a/.github/workflows/run_linux_container_tests.yml
+++ b/.github/workflows/run_linux_container_tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.inputs.run_id }}
+          run-id: ${{ inputs.run_id }}
           name: homefolders
           path: ${{ github.workspace }}/src/Agent
           repository: ${{ github.repository }}


### PR DESCRIPTION
Updates all workflows to use `inputs` instead of `github.event.inputs` for consistency. 

See [this GitHub blog](https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/) for more information.