### PR TITLE
Lambda: Event Support & Tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventType.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventType.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.Extensions.Lambda;
+
+public enum AwsLambdaEventType
+{
+    Unknown,
+    APIGatewayProxyRequest,
+    ApplicationLoadBalancerRequest,
+    CloudWatchScheduledEvent,
+    KinesisStreamingEvent,
+    KinesisFirehoseEvent,
+    SNSEvent,
+    S3Event,
+    SimpleEmailEvent,
+    SQSEvent,
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
@@ -1,0 +1,48 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace NewRelic.Agent.Extensions.Lambda;
+
+public static class AwsLambdaEventTypeExtensions
+{
+    public static AwsLambdaEventType ToEventType(this string typeFullName)
+    {
+        return typeFullName switch
+        {
+            "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest" => AwsLambdaEventType.APIGatewayProxyRequest,
+            "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest" => AwsLambdaEventType.ApplicationLoadBalancerRequest,
+            "Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent" => AwsLambdaEventType.CloudWatchScheduledEvent,
+            "Amazon.Lambda.KinesisEvents.KinesisEvent" => AwsLambdaEventType.KinesisStreamingEvent,
+            "Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent" => AwsLambdaEventType.KinesisFirehoseEvent,
+            "Amazon.Lambda.SNSEvents.SNSEvent" => AwsLambdaEventType.SNSEvent,
+            "Amazon.Lambda.S3Events.S3Event" => AwsLambdaEventType.S3Event,
+            "Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent" => AwsLambdaEventType.SimpleEmailEvent,
+            "Amazon.Lambda.SQSEvents.SQSEvent" => AwsLambdaEventType.SQSEvent,
+            _ => AwsLambdaEventType.Unknown
+        };
+    }
+    public static string ToEventTypeString(this AwsLambdaEventType eventType)
+    {
+        return eventType switch
+        {
+            AwsLambdaEventType.APIGatewayProxyRequest => "apiGateway",
+            AwsLambdaEventType.ApplicationLoadBalancerRequest => "alb",
+            AwsLambdaEventType.CloudWatchScheduledEvent => "cloudWatch_scheduled",
+            AwsLambdaEventType.KinesisStreamingEvent => "kinesis",
+            AwsLambdaEventType.KinesisFirehoseEvent => "firehose",
+            AwsLambdaEventType.SNSEvent => "sns",
+            AwsLambdaEventType.S3Event => "s3",
+            AwsLambdaEventType.SimpleEmailEvent => "ses",
+            AwsLambdaEventType.SQSEvent => "sqs",
+            AwsLambdaEventType.Unknown => "Unknown",
+            _ => throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType"),
+        };
+    }
+
+    public static bool IsWebEvent(this AwsLambdaEventType eventType)
+    {
+        return eventType == AwsLambdaEventType.APIGatewayProxyRequest || eventType == AwsLambdaEventType.ApplicationLoadBalancerRequest;
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using NewRelic.Agent.Api;
+
+namespace NewRelic.Agent.Extensions.Lambda;
+
+public static class LambdaAttributeExtensions
+{
+    public static void AddEventSourceAttribute(this Dictionary<string, string> dict, string suffix, string value)
+    {
+        dict.Add($"aws.lambda.eventSource.{suffix}", value);
+    }
+
+    public static void AddLambdaAttributes(this ITransaction transaction, Dictionary<string, string> attributes)
+    {
+        foreach (var attribute in attributes)
+        {
+            transaction.AddCustomAttribute(attribute.Key, attribute.Value); // TODO: figure out if custom attributes are correct
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -1,0 +1,188 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+
+namespace NewRelic.Agent.Extensions.Lambda;
+
+public static class LambdaEventHelpers
+{
+    public static void AddEventTypeAttributes(IAgent agent, ITransaction transaction, AwsLambdaEventType eventType, object inputObject, Dictionary<string, string> attributes)
+    {
+        switch (eventType)
+        {
+            case AwsLambdaEventType.APIGatewayProxyRequest:
+                dynamic apiReqEvent = inputObject; // Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest
+                SetWebRequestProperties(agent, transaction, apiReqEvent);
+
+                dynamic requestContext = apiReqEvent.RequestContext;
+                // arn is not available
+                attributes.AddEventSourceAttribute("accountId", (string)requestContext.AccountId);
+                attributes.AddEventSourceAttribute("apiId", (string)requestContext.ApiId);
+                attributes.AddEventSourceAttribute("resourceId", (string)requestContext.ResourceId);
+                attributes.AddEventSourceAttribute("resourcePath", (string)requestContext.ResourcePath);
+                attributes.AddEventSourceAttribute("stage", (string)requestContext.Stage);
+
+                TryParseWebRequestDistributedTraceHeaders(apiReqEvent, attributes);
+                break;
+
+            case AwsLambdaEventType.ApplicationLoadBalancerRequest:
+                dynamic albReqEvent = inputObject; //Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest
+
+                SetWebRequestProperties(agent, transaction, albReqEvent);
+
+                attributes.AddEventSourceAttribute("arn", (string)albReqEvent.RequestContext.Elb.TargetGroupArn);
+                TryParseWebRequestDistributedTraceHeaders(albReqEvent, attributes);
+                break;
+
+            case AwsLambdaEventType.CloudWatchScheduledEvent:
+                dynamic cloudWatchScheduledEvent = inputObject; //Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent
+
+                attributes.AddEventSourceAttribute("arn", (string)cloudWatchScheduledEvent.Resources[0]);
+                attributes.AddEventSourceAttribute("account", (string)cloudWatchScheduledEvent.Account);
+                attributes.AddEventSourceAttribute("id", (string)cloudWatchScheduledEvent.Id);
+                attributes.AddEventSourceAttribute("region", (string)cloudWatchScheduledEvent.Region);
+                attributes.AddEventSourceAttribute("resource", (string)cloudWatchScheduledEvent.Resources[0]);
+                attributes.AddEventSourceAttribute("time", (string)cloudWatchScheduledEvent.Time);
+                break;
+
+            case AwsLambdaEventType.KinesisStreamingEvent:
+                dynamic kinesisStreamingEvent = inputObject; //Amazon.Lambda.KinesisEvents.KinesisEvent
+
+                attributes.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
+                attributes.AddEventSourceAttribute("length", (string)kinesisStreamingEvent.Records.Count.ToString());
+                attributes.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
+                break;
+
+            case AwsLambdaEventType.KinesisFirehoseEvent:
+                dynamic kinesisFirehoseEvent = inputObject; //Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
+
+                attributes.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
+                attributes.AddEventSourceAttribute("length", (string)kinesisFirehoseEvent.Records.Count.ToString());
+                attributes.AddEventSourceAttribute("region", (string)kinesisFirehoseEvent.Region);
+                break;
+
+            case AwsLambdaEventType.S3Event:
+                dynamic s3Event = inputObject; //Amazon.Lambda.S3Events.S3Event
+
+                attributes.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
+                attributes.AddEventSourceAttribute("length", (string)s3Event.Records.Count.ToString());
+                attributes.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);
+                attributes.AddEventSourceAttribute("eventName", (string)s3Event.Records[0].EventName);
+                attributes.AddEventSourceAttribute("eventTime", (string)s3Event.Records[0].EventTime);
+                attributes.AddEventSourceAttribute("xAmzId2", (string)s3Event.Records[0].ResponseElements.XAmzId2);
+                attributes.AddEventSourceAttribute("bucketName", (string)s3Event.Records[0].S3.Bucket.Name);
+                attributes.AddEventSourceAttribute("objectKey", (string)s3Event.Records[0].S3.Object.Key);
+                attributes.AddEventSourceAttribute("objectSequencer", (string)s3Event.Records[0].S3.Object.Sequencer);
+                attributes.AddEventSourceAttribute("objectSize", (string)s3Event.Records[0].S3.Object.Size.ToString());
+                break;
+
+            case AwsLambdaEventType.SimpleEmailEvent:
+                dynamic sesEvent = inputObject; //Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
+
+                // arn is not available
+                attributes.AddEventSourceAttribute("length", (string)sesEvent.Records.Count.ToString());
+                attributes.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.Date);
+                attributes.AddEventSourceAttribute("messageId", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.MessageId);
+                attributes.AddEventSourceAttribute("returnPath", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.ReturnPath);
+                break;
+
+            case AwsLambdaEventType.SNSEvent:
+                dynamic snsEvent = inputObject; //Amazon.Lambda.SNSEvents.SNSEvent
+
+                attributes.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
+                attributes.AddEventSourceAttribute("length", (string)snsEvent.Records.Count.ToString());
+                attributes.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);
+                attributes.AddEventSourceAttribute("timestamp", (string)snsEvent.Records[0].Sns.Timestamp);
+                attributes.AddEventSourceAttribute("topicArn", (string)snsEvent.Records[0].Sns.TopicArn);
+                attributes.AddEventSourceAttribute("type", (string)snsEvent.Records[0].Sns.Type);
+
+                TryParseSNSDistributedTraceHeaders(snsEvent, attributes);
+                break;
+
+            case AwsLambdaEventType.SQSEvent:
+                dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
+
+                attributes.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
+                attributes.AddEventSourceAttribute("length", (string)sqsEvent.Records.Count.ToString());
+
+                TryParseSQSDistributedTraceHeaders(sqsEvent, attributes);
+                break;
+
+            case AwsLambdaEventType.Unknown:
+                break; // nothing to do for unknown event type
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType");
+        }
+    }
+
+    private const string NEWRELIC_TRACE_HEADER = "newrelic";
+
+    private static void TryParseWebRequestDistributedTraceHeaders(dynamic webRequestEvent, Dictionary<string, string> attributes)
+    {
+        IList<string> headerValues = null;
+        string headerValue = null;
+        if (webRequestEvent.MultiValueHeaders != null && ((IDictionary<string, IList<string>>)webRequestEvent.MultiValueHeaders).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValues))
+        {
+            attributes.Add(NEWRELIC_TRACE_HEADER, string.Join(",", headerValues));
+        }
+        if (webRequestEvent.Headers != null && ((IDictionary<string, string>)webRequestEvent.Headers).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValue))
+        {
+            attributes.Add(NEWRELIC_TRACE_HEADER, headerValue);
+        }
+    }
+    private static void TryParseSQSDistributedTraceHeaders(dynamic sqsEvent, Dictionary<string, string> attributes)
+    {
+        var record = sqsEvent.Records[0];
+        dynamic traceHeader = null;
+        if (record.MessageAttributes != null && ((Dictionary<string, dynamic>)record.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out traceHeader))
+        {
+            attributes.Add(NEWRELIC_TRACE_HEADER, traceHeader.StringValue);
+        }
+        else if (record.Body != null && record.Body.Contains("\"Type\" : \"Notification\"") && record.Body.Contains("\"MessageAttributes\""))
+        {
+            // This is an an SNS subscription with atttributes
+            var newrelicIndex = record.Body.IndexOf("newrelic", System.StringComparison.InvariantCultureIgnoreCase) + 9;
+            var startIndex = record.Body.IndexOf("Value\":\"", newrelicIndex, System.StringComparison.InvariantCultureIgnoreCase) + 8;
+            var endIndex = record.Body.IndexOf('"', startIndex);
+            var payload = record.Body.Substring(startIndex, endIndex - startIndex);
+            attributes.Add(NEWRELIC_TRACE_HEADER, (string)payload);
+        }
+    }
+    private static void TryParseSNSDistributedTraceHeaders(dynamic snsEvent, Dictionary<string, string> attributes)
+    {
+        var record = snsEvent.Records[0];
+        dynamic traceHeader = null;
+        if (record.Sns.MessageAttributes != null && ((Dictionary<string, dynamic>)record.Sns.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out traceHeader))
+        {
+            attributes.Add(NEWRELIC_TRACE_HEADER, (string)traceHeader.Value);
+        }
+    }
+
+    private static void SetWebRequestProperties(IAgent agent, ITransaction transaction, dynamic webReqEvent)
+    {
+        //HTTP headers
+        IDictionary<string, string> headers = webReqEvent.Headers;
+        Func<IDictionary<string, string>, string, string> headersGetter = (h, k) => h[k];
+
+        IDictionary<string, IList<string>> multiValueHeaders = webReqEvent.MultiValueHeaders;
+        Func<IDictionary<string, IList<string>>, string, string> multiValueHeadersGetter = (h, k) => string.Join(",", h[k]);
+
+        if (multiValueHeaders != null)
+            transaction.SetRequestHeaders(multiValueHeaders, agent.Configuration.AllowAllRequestHeaders ? multiValueHeaders.Keys : Statics.DefaultCaptureHeaders, multiValueHeadersGetter);
+        else
+            transaction.SetRequestHeaders(headers, agent.Configuration.AllowAllRequestHeaders ? webReqEvent.Headers.Keys : Statics.DefaultCaptureHeaders, headersGetter);
+
+        //HTTP method
+        transaction.SetRequestMethod(webReqEvent.HttpMethod);
+        //HTTP uri
+        transaction.SetUri(webReqEvent.Path); // TODO: not sure if this is correct
+        //HTTP query parameters
+        transaction.SetRequestParameters(webReqEvent.QueryStringParameters);
+    }
+
+}

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -12,9 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -13,19 +13,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 {
     public class HandlerMethodWrapper : IWrapper
     {
-        public List<string> WebInputEventTypes = ["APIGatewayProxyRequest", "ALBTargetGroupRequest"];
         public List<string> WebResponseHeaders = ["Content-Type", "Content-Length"];
-        public Dictionary<string, string> EventTypes = new()
-        {
-            { "APIGatewayProxyRequest", "apiGateway" },
-            { "ApplicationLoadBalancerRequest", "alb" },
-            { "CloudWatchEvent", "cloudWatch_scheduled" },
-            { "KinesisEvent", "kinesis" },
-            { "SNSEvent", "sns" },
-            { "S3Event", "s3" },
-            { "SimpleEmailEvent", "ses" },
-            { "SQSEvent", "sqs" },
-        };
 
         private static Func<object, object> _getRequestResponseFromGeneric;
         private static Func<object, string> _getFunctionNameFromLambdaContext;
@@ -58,24 +46,22 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 
             agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"input object fullname = {inputObject.GetType().FullName}");
 
-            var eventTypeName = inputObject.GetType().FullName.Split('.').Last(); // e.g. SQSEvent
-
-            agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"input object type info = {eventTypeName}");
+            var eventType = inputObject.GetType().ToEventType();
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"eventType = {eventType}");
 
             var lambdaFunctionName = functionNameGetter(lambdaContext);
             var lambdaFunctionArn = functionArnGetter(lambdaContext);
             var lambdaFunctionVersion = functionVersionGetter(lambdaContext);
 
             transaction = agent.CreateTransaction(
-                isWeb: WebInputEventTypes.Any(s => s == eventTypeName),
+                isWeb: eventType.IsWebEvent(),
                 category: "Lambda", // TODO: is this is correct/useful?
                 transactionDisplayName: lambdaFunctionName,
                 doNotTrackAsUnitOfWork: true);
 
             var attributes = new Dictionary<string, string>();
 
-            EventTypes.TryGetValue(eventTypeName, out var eventType); // TODO: handle case where the name might not be in the eventType dictionary
-            attributes.AddEventSourceAttribute("eventType", eventType ?? "Unknown");
+            attributes.AddEventSourceAttribute("eventType", eventType.ToEventTypeString());
 
             attributes.Add("aws.requestId", requestIdGetter(lambdaContext));
             attributes.Add("aws.lambda.arn", lambdaFunctionArn);
@@ -85,43 +71,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 
             agent.SetServerlessParameters(lambdaFunctionVersion ?? "$LATEST", lambdaFunctionArn);
 
-            switch (eventType)
-            {
-                case "apiGateway":
-                    dynamic apiReqEvent = inputObject; // APIGatewayProxyRequest
-                    //HTTP headers
-                    IDictionary<string,string> headers = apiReqEvent.Headers;
-                    Func<IDictionary<string, string>, string, string> getter = (h, k) => h[k];
-                    transaction.SetRequestHeaders(headers, agent.Configuration.AllowAllRequestHeaders ? apiReqEvent.Headers.Keys : Statics.DefaultCaptureHeaders, getter);
-                    //HTTP method
-                    transaction.SetRequestMethod(apiReqEvent.HttpMethod);
-                    //HTTP uri
-                    transaction.SetUri(apiReqEvent.Path); // TODO: not sure if this is correct
-                    //HTTP query parameters
-                    transaction.SetRequestParameters(apiReqEvent.QueryStringParameters);
-
-                    //aws.lambda.eventSource.accountId    string  event requestContext.accountId Identifier of the API account
-                    dynamic requestContext = apiReqEvent.RequestContext;
-                    attributes.AddEventSourceAttribute("accountId", (string)requestContext.AccountId);
-                    //aws.lambda.eventSource.apiId string event requestContext.apiId Identifier of the API gateway
-                    attributes.AddEventSourceAttribute("apiId", (string)requestContext.ApiId);
-                    //aws.lambda.eventSource.resourceId string event requestContext.resourceId Identifier of the API resource
-                    attributes.AddEventSourceAttribute("resourceId", (string)requestContext.ResourceId);
-                    //aws.lambda.eventSource.resourcePath string event requestContext.resourcePath Path of the API resource
-                    attributes.AddEventSourceAttribute("resourcePath", (string)requestContext.ResourcePath);
-                    //aws.lambda.eventSource.stage string event requestContext.stage Stage of the API resource
-                    attributes.AddEventSourceAttribute("stage", (string)requestContext.Stage);
-
-                    // TODO: insert distributed tracing headers if they're not already there
-                    break;
-                case "sqs":
-                    dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
-                    attributes.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
-                    attributes.AddEventSourceAttribute("length", (string)sqsEvent.Records.Count.ToString());
-                    break;
-                default:
-                    break;
-            }
+            AddEventTypeAttributes(agent, transaction, eventType, inputObject, attributes);
 
             transaction.AddLambdaAttributes(attributes, agent);
 
@@ -160,6 +110,165 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             }
         }
 
+        private static void AddEventTypeAttributes(IAgent agent, ITransaction transaction, AwsLambdaEventType eventType, object inputObject, Dictionary<string, string> attributes)
+        {
+            switch (eventType)
+            {
+                case AwsLambdaEventType.APIGatewayProxyRequest:
+                    dynamic apiReqEvent = inputObject; // Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest
+                    SetWebRequestProperties(agent, transaction, apiReqEvent);
+
+                    dynamic requestContext = apiReqEvent.RequestContext;
+                    attributes.AddEventSourceAttribute("accountId", (string)requestContext.AccountId);
+                    attributes.AddEventSourceAttribute("apiId", (string)requestContext.ApiId);
+                    attributes.AddEventSourceAttribute("resourceId", (string)requestContext.ResourceId);
+                    attributes.AddEventSourceAttribute("resourcePath", (string)requestContext.ResourcePath);
+                    attributes.AddEventSourceAttribute("stage", (string)requestContext.Stage);
+
+                    TryParseWebRequestDistributedTraceHeaders(apiReqEvent, attributes);
+                    break;
+                case AwsLambdaEventType.ApplicationLoadBalancerRequest:
+                    dynamic albReqEvent = inputObject; //Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest
+
+                    SetWebRequestProperties(agent, transaction, albReqEvent);
+
+                    attributes.AddEventSourceAttribute("arn", (string)albReqEvent.RequestContext.Elb.TargetGroupArn);
+                    TryParseWebRequestDistributedTraceHeaders(albReqEvent, attributes);
+                    break;
+                case AwsLambdaEventType.CloudWatchScheduledEvent:
+                    dynamic cloudWatchScheduledEvent = inputObject; //Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent
+
+                    attributes.AddEventSourceAttribute("account", (string)cloudWatchScheduledEvent.Account);
+                    attributes.AddEventSourceAttribute("id", (string)cloudWatchScheduledEvent.Id);
+                    attributes.AddEventSourceAttribute("region", (string)cloudWatchScheduledEvent.Region);
+                    attributes.AddEventSourceAttribute("resource", (string)cloudWatchScheduledEvent.Resources[0]);
+                    attributes.AddEventSourceAttribute("time", (string)cloudWatchScheduledEvent.Time);
+                    break;
+                case AwsLambdaEventType.KinesisStreamingEvent:
+                    dynamic kinesisStreamingEvent = inputObject; //Amazon.Lambda.KinesisEvents.KinesisEvent
+
+                    attributes.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
+                    attributes.AddEventSourceAttribute("length", (string)kinesisStreamingEvent.Records.Count.ToString());
+                    attributes.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
+                    break;
+                case AwsLambdaEventType.KinesisFirehoseEvent:
+                    dynamic kinesisFirehoseEvent = inputObject; //Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
+
+                    attributes.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
+                    attributes.AddEventSourceAttribute("length", (string)kinesisFirehoseEvent.Records.Count.ToString());
+                    attributes.AddEventSourceAttribute("region", (string)kinesisFirehoseEvent.Region);
+                    break;
+                case AwsLambdaEventType.SNSEvent:
+                    dynamic snsEvent = inputObject; //Amazon.Lambda.SNSEvents.SNSEvent
+
+                    attributes.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
+                    attributes.AddEventSourceAttribute("length", (string)snsEvent.Records.Count.ToString());
+                    attributes.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);
+                    attributes.AddEventSourceAttribute("topicArn", (string)snsEvent.Records[0].Sns.TopicArn);
+                    attributes.AddEventSourceAttribute("timestamp", (string)snsEvent.Records[0].Sns.Timestamp);
+                    attributes.AddEventSourceAttribute("type", (string)snsEvent.Records[0].Sns.Type);
+                    TryParseSNSDistributedTraceHeaders(snsEvent, attributes);
+                    break;
+                case AwsLambdaEventType.S3Event:
+                    dynamic s3Event = inputObject; //Amazon.Lambda.S3Events.S3Event
+
+                    attributes.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
+                    attributes.AddEventSourceAttribute("length", (string)s3Event.Records.Count.ToString());
+                    attributes.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);
+                    attributes.AddEventSourceAttribute("eventName", (string)s3Event.Records[0].EventName);
+                    attributes.AddEventSourceAttribute("eventTime", (string)s3Event.Records[0].EventTime);
+                    attributes.AddEventSourceAttribute("xAmzId2", (string)s3Event.Records[0].ResponseElements.XAmzId2);
+                    attributes.AddEventSourceAttribute("bucketName", (string)s3Event.Records[0].S3.Bucket.Name);
+                    attributes.AddEventSourceAttribute("objectKey", (string)s3Event.Records[0].S3.Object.Key);
+                    attributes.AddEventSourceAttribute("objectSequencer", (string)s3Event.Records[0].S3.Object.Sequencer);
+                    attributes.AddEventSourceAttribute("objectSize", (string)s3Event.Records[0].S3.Object.Size.ToString());
+                    break;
+                case AwsLambdaEventType.SimpleEmailEvent:
+                    dynamic sesEvent = inputObject; //Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
+
+                    // arn is not available
+                    attributes.AddEventSourceAttribute("length", (string)sesEvent.Records.Count.ToString());
+                    attributes.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Mail.CommonHeaders.Date);
+                    attributes.AddEventSourceAttribute("messageId", (string)sesEvent.Records[0].Mail.CommonHeaders.MessageId);
+                    attributes.AddEventSourceAttribute("returnPath", (string)sesEvent.Records[0].Mail.CommonHeaders.ReturnPath);
+                    break;
+                case AwsLambdaEventType.SQSEvent:
+                    dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
+                    attributes.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
+                    attributes.AddEventSourceAttribute("length", (string)sqsEvent.Records.Count.ToString());
+                    TryParseSQSDistributedTraceHeaders(sqsEvent, attributes);
+                    break;
+                case AwsLambdaEventType.Unknown:
+                    break; // nothing to do for unknown event type
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType");
+            }
+        }
+
+        private const string NEWRELIC_TRACE_HEADER = "newrelic";
+
+        private static void TryParseWebRequestDistributedTraceHeaders(dynamic webRequestEvent, Dictionary<string, string> attributes)
+        {
+            IList<string> headerValues = null;
+            string headerValue = null;
+            if (webRequestEvent.MultiValueHeaders != null && ((IDictionary<string, IList<string>>)webRequestEvent.MultiValueHeaders).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValues))
+            {
+                attributes.Add(NEWRELIC_TRACE_HEADER, string.Join(",", headerValues));
+            }
+            if (webRequestEvent.Headers != null && ((IDictionary<string, string>)webRequestEvent.Headers).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValue))
+            {
+                attributes.Add(NEWRELIC_TRACE_HEADER, headerValue);
+            }
+        }
+        private static void TryParseSQSDistributedTraceHeaders(dynamic sqsEvent, Dictionary<string, string> attributes)
+        {
+            var record = sqsEvent.Records[0];
+            if (((Dictionary<string, dynamic>)record.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out var traceHeader))
+            {
+                attributes.Add(NEWRELIC_TRACE_HEADER, traceHeader.StringValue);
+            }
+            else if (record.Body != null && record.Body.Contains("\"Type\" : \"Notification\"") && record.Body.Contains("\"MessageAttributes\""))
+            {
+                // This is an an SNS subscription with atttributes
+                var newrelicIndex = record.Body.IndexOf("newrelic", System.StringComparison.InvariantCultureIgnoreCase) + 9;
+                var startIndex = record.Body.IndexOf("Value\":\"", newrelicIndex, System.StringComparison.InvariantCultureIgnoreCase) + 8;
+                var endIndex = record.Body.IndexOf('"', startIndex);
+                var payload = record.Body.Substring(startIndex, endIndex - startIndex);
+                attributes.Add(NEWRELIC_TRACE_HEADER, (string)payload);
+            }
+        }
+        private static void TryParseSNSDistributedTraceHeaders(dynamic snsEvent, Dictionary<string, string> attributes)
+        {
+            var record = snsEvent.Records[0];
+            dynamic traceHeader = null;
+            if (record.Sns.MessageAttributes != null && ((Dictionary<string, dynamic>)record.Sns.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out traceHeader))
+            {
+                attributes.Add(NEWRELIC_TRACE_HEADER, (string)traceHeader.Value);
+            }
+        }
+
+        private static void SetWebRequestProperties(IAgent agent, ITransaction transaction, dynamic webReqEvent)
+        {
+            //HTTP headers
+            IDictionary<string, string> headers = webReqEvent.Headers;
+            Func<IDictionary<string, string>, string, string> headersGetter = (h, k) => h[k];
+
+            IDictionary<string, IList<string>> multiValueHeaders = webReqEvent.MultiValueHeaders;
+            Func<IDictionary<string, IList<string>>, string, string> multiValueHeadersGetter = (h, k) => string.Join(",", h[k]);
+
+            if (multiValueHeaders != null)
+                transaction.SetRequestHeaders(multiValueHeaders, agent.Configuration.AllowAllRequestHeaders ? multiValueHeaders.Keys : Statics.DefaultCaptureHeaders, multiValueHeadersGetter);
+            else
+                transaction.SetRequestHeaders(headers, agent.Configuration.AllowAllRequestHeaders ? webReqEvent.Headers.Keys : Statics.DefaultCaptureHeaders, headersGetter);
+
+            //HTTP method
+            transaction.SetRequestMethod(webReqEvent.HttpMethod);
+            //HTTP uri
+            transaction.SetUri(webReqEvent.Path); // TODO: not sure if this is correct
+            //HTTP query parameters
+            transaction.SetRequestParameters(webReqEvent.QueryStringParameters);
+        }
+
         private void CaptureResponseData(ITransaction transaction, object response)
         {
             var responseTypeName = response.GetType().FullName;
@@ -167,7 +276,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             {
                 dynamic apiResponse = response;
                 transaction.SetHttpResponseStatusCode(apiResponse.StatusCode); // StatusCode is a public property on both APIGatewayProxyResponse and ApplicationLoadBalancerResponse
-                IDictionary<string,string> responseHeaders = apiResponse.Headers; // Headers is a public property of type IDictionary<string,string> on both types
+                IDictionary<string, string> responseHeaders = apiResponse.Headers; // Headers is a public property of type IDictionary<string,string> on both types
                 foreach (var header in WebResponseHeaders)
                 {
                     if (responseHeaders.TryGetValue(header, out var value))
@@ -200,6 +309,62 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 transaction.AddCustomAttribute(attribute.Key, attribute.Value); // TODO: figure out if custom attributes are correct
             }
         }
-
     }
+
+    public enum AwsLambdaEventType
+    {
+        Unknown,
+        APIGatewayProxyRequest,
+        ApplicationLoadBalancerRequest,
+        CloudWatchScheduledEvent,
+        KinesisStreamingEvent,
+        KinesisFirehoseEvent,
+        SNSEvent,
+        S3Event,
+        SimpleEmailEvent,
+        SQSEvent,
+    }
+
+    public static class AwsLambdaEventTypeExtensions
+    {
+        public static AwsLambdaEventType ToEventType(this Type type)
+        {
+            return type.FullName switch
+            {
+                "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest" => AwsLambdaEventType.APIGatewayProxyRequest,
+                "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest" => AwsLambdaEventType.ApplicationLoadBalancerRequest,
+                "Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent" => AwsLambdaEventType.CloudWatchScheduledEvent,
+                "Amazon.Lambda.KinesisEvents.KinesisEvent" => AwsLambdaEventType.KinesisStreamingEvent,
+                "Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent" => AwsLambdaEventType.KinesisFirehoseEvent,
+                "Amazon.Lambda.SNSEvents.SNSEvent" => AwsLambdaEventType.SNSEvent,
+                "Amazon.Lambda.S3Events.S3Event" => AwsLambdaEventType.S3Event,
+                "Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent" => AwsLambdaEventType.SimpleEmailEvent,
+                "Amazon.Lambda.SQSEvents.SQSEvent" => AwsLambdaEventType.SQSEvent,
+                _ => AwsLambdaEventType.Unknown
+            };
+        }
+        public static string ToEventTypeString(this AwsLambdaEventType eventType)
+        {
+            return eventType switch
+            {
+                AwsLambdaEventType.APIGatewayProxyRequest => "apiGateway",
+                AwsLambdaEventType.ApplicationLoadBalancerRequest => "alb",
+                AwsLambdaEventType.CloudWatchScheduledEvent => "cloudWatch_scheduled",
+                AwsLambdaEventType.KinesisStreamingEvent => "kinesis",
+                AwsLambdaEventType.KinesisFirehoseEvent => "firehose",
+                AwsLambdaEventType.SNSEvent => "sns",
+                AwsLambdaEventType.S3Event => "s3",
+                AwsLambdaEventType.SimpleEmailEvent => "ses",
+                AwsLambdaEventType.SQSEvent => "sqs",
+                AwsLambdaEventType.Unknown => "Unknown",
+                _ => throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType"),
+            };
+        }
+
+        public static bool IsWebEvent(this AwsLambdaEventType eventType)
+        {
+            return eventType == AwsLambdaEventType.APIGatewayProxyRequest || eventType == AwsLambdaEventType.ApplicationLoadBalancerRequest;
+        }
+    }
+
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -4,9 +4,9 @@
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using System.Threading.Tasks;
-using System.Linq;
 using System.Collections.Generic;
 using System;
+using NewRelic.Agent.Extensions.Lambda;
 using NewRelic.Reflection;
 
 namespace NewRelic.Providers.Wrapper.AwsLambda
@@ -46,7 +46,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 
             agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"input object fullname = {inputObject.GetType().FullName}");
 
-            var eventType = inputObject.GetType().ToEventType();
+            var eventType = inputObject.GetType().FullName.ToEventType();
             agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"eventType = {eventType}");
 
             var lambdaFunctionName = functionNameGetter(lambdaContext);
@@ -71,9 +71,9 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
 
             agent.SetServerlessParameters(lambdaFunctionVersion ?? "$LATEST", lambdaFunctionArn);
 
-            AddEventTypeAttributes(agent, transaction, eventType, inputObject, attributes);
+            LambdaEventHelpers.AddEventTypeAttributes(agent, transaction, eventType, inputObject, attributes);
 
-            transaction.AddLambdaAttributes(attributes, agent);
+            transaction.AddLambdaAttributes(attributes);
 
             var segment = transaction.StartTransactionSegment(instrumentedMethodCall.MethodCall, lambdaFunctionName);
 
@@ -110,165 +110,6 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             }
         }
 
-        private static void AddEventTypeAttributes(IAgent agent, ITransaction transaction, AwsLambdaEventType eventType, object inputObject, Dictionary<string, string> attributes)
-        {
-            switch (eventType)
-            {
-                case AwsLambdaEventType.APIGatewayProxyRequest:
-                    dynamic apiReqEvent = inputObject; // Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest
-                    SetWebRequestProperties(agent, transaction, apiReqEvent);
-
-                    dynamic requestContext = apiReqEvent.RequestContext;
-                    attributes.AddEventSourceAttribute("accountId", (string)requestContext.AccountId);
-                    attributes.AddEventSourceAttribute("apiId", (string)requestContext.ApiId);
-                    attributes.AddEventSourceAttribute("resourceId", (string)requestContext.ResourceId);
-                    attributes.AddEventSourceAttribute("resourcePath", (string)requestContext.ResourcePath);
-                    attributes.AddEventSourceAttribute("stage", (string)requestContext.Stage);
-
-                    TryParseWebRequestDistributedTraceHeaders(apiReqEvent, attributes);
-                    break;
-                case AwsLambdaEventType.ApplicationLoadBalancerRequest:
-                    dynamic albReqEvent = inputObject; //Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest
-
-                    SetWebRequestProperties(agent, transaction, albReqEvent);
-
-                    attributes.AddEventSourceAttribute("arn", (string)albReqEvent.RequestContext.Elb.TargetGroupArn);
-                    TryParseWebRequestDistributedTraceHeaders(albReqEvent, attributes);
-                    break;
-                case AwsLambdaEventType.CloudWatchScheduledEvent:
-                    dynamic cloudWatchScheduledEvent = inputObject; //Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent
-
-                    attributes.AddEventSourceAttribute("account", (string)cloudWatchScheduledEvent.Account);
-                    attributes.AddEventSourceAttribute("id", (string)cloudWatchScheduledEvent.Id);
-                    attributes.AddEventSourceAttribute("region", (string)cloudWatchScheduledEvent.Region);
-                    attributes.AddEventSourceAttribute("resource", (string)cloudWatchScheduledEvent.Resources[0]);
-                    attributes.AddEventSourceAttribute("time", (string)cloudWatchScheduledEvent.Time);
-                    break;
-                case AwsLambdaEventType.KinesisStreamingEvent:
-                    dynamic kinesisStreamingEvent = inputObject; //Amazon.Lambda.KinesisEvents.KinesisEvent
-
-                    attributes.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
-                    attributes.AddEventSourceAttribute("length", (string)kinesisStreamingEvent.Records.Count.ToString());
-                    attributes.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
-                    break;
-                case AwsLambdaEventType.KinesisFirehoseEvent:
-                    dynamic kinesisFirehoseEvent = inputObject; //Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
-
-                    attributes.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
-                    attributes.AddEventSourceAttribute("length", (string)kinesisFirehoseEvent.Records.Count.ToString());
-                    attributes.AddEventSourceAttribute("region", (string)kinesisFirehoseEvent.Region);
-                    break;
-                case AwsLambdaEventType.SNSEvent:
-                    dynamic snsEvent = inputObject; //Amazon.Lambda.SNSEvents.SNSEvent
-
-                    attributes.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
-                    attributes.AddEventSourceAttribute("length", (string)snsEvent.Records.Count.ToString());
-                    attributes.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);
-                    attributes.AddEventSourceAttribute("topicArn", (string)snsEvent.Records[0].Sns.TopicArn);
-                    attributes.AddEventSourceAttribute("timestamp", (string)snsEvent.Records[0].Sns.Timestamp);
-                    attributes.AddEventSourceAttribute("type", (string)snsEvent.Records[0].Sns.Type);
-                    TryParseSNSDistributedTraceHeaders(snsEvent, attributes);
-                    break;
-                case AwsLambdaEventType.S3Event:
-                    dynamic s3Event = inputObject; //Amazon.Lambda.S3Events.S3Event
-
-                    attributes.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
-                    attributes.AddEventSourceAttribute("length", (string)s3Event.Records.Count.ToString());
-                    attributes.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);
-                    attributes.AddEventSourceAttribute("eventName", (string)s3Event.Records[0].EventName);
-                    attributes.AddEventSourceAttribute("eventTime", (string)s3Event.Records[0].EventTime);
-                    attributes.AddEventSourceAttribute("xAmzId2", (string)s3Event.Records[0].ResponseElements.XAmzId2);
-                    attributes.AddEventSourceAttribute("bucketName", (string)s3Event.Records[0].S3.Bucket.Name);
-                    attributes.AddEventSourceAttribute("objectKey", (string)s3Event.Records[0].S3.Object.Key);
-                    attributes.AddEventSourceAttribute("objectSequencer", (string)s3Event.Records[0].S3.Object.Sequencer);
-                    attributes.AddEventSourceAttribute("objectSize", (string)s3Event.Records[0].S3.Object.Size.ToString());
-                    break;
-                case AwsLambdaEventType.SimpleEmailEvent:
-                    dynamic sesEvent = inputObject; //Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
-
-                    // arn is not available
-                    attributes.AddEventSourceAttribute("length", (string)sesEvent.Records.Count.ToString());
-                    attributes.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Mail.CommonHeaders.Date);
-                    attributes.AddEventSourceAttribute("messageId", (string)sesEvent.Records[0].Mail.CommonHeaders.MessageId);
-                    attributes.AddEventSourceAttribute("returnPath", (string)sesEvent.Records[0].Mail.CommonHeaders.ReturnPath);
-                    break;
-                case AwsLambdaEventType.SQSEvent:
-                    dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
-                    attributes.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
-                    attributes.AddEventSourceAttribute("length", (string)sqsEvent.Records.Count.ToString());
-                    TryParseSQSDistributedTraceHeaders(sqsEvent, attributes);
-                    break;
-                case AwsLambdaEventType.Unknown:
-                    break; // nothing to do for unknown event type
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType");
-            }
-        }
-
-        private const string NEWRELIC_TRACE_HEADER = "newrelic";
-
-        private static void TryParseWebRequestDistributedTraceHeaders(dynamic webRequestEvent, Dictionary<string, string> attributes)
-        {
-            IList<string> headerValues = null;
-            string headerValue = null;
-            if (webRequestEvent.MultiValueHeaders != null && ((IDictionary<string, IList<string>>)webRequestEvent.MultiValueHeaders).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValues))
-            {
-                attributes.Add(NEWRELIC_TRACE_HEADER, string.Join(",", headerValues));
-            }
-            if (webRequestEvent.Headers != null && ((IDictionary<string, string>)webRequestEvent.Headers).TryGetValue(NEWRELIC_TRACE_HEADER, out headerValue))
-            {
-                attributes.Add(NEWRELIC_TRACE_HEADER, headerValue);
-            }
-        }
-        private static void TryParseSQSDistributedTraceHeaders(dynamic sqsEvent, Dictionary<string, string> attributes)
-        {
-            var record = sqsEvent.Records[0];
-            if (((Dictionary<string, dynamic>)record.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out var traceHeader))
-            {
-                attributes.Add(NEWRELIC_TRACE_HEADER, traceHeader.StringValue);
-            }
-            else if (record.Body != null && record.Body.Contains("\"Type\" : \"Notification\"") && record.Body.Contains("\"MessageAttributes\""))
-            {
-                // This is an an SNS subscription with atttributes
-                var newrelicIndex = record.Body.IndexOf("newrelic", System.StringComparison.InvariantCultureIgnoreCase) + 9;
-                var startIndex = record.Body.IndexOf("Value\":\"", newrelicIndex, System.StringComparison.InvariantCultureIgnoreCase) + 8;
-                var endIndex = record.Body.IndexOf('"', startIndex);
-                var payload = record.Body.Substring(startIndex, endIndex - startIndex);
-                attributes.Add(NEWRELIC_TRACE_HEADER, (string)payload);
-            }
-        }
-        private static void TryParseSNSDistributedTraceHeaders(dynamic snsEvent, Dictionary<string, string> attributes)
-        {
-            var record = snsEvent.Records[0];
-            dynamic traceHeader = null;
-            if (record.Sns.MessageAttributes != null && ((Dictionary<string, dynamic>)record.Sns.MessageAttributes).TryGetValue(NEWRELIC_TRACE_HEADER, out traceHeader))
-            {
-                attributes.Add(NEWRELIC_TRACE_HEADER, (string)traceHeader.Value);
-            }
-        }
-
-        private static void SetWebRequestProperties(IAgent agent, ITransaction transaction, dynamic webReqEvent)
-        {
-            //HTTP headers
-            IDictionary<string, string> headers = webReqEvent.Headers;
-            Func<IDictionary<string, string>, string, string> headersGetter = (h, k) => h[k];
-
-            IDictionary<string, IList<string>> multiValueHeaders = webReqEvent.MultiValueHeaders;
-            Func<IDictionary<string, IList<string>>, string, string> multiValueHeadersGetter = (h, k) => string.Join(",", h[k]);
-
-            if (multiValueHeaders != null)
-                transaction.SetRequestHeaders(multiValueHeaders, agent.Configuration.AllowAllRequestHeaders ? multiValueHeaders.Keys : Statics.DefaultCaptureHeaders, multiValueHeadersGetter);
-            else
-                transaction.SetRequestHeaders(headers, agent.Configuration.AllowAllRequestHeaders ? webReqEvent.Headers.Keys : Statics.DefaultCaptureHeaders, headersGetter);
-
-            //HTTP method
-            transaction.SetRequestMethod(webReqEvent.HttpMethod);
-            //HTTP uri
-            transaction.SetUri(webReqEvent.Path); // TODO: not sure if this is correct
-            //HTTP query parameters
-            transaction.SetRequestParameters(webReqEvent.QueryStringParameters);
-        }
-
         private void CaptureResponseData(ITransaction transaction, object response)
         {
             var responseTypeName = response.GetType().FullName;
@@ -293,78 +134,4 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
         }
 
     }
-
-    public static class LambdaAttributeExtensions
-    {
-        public static void AddEventSourceAttribute(this Dictionary<string, string> dict, string suffix, string value)
-        {
-            dict.Add($"aws.lambda.eventSource.{suffix}", value);
-        }
-
-        public static void AddLambdaAttributes(this ITransaction transaction, Dictionary<string, string> attributes, IAgent agent)
-        {
-            foreach (var attribute in attributes)
-            {
-                agent.Logger.Log(Agent.Extensions.Logging.Level.Debug, $"Lambda Attribute: {attribute.Key}={attribute.Value}"); // TODO: remove before release
-                transaction.AddCustomAttribute(attribute.Key, attribute.Value); // TODO: figure out if custom attributes are correct
-            }
-        }
-    }
-
-    public enum AwsLambdaEventType
-    {
-        Unknown,
-        APIGatewayProxyRequest,
-        ApplicationLoadBalancerRequest,
-        CloudWatchScheduledEvent,
-        KinesisStreamingEvent,
-        KinesisFirehoseEvent,
-        SNSEvent,
-        S3Event,
-        SimpleEmailEvent,
-        SQSEvent,
-    }
-
-    public static class AwsLambdaEventTypeExtensions
-    {
-        public static AwsLambdaEventType ToEventType(this Type type)
-        {
-            return type.FullName switch
-            {
-                "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest" => AwsLambdaEventType.APIGatewayProxyRequest,
-                "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest" => AwsLambdaEventType.ApplicationLoadBalancerRequest,
-                "Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent" => AwsLambdaEventType.CloudWatchScheduledEvent,
-                "Amazon.Lambda.KinesisEvents.KinesisEvent" => AwsLambdaEventType.KinesisStreamingEvent,
-                "Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent" => AwsLambdaEventType.KinesisFirehoseEvent,
-                "Amazon.Lambda.SNSEvents.SNSEvent" => AwsLambdaEventType.SNSEvent,
-                "Amazon.Lambda.S3Events.S3Event" => AwsLambdaEventType.S3Event,
-                "Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent" => AwsLambdaEventType.SimpleEmailEvent,
-                "Amazon.Lambda.SQSEvents.SQSEvent" => AwsLambdaEventType.SQSEvent,
-                _ => AwsLambdaEventType.Unknown
-            };
-        }
-        public static string ToEventTypeString(this AwsLambdaEventType eventType)
-        {
-            return eventType switch
-            {
-                AwsLambdaEventType.APIGatewayProxyRequest => "apiGateway",
-                AwsLambdaEventType.ApplicationLoadBalancerRequest => "alb",
-                AwsLambdaEventType.CloudWatchScheduledEvent => "cloudWatch_scheduled",
-                AwsLambdaEventType.KinesisStreamingEvent => "kinesis",
-                AwsLambdaEventType.KinesisFirehoseEvent => "firehose",
-                AwsLambdaEventType.SNSEvent => "sns",
-                AwsLambdaEventType.S3Event => "s3",
-                AwsLambdaEventType.SimpleEmailEvent => "ses",
-                AwsLambdaEventType.SQSEvent => "sqs",
-                AwsLambdaEventType.Unknown => "Unknown",
-                _ => throw new ArgumentOutOfRangeException(nameof(eventType), eventType, "Unexpected eventType"),
-            };
-        }
-
-        public static bool IsWebEvent(this AwsLambdaEventType eventType)
-        {
-            return eventType == AwsLambdaEventType.APIGatewayProxyRequest || eventType == AwsLambdaEventType.ApplicationLoadBalancerRequest;
-        }
-    }
-
 }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
@@ -1,0 +1,44 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Extensions.Lambda;
+using NUnit.Framework;
+
+namespace Agent.Extensions.Tests.Lambda
+{
+    internal class AwsLambdaEventTypeExtensionsTests
+    {
+        [Test]
+        [TestCase("Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest", AwsLambdaEventType.APIGatewayProxyRequest)]
+        [TestCase("Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest", AwsLambdaEventType.ApplicationLoadBalancerRequest)]
+        [TestCase("Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent", AwsLambdaEventType.CloudWatchScheduledEvent)]
+        [TestCase("Amazon.Lambda.KinesisEvents.KinesisEvent", AwsLambdaEventType.KinesisStreamingEvent)]
+        [TestCase("Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent", AwsLambdaEventType.KinesisFirehoseEvent)]
+        [TestCase("Amazon.Lambda.SNSEvents.SNSEvent", AwsLambdaEventType.SNSEvent)]
+        [TestCase("Amazon.Lambda.S3Events.S3Event", AwsLambdaEventType.S3Event)]
+        [TestCase("Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent", AwsLambdaEventType.SimpleEmailEvent)]
+        [TestCase("Amazon.Lambda.SQSEvents.SQSEvent", AwsLambdaEventType.SQSEvent)]
+        [TestCase("Gibberish", AwsLambdaEventType.Unknown)]
+        public void ToEventType_ReturnsCorrectEventType(string inputType, AwsLambdaEventType expectedEventType)
+        {
+            var actualEventType = inputType.ToEventType();
+            Assert.That(actualEventType, Is.EqualTo(expectedEventType));
+        }
+        [Test]
+        [TestCase(AwsLambdaEventType.APIGatewayProxyRequest, "apiGateway")]
+        [TestCase(AwsLambdaEventType.ApplicationLoadBalancerRequest, "alb")]
+        [TestCase(AwsLambdaEventType.CloudWatchScheduledEvent, "cloudWatch_scheduled")]
+        [TestCase(AwsLambdaEventType.KinesisStreamingEvent, "kinesis")]
+        [TestCase(AwsLambdaEventType.KinesisFirehoseEvent, "firehose")]
+        [TestCase(AwsLambdaEventType.SNSEvent, "sns")]
+        [TestCase(AwsLambdaEventType.S3Event, "s3")]
+        [TestCase(AwsLambdaEventType.SimpleEmailEvent, "ses")]
+        [TestCase(AwsLambdaEventType.SQSEvent, "sqs")]
+        [TestCase(AwsLambdaEventType.Unknown, "Unknown")]
+        public void ToEventTypeString_ReturnsCorrectEventTypeString(AwsLambdaEventType inputEventType, string expectedEventTypeString)
+        {
+            var actualEventTypeString = inputEventType.ToEventTypeString();
+            Assert.That(actualEventTypeString, Is.EqualTo(expectedEventTypeString));
+        }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
@@ -1,0 +1,44 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Lambda;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace Agent.Extensions.Tests.Lambda
+{
+    public class LambdaAttributeExtensionsTests
+    {
+        [Test]
+        public void AddEventSourceAttribute_AddsToDictionary()
+        {
+            var dict = new Dictionary<string, string>();
+            dict.AddEventSourceAttribute("suffix", "value");
+
+            Assert.That(dict.Count, Is.EqualTo(1));
+            Assert.That(dict["aws.lambda.eventSource.suffix"], Is.EqualTo("value"));
+        }
+        [Test]
+        public void AddLambdaAttributes_AddsToTransaction()
+        {
+            var transaction = Mock.Create<ITransaction>();
+            Dictionary<string, object> actualCustomAttributes = new();;
+            Mock.Arrange(() => transaction.AddCustomAttribute(Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .DoInstead((string key, object value) => actualCustomAttributes.Add(key, value));
+
+            var attributes = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+
+            transaction.AddLambdaAttributes(attributes);
+
+            Assert.That(actualCustomAttributes.Count, Is.EqualTo(2));
+            Assert.That(actualCustomAttributes["key1"], Is.EqualTo("value1"));
+            Assert.That(actualCustomAttributes["key2"], Is.EqualTo("value2"));
+        }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -1,0 +1,367 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NUnit.Framework;
+using Telerik.JustMock;
+using NewRelic.Agent.Extensions.Lambda;
+using NewRelic.Agent.Api;
+using System.Collections.Generic;
+using System;
+
+namespace Agent.Extensions.Tests.Lambda;
+
+[TestFixture]
+public class LambdaEventHelpersTests
+{
+    private IAgent _agent;
+    private ITransaction _transaction;
+    private Dictionary<string, string> _attributes;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _agent = Mock.Create<IAgent>();
+        _transaction = Mock.Create<ITransaction>();
+        _attributes = new Dictionary<string, string>();
+    }
+
+    // APIGatewayProxyRequest
+    [Test]
+    public void AddEventTypeAttributes_APIGatewayProxyRequest_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.APIGatewayProxyRequest;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest
+        {
+            RequestContext = new NewRelic.Mock.Amazon.Lambda.APIGatewayEvents.RequestContext
+            {
+                AccountId = "testAccountId",
+                ApiId = "testApiId",
+                ResourceId = "testResourceId",
+                ResourcePath = "testResourcePath",
+                Stage = "testStage"
+            },
+            Headers = new Dictionary<string, string>
+            {
+                { "header1", "value1" },
+                { "header2", "value2" }
+            },
+            HttpMethod = "GET",
+            Path = "/test/path",
+            QueryStringParameters = new Dictionary<string, string>
+            {
+                { "param1", "value1" },
+                { "param2", "value2" }
+            }
+        };
+
+        // Mock the SetRequestHeaders, SetRequestMethod, SetUri, and SetRequestParameters methods
+        Mock.Arrange(() => _transaction.SetRequestHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<IEnumerable<string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, string>>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetRequestMethod(Arg.IsAny<string>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetUri(Arg.IsAny<string>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, (dynamic)inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.accountId"], Is.EqualTo("testAccountId"));
+            Assert.That(_attributes["aws.lambda.eventSource.apiId"], Is.EqualTo("testApiId"));
+            Assert.That(_attributes["aws.lambda.eventSource.resourceId"], Is.EqualTo("testResourceId"));
+            Assert.That(_attributes["aws.lambda.eventSource.resourcePath"], Is.EqualTo("testResourcePath"));
+            Assert.That(_attributes["aws.lambda.eventSource.stage"], Is.EqualTo("testStage"));
+
+            // Assert that the SetRequestHeaders, SetRequestMethod, SetUri, and SetRequestParameters methods were called with the correct arguments
+            Mock.Assert(() => _transaction.SetRequestHeaders(inputObject.Headers, Arg.IsAny<IEnumerable<string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, string>>()));
+            Mock.Assert(() => _transaction.SetRequestMethod(inputObject.HttpMethod));
+            Mock.Assert(() => _transaction.SetUri(inputObject.Path));
+            Mock.Assert(() => _transaction.SetRequestParameters(inputObject.QueryStringParameters));
+        });
+    }
+
+    // ApplicationLoadBalancerRequest
+    [Test]
+    public void AddEventTypeAttributes_ApplicationLoadBalancerRequest_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.ApplicationLoadBalancerRequest;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest
+        {
+            RequestContext = new NewRelic.Mock.Amazon.Lambda.ApplicationLoadBalancerEvents.RequestContext
+            {
+                Elb = new NewRelic.Mock.Amazon.Lambda.ApplicationLoadBalancerEvents.RequestContextElb
+                {
+                    TargetGroupArn = "testTargetGroupArn"
+                }
+            },
+            Headers = new Dictionary<string, string>
+            {
+                { "header1", "value1" },
+                { "header2", "value2" }
+            },
+            HttpMethod = "GET",
+            Path = "/test/path",
+            QueryStringParameters = new Dictionary<string, string>
+            {
+                { "param1", "value1" },
+                { "param2", "value2" }
+            }
+        };
+
+        // Mock the SetRequestHeaders, SetRequestMethod, SetUri, and SetRequestParameters methods
+        Mock.Arrange(() => _transaction.SetRequestHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<IEnumerable<string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, string>>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetRequestMethod(Arg.IsAny<string>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetUri(Arg.IsAny<string>())).DoNothing();
+        Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testTargetGroupArn"));
+
+            // Assert that the SetRequestHeaders, SetRequestMethod, SetUri, and SetRequestParameters methods were called with the correct arguments
+            Mock.Assert(() => _transaction.SetRequestHeaders(inputObject.Headers, Arg.IsAny<IEnumerable<string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, string>>()));
+            Mock.Assert(() => _transaction.SetRequestMethod(inputObject.HttpMethod));
+            Mock.Assert(() => _transaction.SetUri(inputObject.Path));
+            Mock.Assert(() => _transaction.SetRequestParameters(inputObject.QueryStringParameters));
+        });
+    }
+
+    // CloudWatchScheduledEvent
+    [Test]
+    public void AddEventTypeAttributes_CloudWatchScheduledEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.CloudWatchScheduledEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent
+        {
+            Account = "testAccount",
+            Id = "testId",
+            Region = "testRegion",
+            Resources = ["testResource"],
+            Time = "testTime"
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testResource"));
+            Assert.That(_attributes["aws.lambda.eventSource.account"], Is.EqualTo("testAccount"));
+            Assert.That(_attributes["aws.lambda.eventSource.id"], Is.EqualTo("testId"));
+            Assert.That(_attributes["aws.lambda.eventSource.region"], Is.EqualTo("testRegion"));
+            Assert.That(_attributes["aws.lambda.eventSource.resource"], Is.EqualTo("testResource"));
+            Assert.That(_attributes["aws.lambda.eventSource.time"], Is.EqualTo("testTime"));
+        });
+    }
+
+    // KinesisStreamingEvent
+    [Test]
+    public void AddEventTypeAttributes_KinesisStreamingEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.KinesisStreamingEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.KinesisEvents.KinesisEvent
+        {
+            Records =
+            [
+                new() { EventSourceArn = "testArn", AwsRegion = "testRegion" }
+            ]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testArn"));
+            Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+            Assert.That(_attributes["aws.lambda.eventSource.region"], Is.EqualTo("testRegion"));
+        });
+    }
+
+    // KinesisFirehoseEvent
+    [Test]
+    public void AddEventTypeAttributes_KinesisFirehoseEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.KinesisFirehoseEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
+        {
+            DeliveryStreamArn = "testDeliveryStreamArn",
+            Region = "testRegion",
+            Records =
+            [
+                new() { Data = "testData" }
+            ]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testDeliveryStreamArn"));
+            Assert.That(_attributes["aws.lambda.eventSource.region"], Is.EqualTo("testRegion"));
+            Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+        });
+    }
+
+    // S3Event
+    [Test]
+    public void AddEventTypeAttributes_S3Event_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.S3Event;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.S3Events.S3Event
+        {
+            Records = [
+                new() {
+                    AwsRegion = "testAwsRegion",
+                    EventName = "testEventName",
+                    EventTime = "testEventTime",
+                    ResponseElements = new NewRelic.Mock.Amazon.Lambda.S3Events.S3ResponseElements {
+                        XAmzId2 = "testXAmzId2",
+                    },
+                    S3 = new NewRelic.Mock.Amazon.Lambda.S3Events.S3Entity {
+                        Bucket = new NewRelic.Mock.Amazon.Lambda.S3Events.S3BucketEntity {
+                            Name = "testName",
+                            Arn = "testArn"
+                        },
+                        Object = new NewRelic.Mock.Amazon.Lambda.S3Events.S3ObjectEntity {
+                            Key = "testKey",
+                            Sequencer = "testSequencer",
+                            Size = "123"
+                        },
+                    }
+                }
+            ]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testArn"));
+            Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+            Assert.That(_attributes["aws.lambda.eventSource.region"], Is.EqualTo("testAwsRegion"));
+            Assert.That(_attributes["aws.lambda.eventSource.eventName"], Is.EqualTo("testEventName"));
+            Assert.That(_attributes["aws.lambda.eventSource.eventTime"], Is.EqualTo("testEventTime"));
+            Assert.That(_attributes["aws.lambda.eventSource.xAmzId2"], Is.EqualTo("testXAmzId2"));
+            Assert.That(_attributes["aws.lambda.eventSource.bucketName"], Is.EqualTo("testName"));
+            Assert.That(_attributes["aws.lambda.eventSource.objectKey"], Is.EqualTo("testKey"));
+            Assert.That(_attributes["aws.lambda.eventSource.objectSequencer"], Is.EqualTo("testSequencer"));
+            Assert.That(_attributes["aws.lambda.eventSource.objectSize"], Is.EqualTo("123"));
+        });
+    }
+
+    // SimpleEmailEvent
+    [Test]
+    public void AddEventTypeAttributes_SimpleEmailEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.SimpleEmailEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
+        {
+            Records = [
+                new() {
+                    Ses = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SesEntity {
+                        Mail = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SimpleEmailEntity {
+                            CommonHeaders = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SimpleEmailCommonHeadersEntity
+                            {
+                                Date = "testDate",
+                                MessageId = "testMessageId",
+                                ReturnPath = "testReturnPath",
+                            }
+                        }
+                    }
+                }
+            ]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.date"], Is.EqualTo("testDate"));
+            Assert.That(_attributes["aws.lambda.eventSource.messageId"], Is.EqualTo("testMessageId"));
+            Assert.That(_attributes["aws.lambda.eventSource.returnPath"], Is.EqualTo("testReturnPath"));
+            Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+        });
+    }
+
+    // SNSEvent
+    [Test]
+    public void AddEventTypeAttributes_SNSEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.SNSEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SNSEvents.SNSEvent
+        {
+            Records =
+            [
+                new() {
+                    EventSubscriptionArn = "testEventSubscriptionArn",
+                    Sns = new NewRelic.Mock.Amazon.Lambda.SNSEvents.SNS {
+                        MessageId = "testMessageId",
+                        TopicArn = "testTopicArn",
+                        Timestamp = "testTimestamp",
+                        Type = "testType"
+                    }
+                }
+            ]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testEventSubscriptionArn"));
+            Assert.That(_attributes["aws.lambda.eventSource.messageId"], Is.EqualTo("testMessageId"));
+            Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+            Assert.That(_attributes["aws.lambda.eventSource.timestamp"], Is.EqualTo("testTimestamp"));
+            Assert.That(_attributes["aws.lambda.eventSource.topicArn"], Is.EqualTo("testTopicArn"));
+            Assert.That(_attributes["aws.lambda.eventSource.type"], Is.EqualTo("testType"));
+        });
+    }
+
+    // SQSEvent
+    [Test]
+    public void AddEventTypeAttributes_SQSEvent_AddsCorrectAttributes()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.SQSEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SQSEvents.SQSEvent
+        {
+            Records = [
+                new() {
+                    EventSourceArn = "testEventSourceArn",
+                }]
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testEventSourceArn"));
+                Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo("1"));
+        });
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayEventsModel.cs
@@ -1,0 +1,26 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.APIGatewayEvents
+{
+    public class APIGatewayProxyRequest
+    {
+        public RequestContext RequestContext { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<string, IList<string>> MultiValueHeaders {get; set;}
+        public string HttpMethod { get; set; }
+        public string Path { get; set; }
+        public Dictionary<string, string> QueryStringParameters { get; set; }
+    }
+
+    public class RequestContext
+    {
+        public string AccountId { get; set; }
+        public string ApiId { get; set; }
+        public string ResourceId { get; set; }
+        public string ResourcePath { get; set; }
+        public string Stage { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisEventsModel.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.KinesisEvents
+{
+    public class KinesisEvent
+    {
+        public List<KinesisEventRecord> Records { get; set; }
+    }
+
+    public class KinesisEventRecord
+    {
+        public string EventSourceArn { get; set; }
+        public string AwsRegion { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisFirehoseEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisFirehoseEventsModel.cs
@@ -1,0 +1,19 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.KinesisFirehoseEvents
+{
+    public class KinesisFirehoseEvent
+    {
+        public string DeliveryStreamArn { get; set; }
+        public string Region { get; set; }
+        public List<KinesisFirehoseEventRecord> Records { get; set; }
+    }
+
+    public class KinesisFirehoseEventRecord
+    {
+        public string Data { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonLoadBalancerEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonLoadBalancerEventsModel.cs
@@ -1,0 +1,28 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.ApplicationLoadBalancerEvents
+{
+
+    public class RequestContextElb
+    {
+        public string TargetGroupArn { get; set; }
+    }
+
+    public class RequestContext
+    {
+        public RequestContextElb Elb { get; set; }
+    }
+
+    public class ApplicationLoadBalancerRequest
+    {
+        public RequestContext RequestContext { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<string, IList<string>> MultiValueHeaders {get; set;}
+        public string HttpMethod { get; set; }
+        public string Path { get; set; }
+        public Dictionary<string, string> QueryStringParameters { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonS3EventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonS3EventsModel.cs
@@ -1,0 +1,44 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.S3Events
+{
+    public class S3Event
+    {
+        public List<S3EventRecord> Records { get; set; }
+    }
+
+    public class S3EventRecord
+    {
+        public string AwsRegion { get; set; }
+        public string EventTime { get; set; }
+        public string EventName { get; set; }
+        public S3Entity S3 { get; set; }
+        public S3ResponseElements ResponseElements { get; set; }
+    }
+
+    public class S3Entity
+    {
+        public S3BucketEntity Bucket { get; set; }
+        public S3ObjectEntity Object { get; set; }
+    }
+
+    public class S3BucketEntity
+    {
+        public string Name { get; set; }
+        public string Arn { get; set; }
+    }
+
+    public class S3ObjectEntity
+    {
+        public string Key { get; set; }
+        public string Size { get; set; }
+        public string Sequencer { get; set; }
+    }
+    public class S3ResponseElements
+    {
+        public string XAmzId2 { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSNSEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSNSEventsModel.cs
@@ -1,0 +1,27 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.SNSEvents
+{
+    public class SNSEvent
+    {
+        public List<SNSEventRecord> Records { get; set; }
+    }
+
+    public class SNSEventRecord
+    {
+        public string EventSubscriptionArn { get; set; }
+        public SNS Sns { get; set; }
+    }
+
+    public class SNS
+    {
+        public string MessageId { get; set; }
+        public string Timestamp { get; set; }
+        public string TopicArn { get; set; }
+        public string Type { get; set; }
+        public Dictionary<string, object> MessageAttributes {get;set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSNSEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSNSEventsModel.cs
@@ -22,6 +22,7 @@ namespace NewRelic.Mock.Amazon.Lambda.SNSEvents
         public string Timestamp { get; set; }
         public string TopicArn { get; set; }
         public string Type { get; set; }
-        public Dictionary<string, object> MessageAttributes {get;set; }
+        public Dictionary<string, object> MessageAttributes { get; set; }
     }
 }
+

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSQSEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSQSEventsModel.cs
@@ -1,0 +1,19 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.SQSEvents
+{
+    public class SQSEvent
+    {
+        public List<SQSEventRecord> Records { get; set; }
+    }
+
+    public class SQSEventRecord
+    {
+        public string EventSourceArn { get; set; }
+        public Dictionary<string, object> MessageAttributes { get; set; }
+        public string Body { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonScheduledEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonScheduledEventsModel.cs
@@ -1,0 +1,16 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.CloudWatchEvents.ScheduledEvents
+{
+    public class ScheduledEvent
+    {
+        public string Account { get; set; }
+        public string Id { get; set; }
+        public string Region { get; set; }
+        public List<string> Resources { get; set; }
+        public string Time { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSimpleMailEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSimpleMailEventsModel.cs
@@ -1,0 +1,33 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents
+{
+    public class SimpleEmailEvent
+    {
+        public List<SimpleEmailEventRecord> Records { get; set; }
+    }
+
+    public class SimpleEmailEventRecord
+    {
+        public SesEntity Ses { get; set; }
+    }
+
+    public class SesEntity
+    {
+        public SimpleEmailEntity Mail { get; set; }
+    }
+
+    public class SimpleEmailEntity
+    {
+        public SimpleEmailCommonHeadersEntity CommonHeaders { get; set; }
+    }   
+    public class SimpleEmailCommonHeadersEntity
+    {
+        public string MessageId { get; set; }
+        public string Date { get; set; }
+        public string ReturnPath { get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/DistributedTraceHeaderModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/DistributedTraceHeaderModel.cs
@@ -1,0 +1,11 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Mock.DistributedTrace
+{
+    public class DistributedTraceHeaderModel
+    {
+        public string Value { get; set; }
+        public string StringValue {get; set; }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.10.0">


### PR DESCRIPTION
Adds support for all event types called out in the Lambda spec, with unit tests for each.

There are still some TODOs that need to be worked out eventually but are not blockers for this PR.

It's also not clear (and won't be until we have working integration tests) how much additional null checking might be required - the current code assumes the dynamic properties it references exist and are non-null in almost all cases.