### PR TITLE
test: Update NServiceBus tests to include v8 and v9

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -211,9 +211,8 @@
     <PackageReference Include="NServiceBus" Version="6.5.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <!-- NServiceBus 6.5 only appears to support .NET Framework. Uncomment for 'fun' -->
-    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="NServiceBus" Version="7.7.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NServiceBus" Version="8.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="NServiceBus" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/Handlers/AsyncCommandHandler.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/Handlers/AsyncCommandHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Threading.Tasks;
@@ -15,7 +15,9 @@ namespace NsbTests
         public async Task Handle(Command command, IMessageHandlerContext context)
         {
             ConsoleMFLogger.Info($"Async Command handler received message with Id {command.Id}.");
+#pragma warning disable NSB0002 // Forward the 'CancellationToken' property of the context parameter to methods
             await Task.Delay(500);
+#pragma warning restore NSB0002 // Forward the 'CancellationToken' property of the context parameter to methods
             ConsoleMFLogger.Info($"Async Command handler done delaying message with Id {command.Id}.");
             // Make sure segment/transaction ends
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/Handlers/AsyncEventHandler.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/Handlers/AsyncEventHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Threading.Tasks;
@@ -15,7 +15,9 @@ namespace NsbTests
         public async Task Handle(Event message, IMessageHandlerContext context)
         {
             ConsoleMFLogger.Info($"Async Event handler received message with Id {message.Id}.");
+#pragma warning disable NSB0002 // Forward the 'CancellationToken' property of the context parameter to methods
             await Task.Delay(500);
+#pragma warning restore NSB0002 // Forward the 'CancellationToken' property of the context parameter to methods
             ConsoleMFLogger.Info($"Async Event handler done delaying message with Id {message.Id}.");
             // Make sure segment/transaction ends
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/NServiceBus/NServiceBusDriver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using MultiFunctionApplicationHelpers;
@@ -34,6 +34,10 @@ namespace NsbTests
             transport.StorageDirectory(".lt");
             endpointConfiguration.SendFailedMessagesTo("error");
             endpointConfiguration.EnableInstallers();
+
+#if NET8_0_OR_GREATER // serializer must be specified starting with NServiceBus 9.0.0
+            endpointConfiguration.UseSerialization<XmlSerializer>();
+#endif
 
             // We want to control which handlers are loaded for different test cases
             endpointConfiguration.AssemblyScanner().ScanAppDomainAssemblies = false;


### PR DESCRIPTION
Updates unbounded tests to use NServiceBus v8.2.0 and v9.0.0. 

Required a couple minor changes to the test code but no changes in instrumentation.
