### PR TITLE
chore: Refactor serverless bootstrap config into a separate bootstrap config.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -95,9 +95,11 @@ namespace NewRelic.Agent.Core
         {
             // load the configuration
             configuration config = null;
+            IBootstrapConfiguration bootstrapConfig = null;
             try
             {
                 config = ConfigurationLoader.Initialize(false);
+                bootstrapConfig = ConfigurationLoader.BootstrapConfig;
             }
             catch
             {
@@ -112,7 +114,7 @@ namespace NewRelic.Agent.Core
             }
 
             _container = AgentServices.GetContainer();
-            AgentServices.RegisterServices(_container, config.ServerlessModeEnabled);
+            AgentServices.RegisterServices(_container, bootstrapConfig.ServerlessModeEnabled);
 
             // Resolve IConfigurationService (so that it starts listening to config change events) and then publish the serialized event
             _container.Resolve<IConfigurationService>();
@@ -150,20 +152,20 @@ namespace NewRelic.Agent.Core
             _wrapperService = _container.Resolve<IWrapperService>();
 
             // Attempt to auto start the agent once all services have resolved, except in serverless mode
-            if (!config.ServerlessModeEnabled)
+            if (!bootstrapConfig.ServerlessModeEnabled)
                 _container.Resolve<IConnectionManager>().AttemptAutoStart();
             else
             {
                 Log.Info("The New Relic agent is operating in serverless mode.");
             }
 
-            AgentServices.StartServices(_container, config.ServerlessModeEnabled);
+            AgentServices.StartServices(_container, bootstrapConfig.ServerlessModeEnabled);
 
             // Setup the internal API first so that AgentApi can use it.
             InternalApi.SetAgentApiImplementation(agentApi);
             AgentApi.SetSupportabilityMetricCounters(_container.Resolve<IApiSupportabilityMetricCounters>());
 
-            Initialize(config.ServerlessModeEnabled);
+            Initialize(bootstrapConfig.ServerlessModeEnabled);
             _isInitialized = true;
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -1,0 +1,60 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Core.Config
+{
+    public interface IBootstrapConfiguration
+    {
+        bool ServerlessModeEnabled { get; }
+    }
+
+    /// <summary>
+    /// This configuration class is used during the bootstrapping process before the configuration service is available.
+    /// This configuration is made available to the configuration service through a static property on the ConfigurationLoader
+    /// which is using during the bootstrapping process. The configuration in this class should not change at runtime and is
+    /// mostly meant for things that must be configured before the configuration service is available and cannot be changed
+    /// at a later point in time.
+    /// </summary>
+    public class BootstrapConfiguration : IBootstrapConfiguration
+    {
+        private BootstrapConfiguration() { }
+        public BootstrapConfiguration(configuration localConfiguration)
+        {
+            ServerlessModeEnabled = CheckServerlessModeEnabled(localConfiguration);
+        }
+
+        /// <summary>
+        /// This helper method is meant to define a set of default values useful for the unit tests, and a fallback in case
+        /// something changes in the agent and the ConfigurationLoader.BootstrapConfig property is not set.
+        /// </summary>
+        /// <returns>A bootstrap configuration instance with reasonable default values.</returns>
+        public static IBootstrapConfiguration GetDefault()
+        {
+            return new BootstrapConfiguration();
+        }
+
+        /// <summary>
+        /// Gets whether or not serverless mode is enabled.
+        /// </summary>
+        public bool ServerlessModeEnabled { get; private set; }
+
+        private bool CheckServerlessModeEnabled(configuration localConfiguration)
+        {
+            // according to the spec, environment variable takes precedence over config file
+            var serverlessModeEnvVariable = ConfigurationLoader.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");
+
+            if (serverlessModeEnvVariable.TryToBoolean(out var enabledViaEnvVariable))
+            {
+                return enabledViaEnvVariable;
+            }
+
+            // env variable is not set, check for function name
+            var awsLambdaFunctionName = ConfigurationLoader.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
+            if (!string.IsNullOrEmpty(awsLambdaFunctionName))
+                return true;
+
+            // fall back to config file
+            return localConfiguration.serverlessModeEnabled;
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -70,6 +70,13 @@ namespace NewRelic.Agent.Core.Config
         #endregion Unit test helpers
 
         /// <summary>
+        /// Gets the bootstrap configuration for the agent. The settings in this config does not change over time, and
+        /// it is only available after the ConfigurationLoader.Initialize method has been called. If this property is
+        /// accessed before the Initialize method has been called, it will return a default bootstrap configuration.
+        /// </summary>
+        public static IBootstrapConfiguration BootstrapConfig { get; private set; } = BootstrapConfiguration.GetDefault();
+
+        /// <summary>
         /// Reads an application setting from the web configuration associated with the current virtual path,
         /// or from the web site if none is found.
         /// Typically, this will attempt to read the "web.config" or "Web.Config" file for the path.
@@ -321,7 +328,9 @@ namespace NewRelic.Agent.Core.Config
                 {
                     throw new ConfigurationLoaderException(string.Format("The New Relic Agent configuration file does not exist: {0}", fileName));
                 }
-                return Initialize(fileName, publishDeserializedEvent);
+                var config = Initialize(fileName, publishDeserializedEvent);
+                BootstrapConfig = new BootstrapConfiguration(config);
+                return config;
             }
             catch (FileNotFoundException ex)
             {

--- a/src/Agent/NewRelic/Agent/Core/Config/configurationPartial.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/configurationPartial.cs
@@ -14,11 +14,9 @@
     // different origins of the property names.
     //
     // Property names such as "agentEnabled" come to us from Configuration.xsd via Configuration.cs.
-    // Property names such as "AgentEnabled" are added in here or inherited from BootstrapConfig.
+    // Property names such as "AgentEnabled" are added in here.
     public partial class configuration
     {
-        private string _awsLambdaFunctionName;
-
         public string Xml { get; set; }
 
         [XmlIgnore]
@@ -53,44 +51,4 @@
 
         [XmlIgnore]
         public ILogConfig LogConfig { get { return log; } }
-
-        private bool? _serverlessModeEnabled;
-        [XmlIgnore]
-        public bool ServerlessModeEnabled
-        {
-            get
-            {
-                return _serverlessModeEnabled ??= CheckServerlessModeEnabled();
-            }
-
-            // for unit tests only, remove if we refactor to move this property into DefaultConfiguration
-            set { _serverlessModeEnabled = value; }
-        }
-
-        private bool CheckServerlessModeEnabled()
-        {
-            // according to the spec, environment variable takes precedence over config file
-            var serverlessModeEnvVariable = ConfigurationLoader.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");
-
-            if (serverlessModeEnvVariable.TryToBoolean(out var enabledViaEnvVariable))
-            {
-                return enabledViaEnvVariable;
-            }
-
-            // env variable is not set, check for function name
-            if (!string.IsNullOrEmpty(AwsLambdaFunctionName))
-                return true;
-
-            // fall back to config file
-            return serverlessModeEnabled;
-        }
-
-        [XmlIgnore]
-        public string AwsLambdaFunctionName
-        {
-            get
-            {
-                return _awsLambdaFunctionName ??= ConfigurationLoader.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
-            }
-        }
     }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
@@ -11,7 +11,6 @@ using NewRelic.SystemInterfaces;
 using NewRelic.SystemInterfaces.Web;
 using System;
 using System.Linq;
-using System.Reflection;
 
 namespace NewRelic.Agent.Core.Configuration
 {
@@ -22,6 +21,7 @@ namespace NewRelic.Agent.Core.Configuration
         private ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
         private RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
+        private readonly IBootstrapConfiguration _bootstrapConfiguration = ConfigurationLoader.BootstrapConfig;
         private readonly Subscriptions _subscriptions = new Subscriptions();
         private readonly IProcessStatic _processStatic;
         private readonly IHttpRuntimeStatic _httpRuntimeStatic;
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.Core.Configuration
             _configurationManagerStatic = configurationManagerStatic;
             _dnsStatic = dnsStatic;
 
-            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, dnsStatic);
+            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, dnsStatic);
 
             _subscriptions.Add<ConfigurationDeserializedEvent>(OnConfigurationDeserialized);
             _subscriptions.Add<ServerConfigurationUpdatedEvent>(OnServerConfigurationUpdated);
@@ -100,7 +100,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         private void UpdateAndPublishConfiguration(ConfigurationUpdateSource configurationUpdateSource)
         {
-            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
             var configurationUpdatedEvent = new ConfigurationUpdatedEvent(Configuration, configurationUpdateSource);
             EventBus<ConfigurationUpdatedEvent>.Publish(configurationUpdatedEvent);

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -57,6 +57,7 @@ namespace NewRelic.Agent.Core.Configuration
         private readonly ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
         private readonly RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
         private readonly SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+        private readonly IBootstrapConfiguration _bootstrapConfiguration = BootstrapConfiguration.GetDefault();
         private Dictionary<string, string> _newRelicAppSettings { get; }
 
         public bool UseResourceBasedNamingForWCFEnabled { get; }
@@ -72,7 +73,7 @@ namespace NewRelic.Agent.Core.Configuration
             ConfigurationVersion = Interlocked.Increment(ref _currentConfigurationVersion);
         }
 
-        protected DefaultConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
+        protected DefaultConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
             : this()
         {
             _environment = environment;
@@ -101,6 +102,10 @@ namespace NewRelic.Agent.Core.Configuration
             if (securityPoliciesConfiguration != null)
             {
                 _securityPoliciesConfiguration = securityPoliciesConfiguration;
+            }
+            if (_bootstrapConfiguration != null)
+            {
+                _bootstrapConfiguration = bootstrapConfiguration;
             }
 
             LogDisabledWarnings();
@@ -208,7 +213,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public bool ServerlessModeEnabled => _localConfiguration.ServerlessModeEnabled;
+        public bool ServerlessModeEnabled => _bootstrapConfiguration.ServerlessModeEnabled;
 
         private string _agentLicenseKey;
         public virtual string AgentLicenseKey

--- a/src/Agent/NewRelic/Agent/Core/Configuration/InternalConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/InternalConfiguration.cs
@@ -12,8 +12,8 @@ namespace NewRelic.Agent.Core.Configuration
     /// </summary>
     internal class InternalConfiguration : DefaultConfiguration
     {
-        public InternalConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) :
-            base(environment, localConfiguration, serverConfiguration, runTimeConfiguration, securityPoliciesConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic)
+        public InternalConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) :
+            base(environment, localConfiguration, serverConfiguration, runTimeConfiguration, securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic)
         { }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/AttributeDefinitionServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using NUnit.Framework;
@@ -36,6 +36,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         private ServerConfiguration _serverConfig;
         private RunTimeConfiguration _runTimeConfiguration;
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
+        private IBootstrapConfiguration _bootstrapConfiguration;
 
         private IEnvironment _environment;
         private IHttpRuntimeStatic _httpRuntimeStatic;
@@ -61,6 +62,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
             _configurationManagerStatic = new ConfigurationManagerStaticMock();
             _dnsStatic = Mock.Create<IDnsStatic>();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
 
             _runTimeConfiguration = new RunTimeConfiguration();
             _serverConfig = new ServerConfiguration();
@@ -84,7 +86,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
 
         private void UpdateConfig()
         {
-            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
             EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(_configuration, ConfigurationUpdateSource.Local));
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Attributes/LogContextDataFilterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Attributes/LogContextDataFilterTests.cs
@@ -28,6 +28,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         private ServerConfiguration _serverConfig;
         private RunTimeConfiguration _runTimeConfiguration;
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
+        private IBootstrapConfiguration _bootstrapConfiguration;
 
         private IEnvironment _environment;
         private IHttpRuntimeStatic _httpRuntimeStatic;
@@ -55,6 +56,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
             _configurationManagerStatic = new ConfigurationManagerStaticMock();
             _dnsStatic = Mock.Create<IDnsStatic>();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
 
             _runTimeConfiguration = new RunTimeConfiguration();
             _serverConfig = new ServerConfiguration();
@@ -156,7 +158,7 @@ namespace NewRelic.Agent.Core.Attributes.Tests
         }
         private void UpdateConfig()
         {
-            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
             EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(_configuration, ConfigurationUpdateSource.Local));
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Config/ServerlessModeConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Config/ServerlessModeConfigurationTests.cs
@@ -63,8 +63,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -88,8 +87,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -111,8 +109,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -136,8 +133,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -160,8 +156,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -186,8 +181,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -210,8 +204,7 @@ namespace NewRelic.Agent.Core.Config
                 "</configuration>";
 
 
-            var configuration = new configuration();
-            configuration.Initialize(xml, "");
+            var configuration = CreateBootstrapConfiguration(xml);
 
             // Act
             var result = configuration.ServerlessModeEnabled;
@@ -220,5 +213,11 @@ namespace NewRelic.Agent.Core.Config
             Assert.That(result, Is.False);
         }
 
+        private BootstrapConfiguration CreateBootstrapConfiguration(string xml)
+        {
+            var configuration = new configuration();
+            configuration.Initialize(xml, "");
+            return new BootstrapConfiguration(configuration);
+        }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/DataTransport/CollectorHostNameTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/DataTransport/CollectorHostNameTests.cs
@@ -19,7 +19,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.DataTransport
 {
     internal class TestDefaultConfiguration : DefaultConfiguration
     {
-        public TestDefaultConfiguration(IEnvironment environment, configuration localConfig, ServerConfiguration serverConfig, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration _securityPoliciesConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) : base(environment, localConfig, serverConfig, runTimeConfiguration, _securityPoliciesConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic) { }
+        public TestDefaultConfiguration(IEnvironment environment, configuration localConfig, ServerConfiguration serverConfig, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration _securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) : base(environment, localConfig, serverConfig, runTimeConfiguration, _securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic) { }
     }
 
     [TestFixture]
@@ -43,6 +43,8 @@ namespace NewRelic.Agent.Core.CrossAgentTests.DataTransport
 
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
 
+        private IBootstrapConfiguration _bootstrapConfiguration;
+
         private IDnsStatic _dnsStatic;
 
         public static List<TestCaseData> CollectorHostnameTestData
@@ -61,8 +63,9 @@ namespace NewRelic.Agent.Core.CrossAgentTests.DataTransport
             _serverConfig = new ServerConfiguration();
             _runTimeConfig = new RunTimeConfiguration();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
             _dnsStatic = Mock.Create<IDnsStatic>();
-            _defaultConfig = new TestDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            _defaultConfig = new TestDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/RumTests/RumClientConfigTests.cs
@@ -48,6 +48,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.RumTests
         private ServerConfiguration _serverConfig;
         private RunTimeConfiguration _runTimeConfiguration;
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
+        private IBootstrapConfiguration _bootstrapConfiguration;
 
         private IEnvironment _environment;
         private IHttpRuntimeStatic _httpRuntimeStatic;
@@ -87,6 +88,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.RumTests
             _configurationManagerStatic = new ConfigurationManagerStaticMock();
             _dnsStatic = Mock.Create<IDnsStatic>();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
 
             _runTimeConfiguration = new RunTimeConfiguration();
             _serverConfig = new ServerConfiguration();
@@ -106,7 +108,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests.RumTests
             _serverConfig.RumSettingsApplicationId = testCase.ConnectReply.ApplicationId;
             _localConfig.browserMonitoring.attributes.enabled = testCase.BrowserMonitoringAttributesEnabled;
 
-            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
             _configurationService = Mock.Create<IConfigurationService>();
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/ServerSentEvent/ServerSentEventTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CrossAgentTests/ServerSentEvent/ServerSentEventTests.cs
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests
 {
     internal class TestableDefaultConfiguration : DefaultConfiguration
     {
-        public TestableDefaultConfiguration(IEnvironment environment, configuration localConfig, ServerConfiguration serverConfig, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) : base(environment, localConfig, serverConfig, runTimeConfiguration, securityPoliciesConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic) { }
+        public TestableDefaultConfiguration(IEnvironment environment, configuration localConfig, ServerConfiguration serverConfig, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) : base(environment, localConfig, serverConfig, runTimeConfiguration, securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic) { }
     }
 
     [TestFixture]
@@ -41,6 +41,7 @@ namespace NewRelic.Agent.Core.CrossAgentTests
         private configuration _localConfig;
         private ServerConfiguration _serverConfig;
         private RunTimeConfiguration _runTimeConfig;
+        private IBootstrapConfiguration _bootstrapConfig;
         private DefaultConfiguration _defaultConfig;
 
         private ISpanEventAggregator _spanEventAggregator;
@@ -78,8 +79,9 @@ namespace NewRelic.Agent.Core.CrossAgentTests
             _localConfig.distributedTracing.enabled = true;
             _serverConfig = new ServerConfiguration();
             _runTimeConfig = new RunTimeConfiguration();
+            _bootstrapConfig = Mock.Create<IBootstrapConfiguration>();
             _defaultConfig = new TestableDefaultConfiguration(Mock.Create<IEnvironment>(), _localConfig, _serverConfig, _runTimeConfig,
-                new SecurityPoliciesConfiguration(), Mock.Create<IProcessStatic>(), Mock.Create<IHttpRuntimeStatic>(), Mock.Create<IConfigurationManagerStatic>(),
+                new SecurityPoliciesConfiguration(), _bootstrapConfig, Mock.Create<IProcessStatic>(), Mock.Create<IHttpRuntimeStatic>(), Mock.Create<IConfigurationManagerStatic>(),
                 Mock.Create<IDnsStatic>());
 
             _transactionMetricNameMaker = Mock.Create<ITransactionMetricNameMaker>();

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -90,6 +90,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
         private RunTimeConfiguration _runTimeConfiguration;
         private ServerConfiguration _serverConfig;
+        private IBootstrapConfiguration _bootstrapConfiguration;
         private configuration _localConfig;
 
 
@@ -113,7 +114,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
 
         private void PublishConfig()
         {
-            var config = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            var config = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
             _config = config;
             EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(_config, ConfigurationUpdateSource.Local));
         }
@@ -127,6 +128,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             _configurationManagerStatic = Mock.Create<IConfigurationManagerStatic>();
             _dnsStatic = Mock.Create<IDnsStatic>();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
             
             _runTimeConfiguration = new RunTimeConfiguration();
             _serverConfig = new ServerConfiguration();

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -52,6 +52,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
         private ServerConfiguration _serverConfig;
         private RunTimeConfiguration _runTimeConfiguration;
         private SecurityPoliciesConfiguration _securityPoliciesConfiguration;
+        private IBootstrapConfiguration _bootstrapConfiguration;
 
         private IEnvironment _environment;
         private IHttpRuntimeStatic _httpRuntimeStatic;
@@ -63,7 +64,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
         private void UpdateConfiguration()
         {
-            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+            _configuration = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
             EventBus<ConfigurationUpdatedEvent>.Publish(new ConfigurationUpdatedEvent(_configuration, ConfigurationUpdateSource.Local));
         }
@@ -78,6 +79,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             _dnsStatic = Mock.Create<IDnsStatic>();
             _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
             _configurationService = Mock.Create<IConfigurationService>();
+            _bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
 
             _runTimeConfiguration = new RunTimeConfiguration();
             _serverConfig = new ServerConfiguration();
@@ -1642,8 +1644,9 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var runTimeConfig = new RunTimeConfiguration();
             var securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
             var dnsStatic = Mock.Create<IDnsStatic>();
+            var bootstrapConfiguration = Mock.Create<IBootstrapConfiguration>();
 
-            _configuration = new TestableDefaultConfiguration(environment, localConfig, serverConfig, runTimeConfig, securityPoliciesConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic);
+            _configuration = new TestableDefaultConfiguration(environment, localConfig, serverConfig, runTimeConfig, securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic);
             Mock.Arrange(() => _configurationService.Configuration).Returns(_configuration);
 
             Mock.Arrange(() => dnsStatic.GetHostName()).Returns("coconut");


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The agent has a need for a separate bootstrap config that can be used before the configuration service is available. The serverless config is a current example of some of the settings that can be moved. With this change, the logic for the serverless config is now in a separate object from the local config.

This is the start of a path that we can take so that there are only 2 places in the code that control the logic of which "configuration source" takes precedence for all of the agent settings (DefaultConfiguration and BootstrapConfiguration). The BootstrapConfiguration can also be used by DefaultConfiguration so that the agent does not need to look in multiple locations outside of the Bootstrap process (before an instance of DefaultConfiguration is available).

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
