### PR TITLE
Refactoring and tests for serverless mode payload

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModeDataTransportService.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModeDataTransportService.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Text;
 using NewRelic.Agent.Core.Aggregators;
 using NewRelic.Agent.Core.Commands;
 using NewRelic.Agent.Core.Events;
@@ -19,7 +17,6 @@ using NewRelic.Agent.Core.WireModels;
 using NewRelic.Core;
 using NewRelic.Core.Logging;
 using NewRelic.SystemInterfaces;
-using Newtonsoft.Json;
 
 namespace NewRelic.Agent.Core.DataTransport
 {
@@ -37,15 +34,6 @@ namespace NewRelic.Agent.Core.DataTransport
         /// </summary>
         /// <returns></returns>
         bool FlushData(string transactionId);
-    }
-
-    /// <summary>
-    /// Handles building and writing the serverless payload. Created primarily to facilitate unit testing.
-    /// </summary>
-    public interface IServerlessModePayloadManager
-    {
-        void WritePayload(string jsonPayload, string outputPath);
-        string BuildPayload(WireData data);
     }
 
     /// <summary>
@@ -222,163 +210,5 @@ namespace NewRelic.Agent.Core.DataTransport
             ServerlessModePayloadManager.SetMetadata(functionVersion, arn);
         }
 
-    }
-
-    public class FileWrapper : IFileWrapper
-    {
-        public bool Exists(string path)
-        {
-            return File.Exists(path);
-
-        }
-
-        public FileStream OpenWrite(string path)
-        {
-            return File.OpenWrite(path);
-        }
-
-    }
-
-    /// <summary>
-    /// Wraps some File methods to allow for unit testing
-    /// </summary>
-    public interface IFileWrapper
-    {
-        bool Exists(string path);
-        FileStream OpenWrite(string path);
-    }
-
-    public class ServerlessModePayloadManager : IServerlessModePayloadManager
-    {
-        private readonly IFileWrapper _fileWrapper;
-        private readonly IEnvironment _environment;
-        private readonly object _writeLock = new object();
-        private static IDictionary<string, object> _metadata = null;
-        private static string _functionVersion;
-        private static string _arn;
-
-        public ServerlessModePayloadManager(IFileWrapper fileWrapper, IEnvironment environment)
-        {
-            _fileWrapper = fileWrapper;
-            _environment = environment;
-        }
-
-        public void WritePayload(string payloadJson, string path)
-        {
-            bool success = false;
-
-            // Make sure we aren't trying to write two payloads at the same time
-            lock (_writeLock)
-            {
-                try
-                {
-                    var payloadBytes = Encoding.UTF8.GetBytes(payloadJson);
-                    if (_fileWrapper.Exists(path))
-                    {
-                        using (var fs = _fileWrapper.OpenWrite(path))
-                        {
-                            fs.Write(payloadBytes, 0, payloadBytes.Length);
-                            fs.Flush(true);
-                        }
-
-                        success = true;
-                    }
-                    else
-                    {
-                        Log.Warn("Unable to write serverless payload. '{0}' not found", path);
-                    }
-                }
-                catch (Exception e)
-                {
-                    Log.Warn(e, "Failed to write serverless payload to {path}.", path);
-                }
-            }
-
-            if (!success)
-            {
-                // fall back to writing to stdout
-                Log.Debug("Writing serverless payload to stdout");
-
-                Console.WriteLine(payloadJson);
-            }
-        }
-
-        public string BuildPayload(WireData eventsToFlush)
-        {
-            InitializeMetadata();
-            var metadata = GetMetadata();
-            var basePayload = GetCompressiblePayload(eventsToFlush);
-
-            if (Log.IsFinestEnabled)
-            {
-                var uncompressedPayload = new List<object> { 2, "NR_LAMBDA_MONITORING", metadata, basePayload };
-                Log.Finest("Serverless payload: {0}", JsonConvert.SerializeObject(uncompressedPayload));
-            }
-
-            var compressedAndEncodedPayload = CompressAndEncode(JsonConvert.SerializeObject(basePayload));
-            var payload = new List<object> { 2, "NR_LAMBDA_MONITORING", metadata, compressedAndEncodedPayload };
-
-            return JsonConvert.SerializeObject(payload);
-        }
-
-
-        private Dictionary<string, object> GetCompressiblePayload(WireData eventsToFlush)
-        {
-            Dictionary<string, object> result = new Dictionary<string, object>();
-            foreach (var kvp in eventsToFlush)
-            {
-                if (kvp.Value.Any())
-                {
-                    result[kvp.Key] = kvp.Value;
-                }
-            }
-            return result;
-        }
-
-        // gzip compress and base64 encode.
-        private string CompressAndEncode(string compressiblePayload)
-        {
-            try
-            {
-                using MemoryStream output = new MemoryStream();
-                using GZipStream gzip = new GZipStream(output, CompressionLevel.Optimal);
-                var data = Encoding.UTF8.GetBytes(compressiblePayload);
-                gzip.Write(data, 0, data.Length);
-                gzip.Flush();
-                gzip.Close();
-                return Convert.ToBase64String(output.ToArray());
-            }
-            catch (IOException e)
-            {
-                Log.Error(e, "Failed to compress payload");
-            }
-            return string.Empty;
-        }
-
-        private void InitializeMetadata()
-        {
-            if (_metadata == null)
-            {
-                _metadata = new Dictionary<string, object>()
-                {
-                    { "protocol_version", 17 },
-                    { "agent_version", AgentInstallConfiguration.AgentVersion },
-                    { "metadata_version", 2 },
-                    { "agent_language", "dotnet" } // Should match "connect" string
-                };
-                _metadata.AddStringIfNotNullOrEmpty("execution_environment", _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
-                _metadata.AddStringIfNotNullOrEmpty("function_version", _functionVersion);
-                _metadata.AddStringIfNotNullOrEmpty("arn", _arn);
-            }
-        }
-
-        // Metadata is not compressed or encoded.
-        private static IDictionary<string, object> GetMetadata() => _metadata;
-
-        public static void SetMetadata(string functionVersion, string arn)
-        {
-            _functionVersion = functionVersion;
-            _arn = arn;
-        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
@@ -1,0 +1,160 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Core.Logging;
+using NewRelic.SystemInterfaces;
+using Newtonsoft.Json;
+
+namespace NewRelic.Agent.Core.DataTransport
+{
+    /// <summary>
+    /// Handles building and writing the serverless payload. Created primarily to facilitate unit testing.
+    /// </summary>
+    public interface IServerlessModePayloadManager
+    {
+        void WritePayload(string jsonPayload, string outputPath);
+        string BuildPayload(WireData data);
+    }
+
+
+    public class ServerlessModePayloadManager : IServerlessModePayloadManager
+    {
+        private readonly IFileWrapper _fileWrapper;
+        private readonly IEnvironment _environment;
+        private readonly object _writeLock = new object();
+        private static IDictionary<string, object> _metadata = null;
+        private static string _functionVersion;
+        private static string _arn;
+
+        public ServerlessModePayloadManager(IFileWrapper fileWrapper, IEnvironment environment)
+        {
+            _fileWrapper = fileWrapper;
+            _environment = environment;
+        }
+
+        public void WritePayload(string payloadJson, string path)
+        {
+            bool success = false;
+
+            // Make sure we aren't trying to write two payloads at the same time
+            lock (_writeLock)
+            {
+                try
+                {
+                    var payloadBytes = Encoding.UTF8.GetBytes(payloadJson);
+                    if (_fileWrapper.Exists(path))
+                    {
+                        using (var fs = _fileWrapper.OpenWrite(path))
+                        {
+                            fs.Write(payloadBytes, 0, payloadBytes.Length);
+                            fs.Flush(true);
+                        }
+
+                        success = true;
+                    }
+                    else
+                    {
+                        Log.Warn("Unable to write serverless payload. '{0}' not found", path);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.Warn(e, "Failed to write serverless payload to {path}.", path);
+                }
+            }
+
+            if (!success)
+            {
+                // fall back to writing to stdout
+                Log.Debug("Writing serverless payload to stdout");
+
+                Console.WriteLine(payloadJson);
+            }
+        }
+
+        public string BuildPayload(WireData eventsToFlush)
+        {
+            InitializeMetadata();
+            var metadata = GetMetadata();
+            var basePayload = GetCompressiblePayload(eventsToFlush);
+
+            if (Log.IsFinestEnabled)
+            {
+                var uncompressedPayload = new List<object> { 2, "NR_LAMBDA_MONITORING", metadata, basePayload };
+                Log.Finest("Serverless payload: {0}", JsonConvert.SerializeObject(uncompressedPayload));
+            }
+
+            var compressedAndEncodedPayload = CompressAndEncode(JsonConvert.SerializeObject(basePayload));
+            var payload = new List<object> { 2, "NR_LAMBDA_MONITORING", metadata, compressedAndEncodedPayload };
+
+            return JsonConvert.SerializeObject(payload);
+        }
+
+
+        private Dictionary<string, object> GetCompressiblePayload(WireData eventsToFlush)
+        {
+            Dictionary<string, object> result = new Dictionary<string, object>();
+            foreach (var kvp in eventsToFlush)
+            {
+                if (kvp.Value.Any())
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+            return result;
+        }
+
+        // gzip compress and base64 encode.
+        private string CompressAndEncode(string compressiblePayload)
+        {
+            try
+            {
+                using MemoryStream output = new MemoryStream();
+                using GZipStream gzip = new GZipStream(output, CompressionLevel.Optimal);
+                var data = Encoding.UTF8.GetBytes(compressiblePayload);
+                gzip.Write(data, 0, data.Length);
+                gzip.Flush();
+                gzip.Close();
+                return Convert.ToBase64String(output.ToArray());
+            }
+            catch (IOException e)
+            {
+                Log.Error(e, "Failed to compress payload");
+            }
+            return string.Empty;
+        }
+
+        private void InitializeMetadata()
+        {
+            if (_metadata == null)
+            {
+                _metadata = new Dictionary<string, object>()
+                {
+                    { "protocol_version", 17 },
+                    { "agent_version", AgentInstallConfiguration.AgentVersion },
+                    { "metadata_version", 2 },
+                    { "agent_language", "dotnet" } // Should match "connect" string
+                };
+                _metadata.AddStringIfNotNullOrEmpty("execution_environment", _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV"));
+                _metadata.AddStringIfNotNullOrEmpty("function_version", _functionVersion);
+                _metadata.AddStringIfNotNullOrEmpty("arn", _arn);
+            }
+        }
+
+        // Metadata is not compressed or encoded.
+        private static IDictionary<string, object> GetMetadata() => _metadata;
+
+        public static void SetMetadata(string functionVersion, string arn)
+        {
+            _functionVersion = functionVersion;
+            _arn = arn;
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
+++ b/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentServices.cs
@@ -117,7 +117,11 @@ namespace NewRelic.Agent.Core.DependencyInjection
                 container.Register<IDataTransportService, DataTransportService>();
             }
             else
+            {
                 container.Register<IDataTransportService, IServerlessModeDataTransportService, ServerlessModeDataTransportService>();
+                container.Register<IFileWrapper, FileWrapper>();
+                container.Register<IServerlessModePayloadManager, ServerlessModePayloadManager>();
+            }
 
             container.Register<IScheduler, Scheduler>();
             container.Register<ISystemInfo, SystemInfo>();

--- a/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
@@ -1,0 +1,31 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.IO;
+
+namespace NewRelic.Agent.Core.Utilities
+{
+    /// <summary>
+    /// Wraps some File methods to allow for unit testing
+    /// </summary>
+    public interface IFileWrapper
+    {
+        bool Exists(string path);
+        FileStream OpenWrite(string path);
+    }
+
+    public class FileWrapper : IFileWrapper
+    {
+        public bool Exists(string path)
+        {
+            return File.Exists(path);
+
+        }
+
+        public FileStream OpenWrite(string path)
+        {
+            return File.OpenWrite(path);
+        }
+
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using NewRelic.Agent.Core.Attributes;
+using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.SystemInterfaces;
 using Newtonsoft.Json;

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
@@ -1,0 +1,155 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using NewRelic.Agent.Core.Attributes;
+using NewRelic.Agent.Core.WireModels;
+using NewRelic.SystemInterfaces;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace NewRelic.Agent.Core.DataTransport
+{
+    [TestFixture]
+    public class ServerlessModePayloadManagerTests
+    {
+        private ServerlessModePayloadManager _serverlessPayloadManager;
+        private IEnvironment _environment;
+        private IFileWrapper _fileWrapper;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fileWrapper = Mock.Create<IFileWrapper>();
+            _environment = Mock.Create<IEnvironment>();
+
+            _serverlessPayloadManager = new ServerlessModePayloadManager(_fileWrapper, _environment);
+
+        }
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        [Test]
+        public void BuildPayload_Metadata_IsCorrect()
+        {
+            // Arrange
+            var testExecutionEnv = "TEST_EXECUTION_ENV";
+            var testFunctionVersion = "TestFunctionVersion";
+            var testArn = "TestArn";
+
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV")).Returns(testExecutionEnv);
+
+            // Act
+            ServerlessModePayloadManager.SetMetadata(testFunctionVersion, testArn);
+            var payload = _serverlessPayloadManager.BuildPayload(new WireData());
+
+            // Assert
+            var payloadObj = JsonConvert.DeserializeObject<List<object>>(payload);
+
+            Assert.That(payloadObj, Is.Not.Null);
+            Assert.That(payloadObj, Has.Count.EqualTo(4));
+            Assert.That(payloadObj[0].ToString(), Is.EqualTo("2"));
+            Assert.That(payloadObj[1].ToString(), Is.EqualTo("NR_LAMBDA_MONITORING"));
+
+            dynamic metaData = payloadObj[2];
+            Assert.That(metaData["protocol_version"].Value, Is.EqualTo(17));
+            Assert.That(metaData["agent_version"].Value, Is.Not.Null);
+            Assert.That(metaData["metadata_version"].Value, Is.EqualTo(2));
+            Assert.That(metaData["agent_language"].Value, Is.EqualTo("dotnet"));
+            Assert.That(metaData["execution_environment"].Value, Is.EqualTo(testExecutionEnv));
+            Assert.That(metaData["function_version"].Value, Is.EqualTo(testFunctionVersion));
+            Assert.That(metaData["arn"].Value, Is.EqualTo(testArn));
+        }
+
+        [Test]
+        public void BuildPayload_CompressedPayload_DecompressesCorrectly()
+        {
+            // Arrange
+            var testExecutionEnv = "TEST_EXECUTION_ENV";
+            var testFunctionVersion = "TestFunctionVersion";
+            var testArn = "TestArn";
+
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV")).Returns(testExecutionEnv);
+
+            const string expected = @"[1514768400000,1000.0,""Transaction Name"",""Transaction URI"",[1514768400000,{},{},[0.0,1000.0,""Segment Name"",{},[],""Segment Class Name"",""Segment Method Name""],{""agentAttributes"":{},""userAttributes"":{},""intrinsics"":{}}],""Transaction GUID"",null,false,null,null]";
+            var timestamp = new DateTime(2018, 1, 1, 1, 0, 0, DateTimeKind.Utc);
+            var transactionTraceSegment = new TransactionTraceSegment(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Segment Name", new Dictionary<string, object>(), new List<TransactionTraceSegment>(), "Segment Class Name", "Segment Method Name");
+
+            var transactionTrace = new TransactionTraceData(timestamp, transactionTraceSegment, new AttributeValueCollection(AttributeDestinations.TransactionTrace));
+            var transactionSample = new TransactionTraceWireModel(timestamp, TimeSpan.FromSeconds(1), "Transaction Name", "Transaction URI", transactionTrace, "Transaction GUID", null, null, false);
+
+            var wireData = new WireData();
+            wireData["transaction_sample_data"] = new [] {transactionSample };
+
+            // Act
+            ServerlessModePayloadManager.SetMetadata(testFunctionVersion, testArn);
+            var payload = _serverlessPayloadManager.BuildPayload(wireData);
+
+            // Assert
+            var payloadObj = JsonConvert.DeserializeObject<List<object>>(payload);
+
+            Assert.That(payloadObj, Is.Not.Null);
+            Assert.That(payloadObj, Has.Count.EqualTo(4));
+
+            var compressedPayload = payloadObj[3].ToString();
+
+            // Base-64 decode, then unzip to get the raw payload
+            var zippedPayload = Convert.FromBase64String(compressedPayload);
+            using var ms = new MemoryStream(zippedPayload);
+            using var gzip = new GZipStream(ms, CompressionMode.Decompress);
+            using var ms2 = new MemoryStream();
+            gzip.CopyTo(ms2);
+            var unzippedBytes = ms2.ToArray();
+            var unzippedPayload = Encoding.UTF8.GetString(unzippedBytes);
+
+            Assert.That(unzippedPayload, Is.EqualTo($"{{\"transaction_sample_data\":[{expected}]}}"));
+        }
+
+        [Test]
+        public void WritePayload_WritesCorrectly()
+        {
+                        // Arrange
+            var testExecutionEnv = "TEST_EXECUTION_ENV";
+            var testFunctionVersion = "TestFunctionVersion";
+            var testArn = "TestArn";
+
+            // intercept the file output and write it to a memory stream instead
+            var actualMS = new MemoryStream();
+            FileStream fs = Mock.Create<FileStream>(Constructor.Mocked);
+            Mock.Arrange(() => fs.Write(null, 0, 0)).IgnoreArguments()
+                .DoInstead((byte[] content, int offset, int len) => actualMS.Write(content, 0, content.Length));
+            Mock.Arrange(() => _fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
+            Mock.Arrange(() => _fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV")).Returns(testExecutionEnv);
+
+            //const string expected = @"[1514768400000,1000.0,""Transaction Name"",""Transaction URI"",[1514768400000,{},{},[0.0,1000.0,""Segment Name"",{},[],""Segment Class Name"",""Segment Method Name""],{""agentAttributes"":{},""userAttributes"":{},""intrinsics"":{}}],""Transaction GUID"",null,false,null,null]";
+            var timestamp = new DateTime(2018, 1, 1, 1, 0, 0, DateTimeKind.Utc);
+            var transactionTraceSegment = new TransactionTraceSegment(TimeSpan.Zero, TimeSpan.FromSeconds(1), "Segment Name", new Dictionary<string, object>(), new List<TransactionTraceSegment>(), "Segment Class Name", "Segment Method Name");
+
+            var transactionTrace = new TransactionTraceData(timestamp, transactionTraceSegment, new AttributeValueCollection(AttributeDestinations.TransactionTrace));
+            var transactionSample = new TransactionTraceWireModel(timestamp, TimeSpan.FromSeconds(1), "Transaction Name", "Transaction URI", transactionTrace, "Transaction GUID", null, null, false);
+
+            var wireData = new WireData();
+            wireData["transaction_sample_data"] = new [] {transactionSample };
+
+            // Act
+            ServerlessModePayloadManager.SetMetadata(testFunctionVersion, testArn);
+            var payload = _serverlessPayloadManager.BuildPayload(wireData);
+            _serverlessPayloadManager.WritePayload(payload, "gibberish");
+
+            // Assert
+            actualMS.Position = 0;
+            var actualBytes = actualMS.ToArray();
+            // the payload is encoded as UTF8 bytes when writing to the output file.
+            Assert.That(Encoding.UTF8.GetBytes(payload), Is.EqualTo(actualBytes));
+        }
+    }
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
@@ -6,6 +6,7 @@ using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Commands;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Fixtures;
+using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Core.Wrapper;
 using NUnit.Framework;
 using Telerik.JustMock;

--- a/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
@@ -81,16 +81,24 @@ namespace NewRelic.Agent.Core.DependencyInjection
                 Assert.DoesNotThrow(() => container.Resolve<IWrapperService>());
                 Assert.DoesNotThrow(() => AgentServices.StartServices(container, true));
 
-                var dataTransportService = container.Resolve<IDataTransportService>();
-                var expectedDataTransportServiceType = serverlessModeEnabled ? typeof(ServerlessModeDataTransportService) : typeof(DataTransportService);
-                Assert.That(dataTransportService.GetType() == expectedDataTransportServiceType);
-
+                // ensure dependent services are registered
                 if (serverlessModeEnabled)
                 {
                     Assert.DoesNotThrow(() => container.Resolve<IServerlessModePayloadManager>());
                     var serverlessModePayloadManager = container.Resolve<IServerlessModePayloadManager>();
                     Assert.That(serverlessModePayloadManager.GetType() == typeof(ServerlessModePayloadManager));
 
+                    Assert.DoesNotThrow(() => container.Resolve<IFileWrapper>());
+                    var fileWrapper = container.Resolve<IFileWrapper>();
+                    Assert.That(fileWrapper.GetType() == typeof(FileWrapper));
+                }
+
+                var dataTransportService = container.Resolve<IDataTransportService>();
+                var expectedDataTransportServiceType = serverlessModeEnabled ? typeof(ServerlessModeDataTransportService) : typeof(DataTransportService);
+                Assert.That(dataTransportService.GetType() == expectedDataTransportServiceType);
+
+                if (serverlessModeEnabled)
+                {
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<IConnectionHandler>());
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<IConnectionManager>());
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<CommandService>());

--- a/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DependencyInjection/AgentServicesTests.cs
@@ -87,6 +87,10 @@ namespace NewRelic.Agent.Core.DependencyInjection
 
                 if (serverlessModeEnabled)
                 {
+                    Assert.DoesNotThrow(() => container.Resolve<IServerlessModePayloadManager>());
+                    var serverlessModePayloadManager = container.Resolve<IServerlessModePayloadManager>();
+                    Assert.That(serverlessModePayloadManager.GetType() == typeof(ServerlessModePayloadManager));
+
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<IConnectionHandler>());
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<IConnectionManager>());
                     Assert.Throws<ComponentNotRegisteredException>(() => container.Resolve<CommandService>());


### PR DESCRIPTION
* Refactors `ServerlessModeDataTransport` to separate the payload management (building / writing) to a separate class (`ServerlessModePayloadManager`) to allow for unit testing. 
* Adds unit tests to verify that the payload created in serverless mode is correct, including metadata and verification of the compressed portion of the payload. 

Additional tests will be added for `ServerlessModeDataTransport` in a separate PR.