### PR TITLE
feat: Enable configuration of ignored and expected HTTP status code errors with environment variables

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2628,10 +2628,10 @@ namespace NewRelic.Agent.Core.Configuration
             var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
             var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
 
-            var expectedStatusCodesArray = ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal);
+            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal)?.ToList(), @"NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
 
             ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
-            ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? new string[0];
+            ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? new List<string>();
 
             ExpectedErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
             ExpectedErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedMessages);

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2628,7 +2628,7 @@ namespace NewRelic.Agent.Core.Configuration
             var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
             var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
 
-            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal)?.ToList(), @"NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
+            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal)?.ToList(), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
 
             ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
             ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? new List<string>();
@@ -2677,7 +2677,7 @@ namespace NewRelic.Agent.Core.Configuration
                 }
             }
 
-            var ignoreStatusCodes = _serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore;
+            IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore?.ToList(), "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
             if (ignoreStatusCodes == null)
             {
                 ignoreStatusCodes = _localConfiguration.errorCollector.ignoreStatusCodes.code

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2382,7 +2382,7 @@ namespace NewRelic.Agent.Core.Configuration
             return server ?? local;
         }
 
-        private List<string> EnvironmentOverrides(List<string> local, params string[] environmentVariableNames)
+        private IEnumerable<string> EnvironmentOverrides(IEnumerable<string> local, params string[] environmentVariableNames)
         {
             var envValue = (environmentVariableNames ?? Enumerable.Empty<string>())
                 .Select(_environment.GetEnvironmentVariable)
@@ -2628,7 +2628,7 @@ namespace NewRelic.Agent.Core.Configuration
             var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
             var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
 
-            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal)?.ToList(), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
+            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
 
             ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
             ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? new List<string>();
@@ -2677,7 +2677,7 @@ namespace NewRelic.Agent.Core.Configuration
                 }
             }
 
-            IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore?.ToList(), "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
+            IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore, "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
             if (ignoreStatusCodes == null)
             {
                 ignoreStatusCodes = _localConfiguration.errorCollector.ignoreStatusCodes.code

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -999,13 +999,17 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return string.Join(",", _defaultConfig.IgnoreErrorsConfiguration.Keys);
         }
 
-        [TestCase("401", new[] { "405" }, ExpectedResult = new[] { "405" })]
-        [TestCase("401", new string[0], ExpectedResult = new string[0])]
-        [TestCase("401", null, ExpectedResult = new[] { "401" })]
-        public string[] ExpectedStatusCodesSetFromLocalAndServerOverrides(string local, string[] server)
+        [TestCase("401", new[] { "405" }, null, ExpectedResult = new[] { "405" })]
+        [TestCase("401", new string[0], null, ExpectedResult = new string[0])]
+        [TestCase("401", null, null, ExpectedResult = new[] { "401" })]
+        [TestCase(null, null, "401", ExpectedResult = new[] { "401" })]
+        [TestCase(null, new[] { "405" }, "401", ExpectedResult = new[] { "401" })]
+        [TestCase("402", new string[0], "401", ExpectedResult = new[] { "401" })]
+        public string[] ExpectedStatusCodesSetFromLocalServerAndEnvironmentOverrides(string local, string[] server, string env)
         {
             _serverConfig.RpmConfig.ErrorCollectorExpectedStatusCodes = server;
             _localConfig.errorCollector.expectedStatusCodes = (local);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES")).Returns(env);
 
             CreateDefaultConfiguration();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -999,13 +999,14 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return string.Join(",", _defaultConfig.IgnoreErrorsConfiguration.Keys);
         }
 
-        [TestCase("401", new[] { "405" }, null,       ExpectedResult = new[] { "405" })]
-        [TestCase("401", new string[0],   null,       ExpectedResult = new string[0])]
-        [TestCase("401", null,            null,       ExpectedResult = new[] { "401" })]
-        [TestCase(null,  null,            "401",      ExpectedResult = new[] { "401" })]
-        [TestCase(null,  new[] { "405" }, "401",      ExpectedResult = new[] { "401" })]
-        [TestCase("402", new string[0],   "401",      ExpectedResult = new[] { "401" })]
-        [TestCase("402", new string[0],   "401, 503", ExpectedResult = new[] { "401", "503" })]
+        [TestCase("401", new[] { "405" }, null,           ExpectedResult = new[] { "405" })]
+        [TestCase("401", new string[0],   null,           ExpectedResult = new string[0])]
+        [TestCase("401", null,            null,           ExpectedResult = new[] { "401" })]
+        [TestCase(null,  null,            "401",          ExpectedResult = new[] { "401" })]
+        [TestCase(null,  new[] { "405" }, "401",          ExpectedResult = new[] { "401" })]
+        [TestCase("402", new string[0],   "401",          ExpectedResult = new[] { "401" })]
+        [TestCase("402", new string[0],   "401, 503",     ExpectedResult = new[] { "401", "503" })]
+        [TestCase("402", new string[0],   "401, 500-505", ExpectedResult = new[] { "401", "500-505" })]
         public string[] ExpectedStatusCodesSetFromLocalServerAndEnvironmentOverrides(string local, string[] server, string env)
         {
             _serverConfig.RpmConfig.ErrorCollectorExpectedStatusCodes = server;

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -999,12 +999,13 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return string.Join(",", _defaultConfig.IgnoreErrorsConfiguration.Keys);
         }
 
-        [TestCase("401", new[] { "405" }, null, ExpectedResult = new[] { "405" })]
-        [TestCase("401", new string[0], null, ExpectedResult = new string[0])]
-        [TestCase("401", null, null, ExpectedResult = new[] { "401" })]
-        [TestCase(null, null, "401", ExpectedResult = new[] { "401" })]
-        [TestCase(null, new[] { "405" }, "401", ExpectedResult = new[] { "401" })]
-        [TestCase("402", new string[0], "401", ExpectedResult = new[] { "401" })]
+        [TestCase("401", new[] { "405" }, null,       ExpectedResult = new[] { "405" })]
+        [TestCase("401", new string[0],   null,       ExpectedResult = new string[0])]
+        [TestCase("401", null,            null,       ExpectedResult = new[] { "401" })]
+        [TestCase(null,  null,            "401",      ExpectedResult = new[] { "401" })]
+        [TestCase(null,  new[] { "405" }, "401",      ExpectedResult = new[] { "401" })]
+        [TestCase("402", new string[0],   "401",      ExpectedResult = new[] { "401" })]
+        [TestCase("402", new string[0],   "401, 503", ExpectedResult = new[] { "401", "503" })]
         public string[] ExpectedStatusCodesSetFromLocalServerAndEnvironmentOverrides(string local, string[] server, string env)
         {
             _serverConfig.RpmConfig.ErrorCollectorExpectedStatusCodes = server;
@@ -1016,13 +1017,14 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.ExpectedErrorStatusCodesForAgentSettings.ToArray();
         }
 
-        [TestCase(new[] { 401f }, new[] { "405" }, null,  ExpectedResult = new[] { "405" })]
-        [TestCase(new[] { 401f }, new string[0],   null,  ExpectedResult = new string[0])]
-        [TestCase(new[] { 401f }, null,            null,  ExpectedResult = new[] { "401" })]
-        [TestCase(new float[0],   null,            "401", ExpectedResult = new[] { "401" })]
-        [TestCase(new float[0],   new[] { "405" }, "401", ExpectedResult = new[] { "401" })]
-        [TestCase(new[] { 401f }, new string[0], "401",   ExpectedResult = new[] { "401" })]
-        [TestCase(new[] { 401f }, new string[0], "401, 503",   ExpectedResult = new[] { "401", "503" })]
+        [TestCase(new[] { 401f },   new[] { "405" }, null,         ExpectedResult = new[] { "405" })]
+        [TestCase(new[] { 401f },   new string[0],   null,         ExpectedResult = new string[0])]
+        [TestCase(new[] { 401f },   null,            null,         ExpectedResult = new[] { "401" })]
+        [TestCase(new[] { 401.5f }, null,            null,         ExpectedResult = new[] { "401.5" })]
+        [TestCase(new float[0],     null,            "401",        ExpectedResult = new[] { "401" })]
+        [TestCase(new float[0],     new[] { "405" }, "401",        ExpectedResult = new[] { "401" })]
+        [TestCase(new[] { 401f },   new string[0],   "402",        ExpectedResult = new[] { "402" })]
+        [TestCase(new[] { 401f },   new string[0],   "401.5, 503", ExpectedResult = new[] { "401.5", "503" })]
         public string[] IgnoredStatusCodesSetFromLocalServerAndEnvironmentOverrides(float[] local, string[] server, string env)
         {
             _serverConfig.RpmConfig.ErrorCollectorStatusCodesToIgnore = server;

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1016,6 +1016,24 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             return _defaultConfig.ExpectedErrorStatusCodesForAgentSettings.ToArray();
         }
 
+        [TestCase(new[] { 401f }, new[] { "405" }, null,  ExpectedResult = new[] { "405" })]
+        [TestCase(new[] { 401f }, new string[0],   null,  ExpectedResult = new string[0])]
+        [TestCase(new[] { 401f }, null,            null,  ExpectedResult = new[] { "401" })]
+        [TestCase(new float[0],   null,            "401", ExpectedResult = new[] { "401" })]
+        [TestCase(new float[0],   new[] { "405" }, "401", ExpectedResult = new[] { "401" })]
+        [TestCase(new[] { 401f }, new string[0], "401",   ExpectedResult = new[] { "401" })]
+        [TestCase(new[] { 401f }, new string[0], "401, 503",   ExpectedResult = new[] { "401", "503" })]
+        public string[] IgnoredStatusCodesSetFromLocalServerAndEnvironmentOverrides(float[] local, string[] server, string env)
+        {
+            _serverConfig.RpmConfig.ErrorCollectorStatusCodesToIgnore = server;
+            _localConfig.errorCollector.ignoreStatusCodes.code = (local.ToList());
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES")).Returns(env);
+
+            CreateDefaultConfiguration();
+
+            return _defaultConfig.HttpStatusCodesToIgnore.ToArray();
+        }
+
         [TestCase("401-404", new string[] { "401.5", "402.3" }, new bool[] { false, false })] //does not support full status codes
         [TestCase("400,401,404", new string[] { "400", "401", "402", "403", "404" }, new bool[] { true, true, false, false, true })]
         [TestCase("400, 401 ,404", new string[] { "400", "401", "402", "403", "404" }, new bool[] { true, true, false, false, true })]


### PR DESCRIPTION
## Description

This PR resolves #2181 by introducing two new environment variables for configuring agent behavior:
`NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES`
`NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES`

Both env vars support defining multiple HTTP status codes in a comma-separated list, e.g.:
`NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES="401,503"`

The env var for expected error codes also supports defining a range of codes like this:
`NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES="401,500-505"`

The internal logic of the error collector doesn't currently support ranges for ignored error codes, hence the difference.

I will update the description of this PR with a link to the docs site update PR once that is created.

# Author Checklist
- [x] Unit tests, ~Integration tests, and Unbounded tests~ completed
- [ ] ~Performance testing completed with satisfactory results (if required)~ N/A

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
