### PR TITLE
Test and fix data collected for kinesis firehose and streams.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
@@ -15,6 +15,7 @@ public static class AwsLambdaEventTypeExtensions
             "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest" => AwsLambdaEventType.ApplicationLoadBalancerRequest,
             "Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent" => AwsLambdaEventType.CloudWatchScheduledEvent,
             "Amazon.Lambda.KinesisEvents.KinesisEvent" => AwsLambdaEventType.KinesisStreamingEvent,
+            "Amazon.Lambda.KinesisEvents.KinesisTimeWindowEvent" => AwsLambdaEventType.KinesisStreamingEvent,
             "Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent" => AwsLambdaEventType.KinesisFirehoseEvent,
             "Amazon.Lambda.SNSEvents.SNSEvent" => AwsLambdaEventType.SNSEvent,
             "Amazon.Lambda.S3Events.S3Event" => AwsLambdaEventType.S3Event,

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -61,7 +61,7 @@ public static class LambdaEventHelpers
 
                     if (kinesisStreamingEvent.Records != null && kinesisStreamingEvent.Records.Count > 0)
                     {
-                        transaction.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceArn);
+                        transaction.AddEventSourceAttribute("arn", (string)kinesisStreamingEvent.Records[0].EventSourceARN);
                         transaction.AddEventSourceAttribute("length", (int)kinesisStreamingEvent.Records.Count);
                         transaction.AddEventSourceAttribute("region", (string)kinesisStreamingEvent.Records[0].AwsRegion);
                     }

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.CloudWatchEvents" Version="4.4.0" />
     <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.1" />
+    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.0" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
@@ -6,6 +6,8 @@ using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using Amazon.Lambda.CloudWatchEvents.ScheduledEvents;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.DynamoDBEvents;
+using Amazon.Lambda.KinesisEvents;
+using Amazon.Lambda.KinesisFirehoseEvents;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.S3Events;
 using Amazon.Lambda.Serialization.SystemTextJson;
@@ -86,6 +88,18 @@ namespace LambdaSelfExecutingAssembly
                     return HandlerWrapper.GetHandlerWrapper<ScheduledEvent>(ScheduledCloudWatchEventHandler, serializer);
                 case nameof(ScheduledCloudWatchEventHandlerAsync):
                     return HandlerWrapper.GetHandlerWrapper<ScheduledEvent>(ScheduledCloudWatchEventHandlerAsync, serializer);
+                case nameof(KinesisFirehoseEventHandler):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisFirehoseEvent, KinesisFirehoseResponse>(KinesisFirehoseEventHandler, serializer);
+                case nameof(KinesisFirehoseEventHandlerAsync):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisFirehoseEvent, KinesisFirehoseResponse>(KinesisFirehoseEventHandlerAsync, serializer);
+                case nameof(KinesisEventHandler):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisEvent>(KinesisEventHandler, serializer);
+                case nameof(KinesisEventHandlerAsync):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisEvent>(KinesisEventHandlerAsync, serializer);
+                case nameof(KinesisTimeWindowEventHandler):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisTimeWindowEvent>(KinesisTimeWindowEventHandler, serializer);
+                case nameof(KinesisTimeWindowEventHandlerAsync):
+                    return HandlerWrapper.GetHandlerWrapper<KinesisTimeWindowEvent>(KinesisTimeWindowEventHandlerAsync, serializer);
                 default:
                     return null;
             }
@@ -267,6 +281,76 @@ namespace LambdaSelfExecutingAssembly
         public static async Task ScheduledCloudWatchEventHandlerAsync(ScheduledEvent _, ILambdaContext __)
         {
             Console.WriteLine("Executing lambda {0}", nameof(ScheduledCloudWatchEventHandlerAsync));
+            await Task.Delay(100);
+        }
+
+        public static KinesisFirehoseResponse KinesisFirehoseEventHandler(KinesisFirehoseEvent evnt,  ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisFirehoseEventHandler));
+
+            var response = new KinesisFirehoseResponse
+            {
+                Records = new List<KinesisFirehoseResponse.FirehoseRecord>()
+            };
+
+            foreach (var record in evnt.Records)
+            {
+                var transformedRecord = new KinesisFirehoseResponse.FirehoseRecord
+                {
+                    RecordId = record.RecordId,
+                    Result = KinesisFirehoseResponse.TRANSFORMED_STATE_OK
+                };
+                transformedRecord.EncodeData(record.DecodeData().ToUpperInvariant());
+
+                response.Records.Add(transformedRecord);
+            }
+
+            return response;
+        }
+
+        public static async Task<KinesisFirehoseResponse> KinesisFirehoseEventHandlerAsync(KinesisFirehoseEvent evnt, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisFirehoseEventHandlerAsync));
+
+            var response = new KinesisFirehoseResponse
+            {
+                Records = new List<KinesisFirehoseResponse.FirehoseRecord>()
+            };
+
+            foreach (var record in evnt.Records)
+            {
+                var transformedRecord = new KinesisFirehoseResponse.FirehoseRecord
+                {
+                    RecordId = record.RecordId,
+                    Result = KinesisFirehoseResponse.TRANSFORMED_STATE_OK
+                };
+                transformedRecord.EncodeData(record.DecodeData().ToUpperInvariant());
+
+                response.Records.Add(transformedRecord);
+            }
+
+            return await Task.FromResult(response);
+        }
+
+        public static void KinesisEventHandler(KinesisEvent _,  ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisEventHandler));
+        }
+
+        public static async Task KinesisEventHandlerAsync(KinesisEvent _, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisEventHandlerAsync));
+            await Task.Delay(100);
+        }
+
+        public static void KinesisTimeWindowEventHandler(KinesisTimeWindowEvent _, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisEventHandler));
+        }
+
+        public static async Task KinesisTimeWindowEventHandlerAsync(KinesisTimeWindowEvent _, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(KinesisEventHandlerAsync));
             await Task.Delay(100);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisEventTest.cs
@@ -1,0 +1,145 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.AwsLambda
+{
+    [NetCoreTest]
+    public abstract class AwsLambdaKinesisEventTest<T> : NewRelicIntegrationTest<T> where T : LambdaKinesisEventTriggerFixtureBase
+    {
+        private readonly LambdaKinesisEventTriggerFixtureBase _fixture;
+        private readonly string _expectedTransactionName;
+
+        protected AwsLambdaKinesisEventTest(T fixture, ITestOutputHelper output, string expectedTransactionName)
+            : base(fixture)
+        {
+            _expectedTransactionName = expectedTransactionName;
+
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions(
+                exerciseApplication: () =>
+                {
+                    _fixture.EnqueueEvent();
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                }
+                );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
+
+            Assert.Multiple(
+                () => Assert.Single(serverlessPayloads),
+                () => ValidateServerlessPayload(serverlessPayloads[0]),
+                () => Assert.All(serverlessPayloads, ValidateTraceHasNoParent)
+                );
+        }
+
+        private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.arn", "arn:aws:kinesis:us-east-2:111122223333:stream/lambda-stream" },
+                { "aws.lambda.eventSource.eventType", "kinesis" },
+                { "aws.lambda.eventSource.length", 1 },
+                { "aws.lambda.eventSource.region", "us-east-2" }
+            };
+
+            Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
+        }
+
+        private void ValidateTraceHasNoParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == _expectedTransactionName);
+
+            Assertions.SpanEventDoesNotHaveAttributes(["parentId"], SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+    }
+
+    public class AwsLambdaKinesisEventTestNet6 : AwsLambdaKinesisEventTest<LambdaKinesisEventTriggerFixtureNet6>
+    {
+        public AwsLambdaKinesisEventTestNet6(LambdaKinesisEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisEventTestNet6 : AwsLambdaKinesisEventTest<AsyncLambdaKinesisEventTriggerFixtureNet6>
+    {
+        public AwsLambdaAsyncKinesisEventTestNet6(AsyncLambdaKinesisEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisEventAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaKinesisEventTestNet8 : AwsLambdaKinesisEventTest<LambdaKinesisEventTriggerFixtureNet8>
+    {
+        public AwsLambdaKinesisEventTestNet8(LambdaKinesisEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisEventTestNet8 : AwsLambdaKinesisEventTest<AsyncLambdaKinesisEventTriggerFixtureNet8>
+    {
+        public AwsLambdaAsyncKinesisEventTestNet8(AsyncLambdaKinesisEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisEventAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaKinesisTimeWindowEventTestNet6 : AwsLambdaKinesisEventTest<LambdaKinesisTimeWindowEventTriggerFixtureNet6>
+    {
+        public AwsLambdaKinesisTimeWindowEventTestNet6(LambdaKinesisTimeWindowEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisTimeWindowEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisTimeWindowEventTestNet6 : AwsLambdaKinesisEventTest<AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet6>
+    {
+        public AwsLambdaAsyncKinesisTimeWindowEventTestNet6(AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisTimeWindowEventAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaKinesisTimeWindowEventTestNet8 : AwsLambdaKinesisEventTest<LambdaKinesisTimeWindowEventTriggerFixtureNet8>
+    {
+        public AwsLambdaKinesisTimeWindowEventTestNet8(LambdaKinesisTimeWindowEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisTimeWindowEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisTimeWindowEventTestNet8 : AwsLambdaKinesisEventTest<AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet8>
+    {
+        public AwsLambdaAsyncKinesisTimeWindowEventTestNet8(AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisTimeWindowEventAsync")
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisFirehoseEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaKinesisFirehoseEventTest.cs
@@ -1,0 +1,113 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.Models;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.AwsLambda
+{
+    [NetCoreTest]
+    public abstract class AwsLambdaKinesisFirehoseEventTest<T> : NewRelicIntegrationTest<T> where T : LambdaKinesisFirehoseEventTriggerFixtureBase
+    {
+        private readonly LambdaKinesisFirehoseEventTriggerFixtureBase _fixture;
+        private readonly string _expectedTransactionName;
+
+        protected AwsLambdaKinesisFirehoseEventTest(T fixture, ITestOutputHelper output, string expectedTransactionName)
+            : base(fixture)
+        {
+            _expectedTransactionName = expectedTransactionName;
+
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions(
+                exerciseApplication: () =>
+                {
+                    _fixture.EnqueueEvent();
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                }
+                );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
+
+            Assert.Multiple(
+                () => Assert.Single(serverlessPayloads),
+                () => ValidateServerlessPayload(serverlessPayloads[0]),
+                () => Assert.All(serverlessPayloads, ValidateTraceHasNoParent)
+                );
+        }
+
+        private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.arn", "aws:lambda:events" },
+                { "aws.lambda.eventSource.eventType", "firehose" },
+                { "aws.lambda.eventSource.length", 2 },
+                { "aws.lambda.eventSource.region", "us-west-2" }
+            };
+
+            Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
+        }
+
+        private void ValidateTraceHasNoParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == _expectedTransactionName);
+
+            Assertions.SpanEventDoesNotHaveAttributes(["parentId"], SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+    }
+
+    public class AwsLambdaKinesisFirehoseEventTestNet6 : AwsLambdaKinesisFirehoseEventTest<LambdaKinesisFirehoseEventTriggerFixtureNet6>
+    {
+        public AwsLambdaKinesisFirehoseEventTestNet6(LambdaKinesisFirehoseEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisFirehoseEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisFirehoseEventTestNet6 : AwsLambdaKinesisFirehoseEventTest<AsyncLambdaKinesisFirehoseEventTriggerFixtureNet6>
+    {
+        public AwsLambdaAsyncKinesisFirehoseEventTestNet6(AsyncLambdaKinesisFirehoseEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisFirehoseEventAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaKinesisFirehoseEventTestNet8 : AwsLambdaKinesisFirehoseEventTest<LambdaKinesisFirehoseEventTriggerFixtureNet8>
+    {
+        public AwsLambdaKinesisFirehoseEventTestNet8(LambdaKinesisFirehoseEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisFirehoseEvent")
+        {
+        }
+    }
+
+    public class AwsLambdaAsyncKinesisFirehoseEventTestNet8 : AwsLambdaKinesisFirehoseEventTest<AsyncLambdaKinesisFirehoseEventTriggerFixtureNet8>
+    {
+        public AwsLambdaAsyncKinesisFirehoseEventTestNet8(AsyncLambdaKinesisFirehoseEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "OtherTransaction/Lambda/KinesisFirehoseEventAsync")
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaKinesisEventTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaKinesisEventTriggerFixture.cs
@@ -1,0 +1,88 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
+{
+    public abstract class LambdaKinesisEventTriggerFixtureBase : LambdaSelfExecutingAssemblyFixture
+    {
+        private static string GetEventName(bool usesTimeWindow) => $"Kinesis{(usesTimeWindow ? "TimeWindow" : "")}Event";
+
+        protected LambdaKinesisEventTriggerFixtureBase(string targetFramework, bool isAsync, bool usesTimeWindow) :
+            base(targetFramework,
+                null,
+                $"LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::{GetEventName(usesTimeWindow)}Handler" + (isAsync ? "Async" : ""),
+                GetEventName(usesTimeWindow) + (isAsync ? "Async" : ""),
+                null)
+        {
+        }
+
+        // This event json works for both the normal Kinesis and the KinesisTimeWindowEvent.
+        // If we need data specifically defined in the KinesisTimeWindowEvent we can update the tests to separate
+        // the two events.
+        public void EnqueueEvent()
+        {
+            var eventJson = @"{
+    ""Records"": [
+        {
+            ""kinesis"": {
+                ""kinesisSchemaVersion"": ""1.0"",
+                ""partitionKey"": ""1"",
+                ""sequenceNumber"": ""49590338271490256608559692538361571095921575989136588898"",
+                ""data"": ""SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg=="",
+                ""approximateArrivalTimestamp"": 1545084650.987
+            },
+            ""eventSource"": ""aws:kinesis"",
+            ""eventVersion"": ""1.0"",
+            ""eventID"": ""shardId-000000000006:49590338271490256608559692538361571095921575989136588898"",
+            ""eventName"": ""aws:kinesis:record"",
+            ""invokeIdentityArn"": ""arn:aws:iam::111122223333:role/lambda-kinesis-role"",
+            ""awsRegion"": ""us-east-2"",
+            ""eventSourceARN"": ""arn:aws:kinesis:us-east-2:111122223333:stream/lambda-stream""
+        }
+    ]
+}";
+            EnqueueLambdaEvent(eventJson);
+        }
+    }
+
+    public class LambdaKinesisEventTriggerFixtureNet6 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public LambdaKinesisEventTriggerFixtureNet6() : base("net6.0", false, false) { }
+    }
+
+    public class AsyncLambdaKinesisEventTriggerFixtureNet6 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisEventTriggerFixtureNet6() : base("net6.0", true, false) { }
+    }
+
+    public class LambdaKinesisEventTriggerFixtureNet8 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public LambdaKinesisEventTriggerFixtureNet8() : base("net8.0", false, false) { }
+    }
+
+    public class AsyncLambdaKinesisEventTriggerFixtureNet8 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisEventTriggerFixtureNet8() : base("net8.0", true, false) { }
+    }
+
+    public class LambdaKinesisTimeWindowEventTriggerFixtureNet6 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public LambdaKinesisTimeWindowEventTriggerFixtureNet6() : base("net6.0", false, true) { }
+    }
+
+    public class AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet6 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet6() : base("net6.0", true, true) { }
+    }
+
+    public class LambdaKinesisTimeWindowEventTriggerFixtureNet8 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public LambdaKinesisTimeWindowEventTriggerFixtureNet8() : base("net8.0", false, true) { }
+    }
+
+    public class AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet8 : LambdaKinesisEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisTimeWindowEventTriggerFixtureNet8() : base("net8.0", true, true) { }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaKinesisFirehoseEventTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaKinesisFirehoseEventTriggerFixture.cs
@@ -1,0 +1,74 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
+{
+    public abstract class LambdaKinesisFirehoseEventTriggerFixtureBase : LambdaSelfExecutingAssemblyFixture
+    {
+        protected LambdaKinesisFirehoseEventTriggerFixtureBase(string targetFramework, bool isAsync) :
+            base(targetFramework,
+                null,
+                "LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::KinesisFirehoseEventHandler" + (isAsync ? "Async" : ""),
+                "KinesisFirehoseEvent" + (isAsync ? "Async" : ""),
+                null)
+        {
+        }
+
+        public void EnqueueEvent()
+        {
+            var eventJson = @"{
+  ""invocationId"": ""invoked123"",
+  ""deliveryStreamArn"": ""aws:lambda:events"",
+  ""region"": ""us-west-2"",
+  ""records"": [
+    {
+      ""data"": ""SGVsbG8gV29ybGQ="",
+      ""recordId"": ""record1"",
+      ""approximateArrivalTimestamp"": 1510772160000,
+      ""kinesisRecordMetadata"": {
+        ""shardId"": ""shardId-000000000000"",
+        ""partitionKey"": ""4d1ad2b9-24f8-4b9d-a088-76e9947c317a"",
+        ""approximateArrivalTimestamp"": ""2012-04-23T18:25:43.511Z"",
+        ""sequenceNumber"": ""49546986683135544286507457936321625675700192471156785154"",
+        ""subsequenceNumber"": """"
+      }
+    },
+    {
+      ""data"": ""SGVsbG8gV29ybGQ="",
+      ""recordId"": ""record2"",
+      ""approximateArrivalTimestamp"": 151077216000,
+      ""kinesisRecordMetadata"": {
+        ""shardId"": ""shardId-000000000001"",
+        ""partitionKey"": ""4d1ad2b9-24f8-4b9d-a088-76e9947c318a"",
+        ""approximateArrivalTimestamp"": ""2012-04-23T19:25:43.511Z"",
+        ""sequenceNumber"": ""49546986683135544286507457936321625675700192471156785155"",
+        ""subsequenceNumber"": """"
+      }
+    }
+  ]
+}";
+            EnqueueLambdaEvent(eventJson);
+        }
+    }
+
+    public class LambdaKinesisFirehoseEventTriggerFixtureNet6 : LambdaKinesisFirehoseEventTriggerFixtureBase
+    {
+        public LambdaKinesisFirehoseEventTriggerFixtureNet6() : base("net6.0", false) { }
+    }
+
+    public class AsyncLambdaKinesisFirehoseEventTriggerFixtureNet6 : LambdaKinesisFirehoseEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisFirehoseEventTriggerFixtureNet6() : base("net6.0", true) { }
+    }
+
+    public class LambdaKinesisFirehoseEventTriggerFixtureNet8 : LambdaKinesisFirehoseEventTriggerFixtureBase
+    {
+        public LambdaKinesisFirehoseEventTriggerFixtureNet8() : base("net8.0", false) { }
+    }
+
+    public class AsyncLambdaKinesisFirehoseEventTriggerFixtureNet8 : LambdaKinesisFirehoseEventTriggerFixtureBase
+    {
+        public AsyncLambdaKinesisFirehoseEventTriggerFixtureNet8() : base("net8.0", true) { }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
@@ -13,6 +13,7 @@ namespace Agent.Extensions.Tests.Lambda
         [TestCase("Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest", AwsLambdaEventType.ApplicationLoadBalancerRequest)]
         [TestCase("Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent", AwsLambdaEventType.CloudWatchScheduledEvent)]
         [TestCase("Amazon.Lambda.KinesisEvents.KinesisEvent", AwsLambdaEventType.KinesisStreamingEvent)]
+        [TestCase("Amazon.Lambda.KinesisEvents.KinesisTimeWindowEvent", AwsLambdaEventType.KinesisStreamingEvent)]
         [TestCase("Amazon.Lambda.KinesisFirehoseEvents.KinesisFirehoseEvent", AwsLambdaEventType.KinesisFirehoseEvent)]
         [TestCase("Amazon.Lambda.SNSEvents.SNSEvent", AwsLambdaEventType.SNSEvent)]
         [TestCase("Amazon.Lambda.S3Events.S3Event", AwsLambdaEventType.S3Event)]

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -443,7 +443,7 @@ public class LambdaEventHelpersTests
         {
             Records =
             [
-                new() { EventSourceArn = "testArn", AwsRegion = "testRegion" }
+                new() { EventSourceARN = "testArn", AwsRegion = "testRegion" }
             ]
         };
 

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonKinesisEventsModel.cs
@@ -14,7 +14,7 @@ namespace NewRelic.Mock.Amazon.Lambda.KinesisEvents
 
         public class KinesisEventRecord
         {
-            public string EventSourceArn { get; set; }
+            public string EventSourceARN { get; set; }
             public string AwsRegion { get; set; }
         }
     }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Adds integration tests for kinesis streams and firehose lambda event triggers, and fixes the bugs in their current implementation.

For now the KinesisTimeWindowEvents are tested with json from the simpler KinesisEvent, because we do not extract any details from the additional properties.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
