### PR TITLE
Move JSON deserialization and models to NewRelic.Core

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -8,11 +8,11 @@ using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Helpers;
 using NewRelic.Agent.Extensions.Llm;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
-using NewRelic.Providers.Wrapper.Bedrock.Payloads;
 using NewRelic.Reflection;
 using System.Net;
 using System.IO;
 using NewRelic.Core.JsonConverters;
+using NewRelic.Core.JsonConverters.BedrockPayloads;
 
 namespace NewRelic.Providers.Wrapper.Bedrock
 {
@@ -259,16 +259,16 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             switch (model)
             {
                 case LlmModelType.Llama2:
-                    return JsonHelpers.DeserializeObject<Llama2RequestPayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<Llama2RequestPayload>(utf8Json);
                 case LlmModelType.CohereCommand:
-                    return JsonHelpers.DeserializeObject<CohereCommandRequestPayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<CohereCommandRequestPayload>(utf8Json);
                 case LlmModelType.Claude:
-                    return JsonHelpers.DeserializeObject<ClaudeRequestPayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<ClaudeRequestPayload>(utf8Json);
                 case LlmModelType.Titan:
                 case LlmModelType.TitanEmbedded:
-                    return JsonHelpers.DeserializeObject<TitanRequestPayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<TitanRequestPayload>(utf8Json);
                 case LlmModelType.Jurassic:
-                    return JsonHelpers.DeserializeObject<JurassicRequestPayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<JurassicRequestPayload>(utf8Json);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(model), model, "Unexpected LlmModelType");
             }
@@ -287,17 +287,17 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             switch (model)
             {
                 case LlmModelType.Llama2:
-                    return JsonHelpers.DeserializeObject<Llama2ResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<Llama2ResponsePayload>(utf8Json);
                 case LlmModelType.CohereCommand:
-                    return JsonHelpers.DeserializeObject<CohereCommandResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<CohereCommandResponsePayload>(utf8Json);
                 case LlmModelType.Claude:
-                    return JsonHelpers.DeserializeObject<ClaudeResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<ClaudeResponsePayload>(utf8Json);
                 case LlmModelType.Titan:
-                    return JsonHelpers.DeserializeObject<TitanResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<TitanResponsePayload>(utf8Json);
                 case LlmModelType.TitanEmbedded:
-                    return JsonHelpers.DeserializeObject<TitanEmbeddedResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<TitanEmbeddedResponsePayload>(utf8Json);
                 case LlmModelType.Jurassic:
-                    return JsonHelpers.DeserializeObject<JurassicResponsePayload>(utf8Json);
+                    return BedrockHelpers.DeserializeObject<JurassicResponsePayload>(utf8Json);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(model), model, "Unexpected LlmModelType");
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -11,8 +11,8 @@ using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Providers.Wrapper.Bedrock.Payloads;
 using NewRelic.Reflection;
 using System.Net;
-using Newtonsoft.Json;
 using System.IO;
+using NewRelic.Core.JsonConverters;
 
 namespace NewRelic.Providers.Wrapper.Bedrock
 {
@@ -259,16 +259,16 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             switch (model)
             {
                 case LlmModelType.Llama2:
-                    return JsonConvert.DeserializeObject<Llama2RequestPayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<Llama2RequestPayload>(utf8Json);
                 case LlmModelType.CohereCommand:
-                    return JsonConvert.DeserializeObject<CohereCommandRequestPayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<CohereCommandRequestPayload>(utf8Json);
                 case LlmModelType.Claude:
-                    return JsonConvert.DeserializeObject<ClaudeRequestPayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<ClaudeRequestPayload>(utf8Json);
                 case LlmModelType.Titan:
                 case LlmModelType.TitanEmbedded:
-                    return JsonConvert.DeserializeObject<TitanRequestPayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<TitanRequestPayload>(utf8Json);
                 case LlmModelType.Jurassic:
-                    return JsonConvert.DeserializeObject<JurassicRequestPayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<JurassicRequestPayload>(utf8Json);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(model), model, "Unexpected LlmModelType");
             }
@@ -287,17 +287,17 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             switch (model)
             {
                 case LlmModelType.Llama2:
-                    return JsonConvert.DeserializeObject<Llama2ResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<Llama2ResponsePayload>(utf8Json);
                 case LlmModelType.CohereCommand:
-                    return JsonConvert.DeserializeObject<CohereCommandResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<CohereCommandResponsePayload>(utf8Json);
                 case LlmModelType.Claude:
-                    return JsonConvert.DeserializeObject<ClaudeResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<ClaudeResponsePayload>(utf8Json);
                 case LlmModelType.Titan:
-                    return JsonConvert.DeserializeObject<TitanResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<TitanResponsePayload>(utf8Json);
                 case LlmModelType.TitanEmbedded:
-                    return JsonConvert.DeserializeObject<TitanEmbeddedResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<TitanEmbeddedResponsePayload>(utf8Json);
                 case LlmModelType.Jurassic:
-                    return JsonConvert.DeserializeObject<JurassicResponsePayload>(utf8Json);
+                    return JsonHelpers.DeserializeObject<JurassicResponsePayload>(utf8Json);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(model), model, "Unexpected LlmModelType");
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -258,6 +258,8 @@ namespace NewRelic.Providers.Wrapper.Bedrock
 
             switch (model)
             {
+                // We're using a helper method in NewRelic.Core because it has Newtonsoft.Json ILRepacked into it
+                // This avoids depending on Newtonsoft.Json being available in the customer application
                 case LlmModelType.Llama2:
                     return BedrockHelpers.DeserializeObject<Llama2RequestPayload>(utf8Json);
                 case LlmModelType.CohereCommand:

--- a/src/NewRelic.Core/JsonConverters/BedrockHelpers.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockHelpers.cs
@@ -7,8 +7,8 @@ namespace NewRelic.Core.JsonConverters
 {
     public static class BedrockHelpers
     {
-        // This method is intended to be used from wrapper code so that the ILRepacked version of Newtonsoft.Json gets used
-        // rather than relying on the customer application to provide it
+        // This method is used from the Bedrock wrapper code in order to avoid the wrapper
+        // having a dependency on Newtonsoft.Json being available
         public static T DeserializeObject<T>(string payload)
         {
             return JsonConvert.DeserializeObject<T>(payload);

--- a/src/NewRelic.Core/JsonConverters/BedrockHelpers.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockHelpers.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace NewRelic.Core.JsonConverters
 {
-    public static class JsonHelpers
+    public static class BedrockHelpers
     {
         // This method is intended to be used from wrapper code so that the ILRepacked version of Newtonsoft.Json gets used
         // rather than relying on the customer application to provide it

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/ClaudePayloads.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/ClaudePayloads.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public class ClaudeRequestPayload : IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/CohereCommandPayloads.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/CohereCommandPayloads.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public class CohereCommandRequestPayload : IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/JurassicPayloads.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/JurassicPayloads.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public class JurassicRequestPayload : IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/Llama2Payloads.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/Llama2Payloads.cs
@@ -3,7 +3,7 @@
 
 using Newtonsoft.Json;
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public class Llama2RequestPayload : IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/PayloadInterfaces.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/PayloadInterfaces.cs
@@ -1,7 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public interface IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/README.md
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/README.md
@@ -1,0 +1,6 @@
+## AWS Bedrock (LLM) payloads in NewRelic.Core
+
+These classes are used in the Bedrock instrumentation wrapper.  They are placed here in NewRelic.Core.JsonConverters,
+rather than in the wrapper project, to avoid the wrapper having a dependency on Newtonsoft.Json.
+NewRelic.Core already ILRepacks Newtonsoft.Json so it is available here for sure.
+

--- a/src/NewRelic.Core/JsonConverters/BedrockPayloads/TitanPayloads.cs
+++ b/src/NewRelic.Core/JsonConverters/BedrockPayloads/TitanPayloads.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace NewRelic.Providers.Wrapper.Bedrock.Payloads
+namespace NewRelic.Core.JsonConverters.BedrockPayloads
 {
     public class TitanRequestPayload : IRequestPayload
     {

--- a/src/NewRelic.Core/JsonConverters/JsonHelpers.cs
+++ b/src/NewRelic.Core/JsonConverters/JsonHelpers.cs
@@ -1,0 +1,17 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Newtonsoft.Json;
+
+namespace NewRelic.Core.JsonConverters
+{
+    public static class JsonHelpers
+    {
+        // This method is intended to be used from wrapper code so that the ILRepacked version of Newtonsoft.Json gets used
+        // rather than relying on the customer application to provide it
+        public static T DeserializeObject<T>(string payload)
+        {
+            return JsonConvert.DeserializeObject<T>(payload);
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the Bedrock request/response models and the deserialization of their corresponding JSON from the Bedrock wrapper project to `NewRelic.Core`, which ILRepacks `Newtonsoft.Json`, so it will always be available for use.

This prevents assembly load exceptions I found while testing the Bedrock instrumentation with a standalone test app that, unlike our integration test applications, did not include a reference to Newtonsoft.Json.  