### PR TITLE
Add integration tests for SQS events with some attribute changes.

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -80,6 +80,7 @@ jobs:
                  amazon.lambda.s3events
                  amazon.lambda.simpleemailevents
                  amazon.lambda.snsevents
+                 amazon.lambda.sqsevents
                  elasticsearch.net
                  elastic.clients.elasticsearch
                  log4net

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -136,6 +136,7 @@ public static class LambdaEventHelpers
                     {
                         transaction.AddEventSourceAttribute("arn", (string)sqsEvent.Records[0].EventSourceArn);
                         transaction.AddEventSourceAttribute("length", (int)sqsEvent.Records.Count);
+                        transaction.AddEventSourceAttribute("messageId", (string)sqsEvent.Records[0].MessageId);
 
                         TryParseSQSDistributedTraceHeaders(sqsEvent, transaction, agent);
                     }

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj
@@ -47,6 +47,10 @@
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="1.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
+    <!-- 1.2.0 is from October 2020 -->
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="1.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
     <!-- Non-event libraries -->
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
@@ -1,7 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Text;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.ApplicationLoadBalancerEvents;
 using Amazon.Lambda.CloudWatchEvents.ScheduledEvents;
@@ -15,6 +14,7 @@ using Amazon.Lambda.Serialization.SystemTextJson;
 using Amazon.Lambda.SimpleEmailEvents;
 using Amazon.Lambda.SimpleEmailEvents.Actions;
 using Amazon.Lambda.SNSEvents;
+using Amazon.Lambda.SQSEvents;
 using ApplicationLifecycle;
 
 namespace LambdaSelfExecutingAssembly
@@ -43,7 +43,7 @@ namespace LambdaSelfExecutingAssembly
         private static HandlerWrapper? GetHandlerWrapper()
         {
             var serializer = new DefaultLambdaJsonSerializer();
-
+            
             var handlerMethodName = GetHandlerMethodName();
             switch (handlerMethodName)
             {
@@ -109,6 +109,10 @@ namespace LambdaSelfExecutingAssembly
                     return HandlerWrapper.GetHandlerWrapper<KinesisTimeWindowEvent>(KinesisTimeWindowEventHandler, serializer);
                 case nameof(KinesisTimeWindowEventHandlerAsync):
                     return HandlerWrapper.GetHandlerWrapper<KinesisTimeWindowEvent>(KinesisTimeWindowEventHandlerAsync, serializer);
+                case nameof(SqsHandler):
+                    return HandlerWrapper.GetHandlerWrapper<SQSEvent>(SqsHandler, serializer);
+                case nameof(SqsHandlerAsync):
+                    return HandlerWrapper.GetHandlerWrapper<SQSEvent>(SqsHandlerAsync, serializer);
                 default:
                     return null;
             }
@@ -411,6 +415,17 @@ namespace LambdaSelfExecutingAssembly
         public static async Task KinesisTimeWindowEventHandlerAsync(KinesisTimeWindowEvent _, ILambdaContext __)
         {
             Console.WriteLine("Executing lambda {0}", nameof(KinesisEventHandlerAsync));
+            await Task.Delay(100);
+        }
+
+        public static void SqsHandler(SQSEvent _, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(SqsHandler));
+        }
+
+        public static async Task SqsHandlerAsync(SQSEvent _, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(SqsHandlerAsync));
             await Task.Delay(100);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSqsEventTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSqsEventTest.cs
@@ -1,0 +1,112 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.AwsLambda
+{
+    [NetCoreTest]
+    public abstract class AwsLambdaSqsEventTest<T> : NewRelicIntegrationTest<T> where T : LambdaSqsEventTriggerFixtureBase
+    {
+        private readonly LambdaSqsEventTriggerFixtureBase _fixture;
+        private const string TestTraceId = "74be672b84ddc4e4b28be285632bbc0a";
+        private const string TestParentSpanId = "27ddd2d8890283b4";
+        private const string ExpectedTransactionName = "OtherTransaction/Lambda/SqsHandler";
+
+        protected AwsLambdaSqsEventTest(T fixture, ITestOutputHelper output)
+            : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+            _fixture.Actions(
+                exerciseApplication: () =>
+                {
+                    _fixture.EnqueueSqsEvent();
+                    _fixture.EnqueueSqsEventWithDTHeaders(TestTraceId, TestParentSpanId);
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                }
+                );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
+
+            Assert.Multiple(
+                () => Assert.Equal(2, serverlessPayloads.Count),
+                () => Assert.All(serverlessPayloads, ValidateServerlessPayload),
+                () => ValidateTraceHasNoParent(serverlessPayloads[0]),
+                () => ValidateTraceHasParent(serverlessPayloads[1])
+                );
+        }
+
+        private static void ValidateServerlessPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.arn", "arn:{partition}:sqs:{region}:123456789012:MyQueue" },
+                { "aws.lambda.eventSource.eventType", "sqs" },
+                { "aws.lambda.eventSource.length", 1 },
+                { "aws.lambda.eventSource.messageId", "19dd0b57-b21e-4ac1-bd88-01bbb068cb78" }
+            };
+
+            Assert.Equal(ExpectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
+        }
+
+        private static void ValidateTraceHasNoParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == ExpectedTransactionName);
+
+            Assertions.SpanEventDoesNotHaveAttributes(["parentId"], SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+
+        private static void ValidateTraceHasParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == ExpectedTransactionName);
+
+            var expectedAttributeValues = new Dictionary<string, object>
+            {
+                { "traceId", TestTraceId },
+                { "parentId", TestParentSpanId }
+            };
+
+            Assertions.SpanEventHasAttributes(expectedAttributeValues, SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+    }
+
+    public class AwsLambdaSqsEventTestNet6 : AwsLambdaSqsEventTest<LambdaSqsEventTriggerFixtureNet6>
+    {
+        public AwsLambdaSqsEventTestNet6(LambdaSqsEventTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    public class AwsLambdaSqsEventTestNet8 : AwsLambdaSqsEventTest<LambdaSqsEventTriggerFixtureNet8>
+    {
+        public AwsLambdaSqsEventTestNet8(LambdaSqsEventTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaSqsEventTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaSqsEventTriggerFixture.cs
@@ -110,16 +110,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
         public AsyncLambdaSqsEventTriggerFixtureNet6() : base("net6.0", true, true) { }
     }
 
-    public class LambdaHandlerOnlySqsTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
-    {
-        public LambdaHandlerOnlySqsTriggerFixtureNet6() : base("net6.0", false, false) { }
-    }
-
-    public class AsyncLambdaHandlerOnlySqsTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
-    {
-        public AsyncLambdaHandlerOnlySqsTriggerFixtureNet6() : base("net6.0", true, false) { }
-    }
-
     public class LambdaSqsEventTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
     {
         public LambdaSqsEventTriggerFixtureNet8() : base("net8.0", false, true) { }
@@ -128,15 +118,5 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
     public class AsyncLambdaSqsEventTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
     {
         public AsyncLambdaSqsEventTriggerFixtureNet8() : base("net8.0", true, true) { }
-    }
-
-    public class LambdaHandlerOnlySqsTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
-    {
-        public LambdaHandlerOnlySqsTriggerFixtureNet8() : base("net8.0", false, false) { }
-    }
-
-    public class AsyncLambdaHandlerOnlySqsTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
-    {
-        public AsyncLambdaHandlerOnlySqsTriggerFixtureNet8() : base("net8.0", true, false) { }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaSqsEventTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaSqsEventTriggerFixture.cs
@@ -1,0 +1,142 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
+{
+    public abstract class LambdaSqsEventTriggerFixtureBase : LambdaSelfExecutingAssemblyFixture
+    {
+        private static string GetHandlerString(bool isAsync)
+        {
+            return "LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::SqsHandler" + (isAsync ? "Async" : "");
+        }
+
+        protected LambdaSqsEventTriggerFixtureBase(string targetFramework, bool isAsync, bool useNewRelicHandler) :
+            base(targetFramework,
+                useNewRelicHandler ? GetHandlerString(isAsync) : null,
+                useNewRelicHandler ? null : GetHandlerString(isAsync),
+                "SqsHandler" + (isAsync ? "Async" : ""),
+                "1.0")
+        {
+        }
+
+        public void EnqueueSqsEvent()
+        {
+            var sqsJson = """
+                          {
+                            "Records": [
+                              {
+                                "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+                                "receiptHandle": "MessageReceiptHandle",
+                                "body": "Hello from SQS!",
+                                "attributes": {
+                                  "ApproximateReceiveCount": "1",
+                                  "SentTimestamp": "1523232000000",
+                                  "SenderId": "123456789012",
+                                  "ApproximateFirstReceiveTimestamp": "1523232000001"
+                                },
+                                "messageAttributes": {
+                                  "Test": {
+                                    "Type": "String",
+                                    "StringValue": "TestString"
+                                  },
+                                  "TestBinary": {
+                                    "Type": "Binary",
+                                    "BinaryValue": "VGVzdEJpbmFyeQ=="
+                                  }
+                                },
+                                "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+                                "eventSource": "aws:sqs",
+                                "eventSourceARN": "arn:{partition}:sqs:{region}:123456789012:MyQueue",
+                                "awsRegion": "us-west-2"
+                              }
+                            ]
+                          }
+                          """;
+            EnqueueLambdaEvent(sqsJson);
+        }
+
+        public void EnqueueSqsEventWithDTHeaders(string traceId, string spanId)
+        {
+            var sqsJson = $$"""
+                          {
+                            "Records": [
+                              {
+                                "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+                                "receiptHandle": "MessageReceiptHandle",
+                                "body": "Hello from SQS!",
+                                "attributes": {
+                                  "ApproximateReceiveCount": "1",
+                                  "SentTimestamp": "1523232000000",
+                                  "SenderId": "123456789012",
+                                  "ApproximateFirstReceiveTimestamp": "1523232000001"
+                                },
+                                "messageAttributes": {
+                                  "Test": {
+                                    "Type": "String",
+                                    "StringValue": "TestString"
+                                  },
+                                  "TestBinary": {
+                                    "Type": "Binary",
+                                    "BinaryValue": "VGVzdEJpbmFyeQ=="
+                                  },
+                                   "traceparent": {
+                                    "Type": "String",
+                                    "StringValue": "{{GetTestTraceParentHeaderValue(traceId, spanId)}}"
+                                  },
+                                  "tracestate": {
+                                    "Type": "String",
+                                    "StringValue": "{{GetTestTraceStateHeaderValue(spanId)}}"
+                                  }
+                                },
+                                "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+                                "eventSource": "aws:sqs",
+                                "eventSourceARN": "arn:{partition}:sqs:{region}:123456789012:MyQueue",
+                                "awsRegion": "us-west-2"
+                              }
+                            ]
+                          }
+                          """;
+            EnqueueLambdaEvent(sqsJson);
+        }
+    }
+
+    public class LambdaSqsEventTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
+    {
+        public LambdaSqsEventTriggerFixtureNet6() : base("net6.0", false, true) { }
+    }
+
+    public class AsyncLambdaSqsEventTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
+    {
+        public AsyncLambdaSqsEventTriggerFixtureNet6() : base("net6.0", true, true) { }
+    }
+
+    public class LambdaHandlerOnlySqsTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
+    {
+        public LambdaHandlerOnlySqsTriggerFixtureNet6() : base("net6.0", false, false) { }
+    }
+
+    public class AsyncLambdaHandlerOnlySqsTriggerFixtureNet6 : LambdaSqsEventTriggerFixtureBase
+    {
+        public AsyncLambdaHandlerOnlySqsTriggerFixtureNet6() : base("net6.0", true, false) { }
+    }
+
+    public class LambdaSqsEventTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
+    {
+        public LambdaSqsEventTriggerFixtureNet8() : base("net8.0", false, true) { }
+    }
+
+    public class AsyncLambdaSqsEventTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
+    {
+        public AsyncLambdaSqsEventTriggerFixtureNet8() : base("net8.0", true, true) { }
+    }
+
+    public class LambdaHandlerOnlySqsTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
+    {
+        public LambdaHandlerOnlySqsTriggerFixtureNet8() : base("net8.0", false, false) { }
+    }
+
+    public class AsyncLambdaHandlerOnlySqsTriggerFixtureNet8 : LambdaSqsEventTriggerFixtureBase
+    {
+        public AsyncLambdaHandlerOnlySqsTriggerFixtureNet8() : base("net8.0", true, false) { }
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -801,7 +801,8 @@ public class LambdaEventHelpersTests
                         { NewRelicDistributedTraceKey, new() { StringValue = NewRelicDistributedTracePayload } },
                         { W3CTraceParentKey, new() { StringValue = W3CTraceParentPayload } },
                         { W3CTraceStateKey, new() { StringValue = W3CTraceStatePayload } }
-                    }
+                    },
+                    MessageId = "testMessageId"
                 }]
         };
 
@@ -813,6 +814,7 @@ public class LambdaEventHelpersTests
         {
             Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testEventSourceArn"));
             Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo(1));
+            Assert.That(_attributes["aws.lambda.eventSource.messageId"], Is.EqualTo("testMessageId"));
 
             Mock.Assert(() => _transaction.AcceptDistributedTraceHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, IEnumerable<string>>>(), TransportType.Queue));
             Assert.That(_parsedHeaders[NewRelicDistributedTraceKey], Is.EqualTo(NewRelicDistributedTracePayload));
@@ -832,7 +834,8 @@ public class LambdaEventHelpersTests
                 new()
                 {
                     EventSourceArn = "testEventSourceArn",
-                    Body = SnsBodyJson
+                    Body = SnsBodyJson,
+                    MessageId = "testMessageId"
                 }]
         };
 
@@ -844,6 +847,7 @@ public class LambdaEventHelpersTests
         {
             Assert.That(_attributes["aws.lambda.eventSource.arn"], Is.EqualTo("testEventSourceArn"));
             Assert.That(_attributes["aws.lambda.eventSource.length"], Is.EqualTo(1));
+            Assert.That(_attributes["aws.lambda.eventSource.messageId"], Is.EqualTo("testMessageId"));
 
             Mock.Assert(() => _transaction.AcceptDistributedTraceHeaders(Arg.IsAny<IDictionary<string, string>>(), Arg.IsAny<Func<IDictionary<string, string>, string, IEnumerable<string>>>(), TransportType.Queue));
             Assert.That(_parsedHeaders[NewRelicDistributedTraceKey], Is.EqualTo(NewRelicDistributedTracePayload));

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSQSEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonSQSEventsModel.cs
@@ -16,6 +16,7 @@ namespace NewRelic.Mock.Amazon.Lambda.SQSEvents
             public string EventSourceArn { get; set; }
             public Dictionary<string, MessageAttribute> MessageAttributes { get; set; }
             public string Body { get; set; }
+            public string MessageId { get; set; }
         }
 
         public class MessageAttribute


### PR DESCRIPTION
## Description

- Adds capturing the messageId attribute for SQS to instrumentation.  Spec doesn't list this, but it seems odd to not include this (if we don't want this, we can remove it easily).
- Updates unit tests to check for this new attribute.
- Add integration tests for SQS events with some attribute changes.


# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
