### PR TITLE
chore: Update S3Validator to use dotnet publish in post-deploy workflow

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -131,15 +131,13 @@ jobs:
 
       - name: Build and Run S3Validator
         run: |
-          dotnet build --configuration Release "$BUILD_PATH"
-          "$RUN_PATH/S3Validator" -v $AGENT_VERSION -c $CONFIG_PATH
-        shell: bash
+          dotnet publish --configuration Release --output "$PUBLISH_PATH" "$BUILD_PATH"
+          "$PUBLISH_PATH/S3Validator" -v $AGENT_VERSION -c $PUBLISH_PATH/config.yml
+
         env:
           BUILD_PATH: ${{ github.workspace }}/build/S3Validator/S3Validator.csproj
-          RUN_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/
-          CONFIG_PATH: ${{ github.workspace }}/build/S3Validator/bin/Release/net7.0/config.yml
           AGENT_VERSION: ${{ inputs.agent_version }}
-
+          PUBLISH_PATH: ${{ github.workspace }}/build/S3Validator/publish
   validate-nuget-packages:
     name: Validate NuGet Package Deployment
     runs-on: ubuntu-latest
@@ -163,7 +161,7 @@ jobs:
         env:
           AGENT_VERSION: ${{ inputs.agent_version }}
           BUILD_PATH: ${{ github.workspace }}/build/NugetValidator/NugetValidator.csproj
-          PUBLISH_PATH: ${{ github.workspace }}/publish
+          PUBLISH_PATH: ${{ github.workspace }}/build/NugetValidator/publish
 
   report-deprecated-nuget-packages:
     name: Report Deprecated NuGet Packages

--- a/.github/workflows/publish_release_notes.yml
+++ b/.github/workflows/publish_release_notes.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Build Release Notes
         run: |
-          dotnet build --configuration Release "$BUILD_PATH"
-          notes_file=$("$RUN_PATH/ReleaseNotesBuilder" -p "$RUN_PATH/data.yml" -c "$CHANGELOG" -x "$CHECKSUMS" -o "$OUTPUT_PATH")
+          dotnet publish --configuration Release --output "$PUBLISH_PATH" "$BUILD_PATH"
+          notes_file=$("$PUBLISH_PATH/ReleaseNotesBuilder" -p "$PUBLISH_PATH/data.yml" -c "$CHANGELOG" -x "$CHECKSUMS" -o "$OUTPUT_PATH")
           echo "$notes_file"
           echo "notes_file=$notes_file" >> $GITHUB_ENV
         shell: bash
         env:
           BUILD_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/ReleaseNotesBuilder.csproj
-          RUN_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/bin/Release/net8.0/
+          PUBLISH_PATH: ${{ github.workspace }}/build/ReleaseNotesBuilder/publish
           CHANGELOG: ${{ github.workspace }}/src/Agent/CHANGELOG.md
           CHECKSUMS: ${{ github.workspace }}/deploy-artifacts/DownloadSite/SHA256/checksums.md
           OUTPUT_PATH: ${{ github.workspace }}


### PR DESCRIPTION
Modifies the S3Validator job in the post_deploy workflow to use `dotnet publish` so we can avoid a hard-coded output path that changes with .NET version updates.

Also updates the publish_release_notes workflow to follow the same pattern.