### PR TITLE
chore: Update deploy workflow to create version-less .zip and .tar.gz files

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -198,6 +198,10 @@ jobs:
         run: |
           Copy-Item .\working_dir\NewRelicDotNetAgent_*_x64.msi .\working_dir\NewRelicDotNetAgent_x64.msi -Force -Recurse
           Copy-Item .\working_dir\NewRelicDotNetAgent_*_x86.msi .\working_dir\NewRelicDotNetAgent_x86.msi -Force -Recurse
+          Copy-Item .\working_dir\NewRelicDotNetAgent_*_x64.zip .\working_dir\NewRelicDotNetAgent_x64.zip -Force -Recurse
+          Copy-Item .\working_dir\NewRelicDotNetAgent_*_x86.zip .\working_dir\NewRelicDotNetAgent_x86.zip -Force -Recurse
+          Copy-Item .\working_dir\NewRelicDotNetAgent_*_amd64.tar.gz .\working_dir\NewRelicDotNetAgent_amd64.tar.gz -Force -Recurse
+          Copy-Item .\working_dir\NewRelicDotNetAgent_*_arm64.tar.gz .\working_dir\NewRelicDotNetAgent_arm64.tar.gz -Force -Recurse
         shell: powershell
 
       - name: Deploy latest_release to Download Site


### PR DESCRIPTION
Simple update to the existing deploy_agent workflow to create "version-less" `.zip` and `.tar.gz` files to make it easier to reference the "latest" release without needing to know a version number. 