### PR TITLE
Use custom var and fallback for lambda instrumentation point

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.20.2.73"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.21.1.64"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -125,7 +125,16 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             {
                 return;
             }
-            auto lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("AWS_LAMBDA_FUNCTION_NAME"));
+
+            auto lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("_HANDLER"));
+            if (lambdaInstPoint != nullptr)
+            {
+                AddInstrumentationPointToCollectionFromEnvironment(*lambdaInstPoint);
+                _foundServerlessInstrumentationPoint = true;
+                return;
+            }
+
+            lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("NEW_RELIC_LAMBDA_FUNCTION_HANDLER"));
             if (lambdaInstPoint != nullptr)
             {
                 AddInstrumentationPointToCollectionFromEnvironment(*lambdaInstPoint);

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -29,7 +29,6 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     {
         bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings) override
         {
-            instrumentationSettings->GetInstrumentationConfiguration()->CheckForEnvironmentInstrumentationPoint();
             auto instrumentationPoint = instrumentationSettings->GetInstrumentationConfiguration()->TryGetInstrumentationPoint(function);
             if (instrumentationPoint == nullptr)
             {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -249,6 +249,7 @@ namespace NewRelic { namespace Profiler {
                 }
 
                 auto instrumentationConfiguration = InitializeInstrumentationConfig(configuration->GetIgnoreInstrumentationList());
+                instrumentationConfiguration->CheckForEnvironmentInstrumentationPoint();
                 auto methodRewriter = std::make_shared<MethodRewriter::MethodRewriter>(instrumentationConfiguration, _agentCoreDllPath);
                 this->SetMethodRewriter(methodRewriter);
 


### PR DESCRIPTION
The previous solution for auto-detecting the lambda instrumentation point in the profiler would not work in many cases. Now we try two environment variables:
* `_HANDLER` which should be auto-populated but may not be available in all environments (notably the test tool)
* `NEW_RELIC_LAMBDA_FUNCTION_HANDLER` which the user must provide

This is now only checked on startup instead of prior to each method's compilation.