### PR TITLE
test: Fix a flicker in SimpleCacheTests

### DIFF
--- a/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
+++ b/tests/NewRelic.Core.Tests/NewRelic.Cache/SimpleCacheTests.cs
@@ -268,7 +268,7 @@ namespace NewRelic.Core.Tests.NewRelic.Cache
             cache.GetOrAdd("key1", () => "value1");
             cache.GetOrAdd("key2", () => "value2");
 
-            Thread.Sleep(1000);
+            Thread.Sleep(2500); // unnecessarily long, but should eliminate test flickers
 
             EvaluateCacheMetrics(cache, 0, 2, 2, 0);
         }


### PR DESCRIPTION
Adjusted a `.Sleep()` to wait long enough for the cache maintenance thread to do it's thing. 