### PR TITLE
fix: Handle InvalidOperationException in StringsHelper.CleanUri() #2373

### DIFF
--- a/src/Agent/NewRelic/Agent/Parsing/StringsHelper.cs
+++ b/src/Agent/NewRelic/Agent/Parsing/StringsHelper.cs
@@ -30,11 +30,18 @@ namespace NewRelic.Parsing
             if (!uri.IsAbsoluteUri)
                 return CleanUri(uri.ToString());
 
-            return uri.GetComponents(
-                    UriComponents.Scheme |
-                    UriComponents.HostAndPort |
-                    UriComponents.Path,
-                    UriFormat.UriEscaped);
+            try
+            {
+                return uri.GetComponents(
+                        UriComponents.Scheme |
+                        UriComponents.HostAndPort |
+                        UriComponents.Path,
+                        UriFormat.UriEscaped);
+            }
+            catch (InvalidOperationException) // can throw in .NET 6+ if the uri was created with UriCreationOptions.DangerousDisablePathAndQueryCanonicalization = true
+            {
+                return CleanUri(uri.ToString());
+            }
         }
 
         public static string FixDatabaseObjectName(string s)

--- a/tests/Agent/UnitTests/ParsingTests/ParsingTests.csproj
+++ b/tests/Agent/UnitTests/ParsingTests/ParsingTests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <RootNamespace>ParsingTests</RootNamespace>
     <AssemblyName>ParsingTests</AssemblyName>
+    <TargetPlatformIdentifier>windows</TargetPlatformIdentifier>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
@@ -22,8 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.OracleClient" />

--- a/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
+++ b/tests/Agent/UnitTests/ParsingTests/SqlParserTests.cs
@@ -814,6 +814,7 @@ namespace ParsingTests
             });
         }
 
+#if NETFRAMEWORK
         [TestCaseSource(nameof(BinaryTestDatas))]
         public void SqlParserTest_FixParameterizedSql_DoesNotParse_Binary(string originalSql, string expectedSql, string sqlParameterName, object sqlParameterValue)
         {
@@ -834,6 +835,7 @@ namespace ParsingTests
                 Assert.That(shouldGeneratePlan, Is.False, "FixParameterizedSql should return false if it is not parsing a statement");
             });
         }
+#endif
 
         [TestCaseSource(nameof(CustomObjectTestDatas))]
         public void SqlParserTest_FixParameterizedSql_DoesNotParse_CustomObject(string originalSql, string expectedSql, string sqlParameterName, object sqlParameterValue)
@@ -856,6 +858,7 @@ namespace ParsingTests
             });
         }
 
+#if NETFRAMEWORK
         public static IEnumerable<TestCaseData> BinaryTestDatas
         {
             get
@@ -874,6 +877,7 @@ namespace ParsingTests
                     ObjectToByteArray(new List<bool> { true, false }));
             }
         }
+#endif
 
         public static IEnumerable<TestCaseData> CustomObjectTestDatas
         {
@@ -911,7 +915,7 @@ namespace ParsingTests
             }
             return new string(buffer);
         }
-
+#if NETFRAMEWORK
         private static byte[] ObjectToByteArray(object obj)
         {
             using (var ms = new MemoryStream())
@@ -921,5 +925,6 @@ namespace ParsingTests
                 return ms.ToArray();
             }
         }
+#endif
     }
 }

--- a/tests/Agent/UnitTests/ParsingTests/SqlWrapperHelperTests.cs
+++ b/tests/Agent/UnitTests/ParsingTests/SqlWrapperHelperTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Data;
+#if NETFRAMEWORK
 using System.Data.OleDb;
 using System.Data.OracleClient;
+#endif
 using System.Data.SqlClient;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Parsing;
@@ -17,6 +19,7 @@ namespace SqlTests
     {
         #region GetVendorName
 
+#if NETFRAMEWORK
         [Test]
         [TestCase("SQL Server", ExpectedResult = DatastoreVendor.MSSQL)]
         [TestCase("MySql", ExpectedResult = DatastoreVendor.MySQL)]
@@ -33,7 +36,7 @@ namespace SqlTests
 
             return SqlWrapperHelper.GetVendorName(command);
         }
-
+#endif
         [Test]
         [TestCase("SqlCommand", ExpectedResult = DatastoreVendor.MSSQL)]
         [TestCase("MySqlCommand", ExpectedResult = DatastoreVendor.MySQL)]
@@ -56,7 +59,7 @@ namespace SqlTests
 
             Assert.That(datastoreName, Is.EqualTo(DatastoreVendor.MSSQL));
         }
-
+#if NETFRAMEWORK
         [Test]
         public void GetVendorName_ReturnsOracle_IfTypeNameIsNotProvidedAndCommandIsOracleCommand()
         {
@@ -68,7 +71,7 @@ namespace SqlTests
 
             Assert.That(datastoreName, Is.EqualTo(DatastoreVendor.Oracle));
         }
-
+#endif
         [Test]
         public void GetVendorName_ReturnsUnknown_IfCommandIsOfUnknownType()
         {

--- a/tests/Agent/UnitTests/ParsingTests/StringsHelperTest.cs
+++ b/tests/Agent/UnitTests/ParsingTests/StringsHelperTest.cs
@@ -133,5 +133,20 @@ namespace NewRelic.Parsing
             var actual = StringsHelper.CleanUri(uri);
             Assert.That(actual, Is.EqualTo(expected));
         }
+
+#if NET6_0_OR_GREATER
+        [Test]
+        public void validate_CleanUri_handles_invalidoperationexception()
+        {
+            var options = new UriCreationOptions 
+            {
+                DangerousDisablePathAndQueryCanonicalization = true // only avaialable in .NET 6+
+            };
+            var uri = new Uri("http://www.example.com:8080/dir/?query=test", options);
+
+            var actual = StringsHelper.CleanUri(uri);
+            Assert.That(actual, Is.EqualTo("http://www.example.com:8080/dir/"));
+        }
+#endif
     }
 }


### PR DESCRIPTION
## Description

Adds handling for `InvalidOperationException` that can be thrown in certain cases (.NET 6 and later) when calling `Uri.GetComponents()`. 

Updates unit tests for the Parsing project to target .NET 8 in addition to .NET Framework 4.6.2. Had to make a number of tests run only in .NET Framework due to references to Framework-specific types.

Fixes #2373. 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
