### PR TITLE
ci: add the linux container test job to the list of jobs checked in `integration-test-status`

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -136,8 +136,9 @@ jobs:
           if-no-files-found: error
 
   run-linux-container-tests:
-    needs: build-fullagent-msi
     name: Run Linux Container Tests
+    needs: 
+      - build-fullagent-msi
     uses: ./.github/workflows/run_linux_container_tests.yml
     secrets: inherit
         
@@ -694,9 +695,14 @@ jobs:
   integration-test-status:
     name: Check Test Matrix Status
     runs-on: ubuntu-latest
-    needs: [run-integration-tests, run-unbounded-tests]
+    needs: [run-linux-container-tests, run-integration-tests, run-unbounded-tests]
     if: always()
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
       - name: Successful test run
         if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0


### PR DESCRIPTION
Based on a suggestion by @nrcventura, we will add the `run-linux-container-tests` job to the list of jobs that are checked for successful status in `integration-test-status`, which will allow us to remove the `run-linux-container-tests` job as a required status check. 

This (hopefully) will resolve the strange issues we've seen with PRs expecting a status from the container test job, even though that job was skipped.

Also adds a "harden runner" step to that job, which was overlooked when we initially created it.