### PR TITLE
test: Refactor MSSQL stored procedure tests for better performance

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/MicrosoftDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/MicrosoftDataSqlClientExerciser.cs
@@ -181,11 +181,16 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 
             return string.Join(",", teamMembers);
         }
-
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
+        public void MsSqlParameterizedStoredProcedure(string procedureNameWith, string procedureNameWithout)
+        {
+            ExecuteParameterizedStoredProcedure(procedureNameWith, true);
+            ExecuteParameterizedStoredProcedure(procedureNameWithout, false);
+        }
+
+        private void ExecuteParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
 
@@ -203,7 +208,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
                     command.Parameters.Add(new SqlParameter(paramName, parameter.Value));
                 }
 
-                return command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
@@ -186,7 +186,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
+        public void MsSqlParameterizedStoredProcedure(string procedureNameWith, string procedureNameWithout)
+        {
+            ExecuteParameterizedStoredProcedure(procedureNameWith, true);
+            ExecuteParameterizedStoredProcedure(procedureNameWithout, false);
+        }
+
+        private int ExecuteParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
@@ -210,7 +216,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
+        public void MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureNameWith, string procedureNameWithout)
+        {
+            ExecuteParameterizedStoredProcedureUsingOdbcDriver(procedureNameWith, true);
+            ExecuteParameterizedStoredProcedureUsingOdbcDriver(procedureNameWithout, false);
+        }
+
+        private void ExecuteParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.OdbcMsSqlParameters);
 
@@ -230,14 +242,20 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
                     command.Parameters.Add(new OdbcParameter(paramName, parameter.Value)); ;
                 }
 
-                return command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
         }
 
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedureUsingOleDbDriver(string procedureName, bool paramsWithAtSign)
+        public void MsSqlParameterizedStoredProcedureUsingOleDbDriver(string procedureNameWith, string procedureNameWithout)
+        {
+            ExecuteParameterizedStoredProcedureUsingOleDbDriver(procedureNameWith, true);
+            ExecuteParameterizedStoredProcedureUsingOleDbDriver(procedureNameWithout, false);
+        }
+
+        private void ExecuteParameterizedStoredProcedureUsingOleDbDriver(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.OleDbMsSqlParameters);
 
@@ -255,7 +273,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
                     command.Parameters.Add(new OleDbParameter(paramName, parameter.Value));
                 }
 
-                return command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
         }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataSqlClientExerciser.cs
@@ -184,7 +184,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public int MsSqlParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
+        public void MsSqlParameterizedStoredProcedure(string procedureNameWith, string procNameWithout)
+        {
+            ExecuteParameterizedStoredProcedure(procedureNameWith, true);
+            ExecuteParameterizedStoredProcedure(procNameWithout, false);
+        }
+
+        private void ExecuteParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
             using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
@@ -201,7 +207,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
                     command.Parameters.Add(new SqlParameter(paramName, parameter.Value));
                 }
 
-                return command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -19,23 +19,24 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         private readonly ConsoleDynamicMethodFixture _fixture;
         private readonly string _expectedTransactionName;
         private readonly string _tableName;
-        private readonly string _procedureName;
-        private readonly bool _paramsWithAtSigns;
+        private readonly string _procNameWith;
+        private readonly string _procNameWithout;
 
-        public MsSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
+        public MsSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
         {
             MsSqlWarmupHelper.WarmupMsSql();
 
             _fixture = fixture;
             _fixture.TestLogger = output;
             _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedure";
-            _paramsWithAtSigns = paramsWithAtSign;
 
             _tableName = Utilities.GenerateTableName();
-            _procedureName = Utilities.GenerateProcedureName();
+            var procedureName = Utilities.GenerateProcedureName();
+            _procNameWith = $"{procedureName}_with";
+            _procNameWithout = $"{procedureName}_without";
 
             _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedure {_procedureName} {paramsWithAtSign}");
+            _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
             _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
 
 
@@ -72,30 +73,42 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName },
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
             };
 
             var expectedTransactionTraceSegments = new List<string>
             {
-                $"Datastore/statement/MSSQL/{_procedureName.ToLower()}/ExecuteProcedure"
+                $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+                $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure"
             };
 
-            var expectedQueryParameters = _paramsWithAtSigns
-                    ? DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue)
-                    : DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
+            var expectedQueryParametersWith = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+
+            var expectedQueryParametersWithout = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
 
 
-            var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
+            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
 
             var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
             {
                 new Assertions.ExpectedSqlTrace
                 {
                     TransactionName = _expectedTransactionName,
-                    Sql = _procedureName,
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_procedureName.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParameters,
+                    Sql = _procNameWith,
+                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+                    QueryParameters = expectedQueryParametersWith,
+                    HasExplainPlan = true
+                },
+                new Assertions.ExpectedSqlTrace
+                {
+                    TransactionName = _expectedTransactionName,
+                    Sql = _procNameWithout,
+                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
+                    QueryParameters = expectedQueryParametersWithout,
                     HasExplainPlan = true
                 }
             };
@@ -115,7 +128,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             (
                 () => Assertions.MetricsExist(expectedMetrics, metrics),
                 () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
+                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
+                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
                 () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
                 () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
             );
@@ -130,24 +144,11 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataExerciser",
-                  paramsWithAtSign: true)
+                  excerciserName: "SystemDataExerciser")
         {
         }
     }
 
-    [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests_SystemData_NoAtSigns_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlStoredProcedureTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
     #endregion
 
     #region System.Data.SqlClient (.NET Core/5+ only)
@@ -160,22 +161,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    // Set to net7 since the package this relies on does not currently support net8.
-    [NetCoreTest]
-    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore70>
-    {
-        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCore70 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataSqlClientExerciser",
-                  paramsWithAtSign: false)
+                  excerciserName: "SystemDataSqlClientExerciser")
         {
         }
     }
@@ -187,21 +173,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    [NetCoreTest]
-    public class MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreOldest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlStoredProcedureTests_SystemDataSqlClient_NoAtSigns_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataSqlClientExerciser",
-                  paramsWithAtSign: false)
+                  excerciserName: "SystemDataSqlClientExerciser")
         {
         }
     }
@@ -218,21 +190,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
+                  excerciserName: "MicrosoftDataSqlClientExerciser")
         {
         }
     }
@@ -244,21 +202,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    [NetFrameworkTest]
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
+                  excerciserName: "MicrosoftDataSqlClientExerciser")
         {
         }
     }
@@ -271,22 +215,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    // Set to net7 since the package this relies on does not currently support net8.
-    [NetCoreTest]
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCore70>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCore70 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
+                  excerciserName: "MicrosoftDataSqlClientExerciser")
         {
         }
     }
@@ -298,23 +227,10 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
+                  excerciserName: "MicrosoftDataSqlClientExerciser")
         {
         }
     }
 
-    [NetCoreTest]
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
     #endregion
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     configModifier
                         .ConfigureFasterMetricsHarvestCycle(10)
                         .ConfigureFasterTransactionTracesHarvestCycle(10)
-                        .ConfigureFasterSqlTracesHarvestCycle(20)
+                        .ConfigureFasterSqlTracesHarvestCycle(10)
                         .ForceTransactionTraces()
                         .SetLogLevel("finest");
 
@@ -89,20 +89,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/all", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", CallCountAllHarvests = commandList.Count },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", CallCountAllHarvests = commandList.Count },
             };
 
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", CallCountAllHarvests = 1 },
+                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", CallCountAllHarvests = 1 },
             };
 
             foreach (var command in commandList)
@@ -112,7 +112,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                 expectedMetrics.Add(new Assertions.ExpectedMetric
                 {
                     metricName = @"Datastore/statement/MySQL/dates/select",
-                    callCount = 1,
+                    CallCountAllHarvests = 1,
                     metricScope = transactionName
                 });
 
@@ -126,12 +126,12 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     expectedMetrics.Add(new Assertions.ExpectedMetric
                     {
                         metricName = @"DotNet/DatabaseResult/Iterate",
-                        callCount = commandList.Count
+                        CallCountAllHarvests = commandList.Count
                     });
                     expectedMetrics.Add(new Assertions.ExpectedMetric
                     {
                         metricName = @"DotNet/DatabaseResult/Iterate",
-                        callCount = 3,
+                        CallCountAllHarvests = 3,
                         metricScope = transactionName
                     });
                 }
@@ -141,7 +141,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     new Assertions.ExpectedMetric
                     {
                         metricName = @"Datastore/operation/MySQL/select",
-                        callCount = 1,
+                        CallCountAllHarvests = 1,
                         metricScope = transactionName
                     });
             }


### PR DESCRIPTION
Refactors the MS SQL stored procedure integration tests to combine the "with" and "without" @ parameterization into a single test, reducing the number of tests by 50%. Execution time for MSSQL tests dropped from about 19 minutes to about 15 minutes. 