### PR TITLE
Parse W3C trace context payloads from SQS message body

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -109,6 +109,11 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.SQSEvent:
                     dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
 
+                    if (sqsEvent.Records == null || sqsEvent.Records.Count == 0)
+                    {
+                        break;
+                    }
+
                     transaction.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
                     transaction.AddEventSourceAttribute("length", (int)sqsEvent.Records.Count);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/W3CTraceparentTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/W3CTraceparentTests.cs
@@ -3,8 +3,6 @@
 
 using NewRelic.Core.DistributedTracing;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NewRelic.Agent.Core.DistributedTracing
 {


### PR DESCRIPTION
Update SQS tracing header processing to handle W3C trace context data as well as the New Relic proprietary DT data.

Update unit tests to cover both cases alone and combined.
