### PR TITLE
chore(deps): Bump MySqlConnector and ElasticSearch in unbounded tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Instrumentation.xml
@@ -45,5 +45,17 @@ SPDX-License-Identifier: Apache-2.0
       </match>
     </tracerFactory>
 
+    <!--8.12.1+-->
+    <tracerFactory name="RequestWrapper">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1">
+        <exactMethodMatcher methodName="Request" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;" />
+      </match>
+    </tracerFactory>
+
+    <tracerFactory name="RequestWrapper">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1">
+        <exactMethodMatcher methodName="RequestAsync" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;,System.Threading.CancellationToken" />
+      </match>
+    </tracerFactory>
   </instrumentation>
 </extension>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -100,12 +100,12 @@
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySqlConnector" Version="1.3.13" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySqlConnector .NET/Core references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- StackExchange.Redis framework references -->
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.608" Condition="'$(TargetFramework)' == 'net462'" />
@@ -144,12 +144,12 @@
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elastic.Clients.Elasticsearch .NET/Core references - only actually testing oldest and newest -->
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.0" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Serilog .NET framework references -->
     <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />


### PR DESCRIPTION
MySqlConnector 2.3.5 -> 2.3.6 Fixes #2357 
Elastic.Clients.ElasticSearch 8.12.0 -> 8.12.1 Fixes #2371 