### PR TITLE
fix: Accept inbound tracing headers in Kafka consume method instrumentation

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaConsumerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaConsumerWrapper.cs
@@ -134,7 +134,6 @@ namespace NewRelic.Providers.Wrapper.Kafka
         private static Func<object, object> GetValueAccessorFunc(Type t) =>
             VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(t, "Value");
 
-        //IEnumerable<string> GetHeaderValue(IDictionary<string, object> carrier, string key)
         private static IEnumerable<string> DistributedTraceHeadersGetter(MessageMetadata carrier, string key)
         {
             if (carrier.Headers != null)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaConsumerWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Kafka/KafkaConsumerWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text;
 using Confluent.Kafka;
 using NewRelic.Agent.Api;
@@ -65,7 +66,7 @@ namespace NewRelic.Providers.Wrapper.Kafka
                     segment.SetMessageBrokerDestination(topic);
                     transaction.SetKafkaMessageBrokerTransactionName(MessageBrokerDestinationType.Topic, BrokerVendorName, topic);
 
-                    // get the Message.Headers property and add distributed trace headers
+                    // get the Message.Headers property and process distributed trace headers
                     var messageAccessor = MessageAccessorDictionary.GetOrAdd(type, GetMessageAccessorFunc);
                     var messageAsObject = messageAccessor(resultAsObject);
 
@@ -73,7 +74,7 @@ namespace NewRelic.Providers.Wrapper.Kafka
                     if (messageAsObject is MessageMetadata messageMetaData)
                     {
                         headersSize = GetHeadersSize(messageMetaData.Headers);
-                        transaction.InsertDistributedTraceHeaders(messageMetaData, DistributedTraceHeadersSetter);
+                        transaction.AcceptDistributedTraceHeaders(messageMetaData, DistributedTraceHeadersGetter, TransportType.Kafka);
                     }
 
                     ReportSizeMetrics(agent, transaction, topic, headersSize, messageAsObject);
@@ -133,14 +134,23 @@ namespace NewRelic.Providers.Wrapper.Kafka
         private static Func<object, object> GetValueAccessorFunc(Type t) =>
             VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(t, "Value");
 
-        private static void DistributedTraceHeadersSetter(MessageMetadata carrier, string key, string value)
+        //IEnumerable<string> GetHeaderValue(IDictionary<string, object> carrier, string key)
+        private static IEnumerable<string> DistributedTraceHeadersGetter(MessageMetadata carrier, string key)
         {
-            carrier.Headers ??= new Headers();
-            if (!string.IsNullOrEmpty(key))
+            if (carrier.Headers != null)
             {
-                carrier.Headers.Remove(key);
-                carrier.Headers.Add(key, Encoding.ASCII.GetBytes(value));
+                var headerValues = new List<string>();
+                foreach (var item in carrier.Headers)
+                {
+                    if (item.Key.Equals(key, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var decodedHeaderValue = Encoding.UTF8.GetString(item.GetValueBytes());
+                        headerValues.Add(decodedHeaderValue);
+                    }
+                }
+                return headerValues;
             }
+            return null;
         }
 
         private static long TryGetSize(object obj)

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -83,6 +83,8 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
             new Assertions.ExpectedMetric { metricName = consumeTransactionName, callCount = 2 },
             new Assertions.ExpectedMetric { metricName = messageBrokerConsume, callCount = 2 },
             new Assertions.ExpectedMetric { metricName = messageBrokerConsume, metricScope = consumeTransactionName, callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Create/Success", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Accept/Success", callCount = 2 },
         };
 
         NrAssert.Multiple(
@@ -93,7 +95,7 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
             () => Assert.True(consumeTxnSpan.UserAttributes.ContainsKey("kafka.consume.byteCount")),
             () => Assert.InRange((long)consumeTxnSpan.UserAttributes["kafka.consume.byteCount"], 450, 470), // includes headers
             () => Assert.True(consumeTxnSpan.IntrinsicAttributes.ContainsKey("traceId")),
-            () => Assert.False(consumeTxnSpan.IntrinsicAttributes.ContainsKey("parentId"))
+            () => Assert.True(consumeTxnSpan.IntrinsicAttributes.ContainsKey("parentId"))
         );
     }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in our instrumentation for `Confluent.Kafka`.  On the message `Consume` side, we were not property processing inbound distributed tracing headers.  This is now fixed.

I verified with manual testing of two separate test applications, one a Kafka producer and the other a consumer, that before this change, the two application entities would not be shown as linked in the Distributed Tracing UI.  After this change, they are.

The Kafka containerized integration test is updated to assert for the relevant supportability metrics for trace context payload create and accept.

# Author Checklist
- [X] ~Unit tests~, Integration tests, ~and Unbounded tests~ completed
- [X] ~Performance testing completed with satisfactory results (if required)~ N/A

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
