### PR TITLE
ci: Improve post-deploy workflow

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -454,5 +454,6 @@ jobs:
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
+      wait_for_apt_and_yum: true
     secrets: inherit
 

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -10,6 +10,11 @@ on:
       wait_for_apt_and_yum:
         type: boolean
         default: true
+        required: true
+      test_mode:
+        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
+        type: boolean
+        default: false
         required: false
   workflow_call:
     inputs:
@@ -20,8 +25,13 @@ on:
       wait_for_apt_and_yum:
         type: boolean
         default: true
+        required: true
+      test_mode:
+        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
+        type: boolean
+        default: false
         required: false
-  
+    
 permissions:
   contents: read
   packages: read
@@ -147,14 +157,13 @@ jobs:
 
       - name: Build and Run NugetValidator
         run: |
-          dotnet build --configuration Release "$BUILD_PATH"
-          "$RUN_PATH/NugetValidator" -v $AGENT_VERSION -c $CONFIG_PATH
+          dotnet publish --configuration Release --output "$PUBLISH_PATH" "$BUILD_PATH"
+          "$PUBLISH_PATH/NugetValidator" -v $AGENT_VERSION -c $PUBLISH_PATH/config.yml
         shell: bash
         env:
-          BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
-          RUN_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/
           AGENT_VERSION: ${{ inputs.agent_version }}
-          CONFIG_PATH: ${{ github.workspace }}/build/NugetValidator/bin/Release/net7.0/config.yml
+          BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
+          PUBLISH_PATH: ${{ github.workspace }}/publish
 
   report-deprecated-nuget-packages:
     name: Report Deprecated NuGet Packages
@@ -176,10 +185,9 @@ jobs:
 
       - name: Build and Run NugetDeprecator
         run: |
-          dotnet build --configuration Release "$BUILD_PATH"
-          "$RUN_PATH/NugetVersionDeprecator" -c $CONFIG_PATH --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }}
+          dotnet publish --configuration Release --output "$PUBLISH_PATH" "$BUILD_PATH"
+          "$PUBLISH_PATH/NugetVersionDeprecator" -c $PUBLISH_PATH/config.yml --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }} --test-mode ${{ inputs.test_mode }}
         shell: bash
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
-          RUN_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net8.0/
-          CONFIG_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/bin/Release/net8.0/config.yml
+          PUBLISH_PATH: ${{ github.workspace }}/publish

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -50,7 +50,7 @@ jobs:
           disable-sudo: false
           egress-policy: audit
       - name: Wait for APT to update
-        if: ${{ inputs.wait_for_apt_and_yum == 'true' }} # only wait if requested
+        if: ${{ inputs.wait_for_apt_and_yum }} # only wait if requested
         run: |
           echo "Sleeping 5 minutes to wait for apt to update itself"
           sleep 300
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
 
       - name: Wait for YUM to update
-        if: ${{ inputs.wait_for_apt_and_yum == 'true' }} # only wait if this workflow was called by another workflow
+        if: ${{ inputs.wait_for_apt_and_yum }} # only wait if requested
         run: |
           echo "Sleeping 5 minutes to wait for yum to update itself"
           sleep 300


### PR DESCRIPTION
This PR makes the following improvements to the post-deploy workflow:
1. Add a test-mode input that lets us run this workflow without creating duplicate GitHub issues for deprecated Nuget package versions
2. Switch from `dotnet build` to `dotnet publish` for the two Nuget validation/deprecation tools, so we don't have to hardcode the .NET version (TFM) in the execution path.
3. (Finally!) fix the logic for the `wait_for_apt_and_yum` option.  Thanks @tippmar-nr for figuring this one out.