### PR TITLE
Fix issue with errors not appearing in the UI

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -223,7 +223,7 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             }
             else
             {
-                EventHelper.CreateChatCompletionEvent(
+                var completionId = EventHelper.CreateChatCompletionEvent(
                     agent,
                     segment,
                     requestId,
@@ -238,6 +238,17 @@ namespace NewRelic.Providers.Wrapper.Bedrock
                     null,
                     errorData);
 
+                // Prompt
+                EventHelper.CreateChatMessageEvent(
+                        agent,
+                        segment,
+                        requestId,
+                        invokeModelRequest.ModelId,
+                        requestPayload.Prompt,
+                        "user",
+                        0,
+                        completionId,
+                        false);
             }
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMErrorTests.cs
@@ -62,6 +62,9 @@ where TFixture : ConsoleDynamicMethodFixture
             }
             Assert.Equal(2, errors);
 
+            var promptEvents = customEvents.Where(evt => evt.Header.Type == "LlmChatCompletionMessage");
+            Assert.Equal(2, promptEvents.Count());
+
             var completionEvents = customEvents.Where(evt => evt.Header.Type == "LlmChatCompletionSummary");
             Assert.Equal(2, completionEvents.Count());
             foreach (var evt  in completionEvents)


### PR DESCRIPTION
A matching `LlmChatCompletionMessage` also needs to be sent on error, even if we don't get a response.

Also updated the corresponding integration test.

(Just noticed the branch name is wrong; sorry about that)