### PR TITLE
tests: Remove references to Common.Logging

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/BasicMvcApplication.csproj
@@ -58,12 +58,6 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Common.Logging">
-      <Version>3.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Common.Logging.Core">
-      <Version>3.3.1</Version>
-    </PackageReference>
     <PackageReference Include="CouchbaseNetClient">
       <Version>2.3.8</Version>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -41,8 +41,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Common.Logging" Version="3.3.1" />
-    <PackageReference Include="Common.Logging.Core" Version="3.3.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">


### PR DESCRIPTION
This package appears to be unused.
