### PR TITLE
ci: Fix test_mode flag in post_deploy_agent workflow

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -455,5 +455,6 @@ jobs:
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
       wait_for_apt_and_yum: true
+      test_mode: false
     secrets: inherit
 

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -455,6 +455,5 @@ jobs:
     with:
       agent_version: ${{ needs.get-release-info.outputs.release_version }}
       wait_for_apt_and_yum: true
-      test_mode: false
     secrets: inherit
 

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -30,7 +30,7 @@ on:
         description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
         type: boolean
         default: false
-        required: true
+        required: false
     
 permissions:
   contents: read

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -15,7 +15,7 @@ on:
         description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
         type: boolean
         default: false
-        required: false
+        required: true
   workflow_call:
     inputs:
       agent_version:
@@ -30,7 +30,7 @@ on:
         description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
         type: boolean
         default: false
-        required: false
+        required: true
     
 permissions:
   contents: read

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Build and Run NugetDeprecator
         run: |
           dotnet publish --configuration Release --output "$PUBLISH_PATH" "$BUILD_PATH"
-          "$PUBLISH_PATH/NugetVersionDeprecator" -c $PUBLISH_PATH/config.yml --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }} --test-mode ${{ inputs.test_mode }}
+          "$PUBLISH_PATH/NugetVersionDeprecator" -c $PUBLISH_PATH/config.yml --github-token  ${{ secrets.GITHUB_TOKEN }} --api-key ${{ secrets.NEW_RELIC_API_KEY_PRODUCTION }} ${{ inputs.test_mode && '--test-mode' || '' }}
         shell: bash
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj


### PR DESCRIPTION
Fixed a bug in how we were specifying the `--test_mode` flag for the NugetDeprecator.