### PR TITLE
chore: Warn if OpenTracing is detected

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/Instrumentation.xml
@@ -11,5 +11,11 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="RunAsync" />
       </match>
     </tracerFactory>
+    <!-- We want to detect if the OpenTracing solution is running, as it is not compatible with the full Agent. -->
+    <tracerFactory name="OpenTracingWrapper">
+      <match assemblyName="NewRelic.OpenTracing.AmazonLambda.Tracer" className="NewRelic.OpenTracing.AmazonLambda.LambdaTracer">
+        <exactMethodMatcher methodName=".ctor" />
+      </match>
+    </tracerFactory>
   </instrumentation>
 </extension>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/OpenTracingWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/OpenTracingWrapper.cs
@@ -1,0 +1,26 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+
+namespace NewRelic.Providers.Wrapper.AwsLambda
+{
+    public class OpenTracingWrapper : IWrapper
+    {
+        private const string WrapperName = "OpenTracingWrapper";
+
+        public bool IsTransactionRequired => false;
+
+        public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
+        {
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+        }
+
+        public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Warn, "OpenTracing is not compatible with the full .NET Agent and may result in undefined behavior. Please remove OpenTracing from your application.");
+            return Delegates.NoOp;
+        }
+    }
+}


### PR DESCRIPTION
We've learned that our legacy OpenTracing solution will break our Agent running in serverless mode. To catch these use cases early, this will log a warning if the `LambdaTracer` constructor is called. It will look something like this:

```
2024-05-28 20:56:16,925 NewRelic   INFO: [pid: 19112, tid: 1] The New Relic agent is operating in serverless mode.
2024-05-28 20:56:16,964 NewRelic   INFO: [pid: 19112, tid: 1] The New Relic .NET Agent v10.25.0.3 started (pid 19112) on app domain 'My.Application'
2024-05-28 20:57:05,129 NewRelic   WARN: [pid: 19112, tid: 1] OpenTracing is not compatible with the full .NET Agent and may result in undefined behavior. Please remove OpenTracing from your application.
```

Since this is logging-only behavior, I didn't think an integration test was necessary.