### PR TITLE
fix: Fix duplicate key error when using Kafka with DT enabled

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaProducerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaProducerWrapper.cs
@@ -29,15 +29,19 @@ namespace NewRelic.Providers.Wrapper.Kafka
 
             var segment = transaction.StartMessageBrokerSegment(instrumentedMethodCall.MethodCall, MessageBrokerDestinationType.Topic, MessageBrokerAction.Produce, BrokerVendorName, topicPartition.Topic);
 
-            transaction.InsertDistributedTraceHeaders(messageMetadata.Headers, DistributedTraceHeadersSetter);
+            transaction.InsertDistributedTraceHeaders(messageMetadata, DistributedTraceHeadersSetter);
 
             return instrumentedMethodCall.MethodCall.Method.MethodName == "Produce" ? Delegates.GetDelegateFor(segment) : Delegates.GetAsyncDelegateFor<Task>(agent, segment);
         }
 
-        private static void DistributedTraceHeadersSetter(Headers carrier, string key, string value)
+        private static void DistributedTraceHeadersSetter(MessageMetadata carrier, string key, string value)
         {
-            carrier ??= new Headers();
-            carrier.Add(key, Encoding.ASCII.GetBytes(value));
+            carrier.Headers ??= new Headers();
+            if (!string.IsNullOrEmpty(key))
+            {
+                carrier.Headers.Remove(key);
+                carrier.Headers.Add(key, Encoding.ASCII.GetBytes(value));
+            }
         }
 
     }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -91,7 +91,7 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
             () => Assert.True(produceSpan.IntrinsicAttributes.ContainsKey("parentId")),
             () => Assert.NotNull(consumeTxnSpan),
             () => Assert.True(consumeTxnSpan.UserAttributes.ContainsKey("kafka.consume.byteCount")),
-            () => Assert.InRange((long)consumeTxnSpan.UserAttributes["kafka.consume.byteCount"], 20, 30), // usually is 24 - 26
+            () => Assert.InRange((long)consumeTxnSpan.UserAttributes["kafka.consume.byteCount"], 460, 470), // includes headers
             () => Assert.True(consumeTxnSpan.IntrinsicAttributes.ContainsKey("traceId")),
             () => Assert.False(consumeTxnSpan.IntrinsicAttributes.ContainsKey("parentId"))
         );


### PR DESCRIPTION
There were actually two bugs when using Kafka with Distributed Tracing:
* If headers were not present, we weren't creating them (due to a scoping error)
* We were not checking to see if the keys already existed before adding them. This did not cause an immediate problem because the headers are kept in a list rather than a dictionary, but can cause a validation failure later.

The first bug kept us from finding the second problem in our integration tests. Both have been addressed.