### PR TITLE
test: Test latest versions of Elastic.Clients.Elasticsearch and MongoDB.Driver

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -88,13 +88,13 @@
     <PackageReference Include="MongoDB.Driver" Version="2.3.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.24.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.25.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MongoDB.Driver .NET/Core references -->
     <!-- Minimum version we can use with .NET core 3.0 or greater is 2.8.1, due to this bug: https://github.com/mongodb/mongo-csharp-driver/pull/372 -->
     <PackageReference Include="MongoDB.Driver" Version="2.8.1" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="MongoDB.Driver" Version="2.23.1" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.24.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.25.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- MySqlConnector framework references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -144,12 +144,12 @@
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.13.5" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elastic.Clients.Elasticsearch .NET/Core references - only actually testing oldest and newest -->
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.12.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.13.5" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.13.5" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Serilog .NET framework references -->
     <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -85,7 +85,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 .From(0)
                 .Size(10)
                 .Query(q => q
-                    .Term(t => t.Field(t => t.Departure))
+                    .Term(t => t.Field(t => t.Departure)
+                    .Value(FlightRecord.GetSample().Departure)
+                    )
                 )
             );
 #pragma warning restore CS0618

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -1,7 +1,8 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
@@ -46,7 +47,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             // This isn't necessary but will log the response, which can help troubleshoot if
             // you're having connection errors
+#pragma warning disable CS0618 // obsolete usage is ok here
             _client.Ping();
+#pragma warning restore CS0618
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -76,14 +79,16 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Search()
         {
+#pragma warning disable CS0618 // obsolete usage is ok here
             var response = _client.Search<FlightRecord>(s => s
                 .Index(IndexName)
                 .From(0)
                 .Size(10)
                 .Query(q => q
-                    .Term(t => t.Departure, FlightRecord.GetSample().Departure)
+                    .Term(t => t.Field(t => t.Departure))
                 )
             );
+#pragma warning restore CS0618
 
             AssertResponseIsSuccess(response);
         }
@@ -96,7 +101,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 .From(0)
                 .Size(10)
                 .Query(q => q
-                    .Term(t => t.Departure, FlightRecord.GetSample().Departure)
+                    .Term(t => t.Field(t => t.Departure)
+                    .Value(FlightRecord.GetSample().Departure)
+                    )
                 )
             );
 
@@ -133,7 +140,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
             // Currently unable to figure out how to make a real multisearch work in 8.x
             // This empty call is enough to make the instrumentation (wrapper) execute and generate the data
             // we are looking for, but we can't assert for success.
+#pragma warning disable CS0618 // obsolete usage is ok here
             var response = _client.MultiSearch<FlightRecord>();
+#pragma warning restore CS0618
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -158,7 +167,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var client = new ElasticsearchClient(settings);
 
+#pragma warning disable CS0618 // obsolete usage is ok here
             var response = client.Ping();
+#pragma warning restore CS0618
 
             if (response.IsSuccess())
             {


### PR DESCRIPTION
The latest `Elastic.Clients.Elasticsearch` appears to have removed a helper extension that we were using to test the library. I found nothing in the release notes about it going away. The new test code supports both old and new versions. The new release also marks some methods we're using as deprecated, which was causing a warning-as-error build failure.