### PR TITLE
tests: Speed up execution time of AgentLogs integration test namespace

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
@@ -9,7 +9,6 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTestHelpers
@@ -34,25 +33,25 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             var searchPattern = _fileName != string.Empty ? _fileName : "newrelic_agent_*.log";
 
-            do
-            {
-                var mostRecentlyUpdatedFile = Directory.Exists(logDirectoryPath) ?
-                    Directory.GetFiles(logDirectoryPath, searchPattern)
-                        .Where(file => file != null && !file.Contains("audit"))
-                        .OrderByDescending(File.GetLastWriteTimeUtc)
-                        .FirstOrDefault() : null;
-
-                if (mostRecentlyUpdatedFile != null)
-                {
-                    _filePath = mostRecentlyUpdatedFile;
-                    return;
-                }
-
-                Thread.Sleep(TimeSpan.FromSeconds(1));
-            } while (timeTaken.Elapsed < timeout && logFileExpected);
-
             if (logFileExpected)
             {
+                do
+                {
+                    var mostRecentlyUpdatedFile = Directory.Exists(logDirectoryPath) ?
+                        Directory.GetFiles(logDirectoryPath, searchPattern)
+                            .Where(file => file != null && !file.Contains("audit"))
+                            .OrderByDescending(File.GetLastWriteTimeUtc)
+                            .FirstOrDefault() : null;
+
+                    if (mostRecentlyUpdatedFile != null)
+                    {
+                        _filePath = mostRecentlyUpdatedFile;
+                        return;
+                    }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                } while (timeTaken.Elapsed < timeout);
+
                 throw new Exception($"Waited {timeout.TotalSeconds:N0}s but didn't find an agent log matching {Path.Combine(logDirectoryPath, searchPattern)}.");
             }
         }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public bool Found => File.Exists(_filePath);
 
-        public AgentLogFile(string logDirectoryPath, ITestOutputHelper testLogger, string fileName = "", TimeSpan? timeoutOrZero = null, bool throwIfNotFound = true)
+        public AgentLogFile(string logDirectoryPath, ITestOutputHelper testLogger, string fileName = "", TimeSpan? timeoutOrZero = null, bool logFileExpected = true)
             : base(testLogger)
         {
             Contract.Assert(logDirectoryPath != null);
@@ -49,10 +49,12 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 }
 
                 Thread.Sleep(TimeSpan.FromSeconds(1));
-            } while (timeTaken.Elapsed < timeout);
+            } while (timeTaken.Elapsed < timeout && logFileExpected);
 
-            if (throwIfNotFound)
+            if (logFileExpected)
+            {
                 throw new Exception($"Waited {timeout.TotalSeconds:N0}s but didn't find an agent log matching {Path.Combine(logDirectoryPath, searchPattern)}.");
+            }
         }
 
         public override IEnumerable<string> GetFileLines()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/ProfilerLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/ProfilerLogFile.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public bool Found => File.Exists(_filePath);
 
-        public ProfilerLogFile(string logDirectoryPath, TimeSpan? timeoutOrZero = null, bool throwIfNotFound = true)
+        public ProfilerLogFile(string logDirectoryPath, TimeSpan? timeoutOrZero = null, bool logFileExpected = true)
         {
             Contract.Assert(logDirectoryPath != null);
 
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 Thread.Sleep(TimeSpan.FromSeconds(1));
             } while (timeTaken.Elapsed < timeout);
 
-            if (throwIfNotFound)
+            if (logFileExpected)
                 throw new Exception("No profiler log file found.");
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/ProfilerLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/ProfilerLogFile.cs
@@ -31,25 +31,29 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var timeout = timeoutOrZero ?? TimeSpan.Zero;
 
             var timeTaken = Stopwatch.StartNew();
-            do
-            {
-                var mostRecentlyUpdatedFile = Directory.Exists(logDirectoryPath) ?
-                    Directory.EnumerateFiles(logDirectoryPath, "NewRelic.Profiler.*.log")
-                        .Where(file => file != null)
-                        .OrderByDescending(File.GetLastWriteTimeUtc)
-                        .FirstOrDefault() : null;
-
-                if (mostRecentlyUpdatedFile != null)
-                {
-                    _filePath = mostRecentlyUpdatedFile;
-                    return;
-                }
-
-                Thread.Sleep(TimeSpan.FromSeconds(1));
-            } while (timeTaken.Elapsed < timeout);
 
             if (logFileExpected)
+            {
+                do
+                {
+                    var mostRecentlyUpdatedFile = Directory.Exists(logDirectoryPath) ?
+                        Directory.EnumerateFiles(logDirectoryPath, "NewRelic.Profiler.*.log")
+                            .Where(file => file != null)
+                            .OrderByDescending(File.GetLastWriteTimeUtc)
+                            .FirstOrDefault() : null;
+
+                    if (mostRecentlyUpdatedFile != null)
+                    {
+                        _filePath = mostRecentlyUpdatedFile;
+                        return;
+                    }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                } while (timeTaken.Elapsed < timeout);
+
                 throw new Exception("No profiler log file found.");
+            }
+
         }
 
         #region Log Lines

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/ChangeLogFilenameTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/ChangeLogFilenameTests.cs
@@ -35,6 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
+            _fixture.AgentLogExpected = false; // So the test doesn't spend three minutes waiting for an agent log to appear in the expected location
             _testCase = testCase;
             _fixture.Actions
             (

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         public void AgentLog()
         {
             var configLocation = new AgentLogFile(_configLogDirectory, _fixture.TestLogger, logFileExpected: false);
-            var generalEnvLocation = new AgentLogFile(_generalEnvLogDirectory, _fixture.TestLogger, logFileExpected: false);
+            var generalEnvLocation = new AgentLogFile(_generalEnvLogDirectory, _fixture.TestLogger, logFileExpected: true);
             var profilerEnvLocation = new AgentLogFile(_profilerEnvLogDirectory, _fixture.TestLogger, logFileExpected: false);
 
             Assert.False(configLocation.Found);
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         {
             var configLocation = new ProfilerLogFile(_configLogDirectory, logFileExpected: false);
             var generalEnvLocation = new ProfilerLogFile(_generalEnvLogDirectory, logFileExpected: false);
-            var profilerEnvLocation = new ProfilerLogFile(_profilerEnvLogDirectory, logFileExpected: false);
+            var profilerEnvLocation = new ProfilerLogFile(_profilerEnvLogDirectory, logFileExpected: true);
 
             Assert.False(configLocation.Found);
             Assert.False(generalEnvLocation.Found);

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/LogLevelAndDirectoryEnvironmentTests.cs
@@ -26,6 +26,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
+            _fixture.AgentLogExpected = false; // so the test doesn't wait three minutes for a log file to appear in the default location
             _fixture.Actions
             (
                 setupConfiguration: () =>
@@ -46,9 +47,9 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         [Fact]
         public void AgentLog()
         {
-            var configLocation = new AgentLogFile(_configLogDirectory, _fixture.TestLogger, throwIfNotFound: false);
-            var generalEnvLocation = new AgentLogFile(_generalEnvLogDirectory, _fixture.TestLogger, throwIfNotFound: false);
-            var profilerEnvLocation = new AgentLogFile(_profilerEnvLogDirectory, _fixture.TestLogger, throwIfNotFound: false);
+            var configLocation = new AgentLogFile(_configLogDirectory, _fixture.TestLogger, logFileExpected: false);
+            var generalEnvLocation = new AgentLogFile(_generalEnvLogDirectory, _fixture.TestLogger, logFileExpected: false);
+            var profilerEnvLocation = new AgentLogFile(_profilerEnvLogDirectory, _fixture.TestLogger, logFileExpected: false);
 
             Assert.False(configLocation.Found);
             Assert.True(generalEnvLocation.Found);
@@ -62,9 +63,9 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
         [Fact]
         public void ProfilerLog()
         {
-            var configLocation = new ProfilerLogFile(_configLogDirectory, throwIfNotFound: false);
-            var generalEnvLocation = new ProfilerLogFile(_generalEnvLogDirectory, throwIfNotFound: false);
-            var profilerEnvLocation = new ProfilerLogFile(_profilerEnvLogDirectory, throwIfNotFound: false);
+            var configLocation = new ProfilerLogFile(_configLogDirectory, logFileExpected: false);
+            var generalEnvLocation = new ProfilerLogFile(_generalEnvLogDirectory, logFileExpected: false);
+            var profilerEnvLocation = new ProfilerLogFile(_profilerEnvLogDirectory, logFileExpected: false);
 
             Assert.False(configLocation.Found);
             Assert.False(generalEnvLocation.Found);
@@ -77,23 +78,23 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
     }
 
     [NetFrameworkTest]
-    public class LogLevelAndDirectoryEnvironmentTests_net48 : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureFWLatest>
+    public class LogLevelAndDirectoryEnvironmentTestsFrameworkLatest : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public LogLevelAndDirectoryEnvironmentTests_net48(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public LogLevelAndDirectoryEnvironmentTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(fixture, output) { }
     }
 
     [NetCoreTest]
-    public class LogLevelAndDirectoryEnvironmentTestsOldest : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureCoreOldest>
+    public class LogLevelAndDirectoryEnvironmentTestsCoreOldest : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureCoreOldest>
     {
-        public LogLevelAndDirectoryEnvironmentTestsOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        public LogLevelAndDirectoryEnvironmentTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
             : base(fixture, output) { }
     }
 
     [NetCoreTest]
-    public class LogLevelAndDirectoryEnvironmentTestsLatest : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureCoreLatest>
+    public class LogLevelAndDirectoryEnvironmentTestsCoreLatest : LogLevelAndDirectoryEnvironmentTests<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public LogLevelAndDirectoryEnvironmentTestsLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public LogLevelAndDirectoryEnvironmentTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(fixture, output) { }
     }
 }


### PR DESCRIPTION
There were a couple of cases where the integration test harness was waiting for three minutes for an agent log to appear in the default location, that wasn't ever going to be created because the test case involved changing the log file name or directory.  This PR fixes that, as well as tweaking some names to be make more sense (to me, anyway).