### PR TITLE
fix: Fix bug in distributed tracing when `excludeNewrelicHeader` is set to true

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/DistributedTracePayloadHandler.cs
@@ -74,6 +74,10 @@ namespace NewRelic.Agent.Core.DistributedTracing
                         setter(carrier, Constants.DistributedTracePayloadKeyAllLower, distributedTracePayload);
                     }
                 }
+                else
+                {
+                    transaction.SetSampled(_adaptiveSampler);
+                }
 
                 var createOutboundTraceContextHeadersSuccess = false;
                 try

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -243,6 +243,25 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             }
         }
 
+        /// <summary>
+        /// Sets or deletes the excludeNewrelicHeader setting in the newrelic.config.
+        /// </summary>
+        /// <param name="enabled">If null, the setting will be deleted; otherwise, the setting will be set to the value of this parameter.</param>
+        public void SetOrDeleteDistributedTraceExcludeNewRelicHeaders(bool? exclude)
+        {
+            const string config = "configuration";
+            const string distributedTracing = "distributedTracing";
+            if (null == exclude)
+            {
+                CommonUtils.DeleteXmlNodeFromNewRelicConfig(_configFilePath, new[] { config }, distributedTracing);
+            }
+            else
+            {
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { config, distributedTracing },
+                    "excludeNewrelicHeader", exclude.Value ? "true" : "false");
+            }
+        }
+
         public NewRelicConfigModifier SetAllowAllHeaders(bool? enabled)
         {
             const string config = "configuration";

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -247,7 +247,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         /// Sets or deletes the excludeNewrelicHeader setting in the newrelic.config.
         /// </summary>
         /// <param name="enabled">If null, the setting will be deleted; otherwise, the setting will be set to the value of this parameter.</param>
-        public void SetOrDeleteDistributedTraceExcludeNewRelicHeaders(bool? exclude)
+        public void SetOrDeleteDistributedTraceExcludeNewRelicHeader(bool? exclude)
         {
             const string config = "configuration";
             const string distributedTracing = "distributedTracing";

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
         public RemoteService FirstCallApplication { get; set; }
         public RemoteService SecondCallApplication { get; set; }
 
-        public bool IncludeNewRelicHeaders = true;
+        public bool ExcludeNewRelicHeader = false;
 
         private AgentLogFile _firstCallAppAgentLog;
         private AgentLogFile _secondCallAppAgentLog;
@@ -43,8 +43,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
                 configModifier.SetLogLevel("all");
 
                 //Do during setup so TestLogger is set.
-                FirstCallApplication = SetupDistributedTracingApplication(IncludeNewRelicHeaders);
-                SecondCallApplication = SetupDistributedTracingApplication(IncludeNewRelicHeaders);
+                FirstCallApplication = SetupDistributedTracingApplication(ExcludeNewRelicHeader);
+                SecondCallApplication = SetupDistributedTracingApplication(ExcludeNewRelicHeader);
 
                 var environmentVariables = new Dictionary<string, string>();
 
@@ -75,7 +75,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             }
         }
 
-        protected RemoteService SetupDistributedTracingApplication(bool includeNewRelicHeaders)
+        protected RemoteService SetupDistributedTracingApplication(bool excludeNewRelicHeader)
         {
             var service = new RemoteService(
                 ApplicationDirectoryName,
@@ -94,7 +94,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             var configModifier = new NewRelicConfigModifier(service.DestinationNewRelicConfigFilePath);
             configModifier.SetOrDeleteDistributedTraceEnabled(true);
             configModifier.SetOrDeleteSpanEventsEnabled(true);
-            configModifier.SetOrDeleteDistributedTraceExcludeNewRelicHeaders(includeNewRelicHeaders);
+            configModifier.SetOrDeleteDistributedTraceExcludeNewRelicHeader(excludeNewRelicHeader);
             configModifier.SetLogLevel("all");
 
             return service;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AspNetCoreDistTraceRequestChainFixture.cs
@@ -1,7 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 using System;
 using System.Collections.Generic;
 using NewRelic.Agent.IntegrationTestHelpers;
@@ -17,6 +16,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public RemoteService FirstCallApplication { get; set; }
         public RemoteService SecondCallApplication { get; set; }
+
+        public bool IncludeNewRelicHeaders = true;
 
         private AgentLogFile _firstCallAppAgentLog;
         private AgentLogFile _secondCallAppAgentLog;
@@ -42,8 +43,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
                 configModifier.SetLogLevel("all");
 
                 //Do during setup so TestLogger is set.
-                FirstCallApplication = SetupDistributedTracingApplication();
-                SecondCallApplication = SetupDistributedTracingApplication();
+                FirstCallApplication = SetupDistributedTracingApplication(IncludeNewRelicHeaders);
+                SecondCallApplication = SetupDistributedTracingApplication(IncludeNewRelicHeaders);
 
                 var environmentVariables = new Dictionary<string, string>();
 
@@ -74,7 +75,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             }
         }
 
-        protected RemoteService SetupDistributedTracingApplication()
+        protected RemoteService SetupDistributedTracingApplication(bool includeNewRelicHeaders)
         {
             var service = new RemoteService(
                 ApplicationDirectoryName,
@@ -93,6 +94,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
             var configModifier = new NewRelicConfigModifier(service.DestinationNewRelicConfigFilePath);
             configModifier.SetOrDeleteDistributedTraceEnabled(true);
             configModifier.SetOrDeleteSpanEventsEnabled(true);
+            configModifier.SetOrDeleteDistributedTraceExcludeNewRelicHeaders(includeNewRelicHeaders);
             configModifier.SetLogLevel("all");
 
             return service;


### PR DESCRIPTION
When the agent is [configured to exclude the `newrelic` proprietary distributed tracing header](https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/net-agent-configuration/#excludeNewrelicHeader)  on outbound traces (and rely solely on the W3C trace context headers instead), an exception could occur which would show up in agent logs like this:

```
NewRelic  ERROR: [pid: 5412, tid: 73] InsertDistributedTraceHeaders() failed
System.InvalidOperationException: Nullable object must have a value.
at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
at NewRelic.Agent.Core.DistributedTracing.DistributedTracePayloadHandler.BuildTraceParent(IInternalTransaction transaction)
at NewRelic.Agent.Core.DistributedTracing.DistributedTracePayloadHandler.GetOutboundHeader(DistributedTraceHeaderType headerType, IInternalTransaction transaction, DateTime timestamp)
at NewRelic.Agent.Core.DistributedTracing.DistributedTracePayloadHandler.InsertDistributedTraceHeaders[T](IInternalTransaction transaction, T carrier, Action`3 setter)
```

This is because the value of `Transaction.Sampled` was not being set in this scenario.

This PR fixes that issue and adds integration tests to test both configuration options.