### PR TITLE
ci: Update GitHub workflows to ignore certain paths

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - main
       - "feature/**"
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "build/**"
+      - "licenses/**"
+      - "release-please/**"
   release:
     types: [published]
   workflow_dispatch:
-
   schedule:
     - cron: "0 9 * * 1-5"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,20 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "build/**"
+      - "licenses/**"
+      - "release-please/**"
   pull_request:
     branches: [ "main", "feature/*"]
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "build/**"
+      - "licenses/**"
+      - "release-please/**"
   schedule:
     - cron: '20 3 * * 1'
 

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -5,7 +5,19 @@ on:
     branches:
       - main # runs after a completed PR to main
       - feature/* # runs after a push to a feature branch
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "build/**"
+      - "licenses/**"
+      - "release-please/**"
   pull_request: # runs on a PR to any branch
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "build/**"
+      - "licenses/**"
+      - "release-please/**"
   workflow_dispatch: # allows for manual trigger
 
 env:


### PR DESCRIPTION
Updates `all_solutions`, `run_unit_tests` and `codeql` workflows so they get skipped if the only changes are to files in the following paths:
```
      - ".github/**"
      - "docs/**"
      - "build/**"
      - "licenses/**"
      - "release-please/**"
```
This will prevent unnecessary workflow invocations when changes are made that aren't relevant to those workflows.