### PR TITLE
ci: Add check for modified files before analyzing code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-modified-files:
+    name: Check if source files were modified, skip remaining jobs if not
+    uses: ./.github/workflows/check_modified_files.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: read
+
   analyze-dotnet:
     name: Analyze .NET
+    needs: check-modified-files
+    if: needs.check-modified-files.outputs.non-workflow-files-changed == 'true'
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:
@@ -55,6 +65,8 @@ jobs:
 
   analyze-cpp:
     name: Analyze C++
+    needs: check-modified-files
+    if: needs.check-modified-files.outputs.non-workflow-files-changed == 'true'
     runs-on: windows-latest
     timeout-minutes: 120
     permissions:


### PR DESCRIPTION
Updates the CodeQL action to check for modified files before running. Brings the behavior of this action in line with our other "top-level" actions (`all_solutions`, `run_unit_tests`),