### PR TITLE
Test a range of lambda event library versions

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -71,7 +71,16 @@ jobs:
             NEW_RELIC_HOST: staging-collector.newrelic.com
             NEW_RELIC_LICENSE_KEY: ${{ secrets.STAGING_LICENSE_KEY }}
             nugets:
-                 "elasticsearch.net
+                 "amazon.lambda.apigatewayevents
+                 amazon.lambda.applicationloadbalancerevents
+                 amazon.lambda.cloudwatchevents
+                 amazon.lambda.dynamodbevents
+                 amazon.lambda.kinesisevents
+                 amazon.lambda.kinesisfirehoseevents
+                 amazon.lambda.s3events
+                 amazon.lambda.simpleemailevents
+                 amazon.lambda.snsevents
+                 elasticsearch.net
                  elastic.clients.elasticsearch
                  log4net
                  microsoft.extensions.logging

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
@@ -8,17 +8,48 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
-    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.CloudWatchEvents" Version="4.4.0" />
-    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.1" />
-    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" />
-    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.0" />
+    <!-- We use the different targets to test a range of library versions. Note that the minimum versions can't drift too far apart
+    from each other due to a shared dependency on AWSSDK.Core -->
+    
+    <!-- 2.0.0 is from March 2020 -->
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.0.0 is from April 2020 -->
+    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.1.0 is from October 2020 -->
+    <PackageReference Include="Amazon.Lambda.CloudWatchEvents" Version="2.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.CloudWatchEvents" Version="4.4.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.3.0 is from September 2023. DynamoDBTimeWindowEvent not available until 2.3.0 -->
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.3.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.1.0 is from August 2023. KinesisTimeWindowEvent not available until 2.1 -->
+    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.2.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.0.0 is from March 2020 -->
+    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.0.0 is from March 2021 -->
+    <PackageReference Include="Amazon.Lambda.S3Events" Version="2.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 2.1.0 is from October 2020 -->
+    <PackageReference Include="Amazon.Lambda.SimpleEmailEvents" Version="2.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.SimpleEmailEvents" Version="3.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- 1.2.0 is from October 2020 -->
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- Non-event libraries -->
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
-    <PackageReference Include="Amazon.Lambda.S3Events" Version="3.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
-    <PackageReference Include="Amazon.Lambda.SimpleEmailEvents" Version="3.1.0" />
-    <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I rolled everything back as far as I could without hitting version conflicts, and all the tests still pass.

This also adds the event libraries to Dotty so we can watch for breaking changes.