### PR TITLE
fix: Agent license key should be optional in Serverless mode.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -176,8 +176,11 @@ namespace NewRelic.Agent.Core
             if (!Configuration.AgentEnabled)
                 throw new Exception(string.Format("The New Relic agent is disabled.  Update {0}  to re-enable it.", Configuration.AgentEnabledAt));
 
-            if ("REPLACE_WITH_LICENSE_KEY".Equals(Configuration.AgentLicenseKey))
-                throw new Exception("Please set your license key.");
+            if (!Configuration.ServerlessModeEnabled) // license key is not required to be set in serverless mode
+            {
+                if ("REPLACE_WITH_LICENSE_KEY".Equals(Configuration.AgentLicenseKey))
+                    throw new Exception("Please set your license key.");
+            }
         }
 
         private void Initialize(bool serverlessModeEnabled)

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
@@ -70,10 +70,12 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
             }
 
             var licenseKey = _configurationService.Configuration.AgentLicenseKey;
-            if (licenseKey == null)
-                throw new NullReferenceException(nameof(licenseKey));
-            if (licenseKey.Length <= 0)
-                throw new Exception("License key is empty");
+            // serverless mode doesn't require a license key, so this check can fail.
+            if (string.IsNullOrEmpty(licenseKey) || "REPLACE_WITH_LICENSE_KEY".Equals(licenseKey))
+            {
+                Log.Debug("Skipping RUM injection because license key is not set.");
+                return null;
+            }
 
             var browserConfigurationData = GetBrowserConfigurationData(transaction, transactionMetricName, licenseKey);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringScriptMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringScriptMakerTests.cs
@@ -193,15 +193,6 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         }
 
         [Test]
-        public void GetScript_Throws_IfAgentLicenseKeyIsEmpty()
-        {
-            Mock.Arrange(() => _configuration.AgentLicenseKey).Returns(string.Empty);
-            var transaction = BuildTestTransaction();
-
-            Assert.Throws<Exception>(() => _browserMonitoringScriptMaker.GetScript(transaction, null));
-        }
-
-        [Test]
         public void GetScript_Throws_IfBrowserMonitoringBeaconAddressIsNull()
         {
             Mock.Arrange(() => _configuration.BrowserMonitoringBeaconAddress).Returns(null as string);

--- a/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringScriptMakerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/BrowserMonitoring/BrowserMonitoringScriptMakerTests.cs
@@ -182,12 +182,14 @@ namespace NewRelic.Agent.Core.BrowserMonitoring
         }
 
         [Test]
-        public void GetScript_Throws_IfAgentLicenseKeyIsNull()
+        public void GetScript_ReturnsNull_IfAgentLicenseKeyIsNotSet()
         {
             Mock.Arrange(() => _configuration.AgentLicenseKey).Returns(null as string);
             var transaction = BuildTestTransaction();
 
-            Assert.Throws<NullReferenceException>(() => _browserMonitoringScriptMaker.GetScript(transaction, null));
+            var script = _browserMonitoringScriptMaker.GetScript(transaction, null);
+
+            Assert.That(script, Is.Null);
         }
 
         [Test]


### PR DESCRIPTION
## Description

When running in Serverless mode, the Agent License Key is not required to be set (either in config or via an environment variable). 

This PR fixes #2499 by adding a check for serverless mode in `AgentManager.AssertAgentEnabled()`. Additionally,  when browser monitoring is enabled but the license key is not set, we now log a message rather than throwing an exception.