### PR TITLE
Feature work/lambda agent attributes variant

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -126,6 +126,8 @@ namespace NewRelic.Agent.Core.Attributes
         AttributeDefinition<object, object> GetCustomAttributeForSpan(string name);
         AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name);
 
+        AttributeDefinition<string, string> GetLambdaAttribute(string name);
+
         AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName);
 
         AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName);
@@ -176,7 +178,8 @@ namespace NewRelic.Agent.Core.Attributes
         private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _customEventCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
         private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestParameterAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
         private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestHeadersAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
-
+        private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _lambdaAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
+        
         private readonly ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>> _typeAttributes = new ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>>();
 
 
@@ -234,6 +237,21 @@ namespace NewRelic.Agent.Core.Attributes
                 .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
                 .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
                 .Build(_attribFilter);
+        }
+
+        private AttributeDefinition<string, string> CreateLambdaAttribute(string attribName)
+        {
+            return AttributeDefinitionBuilder
+                .CreateString(attribName, AttributeClassification.AgentAttributes)
+                .AppliesTo(AttributeDestinations.TransactionTrace)
+                .AppliesTo(AttributeDestinations.TransactionEvent)
+                .AppliesTo(AttributeDestinations.SpanEvent)
+                .Build(_attribFilter);
+        }
+
+        public AttributeDefinition<string, string> GetLambdaAttribute(string name)
+        {
+            return _lambdaAttributes.GetOrAdd(name, CreateLambdaAttribute);
         }
 
         public AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name)

--- a/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/NoOpTransaction.cs
@@ -317,5 +317,10 @@ namespace NewRelic.Agent.Core.Transactions
         {
             return;
         }
+
+        public void AddLambdaAttribute(string name, string value)
+        {
+            return;
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1357,5 +1357,23 @@ namespace NewRelic.Agent.Core.Transactions
         {
             TransactionMetadata.SetLlmTransaction(isLlmTransaction);
         }
+
+        /// <summary>
+        /// Create an Agent attribute for Lambda.
+        /// Name cannot be null, empty, or whitespace.
+        /// </summary>
+        /// <param name="name">Full name of attribute.</param>
+        /// <param name="value">Value for attribute.</param>
+        public void AddLambdaAttribute(string name, string value)
+        {
+            if(string.IsNullOrWhiteSpace(name))
+            {
+                Log.Debug($"AddLambdaAttribute - Unable to set Lambda value on transaction because the key is null/empty");
+                return;
+            }
+
+            var lambdaAttrib = _attribDefs.GetLambdaAttribute(name);
+            TransactionMetadata.UserAndRequestAttributes.TrySetValue(lambdaAttrib, value);
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -299,5 +299,7 @@ namespace NewRelic.Agent.Api
         void SetUserId(string userid);
 
         void SetLlmTransaction(bool isLlmTransaction);
+
+        void AddLambdaAttribute(string name, string value);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
@@ -1,23 +1,15 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
 using NewRelic.Agent.Api;
 
 namespace NewRelic.Agent.Extensions.Lambda;
 
 public static class LambdaAttributeExtensions
 {
-    public static void AddEventSourceAttribute(this Dictionary<string, string> dict, string suffix, string value)
+    public static void AddEventSourceAttribute(this ITransaction transaction, string suffix, string value)
     {
-        dict.Add($"aws.lambda.eventSource.{suffix}", value);
-    }
-
-    public static void AddLambdaAttributes(this ITransaction transaction, Dictionary<string, string> attributes)
-    {
-        foreach (var attribute in attributes)
-        {
-            transaction.AddLambdaAttribute(attribute.Key, attribute.Value);
-        }
+        // This is faster than string interpolation
+        transaction.AddLambdaAttribute("aws.lambda.eventSource." + suffix, value);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaAttributeExtensions.cs
@@ -17,7 +17,7 @@ public static class LambdaAttributeExtensions
     {
         foreach (var attribute in attributes)
         {
-            transaction.AddCustomAttribute(attribute.Key, attribute.Value); // TODO: figure out if custom attributes are correct
+            transaction.AddLambdaAttribute(attribute.Key, attribute.Value);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -201,25 +201,21 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 transaction.DetachFromPrimary(); //Remove from thread-local type storage
             }
 
-            var attributes = new Dictionary<string, string>();
-
-            attributes.AddEventSourceAttribute("eventType", _functionDetails.EventType.ToEventTypeString());
+            transaction.AddEventSourceAttribute("eventType", _functionDetails.EventType.ToEventTypeString());
 
             if (requestId != null)
             {
-                attributes.Add("aws.requestId", requestId);
+                transaction.AddLambdaAttribute("aws.requestId", requestId);
             }
             if (_functionDetails.Arn != null)
             {
-                attributes.Add("aws.lambda.arn", _functionDetails.Arn);
+                transaction.AddLambdaAttribute("aws.lambda.arn", _functionDetails.Arn);
             }
 
             if (IsColdStart) // only report this attribute if it's a cold start
-                attributes.Add("aws.lambda.coldStart", "true");
+                transaction.AddLambdaAttribute("aws.lambda.coldStart", "true");
 
-            LambdaEventHelpers.AddEventTypeAttributes(agent, transaction, _functionDetails.EventType, inputObject, attributes);
-
-            transaction.AddLambdaAttributes(attributes);
+            LambdaEventHelpers.AddEventTypeAttributes(agent, transaction, _functionDetails.EventType, inputObject);
 
             var segment = transaction.StartTransactionSegment(instrumentedMethodCall.MethodCall, _functionDetails.FunctionName);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaMultipleInvocationsTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaMultipleInvocationsTest.cs
@@ -63,9 +63,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda
         private static bool IsColdStartPayload(ServerlessPayload serverlessPayload)
         {
             var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
-
-            // TODO: Check for the cold start in an agent attribute once that fix is merged
-            return transactionEvent.UserAttributes.TryGetValue("aws.lambda.coldStart", out var coldStartAttributeValue)
+            return transactionEvent.AgentAttributes.TryGetValue("aws.lambda.coldStart", out var coldStartAttributeValue)
                 && (string)coldStartAttributeValue == "true";
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Spans/SpanEventMakerTests.cs
@@ -658,6 +658,7 @@ namespace NewRelic.Agent.Core.Spans.UnitTest
             var allAttribValues = _transactionAttribMaker.GetAttributes(immutableTransaction, transactionMetricName, TimeSpan.FromSeconds(1), immutableTransaction.Duration, metricStatsCollection);
 
             _attribDefs.GetCustomAttributeForTransaction("trxCustomAttrib").TrySetValue(allAttribValues, "trxCustomAttribValue");
+            _attribDefs.GetLambdaAttribute("lambdaAttributeKey").TrySetValue(allAttribValues, "lambdaAttributeValue");
             _attribDefs.OriginalUrl.TrySetValue(allAttribValues, "http://www.test.com");
 
             // ACT

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
@@ -505,4 +505,36 @@ public class TransactionTests
         // Assert
         Assert.That(_transaction.TransactionMetadata.IsLlmTransaction, Is.True);
     }
+
+    [Test]
+    public void AddLambdaAttribute_SetAttributeInTransactionMetadata()
+    {
+        // Arrange
+        var key = "TestAttribute";
+        var value = "TestValue";
+
+        // Act
+        _transaction.AddLambdaAttribute(key, value);
+
+        // Assert
+        var allAttributeValuesDic = _transaction.TransactionMetadata.UserAndRequestAttributes.GetAllAttributeValuesDic();
+
+        var attributeValue = allAttributeValuesDic[key];
+        Assert.That(attributeValue, Is.EqualTo(value));
+    }
+
+    [TestCase("   ")]
+    [TestCase("")]
+    [TestCase(null)]
+    public void AddLambdaAttribute_DoesNotSetAttribute_WhenKeyIsBad(string key)
+    {
+        // Arrange
+        var value = "TestValue";
+
+        // Act
+        _transaction.AddLambdaAttribute(key, value);
+
+        // Assert
+        Assert.That(_transaction.TransactionMetadata.UserAndRequestAttributes.Count, Is.EqualTo(0));
+    }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transformers/TransactionTransformer/TransactionAttributeMakerTests.cs
@@ -342,6 +342,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var priority = 0.5f;
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.SetRequestParameters(new[]
             {
                 new KeyValuePair<string,string>("requestParameterKey", "requestParameterValue"),
@@ -392,7 +393,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(45)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(transactionAttributes), Is.EqualTo(46)),  // Assert that only these attributes are generated
                 () => Assert.That(GetAttributeValue(attributes, "type", AttributeDestinations.TransactionEvent), Is.EqualTo("Transaction")),
                 () => Assert.That(GetAttributeValue(attributes, "type", AttributeDestinations.ErrorEvent), Is.EqualTo("TransactionError")),
                 () => Assert.That(GetAttributeValue(attributes, "timestamp", AttributeDestinations.TransactionEvent), Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
@@ -416,6 +417,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(GetAttributeValue(transactionAttributes, "http.statusCode"), Is.EqualTo(400)),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "request.parameters.requestParameterKey"), Is.EqualTo("requestParameterValue")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "userAttributeKey"), Is.EqualTo("userAttributeValue")),
+                () => Assert.That(GetAttributeValue(transactionAttributes, "lambdaAttributeKey"), Is.EqualTo("lambdaAttributeValue")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "client_cross_process_id"), Is.EqualTo("referrerProcessId")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "trip_id"), Is.EqualTo("referrerTripId")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "nr.tripId"), Is.EqualTo("referrerTripId")),
@@ -517,6 +519,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -540,7 +543,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var tripId = immutableTransaction.Guid;
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(28)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(29)),  // Assert that only these attributes are generated
                 () => Assert.That(GetAttributeValue(transactionAttributes, "type", AttributeDestinations.TransactionEvent), Is.EqualTo("Transaction")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "timestamp", AttributeDestinations.TransactionEvent), Is.EqualTo(expectedStartTime.ToUnixTimeMilliseconds())),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "name"), Is.EqualTo("WebTransaction/TransactionName")),
@@ -567,7 +570,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(GetAttributeValue(transactionAttributes, "path_hash"), Is.EqualTo("pathHash2")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "nr.pathHash"), Is.EqualTo("pathHash2")),
                 () => Assert.That(GetAttributeValue(transactionAttributes, "nr.alternatePathHashes"), Is.EqualTo("pathHash")),
-                () => Assert.That(DoAttributesContain(transactionAttributes, "host.displayName"), Is.True)
+                () => Assert.That(DoAttributesContain(transactionAttributes, "host.displayName"), Is.True),
+                () => Assert.That(GetAttributeValue(transactionAttributes, "lambdaAttributeKey"), Is.EqualTo("lambdaAttributeValue"))
             );
         }
 
@@ -616,6 +620,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -640,7 +645,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(39)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(40)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes, "type", AttributeDestinations.TransactionEvent, AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.CustomEvent, AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "name", AttributeDestinations.TransactionEvent),
@@ -675,7 +680,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => AssertAttributeShouldBeAvailableFor(attributes, "errorMessage", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "error.message", AttributeDestinations.ErrorEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "error", AttributeDestinations.TransactionEvent),
-                () => AssertAttributeShouldBeAvailableFor(attributes, "host.displayName", AttributeDestinations.TransactionTrace , AttributeDestinations.TransactionEvent , AttributeDestinations.ErrorTrace , AttributeDestinations.ErrorEvent)
+                () => AssertAttributeShouldBeAvailableFor(attributes, "host.displayName", AttributeDestinations.TransactionTrace , AttributeDestinations.TransactionEvent , AttributeDestinations.ErrorTrace , AttributeDestinations.ErrorEvent),
+                () => AssertAttributeShouldBeAvailableFor(attributes, "lambdaAttributeKey", AttributeDestinations.TransactionEvent, AttributeDestinations.TransactionTrace)
             );
         }
 
@@ -694,6 +700,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -720,7 +727,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             // ASSERT
             NrAssert.Multiple
             (
-                () => Assert.That(GetCount(attributes), Is.EqualTo(32)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(33)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes, Has.Member("type")),
                 () => Assert.That(transactionAttributes, Has.Member("timestamp")),
                 () => Assert.That(transactionAttributes, Has.Member("name")),
@@ -751,7 +758,8 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(transactionAttributes, Has.Member("nr.referringPathHash")),
                 () => Assert.That(transactionAttributes, Has.Member("referring_transaction_guid")),
                 () => Assert.That(transactionAttributes, Has.Member("nr.referringTransactionGuid")),
-                () => Assert.That(transactionAttributes, Has.Member("nr.alternatePathHashes"))
+                () => Assert.That(transactionAttributes, Has.Member("nr.alternatePathHashes")),
+                () => Assert.That(transactionAttributes, Has.Member("lambdaAttributeKey"))
             );
 
 
@@ -772,6 +780,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.SetHttpResponseStatusCode(200, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
             transaction.TransactionMetadata.SetQueueTime(TimeSpan.FromSeconds(1));
@@ -800,7 +809,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(34)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(35)),  // Assert that only these attributes are generated
                 () => AssertAttributeShouldBeAvailableFor(attributes, "type", AttributeDestinations.TransactionEvent),
                 () => AssertAttributeShouldBeAvailableFor(attributes, "timestamp", AttributeDestinations.TransactionEvent, AttributeDestinations.SpanEvent, AttributeDestinations.CustomEvent),
                 () => Assert.That(intrinsicAttributes, Has.Member("name")),
@@ -823,6 +832,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(agentAttributes, Has.Member("http.statusCode")),
                 () => Assert.That(agentAttributes, Has.Member("request.parameters.requestParameterKey")),
                 () => Assert.That(agentAttributes, Has.Member("host.displayName")),
+                () => Assert.That(agentAttributes, Has.Member("lambdaAttributeKey")),
                 () => Assert.That(intrinsicAttributes, Has.Member("client_cross_process_id")),
                 () => Assert.That(intrinsicAttributes, Has.Member("trip_id")),
                 () => Assert.That(intrinsicAttributes, Has.Member("nr.tripId")),
@@ -1392,6 +1402,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
             var transaction = new Transaction(_configuration, TransactionName.ForWebTransaction("transactionCategory", "transactionName"), timer, expectedStartTime, Mock.Create<ICallStackManager>(), _databaseService, priority, Mock.Create<IDatabaseStatementParser>(), _distributedTracePayloadHandler, _errorService, _attribDefs);
             transaction.SetRequestParameters(new[] { new KeyValuePair<string, string>("requestParameterKey", "requestParameterValue") });
             transaction.AddCustomAttribute("userAttributeKey", "userAttributeValue");
+            transaction.AddLambdaAttribute("lambdaAttributeKey", "lambdaAttributeValue");
             transaction.TransactionMetadata.TransactionErrorState.AddCustomErrorData(MakeErrorData());
             transaction.SetHttpResponseStatusCode(400, null);
             transaction.TransactionMetadata.SetOriginalUri("originalUri");
@@ -1423,7 +1434,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
 
             // ASSERT
             NrAssert.Multiple(
-                () => Assert.That(GetCount(builderAttributes), Is.EqualTo(11)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(builderAttributes), Is.EqualTo(12)),  // Assert that only these attributes are generated
                 () => Assert.That(txBuilderAttributes["original_url"], Is.EqualTo("originalUri")),
                 () => Assert.That(transactionAttributes["request.uri"], Is.EqualTo("uri")),
                 () => Assert.That(txBuilderAttributes["request.referer"], Is.EqualTo("referrerUri")),
@@ -1434,10 +1445,11 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(txBuilderAttributes["userAttributeKey"], Is.EqualTo("userAttributeValue")),
                 () => Assert.That(txBuilderAttributes["userErrorAttributeKey"], Is.EqualTo("userErrorAttributeValue")),
                 () => Assert.That(txBuilderAttributes["llm"], Is.EqualTo(true)),
-                () => Assert.That(txBuilderAttributes.Keys, Does.Contain("host.displayName"))
+                () => Assert.That(txBuilderAttributes.Keys, Does.Contain("host.displayName")),
+                () => Assert.That(txBuilderAttributes["lambdaAttributeKey"], Is.EqualTo("lambdaAttributeValue"))
             );
             NrAssert.Multiple(
-                () => Assert.That(GetCount(attributes), Is.EqualTo(11)),  // Assert that only these attributes are generated
+                () => Assert.That(GetCount(attributes), Is.EqualTo(12)),  // Assert that only these attributes are generated
                 () => Assert.That(transactionAttributes["original_url"], Is.EqualTo("originalUri")),
                 () => Assert.That(transactionAttributes["request.uri"], Is.EqualTo("uri")),
                 () => Assert.That(transactionAttributes["request.referer"], Is.EqualTo("referrerUri")),
@@ -1447,6 +1459,7 @@ namespace NewRelic.Agent.Core.Transformers.TransactionTransformer.UnitTest
                 () => Assert.That(transactionAttributes["request.parameters.requestParameterKey"], Is.EqualTo("requestParameterValue")),
                 () => Assert.That(transactionAttributes["userAttributeKey"], Is.EqualTo("userAttributeValue")),
                 () => Assert.That(transactionAttributes["userErrorAttributeKey"], Is.EqualTo("userErrorAttributeValue")),
+                () => Assert.That(transactionAttributes["lambdaAttributeKey"], Is.EqualTo("lambdaAttributeValue")),
                 () => Assert.That(transactionAttributes["llm"], Is.EqualTo(true)),
                 () => Assert.That(transactionAttributes.Keys, Does.Contain("host.displayName"))
             );

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
@@ -12,33 +12,19 @@ namespace Agent.Extensions.Tests.Lambda
     public class LambdaAttributeExtensionsTests
     {
         [Test]
-        public void AddEventSourceAttribute_AddsToDictionary()
-        {
-            var dict = new Dictionary<string, string>();
-            dict.AddEventSourceAttribute("suffix", "value");
-
-            Assert.That(dict.Count, Is.EqualTo(1));
-            Assert.That(dict["aws.lambda.eventSource.suffix"], Is.EqualTo("value"));
-        }
-        [Test]
-        public void AddLambdaAttributes_AddsToTransaction()
+        public void AddEventSourceAttribute_AddsToTransaction()
         {
             var transaction = Mock.Create<ITransaction>();
-            Dictionary<string, string> actualCustomAttributes = new();;
+            Dictionary<string, string> actualCustomAttributes = new();
             Mock.Arrange(() => transaction.AddLambdaAttribute(Arg.IsAny<string>(), Arg.IsAny<string>()))
                 .DoInstead((string key, string value) => actualCustomAttributes.Add(key, value));
 
-            var attributes = new Dictionary<string, string>
-            {
-                { "key1", "value1" },
-                { "key2", "value2" }
-            };
-
-            transaction.AddLambdaAttributes(attributes);
+            transaction.AddEventSourceAttribute("key1", "value1");
+            transaction.AddEventSourceAttribute("key2", "value2");
 
             Assert.That(actualCustomAttributes.Count, Is.EqualTo(2));
-            Assert.That(actualCustomAttributes["key1"], Is.EqualTo("value1"));
-            Assert.That(actualCustomAttributes["key2"], Is.EqualTo("value2"));
+            Assert.That(actualCustomAttributes["aws.lambda.eventSource.key1"], Is.EqualTo("value1"));
+            Assert.That(actualCustomAttributes["aws.lambda.eventSource.key2"], Is.EqualTo("value2"));
         }
     }
 }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaAttributeExtensionsTests.cs
@@ -24,9 +24,9 @@ namespace Agent.Extensions.Tests.Lambda
         public void AddLambdaAttributes_AddsToTransaction()
         {
             var transaction = Mock.Create<ITransaction>();
-            Dictionary<string, object> actualCustomAttributes = new();;
-            Mock.Arrange(() => transaction.AddCustomAttribute(Arg.IsAny<string>(), Arg.IsAny<string>()))
-                .DoInstead((string key, object value) => actualCustomAttributes.Add(key, value));
+            Dictionary<string, string> actualCustomAttributes = new();;
+            Mock.Arrange(() => transaction.AddLambdaAttribute(Arg.IsAny<string>(), Arg.IsAny<string>()))
+                .DoInstead((string key, string value) => actualCustomAttributes.Add(key, value));
 
             var attributes = new Dictionary<string, string>
             {

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -21,9 +21,12 @@ public class LambdaEventHelpersTests
     [SetUp]
     public void SetUp()
     {
+        _attributes = new Dictionary<string, string>();
         _agent = Mock.Create<IAgent>();
         _transaction = Mock.Create<ITransaction>();
-        _attributes = new Dictionary<string, string>();
+        Mock.Arrange(() => _transaction.AddLambdaAttribute(Arg.IsAny<string>(), Arg.IsAny<string>()))
+            .DoInstead((string key, string value) => _attributes.Add(key, value));
+        
     }
 
     // APIGatewayProxyRequest
@@ -64,7 +67,7 @@ public class LambdaEventHelpersTests
         Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, (dynamic)inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, (dynamic)inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -120,7 +123,7 @@ public class LambdaEventHelpersTests
         Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, (dynamic)inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, (dynamic)inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -179,7 +182,7 @@ public class LambdaEventHelpersTests
         Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -230,7 +233,7 @@ public class LambdaEventHelpersTests
         Mock.Arrange(() => _transaction.SetRequestParameters(Arg.IsAny<IDictionary<string, string>>())).DoNothing();
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -263,7 +266,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -292,7 +295,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -320,7 +323,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -364,7 +367,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -407,7 +410,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -444,7 +447,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -475,7 +478,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>
@@ -500,7 +503,7 @@ public class LambdaEventHelpersTests
         };
 
         // Act
-        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject, _attributes);
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
 
         // Assert
         Assert.Multiple(() =>


### PR DESCRIPTION
## Description

Variant of https://github.com/newrelic/newrelic-dotnet-agent/pull/2414 (closed in favor of this PR)

- Adds new attribute definition and method for creating lambda specific attributes as agent attributes.
- Adds `AddLambdaAttribute(string name, string value)` method to `API/ITransaction` for adding Lambda specific attributes.
- Removes dictionary for attributes and instead adds them directly to the transaction, changing `LambdaAttributeExtensions` to support only one method.
- Updates `TransactionTests`, `TransactionAttributeMakerTests`, and `SpanEventMakerTests` to test that the new agent attribute is working properly.
- Updates `LambdaAttributeExtensionsTests` to call `AddLambdaAttribute` instead of `AddCustomAttribute`.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
