### PR TITLE
More Lambda / DT configuration tweaks

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -929,13 +929,13 @@ namespace NewRelic.Agent.Core.Configuration
             EnvironmentOverrides(_localConfiguration.distributedTracing.account_id, "NEW_RELIC_ACCOUNT_ID")
             : _serverConfiguration.AccountId;
 
-        public int? SamplingTarget => _serverConfiguration.SamplingTarget;
+        public int? SamplingTarget => ServerlessModeEnabled ? 10 : _serverConfiguration.SamplingTarget;
 
         // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
         public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
            EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
 
-        public int? SamplingTargetPeriodInSeconds => _serverConfiguration.SamplingTargetPeriodInSeconds;
+        public int? SamplingTargetPeriodInSeconds => ServerlessModeEnabled ? 60 : _serverConfiguration.SamplingTargetPeriodInSeconds;
 
         public bool PayloadSuccessMetricsEnabled => _localConfiguration.distributedTracing.enableSuccessMetrics;
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -74,10 +74,8 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 
             var attributes = new Dictionary<string, string>();
 
-            EventTypes.TryGetValue(eventTypeName, out var eventType); // handle case where the name might not be in the eventType dictionary
-
-            attributes.AddEventSourceAttribute("eventType", eventType ?? "Unknown"); // TODO: Is this correct?
-            attributes.AddEventSourceAttribute("arn", "????"); // TODO: how to get this value? Spec says "ARN of the invocation source" 
+            EventTypes.TryGetValue(eventTypeName, out var eventType); // TODO: handle case where the name might not be in the eventType dictionary
+            attributes.AddEventSourceAttribute("eventType", eventType ?? "Unknown");
 
             attributes.Add("aws.requestId", requestIdGetter(lambdaContext));
             attributes.Add("aws.lambda.arn", lambdaFunctionArn);
@@ -85,7 +83,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             if (IsColdStart) // only report this attribute if it's a cold start
                 attributes.Add("aws.coldStart", "true");
 
-            agent.SetServerlessParameters(lambdaFunctionVersion ?? "$LATEST", lambdaFunctionArn); // TODO: Is the default for version correct?
+            agent.SetServerlessParameters(lambdaFunctionVersion ?? "$LATEST", lambdaFunctionArn);
 
             switch (eventType)
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2221,12 +2221,38 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
+        public void SamplingTarget_Is10_InServerlessMode()
+        {
+            // Arrange
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+
+            // Act
+            var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+            // Assert
+            Assert.That(defaultConfig.SamplingTarget, Is.EqualTo(10));
+        }
+
+        [Test]
         [TestCase(1234, 1234)]
         public void SamplingTargetPeriodInSecondsValue(int server, int expectedResult)
         {
             _serverConfig.SamplingTargetPeriodInSeconds = server;
 
             Assert.That(expectedResult, Is.EqualTo(_defaultConfig.SamplingTargetPeriodInSeconds));
+        }
+
+        [Test]
+        public void SamplingTargetPeriodInSeconds_Is60_InServerlessMode()
+        {
+            // Arrange
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+
+            // Act
+            var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+            // Assert
+            Assert.That(defaultConfig.SamplingTargetPeriodInSeconds, Is.EqualTo(60));
         }
 
         [Test]


### PR DESCRIPTION
* Adds an override for `SamplingTarget` and `SamplingTargetPeriodInSeconds` when in Serverless mode, as per the spec. 
* Minor cleanup in the function handler wrapper.