### PR TITLE
chore: Update build tools to net8.0

### DIFF
--- a/build/ArtifactBuilder/ArtifactBuilder.csproj
+++ b/build/ArtifactBuilder/ArtifactBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/NugetValidator/NugetValidator.csproj
+++ b/build/NugetValidator/NugetValidator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+++ b/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Protocol" Version="6.9.1" />
-    <PackageReference Include="Octokit" Version="10.0.0" />
+    <PackageReference Include="Octokit" Version="11.0.1" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />

--- a/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
+++ b/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/build/S3Validator/S3Validator.csproj
+++ b/build/S3Validator/S3Validator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Update build tool projects to .NET 8.  I tested everything locally other than ReleaseNotesBuilder (complex test setup) and it all worked as expected.