### PR TITLE
feat:Add a new API method to time currently unsupported datastore method calls.

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/ITransaction.cs
+++ b/src/Agent/NewRelic.Api.Agent/ITransaction.cs
@@ -80,5 +80,20 @@ namespace NewRelic.Api.Agent
         /// </summary>
         /// <param name="userid">The User Id for this transaction.</param>
         void SetUserId(string userid);
+
+        /// <summary>
+        /// Records a datastore segment.
+        /// This function allows an unsupported datastore to be instrumented in the same way as the .NET agent automatically instruments its supported datastores.
+        /// </summary>
+        /// <param name="vendor">Datastore vendor name, for example MySQL, MSSQL, MongoDB.</param>
+        /// <param name="model">Table name or similar in non-relational datastores.</param>
+        /// <param name="operation">Operation being performed, for example "SELECT" or "UPDATE" for SQL databases.</param>
+        /// <param name="commandText">Optional. Query or similar in non-relational datastores.</param>
+        /// <param name="host">Optional. Server hosting the datastore</param>
+        /// <param name="portPathOrID">Optional. Port, path or other ID to aid in identifying the datastore.</param>
+        /// <param name="databaseName">Optional. Datastore name.</param>
+        /// <returns>IDisposable segment wrapper that both creates and ends the segment automatically.</returns>
+        SegmentWrapper? RecordDatastoreSegment(string vendor, string model, string operation,
+            string? commandText = null, string? host = null, string? portPathOrID = null, string? databaseName = null);
     }
 }

--- a/src/Agent/NewRelic.Api.Agent/NoOpTransaction.cs
+++ b/src/Agent/NewRelic.Api.Agent/NoOpTransaction.cs
@@ -28,5 +28,11 @@ namespace NewRelic.Api.Agent
         public void SetUserId(string userid)
         {
         }
+
+        public SegmentWrapper? RecordDatastoreSegment(string vendor, string model, string operation,
+            string? commandText, string? host, string? portPathOrID, string? databaseName)
+        {
+            return null;
+        }
     }
 }

--- a/src/Agent/NewRelic.Api.Agent/SegmentWrapper.cs
+++ b/src/Agent/NewRelic.Api.Agent/SegmentWrapper.cs
@@ -1,0 +1,30 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace NewRelic.Api.Agent
+{
+    public class SegmentWrapper : IDisposable
+    {
+        private volatile dynamic _segment;
+
+        public static SegmentWrapper GetDatastoreWrapper(dynamic transaction,
+            string vendor, string model, string operation,
+            string? commandText, string? host, string? portPathOrID, string? databaseName)
+        {
+            return new SegmentWrapper(transaction.StartDatastoreSegment(vendor, model, operation,
+                commandText, host, portPathOrID, databaseName));
+        }
+
+        private SegmentWrapper(dynamic segment)
+        {
+            _segment = segment;
+        }
+
+        public void Dispose()
+        {
+            _segment.End();
+        }
+    }
+}

--- a/src/Agent/NewRelic.Api.Agent/Transaction.cs
+++ b/src/Agent/NewRelic.Api.Agent/Transaction.cs
@@ -118,5 +118,39 @@ namespace NewRelic.Api.Agent
                 _isSetUserIdAvailable = false;
             }
         }
+
+        private static bool _isCreateDatastoreSegmentAvailable = true;
+        /// <summary>
+        /// Records a datastore segment.
+        /// This function allows an unsupported datastore to be instrumented in the same way as the .NET agent automatically instruments its supported datastores.
+        /// </summary>
+        /// <param name="vendor">Datastore vendor name, for example MySQL, MSSQL, MongoDB.</param>
+        /// <param name="model">Table name or similar in non-relational datastores.</param>
+        /// <param name="operation">Operation being performed, for example "SELECT" or "UPDATE" for SQL databases.</param>
+        /// <param name="commandText">Optional. Query or similar in non-relational datastores.</param>
+        /// <param name="host">Optional. Server hosting the datastore</param>
+        /// <param name="portPathOrID">Optional. Port, path or other ID to aid in identifying the datastore.</param>
+        /// <param name="databaseName">Optional. Datastore name.</param>
+        /// <returns>IDisposable segment wrapper that both creates and ends the segment automatically.</returns>
+        public SegmentWrapper? RecordDatastoreSegment(string vendor, string model, string operation,
+            string? commandText, string? host, string? portPathOrID, string? databaseName)
+        {
+            if (!_isCreateDatastoreSegmentAvailable)
+            {
+                return null;
+            }
+
+            try
+            {
+                return SegmentWrapper.GetDatastoreWrapper(_wrappedTransaction, vendor, model, operation,
+                    commandText, host, portPathOrID, databaseName);
+            }
+            catch (RuntimeBinderException)
+            {
+                _isCreateDatastoreSegmentAvailable = false;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Metrics/ApiSupportabilityMetricCounters.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/ApiSupportabilityMetricCounters.cs
@@ -36,7 +36,8 @@ namespace NewRelic.Agent.Core.Metrics
         AcceptDistributedTraceHeaders = 22,
         SpanSetName = 23,
         SetErrorGroupCallback = 24,
-        SetUserId = 25
+        SetUserId = 25,
+        StartDatastoreSegment = 26
     }
 
     public interface IApiSupportabilityMetricCounters : IOutOfBandMetricSource

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/ApiCallsTests.cs
@@ -33,7 +33,9 @@ namespace NewRelic.Agent.IntegrationTests.Api
         private readonly string[] ApiCalls = new string[]
             {
                 "TestTraceMetadata",
-                "TestGetLinkingMetadata"
+                "TestGetLinkingMetadata",
+                "TestFullRecordDatastoreSegment",
+                "TestRequiredRecordDatastoreSegment"
             };
 
         protected readonly TFixture Fixture;
@@ -68,7 +70,8 @@ namespace NewRelic.Agent.IntegrationTests.Api
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Supportability/ApiInvocation/TraceMetadata" },
-                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Supportability/ApiInvocation/GetLinkingMetadata"}
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Supportability/ApiInvocation/GetLinkingMetadata"},
+                new Assertions.ExpectedMetric(){ callCount = 2, metricName = "Supportability/ApiInvocation/StartDatastoreSegment"}
             };
 
             var actualMetrics = Fixture.AgentLog.GetMetrics().ToList();

--- a/tests/Agent/IntegrationTests/IntegrationTests/Api/RecordDatastoreSegmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Api/RecordDatastoreSegmentTests.cs
@@ -1,0 +1,140 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.Api
+{
+    [NetFrameworkTest]
+    public class RecordDatastoreSegment_Full_TestsFWLatest : RecordDatastoreSegmentTests<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public RecordDatastoreSegment_Full_TestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class RecordDatastoreSegment_RequiredOnly_TestsFWLatest : RecordDatastoreSegmentTests<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public RecordDatastoreSegment_RequiredOnly_TestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class RecordDatastoreSegment_Full_TestsCoreLatest : RecordDatastoreSegmentTests<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public RecordDatastoreSegment_Full_TestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, true)
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class RecordDatastoreSegment_RequiredOnly_TestsCoreLatest : RecordDatastoreSegmentTests<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public RecordDatastoreSegment_RequiredOnly_TestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output, false)
+        {
+        }
+    }
+
+    public abstract class RecordDatastoreSegmentTests<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    {
+        protected readonly TFixture _fixture;
+
+        private bool _allOptions;
+
+        public RecordDatastoreSegmentTests(TFixture fixture, ITestOutputHelper output, bool allOptions) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _allOptions = allOptions;
+
+            if(_allOptions)
+            {
+                _fixture.AddCommand("ApiCalls TestFullRecordDatastoreSegment");
+            }
+            else
+            {
+                _fixture.AddCommand("ApiCalls TestRequiredRecordDatastoreSegment");
+            }
+
+            _fixture.Actions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                    configModifier.SetLogLevel("finest");
+                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+                    configModifier.ConfigureFasterMetricsHarvestCycle(25);
+                    configModifier.ConfigureFasterSqlTracesHarvestCycle(30);
+                }
+            );
+
+            _fixture.AddActions
+            (
+                exerciseApplication: () =>
+                {
+                    var threadProfileMatch = _fixture.AgentLog.WaitForLogLine(AgentLogFile.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Supportability/ApiInvocation/StartDatastoreSegment" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/statement/Other/MyModel/MyOperation" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/operation/Other/MyOperation" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/all" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/allOther" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/Other/all" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/Other/allOther" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = _allOptions ? "Datastore/instance/Other/MyHost/MyPath" : "Datastore/instance/Other/unknown/unknown" },
+                new Assertions.ExpectedMetric(){ callCount = 1, metricName = "Datastore/statement/Other/MyModel/MyOperation", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.Libraries.ApiCalls/RecordDatastoreSegment" },
+            };
+
+            // this will not exist if command text is missing.
+            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+            {
+                new Assertions.ExpectedSqlTrace()
+                {
+                    Sql = "MyCommandText",
+                    DatastoreMetricName = "Datastore/statement/Other/MyModel/MyOperation",
+                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.Libraries.ApiCalls/RecordDatastoreSegment",
+                    HasExplainPlan = false
+                }
+            };
+
+            var actualMetrics = _fixture.AgentLog.GetMetrics().ToList();
+
+            var actualSqlTraces = _fixture.AgentLog.GetSqlTraces().ToList(); //0
+
+            Assertions.MetricsExist(expectedMetrics, actualMetrics);
+
+            if (_allOptions)
+            {
+                Assertions.SqlTraceExists(expectedSqlTraces, actualSqlTraces);
+            }
+            else // RequiredOnly
+            {
+                Assert.True(actualSqlTraces.Count == 0);
+            }
+            
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/ApiCalls.cs
@@ -100,5 +100,37 @@ namespace MultiFunctionApplicationHelpers.Libraries
             }
         }
 
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void RecordDatastoreSegment(string vendor, string model, string operation,
+             string commandText = null, string host = null, string portPathOrID = null, string databaseName = null)
+        {
+            var transaction = NewRelic.Api.Agent.NewRelic.GetAgent().CurrentTransaction;
+            using (transaction.RecordDatastoreSegment(vendor, model, operation,
+                commandText, host, portPathOrID, databaseName))
+            {
+                DatastoreWorker();
+            }
+        }
+
+        private static void DatastoreWorker()
+        {
+            System.Threading.Thread.Sleep(1000);
+        }
+
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestFullRecordDatastoreSegment()
+        {
+            RecordDatastoreSegment("MyVendor", "MyModel", "MyOperation",
+                "MyCommandText", "MyHost", "MyPath", "MyDatabase");
+        }
+
+        [LibraryMethod]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void TestRequiredRecordDatastoreSegment()
+        {
+            RecordDatastoreSegment("MyVendor", "MyModel", "MyOperation");
+        }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Api/TransactionBridgeApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Api/TransactionBridgeApiTests.cs
@@ -3,9 +3,12 @@
 
 
 using System;
+using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NUnit.Framework;
 using Telerik.JustMock;
 
@@ -54,6 +57,65 @@ namespace NewRelic.Agent.Core.Api
 
             // verify we didn't set a UserId
             Mock.Assert(() => _transaction.SetUserId(Arg.AnyString), Occurs.Never());
+        }
+
+        [Test]
+        public void StartDatastoreSegment_AddsSupportabilityMetric()
+        {
+            _transactionBridgeApi.StartDatastoreSegment("Vendor", "Model", "Operation", "CommandText", "Host", "PortPathOrID", "DatabaseName");
+
+            Mock.Assert(() => _apiSupportabilityMetricCounters.Record(Arg.Matches<ApiMethod>(apiMethod => apiMethod == ApiMethod.StartDatastoreSegment)));
+        }
+
+        [Test]
+        public void StartDatastoreSegment_AllValues_CallsTransactionStartDatastoreSegment()
+        {
+            var expectedVendor = "Vendor";
+            var expectedModel = "Model";
+            var expectedOperation = "Operation";
+            var expectedCommandText = "CommandText";
+            var expectedHost = "Host";
+            var expectedPortPathOrID = "PortPathOrID";
+            var expectedDatabaseName = "DatabaseName";
+
+            _transactionBridgeApi.StartDatastoreSegment(expectedVendor, expectedModel, expectedOperation, expectedCommandText, expectedHost, expectedPortPathOrID, expectedDatabaseName);
+
+            Mock.Assert(() => _transaction.StartDatastoreSegment(
+                Arg.Matches<MethodCall>(methodCall =>
+                    methodCall.Method.Type == typeof(object)
+                    && methodCall.Method.MethodName == "StartDatastoreSegment"
+                    && methodCall.Method.ParameterTypeNames == string.Empty),
+                Arg.Matches<ParsedSqlStatement>(statement =>
+                    statement.DatastoreVendor == DatastoreVendor.Other
+                    && statement.Model == expectedModel
+                    && statement.Operation == expectedOperation),
+                Arg.Matches<ConnectionInfo>(info =>
+                    info.Host == expectedHost
+                    && info.PortPathOrId == expectedPortPathOrID
+                    && info.DatabaseName == expectedDatabaseName),
+                Arg.Matches<string>(commandText => commandText == expectedCommandText),
+                Arg.IsNull<IDictionary<string, IConvertible>>(),
+                Arg.Matches<bool>(isLeaf => isLeaf == false)
+            ));
+        }
+
+        [Test]
+        public void StartDatastoreSegment_HandlesException()
+        {
+            Mock.Arrange(() => _apiSupportabilityMetricCounters.Record(Arg.IsAny<ApiMethod>())).Throws<Exception>();
+
+            var expectedVendor = "Vendor";
+            var expectedModel = "Model";
+            var expectedOperation = "Operation";
+            var expectedCommandText = "CommandText";
+            var expectedHost = "Host";
+            var expectedPortPathOrID = "PortPathOrID";
+            var expectedDatabaseName = "DatabaseName";
+
+            _transactionBridgeApi.StartDatastoreSegment(expectedVendor, expectedModel, expectedOperation, expectedCommandText, expectedHost, expectedPortPathOrID, expectedDatabaseName);
+
+            // verify we didn't start a datastore segment
+            Mock.Assert(() => _transaction.StartDatastoreSegment(Arg.IsAny<MethodCall>(), Arg.IsAny<ParsedSqlStatement>(), Arg.IsAny<ConnectionInfo>(), Arg.IsAny<string>(), Arg.IsAny<IDictionary<string, IConvertible>>(), Arg.IsAny<bool>()), Occurs.Never());
         }
     }
 }


### PR DESCRIPTION
## Description

Adds a new public API for timing unsupported datastore calls called `RecordDatastoreSegment`,  To support this, a new IDisposable type has been added to the API called SegmentWrapper that creates and ends segments. It has a private constructor and uses static methods to create segments, currently only Datastore segments, to allow it to be extended to other segment types in the future.

The RecordDatastoreSegment API call requires a vendor name, model, and operation since this are needed to make useful datastore segments. There are four optional parameters to capture more of the rest of data used to make sql traces.  Not included were query parameters since that would require the other data to be in a very specific format that I don't think would be intuitive for out customers.

Includes unit tests for the added TransactionBridgeApi method and integration tests for the rest of the work.

API:
```
SegmentWrapper? RecordDatastoreSegment(string vendor, string model, string operation,
    string? commandText = null, string? host = null, string? portPathOrID = null, string? databaseName = null)
```



# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
