### PR TITLE
test: Fix a MySql flicker by introducing an intentional delay

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
@@ -228,7 +228,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MySql
         }
 
         private const string Query = "SELECT _date FROM dates WHERE _date LIKE '2%' ORDER BY _date DESC LIMIT 1";
-        private const string QueryWithDelay = "SELECT _date FROM dates WHERE SLEEP(3) = 0 AND _date LIKE '2%' ORDER BY _date DESC LIMIT 1";
+        private const string QueryWithDelay = "SELECT SLEEP(2), _date FROM dates WHERE _date LIKE '2%' ORDER BY _date DESC LIMIT 1";
 
         private string ExecuteCommand(Func<MySqlCommand, string> action, bool delay = false)
         {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MySql/MySqlConnectorExerciser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -38,6 +38,28 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MySql
                 return res;
             });
         }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public void ExecuteReaderWithDelay()
+        {
+            ExecuteCommand(command =>
+            {
+                var dates = new List<string>();
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        dates.Add(reader.GetString(reader.GetOrdinal("_date")));
+                    }
+                }
+                string res = string.Join(",", dates);
+                ConsoleMFLogger.Info(res);
+                return res;
+            }, true); // add a delay to the query to make sure this is the slowest one that executes, helps test reliability
+        }
+
 
         [LibraryMethod]
         [Transaction]
@@ -206,13 +228,14 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MySql
         }
 
         private const string Query = "SELECT _date FROM dates WHERE _date LIKE '2%' ORDER BY _date DESC LIMIT 1";
+        private const string QueryWithDelay = "SELECT _date FROM dates WHERE SLEEP(3) = 0 AND _date LIKE '2%' ORDER BY _date DESC LIMIT 1";
 
-        private string ExecuteCommand(Func<MySqlCommand, string> action)
+        private string ExecuteCommand(Func<MySqlCommand, string> action, bool delay = false)
         {
             string result;
 
             using (var connection = new MySqlConnection(MySqlTestConfiguration.MySqlConnectionString))
-            using (var command = new MySqlCommand(Query, connection))
+            using (var command = new MySqlCommand(delay ? QueryWithDelay : Query, connection))
             {
                 connection.Open();
                 result = action(command);

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -146,7 +146,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     });
             }
 
-            var queryWithDelay = "SELECT _date FROM dates WHERE SLEEP(?) = ? AND _date LIKE ? ORDER BY _date DESC LIMIT ?";
+            var queryWithDelay = "SELECT SLEEP(?), _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?";
 
             var expectedTransactionTraceSegments = new List<string> { "Datastore/statement/MySQL/dates/select" };
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -56,9 +56,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     var configModifier = new NewRelicConfigModifier(configPath);
 
                     configModifier
-                        .ConfigureFasterMetricsHarvestCycle(21)
-                        .ConfigureFasterTransactionTracesHarvestCycle(13)
-                        .ConfigureFasterSqlTracesHarvestCycle(10)
+                        .ConfigureFasterMetricsHarvestCycle(30)
+                        .ConfigureFasterTransactionTracesHarvestCycle(30)
+                        .ConfigureFasterSqlTracesHarvestCycle(30)
                         .ForceTransactionTraces()
                         .SetLogLevel("finest");
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -56,8 +56,8 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                     var configModifier = new NewRelicConfigModifier(configPath);
 
                     configModifier
-                        .ConfigureFasterMetricsHarvestCycle(10)
-                        .ConfigureFasterTransactionTracesHarvestCycle(10)
+                        .ConfigureFasterMetricsHarvestCycle(21)
+                        .ConfigureFasterTransactionTracesHarvestCycle(13)
                         .ConfigureFasterSqlTracesHarvestCycle(10)
                         .ForceTransactionTraces()
                         .SetLogLevel("finest");
@@ -74,8 +74,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
                 exerciseApplication: () =>
                 {
                     // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex,
-                        TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
                     _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );


### PR DESCRIPTION
Added an intentional delay in one of the MySql queries to ensure that we always know it will be the slowest, which should address a recent frequently-occurring failure. This same change may need to be more widely applied if other flickers show up, but for now it's just focused on a single test.