### PR TITLE
feat: Add transaction ID to intrinsic attributes for error events and traces regardless of DT/CAT settings

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transformers/TransactionTransformer/TransactionAttributeMaker.cs
@@ -48,6 +48,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             _attribDefs.TransactionName.TrySetValue(attribValues, transactionMetricName.PrefixedName);
             _attribDefs.TransactionNameForError.TrySetValue(attribValues, transactionMetricName.PrefixedName);
+            _attribDefs.Guid.TrySetValue(attribValues, immutableTransaction.Guid);
 
             // Duration is just EndTime minus StartTime for non-web transactions and response time otherwise
             _attribDefs.Duration.TrySetValue(attribValues, immutableTransaction.ResponseTimeOrDuration);
@@ -161,7 +162,6 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer
 
             if (_configurationService.Configuration.DistributedTracingEnabled)
             {
-                _attribDefs.Guid.TrySetValue(attribValues, immutableTransaction.Guid);
                 _attribDefs.DistributedTraceId.TrySetValue(attribValues, immutableTransaction.TraceId);
                 _attribDefs.Priority.TrySetValue(attribValues, immutableTransaction.Priority);
                 _attribDefs.Sampled.TrySetValue(attribValues, immutableTransaction.Sampled);

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Assertions.cs
@@ -758,6 +758,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 }
 
                 var actualValue = actualAttributes[expectedAttribute.Key] as string;
+                if (actualValue == null && actualAttributes[expectedAttribute.Key].GetType() ==  typeof(bool))
+                {
+                    actualValue = actualAttributes[expectedAttribute.Key].ToString().ToLowerInvariant();
+                }
+
                 if (actualValue != expectedAttribute.Value)
                 {
                     builder.AppendFormat("Attribute named {0} in the transaction event had an unexpected value.  Expected: {1}, Actual: {2}", expectedAttribute.Key, expectedAttribute.Value, actualValue);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceMvc.cs
@@ -80,24 +80,26 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 new Assertions.ExpectedMetric { metricName = @"Supportability/Transactions/allOther" },
             };
 
-            var expectedAttributes = new Dictionary<string, string>
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            var errorTraces = _fixture.AgentLog.GetErrorTraces().ToList();
+            var transactionEvents = _fixture.AgentLog.GetTransactionEvents().ToList();
+            var errorEvents = _fixture.AgentLog.GetErrorEvents().ToList();
+
+            var transactionId = transactionEvents[0].IntrinsicAttributes["guid"].ToString();
+
+            var expectedTransactionEventAttributes = new Dictionary<string, string>
             {
                 { "errorType", "System.Exception" },
                 { "errorMessage", "!Exception~Message!" },
+                { "error", "true" }
             };
 
             var expectedErrorEventAttributes = new Dictionary<string, string>
             {
                 { "error.class", "System.Exception" },
                 { "error.message", "!Exception~Message!" },
+                { "guid", transactionId }
             };
-
-            var expectedErrorTransactionEventAttributes2 = new List<string> { "error" };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var errorTraces = _fixture.AgentLog.GetErrorTraces().ToList();
-            var transactionEvents = _fixture.AgentLog.GetTransactionEvents().ToList();
-            var errorEvents = _fixture.AgentLog.GetErrorEvents().ToList();
 
             NrAssert.Multiple(
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
@@ -108,12 +110,12 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 () => Assert.Equal("System.Exception", errorTraces[0].ExceptionClassName),
                 () => Assert.Equal("!Exception~Message!", errorTraces[0].Message),
                 () => Assert.NotEmpty(errorTraces[0].Attributes.StackTrace),
+                () => Assert.Equal(errorTraces[0].Attributes.IntrinsicAttributes["guid"], transactionId),
                 () => Assert.True(transactionEvents.Any(), "No transaction events found."),
                 () => Assert.True(transactionEvents.Count == 1, $"Expected 1 transaction event but found {transactionEvents.Count}"),
-                () => Assertions.TransactionEventHasAttributes(expectedAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[0]),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[0]),
                 () => Assert.Single(errorEvents),
-                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvents[0]),
-                () => Assertions.TransactionEventHasAttributes(expectedErrorTransactionEventAttributes2, TransactionEventAttributeType.Intrinsic, transactionEvents[0])
+                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvents[0])
             );
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebApi.cs
@@ -50,13 +50,13 @@ namespace NewRelic.Agent.IntegrationTests.Errors
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-				// error metrics
-				new Assertions.ExpectedMetric {metricName = @"Errors/all", callCount = 1},
+                // error metrics
+                new Assertions.ExpectedMetric {metricName = @"Errors/all", callCount = 1},
                 new Assertions.ExpectedMetric {metricName = @"Errors/allWeb", callCount = 1},
                 new Assertions.ExpectedMetric {metricName = @"Errors/WebTransaction/WebAPI/Values/ThrowException", callCount = 1 },
 
-				// other
-				new Assertions.ExpectedMetric { metricName = @"WebTransaction", callCount = 1 }
+                // other
+                new Assertions.ExpectedMetric { metricName = @"WebTransaction", callCount = 1 }
             };
 
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
@@ -64,28 +64,28 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 new Assertions.ExpectedMetric { metricName = @"OtherTransaction/all", callCount = 5 },
             };
 
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            var errorTrace = _fixture.AgentLog.GetErrorTraces().ToList().FirstOrDefault();
+            var transactionEvent = _fixture.AgentLog.GetTransactionEvents().ToList().FirstOrDefault();
+            var errorEvent = _fixture.AgentLog.GetErrorEvents().FirstOrDefault();
+
             var expectedErrorClass = "System.Exception";
             var expectedErrorMessage = "ExceptionMessage";
+            var transactionId = transactionEvent.IntrinsicAttributes["guid"].ToString();
 
-            var expectedAttributes = new Dictionary<string, string>
+            var expectedTransactionEventAttributes = new Dictionary<string, string>
             {
                 { "errorType", expectedErrorClass },
                 { "errorMessage", expectedErrorMessage },
+                { "error", "true" },
             };
-
 
             var expectedErrorEventAttributes = new Dictionary<string, string>
             {
                 { "error.class", expectedErrorClass },
                 { "error.message", expectedErrorMessage },
+                { "guid", transactionId },
             };
-
-            var expectedErrorTransactionEventAttributes2 = new List<string> { "error" };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var errorTrace = _fixture.AgentLog.GetErrorTraces().ToList().FirstOrDefault();
-            var transactionEvent = _fixture.AgentLog.GetTransactionEvents().ToList().FirstOrDefault();
-            var errorEvent = _fixture.AgentLog.GetErrorEvents().FirstOrDefault();
 
             NrAssert.Multiple(
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
@@ -96,10 +96,10 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 () => Assert.Equal("WebTransaction/WebAPI/Values/ThrowException", errorTrace.Path),
                 () => Assert.Equal(expectedErrorClass, errorTrace.ExceptionClassName),
                 () => Assert.Equal(expectedErrorMessage, errorTrace.Message),
+                () => Assert.Equal(transactionId, errorTrace.Attributes.IntrinsicAttributes["guid"]),
                 () => Assert.NotEmpty(errorTrace.Attributes.StackTrace),
-                () => Assertions.TransactionEventHasAttributes(expectedAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvent),
-                () => Assertions.TransactionEventHasAttributes(expectedErrorTransactionEventAttributes2, TransactionEventAttributeType.Intrinsic, transactionEvent)
+                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvent)
             );
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ErrorTraceWebService.cs
@@ -52,13 +52,13 @@ namespace NewRelic.Agent.IntegrationTests.Errors
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-				// error metrics
-				new Assertions.ExpectedMetric {metricName = @"Errors/all", callCount = 2},
+                // error metrics
+                new Assertions.ExpectedMetric {metricName = @"Errors/all", callCount = 2},
                 new Assertions.ExpectedMetric {metricName = @"Errors/allWeb", callCount = 2},
                 new Assertions.ExpectedMetric {metricName = @"Errors/WebTransaction/WebService/BasicWebService.TestWebService.ThrowException", callCount = 2},
 
-				// other
-				new Assertions.ExpectedMetric {metricName = @"WebTransaction/WebService/BasicWebService.TestWebService.ThrowException", callCount = 2},
+                // other
+                new Assertions.ExpectedMetric {metricName = @"WebTransaction/WebService/BasicWebService.TestWebService.ThrowException", callCount = 2},
                 new Assertions.ExpectedMetric {metricName = @"DotNet/BasicWebService.TestWebService.ThrowException", callCount = 2},
                 new Assertions.ExpectedMetric {metricName = @"DotNet/BasicWebService.TestWebService.ThrowException", metricScope = "WebTransaction/WebService/BasicWebService.TestWebService.ThrowException", callCount = 2}
             };
@@ -70,10 +70,16 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 new Assertions.ExpectedMetric { metricName = @"OtherTransaction/all" },
             };
 
-            var expectedAttributes = new Dictionary<string, string>
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            var errorTraces = _fixture.AgentLog.GetErrorTraces().ToList();
+            var transactionEvents = _fixture.AgentLog.GetTransactionEvents().ToList();
+            var errorEvents = _fixture.AgentLog.GetErrorEvents();
+
+            var expectedTransactonEventAttributes = new Dictionary<string, string>
             {
                 { "errorType", ExpectedExceptionType },
                 { "errorMessage", "Oh no!" },
+                { "error", "true" },
             };
 
             var expectedErrorEventAttributes = new Dictionary<string, string>
@@ -81,11 +87,6 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 { "error.class", ExpectedExceptionType },
                 { "error.message", "Oh no!" },
             };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var errorTraces = _fixture.AgentLog.GetErrorTraces().ToList();
-            var transactionEvents = _fixture.AgentLog.GetTransactionEvents().ToList();
-            var errorEvents = _fixture.AgentLog.GetErrorEvents();
 
             NrAssert.Multiple(
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
@@ -96,16 +97,19 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                 () => Assert.Equal(ExpectedExceptionType, errorTraces[0].ExceptionClassName),
                 () => Assert.Equal("Oh no!", errorTraces[0].Message),
                 () => Assert.NotEmpty(errorTraces[0].Attributes.StackTrace),
+                () => Assert.NotNull(errorTraces[0].Attributes.IntrinsicAttributes["guid"]),
                 () => Assert.Equal("WebTransaction/WebService/BasicWebService.TestWebService.ThrowException", errorTraces[1].Path),
                 () => Assert.Equal(ExpectedExceptionType, errorTraces[1].ExceptionClassName),
                 () => Assert.Equal("Oh no!", errorTraces[1].Message),
                 () => Assert.NotEmpty(errorTraces[1].Attributes.StackTrace),
+                () => Assert.NotNull(errorTraces[1].Attributes.IntrinsicAttributes["guid"]),
                 () => Assert.True(transactionEvents.Any(), "No transaction events found."),
                 () => Assert.True(transactionEvents.Count == 2, $"Expected 2 transaction event but found {transactionEvents.Count}"),
-                () => Assertions.TransactionEventHasAttributes(expectedAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[0]),
-                () => Assertions.TransactionEventHasAttributes(expectedAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[1]),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactonEventAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[0]),
+                () => Assertions.TransactionEventHasAttributes(expectedTransactonEventAttributes, TransactionEventAttributeType.Intrinsic, transactionEvents[1]),
                 () => Assert.Equal(2, errorEvents.Count()),
-                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvents.FirstOrDefault())
+                () => Assertions.ErrorEventHasAttributes(expectedErrorEventAttributes, EventAttributeType.Intrinsic, errorEvents.FirstOrDefault()),
+                () => Assert.NotNull(errorEvents.FirstOrDefault().IntrinsicAttributes["guid"])
             );
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Owin/OwinCATChainTests.cs
@@ -79,7 +79,6 @@ namespace NewRelic.Agent.IntegrationTests.Owin
                 "parent.account",
                 "parent.transportType",
                 "parent.transportDuration",
-                "guid",
                 "traceId",
                 "priority",
                 "sampled"

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/ErrorEventMakerTests.cs
@@ -127,7 +127,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             NrAssert.Multiple(
                 () => Assert.That(errorEvent.IsSynthetics, Is.EqualTo(false)),
                 () => Assert.That(agentAttributes, Has.Length.EqualTo(7)),
-                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(7)),
+                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(8)),
                 () => Assert.That(userAttributes, Is.Empty),
 
                 () => Assert.That(agentAttributes, Does.Contain("queue_wait_time_ms")),
@@ -143,6 +143,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(intrinsicAttributes, Does.Contain("error.message")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("queueDuration")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("transactionName")),
+                () => Assert.That(intrinsicAttributes, Does.Contain("guid")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("timestamp")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("type"))
             );
@@ -170,7 +171,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             NrAssert.Multiple(
                 () => Assert.That(errorEvent.IsSynthetics, Is.EqualTo(false)),
                 () => Assert.That(agentAttributes, Has.Length.EqualTo(7)),
-                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(7)),
+                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(8)),
                 () => Assert.That(userAttributes, Is.Empty),
 
                 () => Assert.That(agentAttributes, Does.Contain("queue_wait_time_ms")),
@@ -186,6 +187,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(intrinsicAttributes, Does.Contain("error.message")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("queueDuration")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("transactionName")),
+                () => Assert.That(intrinsicAttributes, Does.Contain("guid")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("timestamp")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("type"))
             );
@@ -222,7 +224,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(errorEvent.IsSynthetics, Is.EqualTo(true)),
 
                 () => Assert.That(agentAttributes, Has.Length.EqualTo(7)),
-                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(16)),
+                () => Assert.That(intrinsicAttributes, Has.Length.EqualTo(17)),
                 () => Assert.That(userAttributes, Has.Length.EqualTo(1)),
 
                 () => Assert.That(agentAttributes, Does.Contain("queue_wait_time_ms")),
@@ -238,6 +240,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(intrinsicAttributes, Does.Contain("error.message")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("queueDuration")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("transactionName")),
+                () => Assert.That(intrinsicAttributes, Does.Contain("guid")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("timestamp")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("type")),
                 () => Assert.That(intrinsicAttributes, Does.Contain("nr.syntheticsJobId")),

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -133,11 +133,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(transactionAttributes.Count(), Is.EqualTo(11)),  // Assert that only these attributes are generated
+                () => Assert.That(transactionAttributes.Count(), Is.EqualTo(12)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(transactionAttributes["timestamp"], Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(transactionAttributes["name"], Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(transactionAttributes["transactionName"], Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(transactionAttributes["guid"], Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(transactionAttributes["duration"], Is.EqualTo(0.5f)),
                 () => Assert.That(transactionAttributes["totalTime"], Is.EqualTo(1)),
                 () => Assert.That(transactionAttributes["nr.tripId"], Is.Not.Null),
@@ -172,11 +173,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(transactionAttributes.Count(), Is.EqualTo(13)),  // Assert that only these attributes are generated
+                () => Assert.That(transactionAttributes.Count(), Is.EqualTo(14)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(transactionAttributes["timestamp"], Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(transactionAttributes["name"], Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(transactionAttributes["transactionName"], Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(transactionAttributes["guid"], Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(transactionAttributes["duration"], Is.EqualTo(0.5f)),
                 () => Assert.That(transactionAttributes["totalTime"], Is.EqualTo(1)),
                 () => Assert.That(transactionAttributes["nr.tripId"], Is.Not.Null),
@@ -217,11 +219,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(transactionAttributes, Has.Count.EqualTo(13)),  // Assert that only these attributes are generated
+                () => Assert.That(transactionAttributes, Has.Count.EqualTo(14)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(transactionAttributes["timestamp"], Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(transactionAttributes["name"], Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(transactionAttributes["transactionName"], Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(transactionAttributes["guid"], Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(transactionAttributes["duration"], Is.EqualTo(0.5f)),
                 () => Assert.That(transactionAttributes["totalTime"], Is.EqualTo(1)),
                 () => Assert.That(transactionAttributes["nr.tripId"], Is.Not.Null),
@@ -259,11 +262,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(transactionAttributes, Has.Count.EqualTo(13)),  // Assert that only these attributes are generated
+                () => Assert.That(transactionAttributes, Has.Count.EqualTo(14)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(transactionAttributes["timestamp"], Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(transactionAttributes["name"], Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(transactionAttributes["transactionName"], Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(transactionAttributes["guid"], Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(transactionAttributes["duration"], Is.EqualTo(0.5f)),
                 () => Assert.That(transactionAttributes["totalTime"], Is.EqualTo(1)),
                 () => Assert.That(transactionAttributes["nr.tripId"], Is.Not.Null),
@@ -304,11 +308,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(transactionAttributes, Has.Count.EqualTo(13)),  // Assert that only these attributes are generated
+                () => Assert.That(transactionAttributes, Has.Count.EqualTo(14)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(transactionAttributes["timestamp"], Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(transactionAttributes["name"], Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(transactionAttributes["transactionName"], Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(transactionAttributes["guid"], Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(transactionAttributes["duration"], Is.EqualTo(0.5f)),
                 () => Assert.That(transactionAttributes["totalTime"], Is.EqualTo(1)),
                 () => Assert.That(transactionAttributes["nr.tripId"], Is.Not.Null),
@@ -385,13 +390,14 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(44)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(45)),  // Assert that only these attributes are generated
                 () => Assert.That(GetAttributeValue(attributes, "type", AttributeDestinations.TransactionEvent), Is.EqualTo("Transaction")),
                 () => Assert.That(GetAttributeValue(attributes, "type", AttributeDestinations.ErrorEvent), Is.EqualTo("TransactionError")),
                 () => Assert.That(GetAttributeValue(attributes, "timestamp", AttributeDestinations.TransactionEvent), Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "timestamp", AttributeDestinations.ErrorEvent), Is.EqualTo(immutableTransaction.TransactionMetadata.ReadOnlyTransactionErrorState.ErrorData.NoticedAt.ToUnixTimeMilliseconds())),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "name"), Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "transactionName"), Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(GetAttributeValue(transactionAttributes, "guid"), Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "nr.guid"), Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "duration"), Is.EqualTo(0.5f)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "totalTime"), Is.EqualTo(1)),
@@ -485,7 +491,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(15)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(16)),  // Assert that only these attributes are generated
 
                 () => Assert.That(DoAttributesContain(transactionAttributes, "request.headers.key1"), Is.False),
                 () => Assert.That(DoAttributesContain(transactionAttributes, "request.headers.key2"), Is.False),
@@ -532,11 +538,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var tripId = immutableTransaction.Guid;
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(27)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(28)),  // Assert that only these attributes are generated
                 () => Assert.That(GetAttributeValue(transactionAttributes, "type", AttributeDestinations.TransactionEvent), Is.EqualTo("Transaction")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "timestamp", AttributeDestinations.TransactionEvent), Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "name"), Is.EqualTo("WebTransaction/TransactionName")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "transactionName"), Is.EqualTo("WebTransaction/TransactionName")),
+                () => Assert.That(GetAttributeValue(transactionAttributes, "guid"), Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "nr.guid"), Is.EqualTo(immutableTransaction.Guid)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "duration"), Is.EqualTo(0.5f)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "totalTime"), Is.EqualTo(1)),
@@ -631,11 +638,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(38)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(39)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes, "type", AttributeDestinations.TransactionEvent, AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.CustomEvent, AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "name", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "transactionName", AttributeDestinations.ErrorEvent),
+                () => AssertAttributeShouldBeAvailableFor(attributes, "guid", AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "nr.guid", AttributeDestinations.TransactionEvent , AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "duration", AttributeDestinations.TransactionEvent , AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "webDuration", AttributeDestinations.TransactionEvent),
@@ -710,11 +718,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             // ASSERT
             NrAssert.Multiple
             (
-                () => Assert.That(GetCount(attributes), Is.EqualTo(31)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(32)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes, Has.Member("type")),
                 () => Assert.That(transactionAttributes, Has.Member("timestamp")),
                 () => Assert.That(transactionAttributes, Has.Member("name")),
                 () => Assert.That(transactionAttributes, Has.Member("transactionName")),
+                () => Assert.That(transactionAttributes, Has.Member("guid")),
                 () => Assert.That(transactionAttributes, Has.Member("nr.guid")),
                 () => Assert.That(transactionAttributes, Has.Member("duration")),
                 () => Assert.That(transactionAttributes, Has.Member("totalTime")),
@@ -789,11 +798,12 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(33)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(34)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes, "type", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.SpanEvent, AttributeDestinations.CustomEvent),
                 () => Assert.That(intrinsicAttributes, Has.Member("name")),
                 () => Assert.That(intrinsicAttributes, Has.Member("transactionName")),
+                () => Assert.That(intrinsicAttributes, Has.Member("guid")),
                 () => Assert.That(intrinsicAttributes, Has.Member("nr.guid")),
                 () => Assert.That(intrinsicAttributes, Has.Member("duration")),
                 () => Assert.That(intrinsicAttributes, Has.Member("totalTime")),

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionEventMakerTests.cs
@@ -127,7 +127,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             // ASSERT
             NrAssert.Multiple(
                 () => Assert.That(filteredIntrinsicsDic.Keys, Is.EquivalentTo(unfilteredIntrinsicsDic.Keys)),
-                () => Assert.That(intrinsicAttributes, Has.Count.EqualTo(19)),
+                () => Assert.That(intrinsicAttributes, Has.Count.EqualTo(20)),
                 () => Assert.That(intrinsicAttributes["type"], Is.EqualTo("Transaction")),
                 () => Assert.That(agentAttributes, Has.Count.EqualTo(4)),
                 () => Assert.That(agentAttributes["response.status"], Is.EqualTo("200")),


### PR DESCRIPTION
## Description

To insure proper linking of error events and error traces to transactions, the transaction ID (guid) needs to be added to the intrinsic attributes of error events and error traces, regardless of whether distributed tracing is enabled or not.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] ~Performance testing completed with satisfactory results (if required)~ N/A

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
