### PR TITLE
Bedrock: Revert some work, add some unit tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -445,7 +445,7 @@ namespace NewRelic.Agent.Core
 
             // check the event type first since completions don't have token_count
             if ((eventType == "LlmChatCompletionMessage" || eventType == "LlmEmbedding")
-                && attributes["token_count"] == null 
+                && !attributes.ContainsKey("token_count") 
                 && _configurationService.Configuration.LlmTokenCountingCallback != null)
             {
                 // message and embedding events have different attribute names for the content of the message

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Llm/EventHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Llm/EventHelper.cs
@@ -84,8 +84,7 @@ namespace NewRelic.Agent.Extensions.Llm
             int sequence,
             string completionId,
             int? tokenCount,
-            bool isResponse,
-            bool contentRecordingEnabled)
+            bool isResponse)
         {
             var attributes = new Dictionary<string, object>
             {
@@ -96,7 +95,7 @@ namespace NewRelic.Agent.Extensions.Llm
                 { "response.model", responseModel },
                 { "vendor", "bedrock" },
                 { "ingest_source", "DotNet" },
-                { "content", contentRecordingEnabled ? content : null },
+                { "content", content },
                 { "role", role },
                 { "sequence", sequence },
                 { "completion_id", completionId },
@@ -122,8 +121,7 @@ namespace NewRelic.Agent.Extensions.Llm
             int? tokenCount,
             bool isError,
             IDictionary<string, string> headers,
-            LlmErrorData errorData,
-            bool contentRecordingEnabled)
+            LlmErrorData errorData)
         {
             var embeddingId = Guid.NewGuid().ToString();
 
@@ -133,7 +131,7 @@ namespace NewRelic.Agent.Extensions.Llm
                 { "request_id", requestId },
                 { "span_id", segment.SpanId },
                 { "trace_id", agent.GetLinkingMetadata()["trace.id"] },
-                { "input", contentRecordingEnabled ? input : null },
+                { "input", input },
                 { "request.model", requestModel },
                 { "response.model", responseModel },
                 //{ "response.organization", "not available" },

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -126,8 +126,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                     responsePayload.Responses[0].TokenCount,
                     false,
                     null, // not available in AWS
-                    null,
-                    agent.Configuration.AiMonitoringRecordContentEnabled
+                    null
                 );
 
                 return;
@@ -160,8 +159,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                     0,
                     completionId,
                     responsePayload.PromptTokenCount,
-                    true,
-                    agent.Configuration.AiMonitoringRecordContentEnabled);
+                    true);
 
             // Responses
             for (var i = 0; i < responsePayload.Responses.Length; i++)
@@ -176,8 +174,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                     i + 1,
                     completionId,
                     responsePayload.Responses[i].TokenCount,
-                    true,
-                    agent.Configuration.AiMonitoringRecordContentEnabled);
+                    true);
             }
         }
 
@@ -225,8 +222,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                     null,
                     true,
                     null,
-                    errorData,
-                    agent.Configuration.AiMonitoringRecordContentEnabled);
+                    errorData);
             }
             else
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Wrapper/AgentWrapperApi/AgentWrapperApiTests.cs
@@ -2024,6 +2024,244 @@ namespace NewRelic.Agent.Core.Wrapper.AgentWrapperApi
 
         #endregion
 
+        #region RecordLlmEvent
+        [Test]
+        public void RecordLlmEvent_DoesNothing_WhenAiMonitoringIsDisabled()
+        {
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(false);
+
+            var eventName = "eventName";
+            var attributes = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
+
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventName, attributes);
+
+            Mock.Assert(() => _transactionService.GetCurrentInternalTransaction(), Occurs.Never());
+        }
+        [Test]
+        public void RecordLlmEvent_RecordsSupportabilityMetric_WhenAiMonitoringStreamingEnabledIsDisabled()
+        {
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringStreamingEnabled)
+                .Returns(false);
+
+            var eventName = "eventName";
+            var attributes = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
+
+            SetupTransaction();
+
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventName, attributes);
+
+            Mock.Assert(() => _agentHealthReporter.ReportSupportabilityCountMetric("Supportability/DotNet/ML/Streaming/Disabled", 1), Occurs.Once());
+        }
+        [Test]
+        public void RecordLlmEvent_SetsLlmTransactionMetadata()
+        {
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringStreamingEnabled)
+                .Returns(true);
+
+            var eventName = "eventName";
+            var attributes = new Dictionary<string, object>() { { "key1", "value1" }, { "key2", 1 } };
+
+            SetupTransaction();
+
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventName, attributes);
+
+            var transaction = _transactionService.GetCurrentInternalTransaction();
+            Assert.That(transaction.TransactionMetadata.IsLlmTransaction, Is.True);
+        }
+
+        [Test]
+        public void RecordLlmEvent_IncludesCustomAttributes_WithLlmPrefix()
+        {
+            // Arrange
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+
+            var actualAttributes = new Dictionary<string, object>();
+            Mock.Arrange(() => _customEventTransformer.Transform(Arg.IsAny<string>(), Arg.IsAny<IEnumerable<KeyValuePair<string, object>>>(), Arg.IsAny<float>()))
+            .DoInstead<string, IEnumerable<KeyValuePair<string, object>>, float>((eventType, attributes, priority) =>
+            {
+                foreach (var attribute in attributes)
+                {
+                    actualAttributes.Add(attribute.Key, attribute.Value);
+                }
+            });
+
+            var eventName = "eventName";
+
+            SetupTransaction();
+            _transaction.AddCustomAttribute("llm.key1", "value1");
+            _transaction.AddCustomAttribute("llm.key2", 1);
+            _transaction.AddCustomAttribute("key3", "value3");
+
+            // Act
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventName, new Dictionary<string, object>());
+
+            var expectedAttributes = new Dictionary<string, object>() { { "llm.key1", "value1" }, { "llm.key2", 1 } };
+            Assert.That(actualAttributes, Is.EqualTo(expectedAttributes));
+        }
+        [Test]
+        [TestCase("LlmChatCompletionMessage")]
+        [TestCase("LlmEmbedding")]
+        public void RecordLlmEvent_SetsTokenCount_IfLlmTokenCountingCallback_IsSetAndReturnsGreaterThanZero(string eventType)
+        {
+            // Arrange
+            var actualAttributes = new Dictionary<string, object>();
+            Mock.Arrange(() => _customEventTransformer.Transform(Arg.IsAny<string>(), Arg.IsAny<IEnumerable<KeyValuePair<string, object>>>(), Arg.IsAny<float>()))
+                .DoInstead<string, IEnumerable<KeyValuePair<string, object>>, float>((eventType, attributes, priority) =>
+                {
+                    foreach (var attribute in attributes)
+                    {
+                        actualAttributes.Add(attribute.Key, attribute.Value);
+                    }
+                });
+
+            Mock.Arrange(() => _configurationService.Configuration.LlmTokenCountingCallback).Returns((model, content) =>
+            {
+                if (model == "model1" && content == "This is a test message")
+                {
+                    return 10;
+                }
+                return 0;
+            });
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+
+            var attributes = new Dictionary<string, object>
+            {
+                { eventType == "LlmChatCompletionMessage" ? "content" : "input", "This is a test message" },
+                { "request.model", "model1" }
+            };
+
+            SetupTransaction();
+
+            // Act
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventType, attributes);
+
+            // Assert
+            Assert.That(actualAttributes["token_count"], Is.EqualTo(10));
+        }
+        [Test]
+        public void RecordLlmEvent_DoesNotSetTokenCount_IfLlmTokenCountingCallback_IsNotSet()
+        {
+            // Arrange
+            var actualAttributes = new Dictionary<string, object>();
+            Mock.Arrange(() => _customEventTransformer.Transform(Arg.IsAny<string>(), Arg.IsAny<IEnumerable<KeyValuePair<string, object>>>(), Arg.IsAny<float>()))
+                .DoInstead<string, IEnumerable<KeyValuePair<string, object>>, float>((eventType, attributes, priority) =>
+                {
+                    foreach (var attribute in attributes)
+                    {
+                        actualAttributes.Add(attribute.Key, attribute.Value);
+                    }
+                });
+
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+
+            var attributes = new Dictionary<string, object>
+            {
+                { "content", "This is a test message" },
+                { "request.model", "model1" }
+            };
+
+            SetupTransaction();
+
+            // Act
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent("LlmChatCompletionMessage", attributes);
+
+            // Assert
+            Assert.That(actualAttributes.ContainsKey("token_count"), Is.False);
+        }
+
+        [Test]
+        public void RecordLlmEvent_DoesNotSetTokenCount_IfLlmTokenCountingCallback_ReturnsZero()
+        {
+            // Arrange
+            var actualAttributes = new Dictionary<string, object>();
+            Mock.Arrange(() => _customEventTransformer.Transform(Arg.IsAny<string>(), Arg.IsAny<IEnumerable<KeyValuePair<string, object>>>(), Arg.IsAny<float>()))
+                .DoInstead<string, IEnumerable<KeyValuePair<string, object>>, float>((eventType, attributes, priority) =>
+                {
+                    foreach (var attribute in attributes)
+                    {
+                        actualAttributes.Add(attribute.Key, attribute.Value);
+                    }
+                });
+
+            Mock.Arrange(() => _configurationService.Configuration.LlmTokenCountingCallback).Returns((model, content) => 0);
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                .Returns(true);
+
+            var attributes = new Dictionary<string, object>
+            {
+                { "content", "This is a test message" },
+                { "request.model", "model1" }
+            };
+
+            SetupTransaction();
+
+            // Act
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent("LlmChatCompletionMessage", attributes);
+
+            // Assert
+            Assert.That(actualAttributes.ContainsKey("token_count"), Is.False);
+        }
+
+        [Test]
+        [TestCase("LlmChatCompletionMessage", "content", true, false)]
+        [TestCase("LlmChatCompletionMessage", "content", false, true)]
+        [TestCase("LlmEmbedding", "input", true, false)]
+        [TestCase("LlmEmbedding", "input", false, true)]
+        public void RecordLlmEvent_RemovesAttribute_IfHighSecurityMode_IsEnabled_OrRecordContentIsDisabled(string eventType, string attributeName, bool highSecurityMode, bool recordContentEnabled)
+        {
+            // Arrange
+            var actualAttributes = new Dictionary<string, object>();
+            Mock.Arrange(() => _customEventTransformer.Transform(Arg.IsAny<string>(), Arg.IsAny<IEnumerable<KeyValuePair<string, object>>>(), Arg.IsAny<float>()))
+                .DoInstead<string, IEnumerable<KeyValuePair<string, object>>, float>((_, attributes, priority) =>
+                {
+                    foreach (var attribute in attributes)
+                    {
+                        actualAttributes.Add(attribute.Key, attribute.Value);
+                    }
+                });
+
+            if (highSecurityMode)
+                Mock.Arrange(() => _configurationService.Configuration.HighSecurityModeEnabled)
+                    .Returns(true);
+            if (!recordContentEnabled)
+                Mock.Arrange(() => _configurationService.Configuration.AiMonitoringRecordContentEnabled)
+                    .Returns(false);
+
+            Mock.Arrange(() => _configurationService.Configuration.AiMonitoringEnabled)
+                    .Returns(true);
+
+            var attributes = new Dictionary<string, object>
+            {
+                { attributeName, "This is a test message" },
+                { "request.model", "model1" }
+            };
+
+            SetupTransaction();
+
+            // Act
+            var xapi = _agent as IAgentExperimental;
+            xapi.RecordLlmEvent(eventType, attributes);
+
+            // Assert
+            Assert.That(actualAttributes.ContainsKey(attributeName), Is.False);
+        }
+        #endregion
+
         private void SetupTransaction()
         {
             var transactionName = TransactionName.ForWebTransaction("foo", "bar");

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Llm/EventHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Llm/EventHelperTests.cs
@@ -202,9 +202,7 @@ namespace Agent.Extensions.Tests.Llm
         }
 
         [Test]
-        [TestCase(false)]
-        [TestCase(true)]
-        public void CreateChatMessageEvent_ShouldRecordLlmChatCompletionEvent(bool contentRecordingEnabled)
+        public void CreateChatMessageEvent_ShouldRecordLlmChatCompletionEvent()
         {
             // Arrange
             var requestId = "123";
@@ -231,7 +229,7 @@ namespace Agent.Extensions.Tests.Llm
                 });
 
             // Act
-            EventHelper.CreateChatMessageEvent(_agent, _segment, requestId, responseModel, content, role, sequence, completionId, tokenCount, isResponse, contentRecordingEnabled);
+            EventHelper.CreateChatMessageEvent(_agent, _segment, requestId, responseModel, content, role, sequence, completionId, tokenCount, isResponse);
 
             // Assert
             Mock.Assert(() => _agent.RecordLlmEvent("LlmChatCompletionMessage", Arg.IsAny<Dictionary<string, object>>()), Occurs.Once());
@@ -248,7 +246,7 @@ namespace Agent.Extensions.Tests.Llm
                 Assert.That(llmAttributes["response.model"], Is.EqualTo(responseModel));
                 Assert.That(llmAttributes["vendor"], Is.EqualTo("bedrock"));
                 Assert.That(llmAttributes["ingest_source"], Is.EqualTo("DotNet"));
-                Assert.That(llmAttributes["content"], Is.EqualTo(contentRecordingEnabled ? content : null));
+                Assert.That(llmAttributes["content"], Is.EqualTo(content));
                 Assert.That(llmAttributes["role"], Is.EqualTo(role));
                 Assert.That(llmAttributes["sequence"], Is.EqualTo(sequence));
                 Assert.That(llmAttributes["completion_id"], Is.EqualTo(completionId));
@@ -258,9 +256,7 @@ namespace Agent.Extensions.Tests.Llm
         }
 
         [Test]
-        [TestCase(false)]
-        [TestCase(true)]
-        public void CreateEmbeddingEvent_ShouldRecordLlmEmbeddingEvent(bool contentRecordingEnabled)
+        public void CreateEmbeddingEvent_ShouldRecordLlmEmbeddingEvent()
         {
             // Arrange
             var requestId = "123";
@@ -301,7 +297,7 @@ namespace Agent.Extensions.Tests.Llm
                 });
 
             // Act
-            EventHelper.CreateEmbeddingEvent(_agent, _segment, requestId, input, requestModel, responseModel, vendor, tokenCount, false, headers, null, contentRecordingEnabled);
+            EventHelper.CreateEmbeddingEvent(_agent, _segment, requestId, input, requestModel, responseModel, vendor, tokenCount, false, headers, null);
 
             // Assert
             Mock.Assert(() => _agent.RecordLlmEvent("LlmEmbedding", Arg.IsAny<Dictionary<string, object>>()), Occurs.Once());
@@ -314,7 +310,7 @@ namespace Agent.Extensions.Tests.Llm
                 Assert.That(llmAttributes["request_id"], Is.EqualTo(requestId));
                 Assert.That(llmAttributes["span_id"], Is.EqualTo(_segment.SpanId));
                 Assert.That(llmAttributes["trace_id"], Is.EqualTo(_agent.GetLinkingMetadata()["trace.id"]));
-                Assert.That(llmAttributes["input"], Is.EqualTo(contentRecordingEnabled ? input : null));
+                Assert.That(llmAttributes["input"], Is.EqualTo(input));
                 Assert.That(llmAttributes["request.model"], Is.EqualTo(requestModel));
                 Assert.That(llmAttributes["response.model"], Is.EqualTo(responseModel));
                 Assert.That(llmAttributes["vendor"], Is.EqualTo(vendor));
@@ -393,7 +389,7 @@ namespace Agent.Extensions.Tests.Llm
             
 
             // Act
-            EventHelper.CreateEmbeddingEvent(_agent, _segment, requestId, input, requestModel, responseModel, vendor, tokenCount, true, null, errorData, true);
+            EventHelper.CreateEmbeddingEvent(_agent, _segment, requestId, input, requestModel, responseModel, vendor, tokenCount, true, null, errorData);
 
             // Assert
             Mock.Assert(() => _agent.RecordLlmEvent("LlmEmbedding", Arg.IsAny<Dictionary<string, object>>()), Occurs.Once());


### PR DESCRIPTION
Reverts most of the changes that were in #2333, as the appropriate work was already implemented in `Agent.RecordLlmEvent()`.

Adds several new unit tests for `Agent.RecordLlmEvent()`