### PR TITLE
Fix profiler bug with tracer flags not being set properly

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.21.1.64"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.21.1.66"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -163,6 +163,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             instrumentationPoint->ClassName = segments[1];
             instrumentationPoint->MethodName = segments[2];
             instrumentationPoint->Parameters = nullptr;
+            instrumentationPoint->TracerFactoryArgs = 0;
 
             (*_instrumentationPointsMap)[instrumentationPoint->GetMatchKey()].insert(instrumentationPoint);
             _instrumentationPointsSet->insert(instrumentationPoint);

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationPoint.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationPoint.h
@@ -29,7 +29,8 @@ namespace NewRelic { namespace Profiler { namespace Configuration
         std::unique_ptr<AssemblyVersion> MinVersion;    // on the <match> node
         std::unique_ptr<AssemblyVersion> MaxVersion;    // on the <match> node
 
-        InstrumentationPoint() {}
+        InstrumentationPoint():
+            TracerFactoryArgs(0) { }
 
         InstrumentationPoint(const InstrumentationPoint& other) :
             TracerFactoryName(other.TracerFactoryName),


### PR DESCRIPTION
This could result in (among other issues) a non-async method being flagged as async, and therefore not instrumenting properly