### PR TITLE
Guard against null/empty records in applicable event types

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -55,6 +55,11 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.KinesisStreamingEvent:
                     dynamic kinesisStreamingEvent = inputObject; //Amazon.Lambda.KinesisEvents.KinesisEvent
 
+                    if (kinesisStreamingEvent.Records == null || kinesisStreamingEvent.Records.Count == 0)
+                    {
+                        break;
+                    }
+
                     transaction.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
                     transaction.AddEventSourceAttribute("length", (int)kinesisStreamingEvent.Records.Count);
                     transaction.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
@@ -62,6 +67,11 @@ public static class LambdaEventHelpers
 
                 case AwsLambdaEventType.KinesisFirehoseEvent:
                     dynamic kinesisFirehoseEvent = inputObject; //Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
+
+                    if (kinesisFirehoseEvent.Records == null)
+                    {
+                        break;
+                    }
 
                     transaction.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
                     transaction.AddEventSourceAttribute("length", (int)kinesisFirehoseEvent.Records.Count);

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -86,6 +86,11 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.SimpleEmailEvent:
                     dynamic sesEvent = inputObject; //Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
 
+                    if (sesEvent.Records == null || sesEvent.Records.Count == 0)
+                    {
+                        break;
+                    }
+
                     // arn is not available
                     transaction.AddEventSourceAttribute("length", (int)sesEvent.Records.Count);
                     transaction.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.Date);

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -96,6 +96,11 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.SNSEvent:
                     dynamic snsEvent = inputObject; //Amazon.Lambda.SNSEvents.SNSEvent
 
+                    if (snsEvent.Records == null || snsEvent.Records.Count == 0)
+                    {
+                        break;
+                    }
+
                     transaction.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
                     transaction.AddEventSourceAttribute("length", (int)snsEvent.Records.Count);
                     transaction.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -55,94 +55,82 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.KinesisStreamingEvent:
                     dynamic kinesisStreamingEvent = inputObject; //Amazon.Lambda.KinesisEvents.KinesisEvent
 
-                    if (kinesisStreamingEvent.Records == null || kinesisStreamingEvent.Records.Count == 0)
+                    if (kinesisStreamingEvent.Records != null && kinesisStreamingEvent.Records.Count > 0)
                     {
-                        break;
+                        transaction.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
+                        transaction.AddEventSourceAttribute("length", (int)kinesisStreamingEvent.Records.Count);
+                        transaction.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
                     }
-
-                    transaction.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
-                    transaction.AddEventSourceAttribute("length", (int)kinesisStreamingEvent.Records.Count);
-                    transaction.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
                     break;
 
                 case AwsLambdaEventType.KinesisFirehoseEvent:
                     dynamic kinesisFirehoseEvent = inputObject; //Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
 
-                    if (kinesisFirehoseEvent.Records == null)
+                    if (kinesisFirehoseEvent.Records != null)
                     {
-                        break;
+                        transaction.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
+                        transaction.AddEventSourceAttribute("length", (int)kinesisFirehoseEvent.Records.Count);
+                        transaction.AddEventSourceAttribute("region", (string)kinesisFirehoseEvent.Region);
                     }
-
-                    transaction.AddEventSourceAttribute("arn", (string)kinesisFirehoseEvent.DeliveryStreamArn);
-                    transaction.AddEventSourceAttribute("length", (int)kinesisFirehoseEvent.Records.Count);
-                    transaction.AddEventSourceAttribute("region", (string)kinesisFirehoseEvent.Region);
                     break;
 
                 case AwsLambdaEventType.S3Event:
                     dynamic s3Event = inputObject; //Amazon.Lambda.S3Events.S3Event
 
-                    if (s3Event.Records == null || s3Event.Records.Count == 0)
+                    if (s3Event.Records != null && s3Event.Records.Count > 0)
                     {
-                        break;
+                        transaction.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
+                        transaction.AddEventSourceAttribute("length", (int)s3Event.Records.Count);
+                        transaction.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);
+                        transaction.AddEventSourceAttribute("eventName", (string)s3Event.Records[0].EventName);
+                        transaction.AddEventSourceAttribute("eventTime", ((DateTime)s3Event.Records[0].EventTime).ToString());
+                        transaction.AddEventSourceAttribute("xAmzId2", (string)s3Event.Records[0].ResponseElements.XAmzId2);
+                        transaction.AddEventSourceAttribute("bucketName", (string)s3Event.Records[0].S3.Bucket.Name);
+                        transaction.AddEventSourceAttribute("objectKey", (string)s3Event.Records[0].S3.Object.Key);
+                        transaction.AddEventSourceAttribute("objectSequencer", (string)s3Event.Records[0].S3.Object.Sequencer);
+                        transaction.AddEventSourceAttribute("objectSize", (long)s3Event.Records[0].S3.Object.Size);
                     }
-
-                    transaction.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
-                    transaction.AddEventSourceAttribute("length", (int)s3Event.Records.Count);
-                    transaction.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);
-                    transaction.AddEventSourceAttribute("eventName", (string)s3Event.Records[0].EventName);
-                    transaction.AddEventSourceAttribute("eventTime", ((DateTime)s3Event.Records[0].EventTime).ToString());
-                    transaction.AddEventSourceAttribute("xAmzId2", (string)s3Event.Records[0].ResponseElements.XAmzId2);
-                    transaction.AddEventSourceAttribute("bucketName", (string)s3Event.Records[0].S3.Bucket.Name);
-                    transaction.AddEventSourceAttribute("objectKey", (string)s3Event.Records[0].S3.Object.Key);
-                    transaction.AddEventSourceAttribute("objectSequencer", (string)s3Event.Records[0].S3.Object.Sequencer);
-                    transaction.AddEventSourceAttribute("objectSize", (long)s3Event.Records[0].S3.Object.Size);
                     break;
 
                 case AwsLambdaEventType.SimpleEmailEvent:
                     dynamic sesEvent = inputObject; //Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent
 
-                    if (sesEvent.Records == null || sesEvent.Records.Count == 0)
+                    if (sesEvent.Records != null && sesEvent.Records.Count > 0)
                     {
-                        break;
+                        // arn is not available
+                        transaction.AddEventSourceAttribute("length", (int)sesEvent.Records.Count);
+                        transaction.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.Date);
+                        transaction.AddEventSourceAttribute("messageId", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.MessageId);
+                        transaction.AddEventSourceAttribute("returnPath", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.ReturnPath);
                     }
-
-                    // arn is not available
-                    transaction.AddEventSourceAttribute("length", (int)sesEvent.Records.Count);
-                    transaction.AddEventSourceAttribute("date", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.Date);
-                    transaction.AddEventSourceAttribute("messageId", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.MessageId);
-                    transaction.AddEventSourceAttribute("returnPath", (string)sesEvent.Records[0].Ses.Mail.CommonHeaders.ReturnPath);
                     break;
 
                 case AwsLambdaEventType.SNSEvent:
                     dynamic snsEvent = inputObject; //Amazon.Lambda.SNSEvents.SNSEvent
 
-                    if (snsEvent.Records == null || snsEvent.Records.Count == 0)
+                    if (snsEvent.Records != null && snsEvent.Records.Count > 0)
                     {
-                        break;
+                        transaction.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
+                        transaction.AddEventSourceAttribute("length", (int)snsEvent.Records.Count);
+                        transaction.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);
+                        transaction.AddEventSourceAttribute("timestamp", ((DateTime)snsEvent.Records[0].Sns.Timestamp).ToString());
+                        transaction.AddEventSourceAttribute("topicArn", (string)snsEvent.Records[0].Sns.TopicArn);
+                        transaction.AddEventSourceAttribute("type", (string)snsEvent.Records[0].Sns.Type);
+
+                        TryParseSNSDistributedTraceHeaders(snsEvent, transaction);
                     }
-
-                    transaction.AddEventSourceAttribute("arn", (string)snsEvent.Records[0].EventSubscriptionArn);
-                    transaction.AddEventSourceAttribute("length", (int)snsEvent.Records.Count);
-                    transaction.AddEventSourceAttribute("messageId", (string)snsEvent.Records[0].Sns.MessageId);
-                    transaction.AddEventSourceAttribute("timestamp", ((DateTime)snsEvent.Records[0].Sns.Timestamp).ToString());
-                    transaction.AddEventSourceAttribute("topicArn", (string)snsEvent.Records[0].Sns.TopicArn);
-                    transaction.AddEventSourceAttribute("type", (string)snsEvent.Records[0].Sns.Type);
-
-                    TryParseSNSDistributedTraceHeaders(snsEvent, transaction);
                     break;
 
                 case AwsLambdaEventType.SQSEvent:
                     dynamic sqsEvent = inputObject; //Amazon.Lambda.SQSEvents.SQSEvent
 
-                    if (sqsEvent.Records == null || sqsEvent.Records.Count == 0)
+                    if (sqsEvent.Records != null && sqsEvent.Records.Count > 0)
                     {
-                        break;
+                        transaction.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
+                        transaction.AddEventSourceAttribute("length", (int)sqsEvent.Records.Count);
+
+                        TryParseSQSDistributedTraceHeaders(sqsEvent, transaction);
                     }
-
-                    transaction.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
-                    transaction.AddEventSourceAttribute("length", (int)sqsEvent.Records.Count);
-
-                    TryParseSQSDistributedTraceHeaders(sqsEvent, transaction);
                     break;
 
                 case AwsLambdaEventType.Unknown:

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -71,6 +71,11 @@ public static class LambdaEventHelpers
                 case AwsLambdaEventType.S3Event:
                     dynamic s3Event = inputObject; //Amazon.Lambda.S3Events.S3Event
 
+                    if (s3Event.Records == null || s3Event.Records.Count == 0)
+                    {
+                        break;
+                    }
+
                     transaction.AddEventSourceAttribute("arn", (string)s3Event.Records[0].S3.Bucket.Arn);
                     transaction.AddEventSourceAttribute("length", (int)s3Event.Records.Count);
                     transaction.AddEventSourceAttribute("region", (string)s3Event.Records[0].AwsRegion);

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -411,6 +411,66 @@ public class LambdaEventHelpersTests
         });
     }
 
+    [Test]
+    public void AddEventTypeAttributes_S3Event_HandlesNullRecords()
+    {
+        // Arrange
+        var eventTime = DateTime.UtcNow;
+        var eventType = AwsLambdaEventType.S3Event;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.S3Events.S3Event
+        {
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.region"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.eventName"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.eventTime"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.xAmzId2"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.bucketName"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectKey"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectSequencer"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectSize"), Is.False);
+        });
+    }
+
+    [Test]
+    public void AddEventTypeAttributes_S3Event_HandlesEmptyRecords()
+    {
+        // Arrange
+        var eventTime = DateTime.UtcNow;
+        var eventType = AwsLambdaEventType.S3Event;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.S3Events.S3Event
+        {
+            Records = []
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.region"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.eventName"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.eventTime"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.xAmzId2"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.bucketName"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectKey"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectSequencer"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.objectSize"), Is.False);
+        });
+    }
+
     // SimpleEmailEvent
     [Test]
     public void AddEventTypeAttributes_SimpleEmailEvent_AddsCorrectAttributes()

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -332,6 +332,50 @@ public class LambdaEventHelpersTests
         });
     }
 
+    [Test]
+    public void AddEventTypeAttributes_KinesisStreamingEvent_HandlesNullRecords()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.KinesisStreamingEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.KinesisEvents.KinesisEvent
+        {
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.region"), Is.False);
+        });
+    }
+
+    [Test]
+    public void AddEventTypeAttributes_KinesisStreamingEvent_HandlesEmptyRecords()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.KinesisStreamingEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.KinesisEvents.KinesisEvent
+        {
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.region"), Is.False);
+        });
+    }
+
     // KinesisFirehoseEvent
     [Test]
     public void AddEventTypeAttributes_KinesisFirehoseEvent_AddsCorrectAttributes()
@@ -357,6 +401,30 @@ public class LambdaEventHelpersTests
             Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testDeliveryStreamArn"));
             Assert.That(_attributes["aws.lambda.eventSource.region"], Is.EqualTo("testRegion"));
             Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AddEventTypeAttributes_KinesisFirehoseEvent_HandlesNullRecords()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.KinesisFirehoseEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent
+        {
+            DeliveryStreamArn = "testDeliveryStreamArn",
+            Region = "testRegion",
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.region"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
         });
     }
 

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -448,6 +448,52 @@ public class LambdaEventHelpersTests
         });
     }
 
+    [Test]
+    public void AddEventTypeAttributes_SimpleEmailEvent_HandlesNullRecords()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.SimpleEmailEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent<NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.MockReceiptAction>
+        {
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.date"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.messageId"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.returnPath"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+        });
+    }
+
+    [Test]
+    public void AddEventTypeAttributes_SimpleEmailEvent_HandlesEmptyRecords()
+    {
+        // Arrange
+        var eventType = AwsLambdaEventType.SimpleEmailEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.SimpleEmailEvent<NewRelic.Mock.Amazon.Lambda.SimpleEmailEvents.MockReceiptAction>
+        {
+            Records = []
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.date"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.messageId"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.returnPath"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+        });
+    }
+
     // SNSEvent
     [Test]
     public void AddEventTypeAttributes_SNSEvent_AddsCorrectAttributes()

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -489,6 +489,62 @@ public class LambdaEventHelpersTests
         });
     }
 
+    [Test]
+    public void AddEventTypeAttributes_SNSEvent_HandlesNullRecords()
+    {
+        // Arrange
+        var testTimestamp = DateTime.UtcNow;
+        var eventType = AwsLambdaEventType.SNSEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SNSEvents.SNSEvent
+        {
+            Records = null
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.messageId"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.timestamp"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.topicArn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.type"), Is.False);
+
+            Mock.Assert(() => _transaction.AcceptDistributedTraceHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, IEnumerable<string>>>(), TransportType.Other), Occurs.Never());
+        });
+    }
+
+    [Test]
+    public void AddEventTypeAttributes_SNSEvent_HandlesEmptyRecords()
+    {
+        // Arrange
+        var testTimestamp = DateTime.UtcNow;
+        var eventType = AwsLambdaEventType.SNSEvent;
+        var inputObject = new NewRelic.Mock.Amazon.Lambda.SNSEvents.SNSEvent
+        {
+            Records = []
+        };
+
+        // Act
+        LambdaEventHelpers.AddEventTypeAttributes(_agent, _transaction, eventType, inputObject);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.arn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.messageId"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.length"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.timestamp"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.topicArn"), Is.False);
+            Assert.That(_attributes.ContainsKey("aws.lambda.eventSource.type"), Is.False);
+
+            Mock.Assert(() => _transaction.AcceptDistributedTraceHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, IEnumerable<string>>>(), TransportType.Other), Occurs.Never());
+        });
+    }
+
     // SQSEvent
     [TestCase(TracingTestCase.Newrelic)]
     [TestCase(TracingTestCase.W3C)]


### PR DESCRIPTION
Adds more guard code and associated unit tests, checking for null/empty `.Records` properties in applicable event types.