### PR TITLE
chore: Deprecate .NET 7, update warning message.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -321,7 +321,7 @@ namespace NewRelic.Agent.Core
 #else
             if (NewRelic.Core.DotnetVersion.IsUnsupportedDotnetCoreVersion(AgentInstallConfiguration.DotnetCoreVersion))
             {
-                Log.Warn("Unsupported .NET version {0} detected. Please use a version of .NET >= net6.", AgentInstallConfiguration.DotnetCoreVersion);
+                Log.Warn("Unsupported .NET version {0} detected. Please use net6 or net8 or newer.", AgentInstallConfiguration.DotnetCoreVersion);
             }
 #endif
         }

--- a/src/NewRelic.Core/DotnetVersion.cs
+++ b/src/NewRelic.Core/DotnetVersion.cs
@@ -136,7 +136,7 @@ namespace NewRelic.Core
             // Newer versions of .net will be flagged as Other until we update our version checking logic.
             // So we can either check against a supported list, or an unsupported list, but the supported list
             // is smaller.
-            var supportedDotnetCoreVersions = new List<DotnetCoreVersion> { DotnetCoreVersion.net6, DotnetCoreVersion.net7, DotnetCoreVersion.net8, DotnetCoreVersion.Other };
+            var supportedDotnetCoreVersions = new List<DotnetCoreVersion> { DotnetCoreVersion.net6, DotnetCoreVersion.net8, DotnetCoreVersion.Other };
             return !supportedDotnetCoreVersions.Contains(version);
         }
 

--- a/tests/NewRelic.Core.Tests/DotnetVersionTests.cs
+++ b/tests/NewRelic.Core.Tests/DotnetVersionTests.cs
@@ -13,7 +13,7 @@ namespace NewRelic.Core.Tests
         [TestCase(DotnetCoreVersion.netcoreapp31, ExpectedResult = true)]
         [TestCase(DotnetCoreVersion.net5, ExpectedResult = true)]
         [TestCase(DotnetCoreVersion.net6, ExpectedResult = false)]
-        [TestCase(DotnetCoreVersion.net7, ExpectedResult = false)]
+        [TestCase(DotnetCoreVersion.net7, ExpectedResult = true)]
         [TestCase(DotnetCoreVersion.net8, ExpectedResult = false)]
         [TestCase(DotnetCoreVersion.Other, ExpectedResult = false)]
         public bool IsUnsupportedDotnetCoreVersion(DotnetCoreVersion version)


### PR DESCRIPTION
Adds .NET 7 to the list of unsupported .NET versions, updates the warning message

Resolves #2429 