### PR TITLE
ci: Deploy a new Lambda layer on Agent release

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -44,6 +44,11 @@ on:
         description: Re-Index the Download Site S3 container
         required: true
         default: true
+      lambdalayer:
+        type: boolean
+        description: Deploy Lambda Layer
+        required: true
+        default: true
 
 permissions:
   contents: read
@@ -443,12 +448,23 @@ jobs:
       run_id: ${{ needs.get-release-info.outputs.workflow_run_id }}
     secrets: inherit
 
+  deploy-lambda-layer:
+    permissions:
+      contents: write
+    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    if: $(( inputs.lambdalayer ))
+    name: Run Lambda Layer Deploy Workflow
+    uses: newrelic/newrelic-dotnet-agent/.github/workflows/deploy_lambda_layer.yml@main
+    with:
+      agent_version: ${{ needs.get-release-info.outputs.release_version }}
+    secrets: inherit
+
   post-deploy:
     permissions:
       issues: write
       contents: read
       packages: read
-    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
+    needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site, deploy-lambda-layer]
     if: ${{ inputs.deploy && inputs.downloadsite && inputs.nuget && inputs.linux && inputs.linux-deploy-to-production }}
     name: Run Post Deploy Workflow
     uses: newrelic/newrelic-dotnet-agent/.github/workflows/post_deploy_agent.yml@main

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -449,8 +449,6 @@ jobs:
     secrets: inherit
 
   deploy-lambda-layer:
-    permissions:
-      contents: write
     needs: [get-release-info, deploy-linux, deploy-nuget, index-download-site]
     if: $(( inputs.lambdalayer ))
     name: Run Lambda Layer Deploy Workflow

--- a/.github/workflows/deploy_lambda_layer.yml
+++ b/.github/workflows/deploy_lambda_layer.yml
@@ -1,0 +1,36 @@
+name: Publish .NET Lambda Layer
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent_version:
+        description: 'Agent version that was released.  Needs to match the version from the Deploy Agent workflow (deploy_agent.yml). Format: X.X.X'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      agent_version:
+        description: 'Agent Version to create a layer for.  Needs to match the version from the Release Workflow (all_solutions.yml). Format: X.X.X'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-layer:
+    name: Create and Publish Lambda Layer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit
+
+      - name: Create Tag
+      # A workflow in the layers repo will trigger off the creation of the tag
+        run: gh release create v${{ inputs.agent_version }}_dotnet --repo "$REPO" -t "$TITLE" --latest=false
+        env:
+          GH_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
+          REPO: https://github.com/newrelic/newrelic-lambda-layers/
+          TITLE: "New Relic .NET Agent v${{ inputs.agent_version }}"

--- a/.github/workflows/deploy_lambda_layer.yml
+++ b/.github/workflows/deploy_lambda_layer.yml
@@ -14,13 +14,12 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
-
 jobs:
   publish-layer:
     name: Create and Publish Lambda Layer
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1


### PR DESCRIPTION
When we deploy a new version of the .NET Agent, this will create a tag in the [New Relic Lambda Layers repo](https://github.com/newrelic/newrelic-lambda-layers/), which in turn will trigger creation of a new .NET Lambda layer. The tag needs to be in the format `vX.Y.Z_dotnet`. This PR is waiting for [that workflow](https://github.com/newrelic/newrelic-lambda-layers/pull/228) to be merged.