### PR TITLE
test: Modify SimpleCache to allow direct call to MaintainCache(), update unit tests.

### DIFF
--- a/src/NewRelic.Core/Caching/SimpleCache.cs
+++ b/src/NewRelic.Core/Caching/SimpleCache.cs
@@ -144,7 +144,10 @@ namespace NewRelic.Core.Caching
             return node;
         }
 
-        private void MaintainCache()
+        /// <summary>
+        /// public only for unit tests. Don't call this method directly!
+        /// </summary>        
+        public void MaintainCache()
         {
             var count = _cacheMap.Count;
             if (count > _capacity)

--- a/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
@@ -261,6 +261,18 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             EvaluateCacheMetrics(cache, expectedHits, expectedMisses, expectedEjections, expectedSize);
         }
 
+        [Test]
+        public void CacheMaintenanceThreadMaintainsCache()
+        {
+            var cache = new SimpleCache<string, string>(1);
+            cache.GetOrAdd("key1", () => "value1");
+            cache.GetOrAdd("key2", () => "value2");
+
+            Thread.Sleep(1000);
+
+            EvaluateCacheMetrics(cache, 0, 2, 2, 0);
+        }
+
         private void EvaluateCacheMetrics<T, V>(SimpleCache<T, V> cache, int expectedHits, int expectedMisses,
             int expectedEjections, int expectedSize) where V : class
         {

--- a/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
@@ -93,7 +93,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             cache.GetOrAdd("key4", () => val4);
             cache.GetOrAdd("key5", () => val5);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
             //This checks that the clearing didn't happen.
             Assert.That(cache.Size, Is.EqualTo(capacity));
@@ -101,7 +101,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             //Overflow the cache
             cache.GetOrAdd("key6", () => val6);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
             //Checks the clearing happened.
             Assert.That(cache.Size, Is.EqualTo(0));
@@ -162,7 +162,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             cache.GetOrAdd("key4", () => val4);
             cache.GetOrAdd("key5", () => val5);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
             //This checks that the clearing didn't happen.
             Assert.That(cache.Size, Is.EqualTo(capacity));
@@ -173,13 +173,13 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             cache.GetOrAdd("key6", () => val6);
             cache.GetOrAdd("key7", () => val7);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
             Assert.That(cache.Size, Is.EqualTo(newCapacity));
 
             //This should overflowt the cache
             cache.GetOrAdd("key8", () => val8);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
             Assert.That(cache.Size, Is.EqualTo(0));
 
 
@@ -209,7 +209,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             cache.GetOrAdd("key4", () => val4);
             cache.GetOrAdd("key5", () => val5);
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
             //This checks that the clearing didn't happen.
             Assert.That(cache.Size, Is.EqualTo(capacity));
@@ -217,7 +217,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             int newCapacity = 3;
             cache.Capacity = newCapacity;
 
-            Thread.Sleep(1000); //allow the cache to check it's size.
+            cache.MaintainCache(); // force cache to maintain, normally done on a timer.
 
             //This checks that the clearing happened and setting new capacity works.
             Assert.That(cache.Size, Is.EqualTo(0));


### PR DESCRIPTION
Addresses a unit test flicker in `SimpleCacheTests` by making `SimpleCache.MaintainCache()` public and calling it directly in the unit tests rather than relying on `Thread.Sleep(1000)` to let the timer make the call.