### PR TITLE
chore: Update lambda handler environment variable to match other Agents

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.21.1.66"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.24.0.10"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -134,7 +134,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
                 return;
             }
 
-            lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("NEW_RELIC_LAMBDA_FUNCTION_HANDLER"));
+            lambdaInstPoint = _systemCalls->TryGetEnvironmentVariable(_X("NEW_RELIC_LAMBDA_HANDLER"));
             if (lambdaInstPoint != nullptr)
             {
                 AddInstrumentationPointToCollectionFromEnvironment(*lambdaInstPoint);

--- a/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
+++ b/tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/Program.cs
@@ -156,12 +156,12 @@ namespace LambdaSelfExecutingAssembly
         }
         private static string GetHandlerName()
         {
-            var handlerName = Environment.GetEnvironmentVariable("NEW_RELIC_LAMBDA_FUNCTION_HANDLER") ??
+            var handlerName = Environment.GetEnvironmentVariable("NEW_RELIC_LAMBDA_HANDLER") ??
                 Environment.GetEnvironmentVariable("_HANDLER");
 
             if (string.IsNullOrWhiteSpace(handlerName))
             {
-                throw new Exception("The lambda handler is missing. Please ensure that the correct handler is defined in either the NEW_RELIC_LAMBDA_FUNCTION_HANDLER or _HANDLER environment variables.");
+                throw new Exception("The lambda handler is missing. Please ensure that the correct handler is defined in either the NEW_RELIC_LAMBDA_HANDLER or _HANDLER environment variables.");
             }
 
             return handlerName;

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                     SetAdditionalEnvironmentVariable("NEW_RELIC_ACCOUNT_ID", TestConfiguration.NewRelicAccountId);
                     SetAdditionalEnvironmentVariable("AWS_LAMBDA_RUNTIME_API", $"localhost:{LambdaTestTool.Port}");
 
-                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_LAMBDA_FUNCTION_HANDLER", newRelicLambdaHandler);
+                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_LAMBDA_HANDLER", newRelicLambdaHandler);
                     AddAdditionalEnvironmentVariableIfNotNull("_HANDLER", lambdaHandler);
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_LAMBDA_FUNCTION_NAME", lambdaName);
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_LAMBDA_FUNCTION_VERSION", lambdaVersion);


### PR DESCRIPTION
Changing `NEW_RELIC_LAMBDA_FUNCTION_HANDLER` to `NEW_RELIC_LAMBDA_HANDLER` to match what the other agents are using.

Requires rebuilding the Profiler, which will be included shortly.
