### PR TITLE
feat: Add support for AWS Lambda `APIGatewayHttpApiV2ProxyRequest`

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventType.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventType.cs
@@ -7,6 +7,7 @@ public enum AwsLambdaEventType
 {
     Unknown,
     APIGatewayProxyRequest,
+    APIGatewayHttpApiV2ProxyRequest,
     ApplicationLoadBalancerRequest,
     CloudWatchScheduledEvent,
     KinesisStreamingEvent,

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/AwsLambdaEventTypeExtensions.cs
@@ -12,6 +12,7 @@ public static class AwsLambdaEventTypeExtensions
         return typeFullName switch
         {
             "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest" => AwsLambdaEventType.APIGatewayProxyRequest,
+            "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest" => AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest,
             "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest" => AwsLambdaEventType.ApplicationLoadBalancerRequest,
             "Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent" => AwsLambdaEventType.CloudWatchScheduledEvent,
             "Amazon.Lambda.KinesisEvents.KinesisEvent" => AwsLambdaEventType.KinesisStreamingEvent,
@@ -32,6 +33,7 @@ public static class AwsLambdaEventTypeExtensions
         return eventType switch
         {
             AwsLambdaEventType.APIGatewayProxyRequest => "apiGateway",
+            AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest => "apiGateway",
             AwsLambdaEventType.ApplicationLoadBalancerRequest => "alb",
             AwsLambdaEventType.CloudWatchScheduledEvent => "cloudWatch_scheduled",
             AwsLambdaEventType.KinesisStreamingEvent => "kinesis",
@@ -48,6 +50,6 @@ public static class AwsLambdaEventTypeExtensions
 
     public static bool IsWebEvent(this AwsLambdaEventType eventType)
     {
-        return eventType == AwsLambdaEventType.APIGatewayProxyRequest || eventType == AwsLambdaEventType.ApplicationLoadBalancerRequest;
+        return eventType == AwsLambdaEventType.APIGatewayProxyRequest || eventType == AwsLambdaEventType.ApplicationLoadBalancerRequest || eventType == AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest;
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -47,8 +47,8 @@ public static class LambdaEventHelpers
                         // arn is not available
                         transaction.AddEventSourceAttribute("accountId", (string)requestContext.AccountId);
                         transaction.AddEventSourceAttribute("apiId", (string)requestContext.ApiId);
-                        transaction.AddEventSourceAttribute("resourceId", (string)requestContext.RouteKey); // TODO: Is this right?
-                        transaction.AddEventSourceAttribute("resourcePath", (string)requestContext.Http.Path); // TODO: Is this right?
+                        // resourceId is not available for v2
+                        // resourcePath is not available for v2
                         transaction.AddEventSourceAttribute("stage", (string)requestContext.Stage);
                     }
                     break;

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -268,7 +268,8 @@ public static class LambdaEventHelpers
                 transaction.AcceptDistributedTraceHeaders(multiValueHeaders, GetMultiHeaderValue, dtTransport);
             }
         }
-        else if (headers != null)
+
+        if (headers != null)
         {
             transaction.SetRequestHeaders(headers, agent.Configuration.AllowAllRequestHeaders ? webReqEvent.Headers?.Keys : Statics.DefaultCaptureHeaders, headersGetter);
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -249,7 +249,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                         }
 
                         // capture response data for specific request / response types
-                        if (_functionDetails.EventType is AwsLambdaEventType.APIGatewayProxyRequest or AwsLambdaEventType.ApplicationLoadBalancerRequest)
+                        if (_functionDetails.EventType is AwsLambdaEventType.APIGatewayProxyRequest or AwsLambdaEventType.ApplicationLoadBalancerRequest or AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest)
                         {
                             var responseGetter = _getRequestResponseFromGeneric ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(responseTask.GetType(), "Result");
                             var response = responseGetter(responseTask);
@@ -290,6 +290,8 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             // check response type based on request type to be sure it has the properties we're looking for 
             var responseType = response.GetType().FullName;
             if ((_functionDetails.EventType == AwsLambdaEventType.APIGatewayProxyRequest && responseType != "Amazon.Lambda.APIGatewayEvents.APIGatewayProxyResponse")
+                ||
+                (_functionDetails.EventType == AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest && responseType != "Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyResponse")
                 ||
                 (_functionDetails.EventType == AwsLambdaEventType.ApplicationLoadBalancerRequest && responseType != "Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerResponse"))
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -110,6 +110,8 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 }
                 return null;
             }
+
+            public bool IsWebRequest => EventType is AwsLambdaEventType.APIGatewayProxyRequest or AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest or AwsLambdaEventType.ApplicationLoadBalancerRequest;
         }
 
         private List<string> _webResponseHeaders = ["content-type", "content-length"];
@@ -249,7 +251,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                         }
 
                         // capture response data for specific request / response types
-                        if (_functionDetails.EventType is AwsLambdaEventType.APIGatewayProxyRequest or AwsLambdaEventType.ApplicationLoadBalancerRequest or AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest)
+                        if (_functionDetails.IsWebRequest)
                         {
                             var responseGetter = _getRequestResponseFromGeneric ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(responseTask.GetType(), "Result");
                             var response = responseGetter(responseTask);
@@ -268,7 +270,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 return Delegates.GetDelegateFor<object>(
                         onSuccess: response =>
                         {
-                            if (_functionDetails.EventType is AwsLambdaEventType.APIGatewayProxyRequest or AwsLambdaEventType.ApplicationLoadBalancerRequest)
+                            if (_functionDetails.IsWebRequest)
                                 CaptureResponseData(transaction, response, agent);
 
                             segment.End();

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
@@ -85,6 +85,10 @@ namespace LambdaSelfExecutingAssembly
                     return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, Stream>(ApiGatewayProxyRequestHandlerReturnsStream, serializer);
                 case nameof (ApiGatewayProxyRequestHandlerReturnsStreamAsync):
                     return HandlerWrapper.GetHandlerWrapper<APIGatewayProxyRequest, Stream>(ApiGatewayProxyRequestHandlerReturnsStreamAsync, serializer);
+                case nameof(ApiGatewayHttpApiV2ProxyRequestHandler):
+                    return HandlerWrapper.GetHandlerWrapper<APIGatewayHttpApiV2ProxyRequest, APIGatewayHttpApiV2ProxyResponse>(ApiGatewayHttpApiV2ProxyRequestHandler, serializer);
+                case nameof(ApiGatewayHttpApiV2ProxyRequestHandlerAsync):
+                    return HandlerWrapper.GetHandlerWrapper<APIGatewayHttpApiV2ProxyRequest, APIGatewayHttpApiV2ProxyResponse>(ApiGatewayHttpApiV2ProxyRequestHandlerAsync, serializer);
                 case nameof(ApplicationLoadBalancerRequestHandler):
                     return HandlerWrapper.GetHandlerWrapper<ApplicationLoadBalancerRequest, ApplicationLoadBalancerResponse>(ApplicationLoadBalancerRequestHandler, serializer);
                 case nameof(ApplicationLoadBalancerRequestHandlerAsync):
@@ -263,6 +267,14 @@ namespace LambdaSelfExecutingAssembly
             return new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
         }
 
+        public static async Task<APIGatewayProxyResponse> ApiGatewayProxyRequestHandlerAsync(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerAsync));
+            await Task.Delay(100);
+
+            return new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+        }
+
         public static Stream ApiGatewayProxyRequestHandlerReturnsStream(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
         {
             Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerReturnsStream));
@@ -290,12 +302,19 @@ namespace LambdaSelfExecutingAssembly
             return stream;
         }
 
-        public static async Task<APIGatewayProxyResponse> ApiGatewayProxyRequestHandlerAsync(APIGatewayProxyRequest apiGatewayProxyRequest, ILambdaContext __)
+        public static APIGatewayHttpApiV2ProxyResponse ApiGatewayHttpApiV2ProxyRequestHandler(APIGatewayHttpApiV2ProxyRequest apiGatewayProxyRequest, ILambdaContext __)
         {
-            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayProxyRequestHandlerAsync));
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayHttpApiV2ProxyRequestHandler));
+
+            return new APIGatewayHttpApiV2ProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+        }
+
+        public static async Task<APIGatewayHttpApiV2ProxyResponse> ApiGatewayHttpApiV2ProxyRequestHandlerAsync(APIGatewayHttpApiV2ProxyRequest apiGatewayProxyRequest, ILambdaContext __)
+        {
+            Console.WriteLine("Executing lambda {0}", nameof(ApiGatewayHttpApiV2ProxyRequestHandlerAsync));
             await Task.Delay(100);
 
-            return new APIGatewayProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
+            return new APIGatewayHttpApiV2ProxyResponse() { Body = apiGatewayProxyRequest.Body, StatusCode = 200, Headers = new Dictionary<string, string> { { "Content-Type", "application/json" }, { "Content-Length", "12345" } } };
         }
 
         public static ApplicationLoadBalancerResponse ApplicationLoadBalancerRequestHandler(ApplicationLoadBalancerRequest applicationLoadBalancerRequest, ILambdaContext __)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
@@ -1,0 +1,142 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
+{
+    [NetCoreTest]
+    public abstract class AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest<T> : NewRelicIntegrationTest<T> where T : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase
+    {
+        private readonly LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase _fixture;
+        private readonly string _expectedTransactionName;
+        private readonly bool _returnsStream;
+        private const string TestTraceId = "74be672b84ddc4e4b28be285632bbc0a";
+        private const string TestParentSpanId = "27ddd2d8890283b4";
+
+        protected AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest(T fixture, ITestOutputHelper output, string expectedTransactionName, bool returnsStream)
+            : base(fixture)
+        {
+            _fixture = fixture;
+            _expectedTransactionName = expectedTransactionName;
+            _returnsStream = returnsStream;
+            _fixture.TestLogger = output;
+            _fixture.SetAdditionalEnvironmentVariable("NEW_RELIC_ATTRIBUTES_INCLUDE", "request.headers.*,request.parameters.*");
+            _fixture.Actions(
+                exerciseApplication: () =>
+                {
+                    _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequest();
+                    _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                }
+            );
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
+
+            Assert.Multiple(
+                () => Assert.Equal(2, serverlessPayloads.Count),
+                () => Assert.All(serverlessPayloads, ValidateServerlessPayload),
+                () => ValidateTraceHasNoParent(serverlessPayloads[0]),
+                () => ValidateTraceHasParent(serverlessPayloads[1])
+                );
+        }
+
+        private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId",
+                "host.displayName"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.accountId", "123456789012" },
+                { "aws.lambda.eventSource.apiId", "api-id" },
+                { "aws.lambda.eventSource.eventType", "apiGateway" },
+                { "aws.lambda.eventSource.stage", "$default" },
+                { "request.headers.header1", "value1" },
+                { "request.headers.header2", "value1,value2" },
+                { "request.method", "POST" },
+                { "request.uri", "/path/to/resource" },
+                { "request.parameters.parameter1", "value1,value2" },
+                { "request.parameters.parameter2", "value" },
+                { "http.statusCode", 200 },
+                { "response.status", "200" },
+                { "response.headers.content-type", "application/json" },
+                { "response.headers.content-length", "12345" }
+            };
+
+            Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
+        }
+
+        private void ValidateTraceHasNoParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == _expectedTransactionName);
+
+            Assertions.SpanEventDoesNotHaveAttributes(["parentId"], SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+
+        private void ValidateTraceHasParent(ServerlessPayload serverlessPayload)
+        {
+            var entrySpan = serverlessPayload.Telemetry.SpanEventsPayload.SpanEvents.Single(s => (string)s.IntrinsicAttributes["name"] == _expectedTransactionName);
+
+            var expectedAttributeValues = new Dictionary<string, object>
+            {
+                { "traceId", TestTraceId },
+                { "parentId", TestParentSpanId }
+            };
+
+            Assertions.SpanEventHasAttributes(expectedAttributeValues, SpanEventAttributeType.Intrinsic, entrySpan);
+        }
+    }
+
+    public class AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestNet6 : AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest<LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6>
+    {
+        public AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestNet6(LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayHttpApiV2ProxyRequestHandler", false)
+        {
+        }
+    }
+
+    public class AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestNet8 : AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest<LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8>
+    {
+        public AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestNet8(LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayHttpApiV2ProxyRequestHandler", false)
+        {
+        }
+    }
+    public class AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestAsyncNet6 : AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest<AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6>
+    {
+        public AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestAsyncNet6(AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayHttpApiV2ProxyRequestHandlerAsync", false)
+        {
+        }
+    }
+
+    public class AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestAsyncNet8 : AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest<AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8>
+    {
+        public AwsLambdaAPIGatewayHttpApiV2ProxyRequestTestAsyncNet8(AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8 fixture, ITestOutputHelper output)
+            : base(fixture, output, "WebTransaction/Lambda/ApiGatewayHttpApiV2ProxyRequestHandlerAsync", false)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
@@ -1,0 +1,205 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+
+using NewRelic.Agent.IntegrationTestHelpers;
+
+namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
+{
+    public abstract class LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase : LambdaSelfExecutingAssemblyFixture
+    {
+        private static string GetHandlerString(bool isAsync)
+        {
+            return "LambdaSelfExecutingAssembly::LambdaSelfExecutingAssembly.Program::ApiGatewayHttpApiV2ProxyRequestHandler"+ (isAsync ? "Async" : "");
+        }
+
+        protected LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase(string targetFramework, bool isAsync) :
+            base(targetFramework,
+                null,
+                GetHandlerString(isAsync),
+                "ApiGatewayHttpApiV2ProxyRequestHandler" + (isAsync ? "Async" : ""),
+                null)
+        {
+        }
+
+        public void EnqueueAPIGatewayHttpApiV2ProxyRequest()
+        {
+            var apiGatewayProxyRequestJson = $$"""
+                                               {
+                                                 "version": "2.0",
+                                                 "routeKey": "$default",
+                                                 "rawPath": "/path/to/resource",
+                                                 "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+                                                 "cookies": [
+                                                   "cookie1",
+                                                   "cookie2"
+                                                 ],
+                                                 "headers": {
+                                                   "Header1": "value1",
+                                                   "Header2": "value1,value2",
+                                                   "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+                                                   "X-Forwarded-Port": "443",
+                                                   "X-Forwarded-Proto": "https"
+                                                 },
+                                                 "queryStringParameters": {
+                                                   "parameter1": "value1,value2",
+                                                   "parameter2": "value"
+                                                 },
+                                                 "requestContext": {
+                                                   "accountId": "123456789012",
+                                                   "apiId": "api-id",
+                                                   "authentication": {
+                                                     "clientCert": {
+                                                       "clientCertPem": "CERT_CONTENT",
+                                                       "subjectDN": "www.example.com",
+                                                       "issuerDN": "Example issuer",
+                                                       "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+                                                       "validity": {
+                                                         "notBefore": "May 28 12:30:02 2019 GMT",
+                                                         "notAfter": "Aug  5 09:36:04 2021 GMT"
+                                                       }
+                                                     }
+                                                   },
+                                                   "authorizer": {
+                                                     "jwt": {
+                                                       "claims": {
+                                                         "claim1": "value1",
+                                                         "claim2": "value2"
+                                                       },
+                                                       "scopes": [
+                                                         "scope1",
+                                                         "scope2"
+                                                       ]
+                                                     }
+                                                   },
+                                                   "domainName": "id.execute-api.us-east-1.amazonaws.com",
+                                                   "domainPrefix": "id",
+                                                   "http": {
+                                                     "method": "POST",
+                                                     "path": "/path/to/resource",
+                                                     "protocol": "HTTP/1.1",
+                                                     "sourceIp": "192.168.0.1/32",
+                                                     "userAgent": "agent"
+                                                   },
+                                                   "requestId": "id",
+                                                   "routeKey": "$default",
+                                                   "stage": "$default",
+                                                   "time": "12/Mar/2020:19:03:58 +0000",
+                                                   "timeEpoch": 1583348638390
+                                                 },
+                                                 "body": "eyJ0ZXN0IjoiYm9keSJ9",
+                                                 "pathParameters": {
+                                                   "parameter1": "value1"
+                                                 },
+                                                 "isBase64Encoded": true,
+                                                 "stageVariables": {
+                                                   "stageVariable1": "value1",
+                                                   "stageVariable2": "value2"
+                                                 }
+                                               }
+                                               """;
+            EnqueueLambdaEvent(apiGatewayProxyRequestJson);
+        }
+
+        public void EnqueueAPIGatewayHttpApiV2ProxyRequestWithDTHeaders(string traceId, string spanId)
+        {
+            var apiGatewayProxyRequestJson = $$"""
+                                               {
+                                                 "version": "2.0",
+                                                 "routeKey": "$default",
+                                                 "rawPath": "/path/to/resource",
+                                                 "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+                                                 "cookies": [
+                                                   "cookie1",
+                                                   "cookie2"
+                                                 ],
+                                                 "headers": {
+                                                   "Header1": "value1",
+                                                   "Header2": "value1,value2",
+                                                   "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+                                                   "X-Forwarded-Port": "443",
+                                                   "X-Forwarded-Proto": "https",
+                                                   "traceparent": "{{GetTestTraceParentHeaderValue(traceId, spanId)}}",
+                                                   "tracestate": "{{GetTestTraceStateHeaderValue(spanId)}}"
+                                                 },
+                                                 "queryStringParameters": {
+                                                   "parameter1": "value1,value2",
+                                                   "parameter2": "value"
+                                                 },
+                                                 "requestContext": {
+                                                   "accountId": "123456789012",
+                                                   "apiId": "api-id",
+                                                   "authentication": {
+                                                     "clientCert": {
+                                                       "clientCertPem": "CERT_CONTENT",
+                                                       "subjectDN": "www.example.com",
+                                                       "issuerDN": "Example issuer",
+                                                       "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+                                                       "validity": {
+                                                         "notBefore": "May 28 12:30:02 2019 GMT",
+                                                         "notAfter": "Aug  5 09:36:04 2021 GMT"
+                                                       }
+                                                     }
+                                                   },
+                                                   "authorizer": {
+                                                     "jwt": {
+                                                       "claims": {
+                                                         "claim1": "value1",
+                                                         "claim2": "value2"
+                                                       },
+                                                       "scopes": [
+                                                         "scope1",
+                                                         "scope2"
+                                                       ]
+                                                     }
+                                                   },
+                                                   "domainName": "id.execute-api.us-east-1.amazonaws.com",
+                                                   "domainPrefix": "id",
+                                                   "http": {
+                                                     "method": "POST",
+                                                     "path": "/path/to/resource",
+                                                     "protocol": "HTTP/1.1",
+                                                     "sourceIp": "192.168.0.1/32",
+                                                     "userAgent": "agent"
+                                                   },
+                                                   "requestId": "id",
+                                                   "routeKey": "$default",
+                                                   "stage": "$default",
+                                                   "time": "12/Mar/2020:19:03:58 +0000",
+                                                   "timeEpoch": 1583348638390
+                                                 },
+                                                 "body": "eyJ0ZXN0IjoiYm9keSJ9",
+                                                 "pathParameters": {
+                                                   "parameter1": "value1"
+                                                 },
+                                                 "isBase64Encoded": true,
+                                                 "stageVariables": {
+                                                   "stageVariable1": "value1",
+                                                   "stageVariable2": "value2"
+                                                 }
+                                               }
+                                               """;
+            EnqueueLambdaEvent(apiGatewayProxyRequestJson);
+        }
+    }
+
+    public class LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase
+    {
+        public LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6() : base("net6.0", false) { }
+    }
+
+    public class AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase
+    {
+        public AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6() : base("net6.0", true) { }
+    }
+
+    public class LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase
+    {
+        public LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8() : base("net8.0", false) { }
+    }
+
+    public class AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase
+    {
+        public AsyncLambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet8() : base("net8.0", true) { }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -40,6 +40,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
 
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");
+                    remoteApplication.NewRelicConfig.SetDebugStartupDelaySeconds(20); // TODO: Testing only
 
                     if (LambdaTestTool.IsRunning)
                     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -40,7 +40,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
 
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");
-                    remoteApplication.NewRelicConfig.SetDebugStartupDelaySeconds(20); // TODO: Testing only
 
                     if (LambdaTestTool.IsRunning)
                     {

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/AwsLambdaEventTypeExtensionsTests.cs
@@ -10,6 +10,7 @@ namespace Agent.Extensions.Tests.Lambda
     {
         [Test]
         [TestCase("Amazon.Lambda.APIGatewayEvents.APIGatewayProxyRequest", AwsLambdaEventType.APIGatewayProxyRequest)]
+        [TestCase("Amazon.Lambda.APIGatewayEvents.APIGatewayHttpApiV2ProxyRequest", AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest)]
         [TestCase("Amazon.Lambda.ApplicationLoadBalancerEvents.ApplicationLoadBalancerRequest", AwsLambdaEventType.ApplicationLoadBalancerRequest)]
         [TestCase("Amazon.Lambda.CloudWatchEvents.ScheduledEvents.ScheduledEvent", AwsLambdaEventType.CloudWatchScheduledEvent)]
         [TestCase("Amazon.Lambda.KinesisEvents.KinesisEvent", AwsLambdaEventType.KinesisStreamingEvent)]
@@ -30,6 +31,7 @@ namespace Agent.Extensions.Tests.Lambda
         }
         [Test]
         [TestCase(AwsLambdaEventType.APIGatewayProxyRequest, "apiGateway")]
+        [TestCase(AwsLambdaEventType.APIGatewayHttpApiV2ProxyRequest, "apiGateway")]
         [TestCase(AwsLambdaEventType.ApplicationLoadBalancerRequest, "alb")]
         [TestCase(AwsLambdaEventType.CloudWatchScheduledEvent, "cloudWatch_scheduled")]
         [TestCase(AwsLambdaEventType.KinesisStreamingEvent, "kinesis")]

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -341,7 +341,7 @@ public class LambdaEventHelpersTests
             Assert.That(_attributes["aws.lambda.eventSource.accountId"], Is.EqualTo("testAccountId"));
             Assert.That(_attributes["aws.lambda.eventSource.apiId"], Is.EqualTo("testApiId"));
             Assert.That(_attributes["aws.lambda.eventSource.resourceId"], Is.EqualTo("testRouteKey"));
-            Assert.That(_attributes["aws.lambda.eventSource.resourcePath"], Is.EqualTo("tesetPath"));
+            Assert.That(_attributes["aws.lambda.eventSource.resourcePath"], Is.EqualTo("testPath"));
             Assert.That(_attributes["aws.lambda.eventSource.stage"], Is.EqualTo("testStage"));
 
             // Assert that the SetRequestHeaders, SetRequestMethod, SetUri, SetRequestParameters, and AcceptDistributedTraceHeaders methods were called with the correct arguments

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/LambdaEventHelpersTests.cs
@@ -340,8 +340,6 @@ public class LambdaEventHelpersTests
         {
             Assert.That(_attributes["aws.lambda.eventSource.accountId"], Is.EqualTo("testAccountId"));
             Assert.That(_attributes["aws.lambda.eventSource.apiId"], Is.EqualTo("testApiId"));
-            Assert.That(_attributes["aws.lambda.eventSource.resourceId"], Is.EqualTo("testRouteKey"));
-            Assert.That(_attributes["aws.lambda.eventSource.resourcePath"], Is.EqualTo("testPath"));
             Assert.That(_attributes["aws.lambda.eventSource.stage"], Is.EqualTo("testStage"));
 
             // Assert that the SetRequestHeaders, SetRequestMethod, SetUri, SetRequestParameters, and AcceptDistributedTraceHeaders methods were called with the correct arguments

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayEventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayEventsModel.cs
@@ -10,7 +10,7 @@ namespace NewRelic.Mock.Amazon.Lambda.APIGatewayEvents
     {
         public ProxyRequestContext RequestContext { get; set; }
         public Dictionary<string, string> Headers { get; set; }
-        public Dictionary<string, IList<string>> MultiValueHeaders {get; set;}
+        public Dictionary<string, IList<string>> MultiValueHeaders { get; set; }
         public string HttpMethod { get; set; }
         public string Path { get; set; }
         public Dictionary<string, string> QueryStringParameters { get; set; }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayV2EventsModel.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Lambda/Models/AmazonAPIGatewayV2EventsModel.cs
@@ -1,0 +1,342 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+
+namespace NewRelic.Mock.Amazon.Lambda.APIGatewayEvents
+{
+    // https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.APIGatewayEvents/APIGatewayHttpApiV2ProxyRequest.cs
+    public class APIGatewayHttpApiV2ProxyRequest
+    {
+        /// <summary>
+        /// The payload format version
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// The route key
+        /// </summary>
+        public string RouteKey { get; set; }
+
+        /// <summary>
+        /// The raw path
+        /// </summary>
+        public string RawPath { get; set; }
+
+        /// <summary>
+        /// The raw query string
+        /// </summary>
+        public string RawQueryString { get; set; }
+
+        /// <summary>
+        /// Cookies sent along with the request
+        /// </summary>
+        public string[] Cookies { get; set; }
+
+        /// <summary>
+        /// Headers sent with the request. Multiple values for the same header will be separated by a comma.
+        /// </summary>
+        public IDictionary<string, string> Headers { get; set; }
+
+        /// <summary>
+        /// Query string parameters sent with the request. Multiple values for the same parameter will be separated by a comma.
+        /// </summary>
+        public IDictionary<string, string> QueryStringParameters { get; set; }
+
+        /// <summary>
+        /// The request context for the request
+        /// </summary>
+        public ProxyRequestContext RequestContext { get; set; }
+
+        /// <summary>
+        /// The HTTP request body.
+        /// </summary>
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Path parameters sent with the request.
+        /// </summary>
+        public IDictionary<string, string> PathParameters { get; set; }
+
+        /// <summary>
+        /// True if the body of the request is base 64 encoded.
+        /// </summary>
+        public bool IsBase64Encoded { get; set; }
+
+        /// <summary>
+        /// The stage variables defined for the stage in API Gateway
+        /// </summary>
+        public IDictionary<string, string> StageVariables { get; set; }
+
+        /// <summary>
+        /// The ProxyRequestContext contains the information to identify the AWS account and resources invoking the 
+        /// Lambda function.
+        /// </summary>
+        public class ProxyRequestContext
+        {
+            /// <summary>
+            /// The account id that owns the executing Lambda function
+            /// </summary>
+            public string AccountId { get; set; }
+
+            /// <summary>
+            /// The API Gateway rest API Id.
+            /// </summary>
+            public string ApiId { get; set; }
+
+            /// <summary>
+            /// Information about the current requesters authorization including claims and scopes.
+            /// </summary>
+            public AuthorizerDescription Authorizer { get; set; }
+
+            /// <summary>
+            /// The domin name.
+            /// </summary>
+            public string DomainName { get; set; }
+
+            /// <summary>
+            ///  The domain prefix
+            /// </summary>
+            public string DomainPrefix { get; set; }
+
+            /// <summary>
+            /// Information about the HTTP request like the method and path.
+            /// </summary>
+            public HttpDescription Http { get; set; }
+
+            /// <summary>
+            /// The unique request id
+            /// </summary>
+            public string RequestId { get; set; }
+
+            /// <summary>
+            ///  The route id
+            /// </summary>
+            public string RouteId { get; set; }
+
+            /// <summary>
+            /// The selected route key.
+            /// </summary>
+            public string RouteKey { get; set; }
+
+            /// <summary>
+            /// The API Gateway stage name
+            /// </summary>
+            public string Stage { get; set; }
+
+            /// <summary>
+            /// Gets and sets the request time.
+            /// </summary>
+            public string Time { get; set; }
+
+            /// <summary>
+            /// Gets and sets the request time as an epoch.
+            /// </summary>
+            public long TimeEpoch { get; set; }
+
+            /// <summary>
+            /// Properties for authentication.
+            /// </summary>
+            public ProxyRequestAuthentication Authentication { get; set; }
+        }
+
+
+        /// <summary>
+        /// Container for authentication properties.
+        /// </summary>
+        public class ProxyRequestAuthentication
+        {
+            /// <summary>
+            /// Properties for a client certificate.
+            /// </summary>
+            public ProxyRequestClientCert ClientCert { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the properties of the client certificate.
+        /// </summary>
+        public class ProxyRequestClientCert
+        {
+            /// <summary>
+            /// The PEM-encoded client certificate that the client presented during mutual TLS authentication. 
+            /// Present when a client accesses an API by using a custom domain name that has mutual 
+            /// TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string ClientCertPem { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the subject of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SubjectDN { get; set; }
+
+            /// <summary>
+            /// The distinguished name of the issuer of the certificate that a client presents. 
+            /// Present when a client accesses an API by using a custom domain name that has 
+            /// mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string IssuerDN { get; set; }
+
+            /// <summary>
+            /// The serial number of the certificate. Present when a client accesses an API by 
+            /// using a custom domain name that has mutual TLS enabled. 
+            /// Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string SerialNumber { get; set; }
+
+            /// <summary>
+            /// The rules for when the client cert is valid.
+            /// </summary>
+            public ClientCertValidity Validity { get; set; }
+        }
+
+        /// <summary>
+        /// Container for the validation properties of a client cert.
+        /// </summary>
+        public class ClientCertValidity
+        {
+            /// <summary>
+            /// The date before which the certificate is invalid. Present when a client accesses an API by using a custom domain name 
+            /// that has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string NotBefore { get; set; }
+
+            /// <summary>
+            /// The date after which the certificate is invalid. Present when a client accesses an API by using a custom domain name that 
+            /// has mutual TLS enabled. Present only in access logs if mutual TLS authentication fails.
+            /// </summary>
+            public string NotAfter { get; set; }
+        }
+
+        /// <summary>
+        /// Information about the HTTP elements for the request.
+        /// </summary>
+        public class HttpDescription
+        {
+            /// <summary>
+            /// The HTTP method like POST or GET.
+            /// </summary>
+            public string Method { get; set; }
+
+            /// <summary>
+            /// The path of the request.
+            /// </summary>
+            public string Path { get; set; }
+
+            /// <summary>
+            /// The protocal used to make the rquest
+            /// </summary>
+            public string Protocol { get; set; }
+
+            /// <summary>
+            /// The source ip for the request.
+            /// </summary>
+            public string SourceIp { get; set; }
+
+            /// <summary>
+            /// The user agent for the request.
+            /// </summary>
+            public string UserAgent { get; set; }
+        }
+
+        /// <summary>
+        /// Information about the current requesters authorization.
+        /// </summary>
+        public class AuthorizerDescription
+        {
+            /// <summary>
+            /// The JWT description including claims and scopes.
+            /// </summary>
+            public JwtDescription Jwt { get; set; }
+
+            /// <summary>
+            /// The Lambda authorizer description
+            /// </summary>
+            public IDictionary<string, object> Lambda { get; set; }
+
+            /// <summary>
+            /// The IAM authorizer description
+            /// </summary>
+            public IAMDescription IAM { get; set; }
+
+
+            /// <summary>
+            /// Describes the information from an IAM authorizer
+            /// </summary>
+            public class IAMDescription
+            {
+                /// <summary>
+                /// The Access Key of the IAM Authorizer
+                /// </summary>
+                public string AccessKey { get; set; }
+
+                /// <summary>
+                /// The Account Id of the IAM Authorizer
+                /// </summary>
+                public string AccountId { get; set; }
+
+                /// <summary>
+                /// The Caller Id of the IAM Authorizer
+                /// </summary>
+                public string CallerId { get; set; }
+
+                /// <summary>
+                /// The Cognito Identity of the IAM Authorizer
+                /// </summary>
+                public CognitoIdentityDescription CognitoIdentity { get; set; }
+
+                /// <summary>
+                /// The Principal Org Id of the IAM Authorizer
+                /// </summary>
+                public string PrincipalOrgId { get; set; }
+
+                /// <summary>
+                /// The User ARN of the IAM Authorizer
+                /// </summary>
+                public string UserARN { get; set; }
+
+                /// <summary>
+                /// The User Id of the IAM Authorizer
+                /// </summary>
+                public string UserId { get; set; }
+            }
+
+            /// <summary>
+            /// The Cognito identity description for an IAM authorizer
+            /// </summary>
+            public class CognitoIdentityDescription
+            {
+                /// <summary>
+                /// The AMR of the IAM Authorizer
+                /// </summary>
+                public IList<string> AMR { get; set; }
+
+                /// <summary>
+                /// The Identity Id of the IAM Authorizer
+                /// </summary>
+                public string IdentityId { get; set; }
+
+                /// <summary>
+                /// The Identity Pool Id of the IAM Authorizer
+                /// </summary>
+                public string IdentityPoolId { get; set; }
+            }
+
+            /// <summary>
+            /// Describes the information in the JWT token
+            /// </summary>
+            public class JwtDescription
+            {
+                /// <summary>
+                /// Map of the claims for the requester.
+                /// </summary>
+                public IDictionary<string, string> Claims { get; set; }
+                /// <summary>
+                /// List of the scopes for the requester.
+                /// </summary>
+                public string[] Scopes { get; set; }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for `APIGatewayHttpApiV2ProxyRequest` and `APIGatewayHttpApiV2ProxyResponse` in AWS Lambda instrumentation. 

Includes unit and integration tests.