### PR TITLE
Lambda - Add tests for `Stream` return type

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
     <PackageReference Include="Amazon.Lambda.SimpleEmailEvents" Version="3.1.0" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using Amazon.Lambda.CloudWatchEvents.ScheduledEvents;
@@ -13,6 +14,7 @@ using Amazon.Lambda.SimpleEmailEvents;
 using Amazon.Lambda.SimpleEmailEvents.Actions;
 using Amazon.Lambda.SNSEvents;
 using ApplicationLifecycle;
+using Newtonsoft.Json;
 
 namespace LambdaSelfExecutingAssembly
 {
@@ -78,10 +80,18 @@ namespace LambdaSelfExecutingAssembly
                     return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, APIGatewayProxyResponse>(ApiGatewayProxyRequestHandler, serializer);
                 case nameof(ApiGatewayProxyRequestHandlerAsync):
                     return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, APIGatewayProxyResponse>(ApiGatewayProxyRequestHandlerAsync, serializer);
+                case nameof (ApiGatewayProxyRequestHandlerReturnsStream):
+                    return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, Stream>(ApiGatewayProxyRequestHandlerReturnsStream, serializer);
+                case nameof (ApiGatewayProxyRequestHandlerReturnsStreamAsync):
+                    return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, Stream>(ApiGatewayProxyRequestHandlerReturnsStreamAsync, serializer);
                 case nameof(ApplicationLoadBalancerRequestHandler):
                     return HandlerWrapper.GetHandlerWrapper<ApplicationLoadBalancerRequest, ApplicationLoadBalancerResponse>(ApplicationLoadBalancerRequestHandler, serializer);
                 case nameof(ApplicationLoadBalancerRequestHandlerAsync):
                     return HandlerWrapper.GetHandlerWrapper<ApplicationLoadBalancerRequest, ApplicationLoadBalancerResponse>(ApplicationLoadBalancerRequestHandlerAsync, serializer);
+                case nameof(ApplicationLoadBalancerRequestHandlerReturnsStream):
+                    return HandlerWrapper.GetHandlerWrapper<ApplicationLoadBalancerRequest, Stream>(ApplicationLoadBalancerRequestHandlerReturnsStream, serializer);
+                case nameof(ApplicationLoadBalancerRequestHandlerReturnsStreamAsync):
+                    return HandlerWrapper.GetHandlerWrapper<ApplicationLoadBalancerRequest, Stream>(ApplicationLoadBalancerRequestHandlerReturnsStreamAsync, serializer);
                 case nameof(ScheduledCloudWatchEventHandler):
                     return HandlerWrapper.GetHandlerWrapper<ScheduledEvent>(ScheduledCloudWatchEventHandler, serializer);
                 case nameof(ScheduledCloudWatchEventHandlerAsync):
@@ -231,14 +241,37 @@ namespace LambdaSelfExecutingAssembly
 
         public static APIGatewayProxyResponse ApiGatewayProxyRequestHandler(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
         {
-            Console.WriteLine("Executing lambda {0}", nameof(APIGatewayProxyRequest));
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandler));
 
             return new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
         }
 
+        public static Stream ApiGatewayProxyRequestHandlerReturnsStream(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerReturnsStream));
+
+            var response = new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+            var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+            var stream = new MemoryStream(bytes);
+            return stream;
+        }
+
+        public static async Task<Stream> ApiGatewayProxyRequestHandlerReturnsStreamAsync(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerReturnsStreamAsync));
+
+            await Task.Delay(100);
+
+            var response = new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+            var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+            var stream = new MemoryStream(bytes);
+
+            return stream;
+        }
+
         public static async Task<APIGatewayProxyResponse> ApiGatewayProxyRequestHandlerAsync(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
         {
-            Console.WriteLine("Executing lambda {0}", nameof(APIGatewayProxyRequest));
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerAsync));
             await Task.Delay(100);
 
             return new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
@@ -246,17 +279,40 @@ namespace LambdaSelfExecutingAssembly
 
         public static ApplicationLoadBalancerResponse ApplicationLoadBalancerRequestHandler(ApplicationLoadBalancerRequest applicationLoadBalancerRequest, ILambdaContext __)
         {
-            Console.WriteLine("Executing lambda {0}", nameof(applicationLoadBalancerRequest));
+            Console.WriteLine("Executing lambda {0}", nameof(ApplicationLoadBalancerRequestHandler));
 
             return new ApplicationLoadBalancerResponse() { Body = applicationLoadBalancerRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
         }
 
         public static async Task<ApplicationLoadBalancerResponse> ApplicationLoadBalancerRequestHandlerAsync(ApplicationLoadBalancerRequest applicationLoadBalancerRequest, ILambdaContext __)
         {
-            Console.WriteLine("Executing lambda {0}", nameof(applicationLoadBalancerRequest));
+            Console.WriteLine("Executing lambda {0}", nameof(ApplicationLoadBalancerRequestHandlerAsync));
             await Task.Delay(100);
 
             return new ApplicationLoadBalancerResponse() { Body = applicationLoadBalancerRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+        }
+
+        public static Stream ApplicationLoadBalancerRequestHandlerReturnsStream(ApplicationLoadBalancerRequest applicationLoadBalancerRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApplicationLoadBalancerRequestHandlerReturnsStream));
+
+            var response = new ApplicationLoadBalancerResponse() { Body = applicationLoadBalancerRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+            var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+            var stream = new MemoryStream(bytes);
+
+            return stream;
+        }
+
+        public static async Task<Stream> ApplicationLoadBalancerRequestHandlerReturnsStreamAsync(ApplicationLoadBalancerRequest applicationLoadBalancerRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApplicationLoadBalancerRequestHandlerReturnsStreamAsync));
+            await Task.Delay(100);
+
+            var response = new ApplicationLoadBalancerResponse() { Body = applicationLoadBalancerRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+            var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response));
+            var stream = new MemoryStream(bytes);
+
+            return stream;
         }
 
         public static void ScheduledCloudWatchEventHandler(ScheduledEvent _, ILambdaContext __)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
@@ -151,4 +151,35 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda
         {
         }
     }
+
+    public class AwsLambdaAPIGatewayProxyRequestReturnsStreamTestNet6 : AwsLambdaAPIGatewayProxyRequestTest<LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6>
+    {
+        public AwsLambdaAPIGatewayProxyRequestReturnsStreamTestNet6(LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayProxyRequestHandlerReturnsStream")
+        {
+        }
+    }
+
+    public class AwsLambdaAPIGatewayProxyRequestReturnsStreamTestNet8 : AwsLambdaAPIGatewayProxyRequestTest<LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8>
+    {
+        public AwsLambdaAPIGatewayProxyRequestReturnsStreamTestNet8(LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayProxyRequestHandlerReturnsStream")
+        {
+        }
+    }
+    public class AwsLambdaAPIGatewayProxyRequestReturnsStreamTestAsyncNet6 : AwsLambdaAPIGatewayProxyRequestTest<AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6>
+    {
+        public AwsLambdaAPIGatewayProxyRequestReturnsStreamTestAsyncNet6(AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayProxyRequestHandlerReturnsStreamAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaAPIGatewayProxyRequestReturnsStreamTestAsyncNet8 : AwsLambdaAPIGatewayProxyRequestTest<AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8>
+    {
+        public AwsLambdaAPIGatewayProxyRequestReturnsStreamTestAsyncNet8(AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayProxyRequestHandlerReturnsStreamAsync")
+        {
+        }
+    }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaApplicationLoadBalancerRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaApplicationLoadBalancerRequestTest.cs
@@ -139,4 +139,35 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda
         {
         }
     }
+
+    public class AwsLambdaApplicationLoadBalancerRequestReturnsStreamTestNet6 : AwsLambdaApplicationLoadBalancerRequestTest<LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6>
+    {
+        public AwsLambdaApplicationLoadBalancerRequestReturnsStreamTestNet6(LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApplicationLoadBalancerRequestHandlerReturnsStream")
+        {
+        }
+    }
+
+    public class AwsLambdaApplicationLoadBalancerRequestReturnsStreamTestNet8 : AwsLambdaApplicationLoadBalancerRequestTest<LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8>
+    {
+        public AwsLambdaApplicationLoadBalancerRequestReturnsStreamTestNet8(LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApplicationLoadBalancerRequestHandlerReturnsStream")
+        {
+        }
+    }
+    public class AwsLambdaApplicationLoadBalancerRequestReturnsStreamAsyncTestNet6 : AwsLambdaApplicationLoadBalancerRequestTest<AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6>
+    {
+        public AwsLambdaApplicationLoadBalancerRequestReturnsStreamAsyncTestNet6(AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApplicationLoadBalancerRequestHandlerReturnsStreamAsync")
+        {
+        }
+    }
+
+    public class AwsLambdaApplicationLoadBalancerRequestReturnsStreamAsyncTestNet8 : AwsLambdaApplicationLoadBalancerRequestTest<AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8>
+    {
+        public AwsLambdaApplicationLoadBalancerRequestReturnsStreamAsyncTestNet8(AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApplicationLoadBalancerRequestHandlerReturnsStreamAsync")
+        {
+        }
+    }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
@@ -13,11 +13,11 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
             return "LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::ApiGatewayProxyRequestHandler" + (isAsync ? "Async" : "");
         }
 
-        protected LambdaAPIGatewayProxyRequestTriggerFixtureBase(string targetFramework, bool isAsync) :
+        protected LambdaAPIGatewayProxyRequestTriggerFixtureBase(string targetFramework, bool isAsync, bool returnsStream) :
             base(targetFramework,
                 null,
                 GetHandlerString(isAsync),
-                "ApiGatewayProxyRequestHandler" + (isAsync ? "Async" : ""),
+                "ApiGatewayProxyRequestHandler" + (returnsStream ? "ReturnsStream" : "") + (isAsync ? "Async" : ""),
                 null)
         {
         }
@@ -155,21 +155,41 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
 
     public class LambdaAPIGatewayProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
     {
-        public LambdaAPIGatewayProxyRequestTriggerFixtureNet6() : base("net6.0", false) { }
+        public LambdaAPIGatewayProxyRequestTriggerFixtureNet6() : base("net6.0", false, false) { }
     }
 
     public class AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
     {
-        public AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet6() : base("net6.0", true) { }
+        public AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet6() : base("net6.0", true, false) { }
     }
 
     public class LambdaAPIGatewayProxyRequestTriggerFixtureNet8 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
     {
-        public LambdaAPIGatewayProxyRequestTriggerFixtureNet8() : base("net8.0", false) { }
+        public LambdaAPIGatewayProxyRequestTriggerFixtureNet8() : base("net8.0", false, false) { }
     }
 
     public class AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet8 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
     {
-        public AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet8() : base("net8.0", true) { }
+        public AsyncLambdaAPIGatewayProxyRequestTriggerFixtureNet8() : base("net8.0", true, false) { }
+    }
+
+    public class LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
+    {
+        public LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6() : base("net6.0", false, true) { }
+    }
+
+    public class AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
+    {
+        public AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet6() : base("net6.0", true, true) { }
+    }
+
+    public class LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
+    {
+        public LambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8() : base("net8.0", false, true) { }
+    }
+
+    public class AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8 : LambdaAPIGatewayProxyRequestTriggerFixtureBase
+    {
+        public AsyncLambdaAPIGatewayProxyRequestReturnsStreamTriggerFixtureNet8() : base("net8.0", true, true) { }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaApplicationLoadBalancerRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaApplicationLoadBalancerRequestTriggerFixture.cs
@@ -13,11 +13,11 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
             return "LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::ApplicationLoadBalancerRequestHandler" + (isAsync ? "Async" : "");
         }
 
-        protected LambdaApplicationLoadBalancerRequestTriggerFixtureBase(string targetFramework, bool isAsync) :
+        protected LambdaApplicationLoadBalancerRequestTriggerFixtureBase(string targetFramework, bool isAsync, bool returnsStream) :
             base(targetFramework,
                 null,
                 GetHandlerString(isAsync),
-                "ApplicationLoadBalancerRequestHandler" + (isAsync ? "Async" : ""),
+                "ApplicationLoadBalancerRequestHandler" + (returnsStream ? "ReturnsStream" : "") + (isAsync ? "Async" : ""),
                 null)
         {
         }
@@ -97,21 +97,41 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
 
     public class LambdaApplicationLoadBalancerRequestTriggerFixtureNet6 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
     {
-        public LambdaApplicationLoadBalancerRequestTriggerFixtureNet6() : base("net6.0", false) { }
+        public LambdaApplicationLoadBalancerRequestTriggerFixtureNet6() : base("net6.0", false, false) { }
     }
 
     public class AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet6 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
     {
-        public AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet6() : base("net6.0", true) { }
+        public AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet6() : base("net6.0", true, false) { }
     }
 
     public class LambdaApplicationLoadBalancerRequestTriggerFixtureNet8 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
     {
-        public LambdaApplicationLoadBalancerRequestTriggerFixtureNet8() : base("net8.0", false) { }
+        public LambdaApplicationLoadBalancerRequestTriggerFixtureNet8() : base("net8.0", false, false) { }
     }
 
     public class AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet8 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
     {
-        public AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet8() : base("net8.0", true) { }
+        public AsyncLambdaApplicationLoadBalancerRequestTriggerFixtureNet8() : base("net8.0", true, false) { }
+    }
+
+    public class LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
+    {
+        public LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6() : base("net6.0", false, true) { }
+    }
+
+    public class AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
+    {
+        public AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet6() : base("net6.0", true, true) { }
+    }
+
+    public class LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
+    {
+        public LambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8() : base("net8.0", false, true) { }
+    }
+
+    public class AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase
+    {
+        public AsyncLambdaApplicationLoadBalancerRequestReturnsStreamTriggerFixtureNet8() : base("net8.0", true, true) { }
     }
 }


### PR DESCRIPTION
Adds tests for APIGatewayProxy and ApplicationLoadBalancer requests where the Lambda function returns `Stream` instead of the actual response type. 