### PR TITLE
fix: Nested logging contexts should not disable context data for Microsoft.Extensions.Logging

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/Logger.cs
@@ -34,24 +34,47 @@ namespace NewRelic.Agent.Core.Logging
         public void Log(Level level, string message)
         {
             if (!IsEnabledFor(level)) return;
-            var messageString = message.ToString();
 
             switch (level)
             {
                 case Level.Finest:
-                    _logger.Verbose(messageString);
+                    _logger.Verbose(message);
                     break;
                 case Level.Debug:
-                    _logger.Debug(messageString);
+                    _logger.Debug(message);
                     break;
                 case Level.Info:
-                    _logger.Information(messageString);
+                    _logger.Information(message);
                     break;
                 case Level.Warn:
-                    _logger.Warning(messageString);
+                    _logger.Warning(message);
                     break;
                 case Level.Error:
-                    _logger.Error(messageString);
+                    _logger.Error(message);
+                    break;
+            }
+        }
+
+        public void Log(Level level, Exception ex, string message)
+        {
+            if (!IsEnabledFor(level)) return;
+
+            switch (level)
+            {
+                case Level.Finest:
+                    _logger.Verbose(ex, message);
+                    break;
+                case Level.Debug:
+                    _logger.Debug(ex, message);
+                    break;
+                case Level.Info:
+                    _logger.Information(ex, message);
+                    break;
+                case Level.Warn:
+                    _logger.Warning(ex, message);
+                    break;
+                case Level.Error:
+                    _logger.Error(ex, message);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/ILogger.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Logging/ILogger.cs
@@ -1,6 +1,8 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+
 namespace NewRelic.Agent.Extensions.Logging
 {
     public enum Level
@@ -16,5 +18,6 @@ namespace NewRelic.Agent.Extensions.Logging
     {
         bool IsEnabledFor(Level level);
         void Log(Level level, string message);
+        void Log(Level level, Exception ex,  string message);
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/DummyMELAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/DummyMELAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -62,6 +62,18 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public void ConfigurePatternLayoutAppenderForDecoration() => CreateMelLogger();
 
         public void ConfigureJsonLayoutAppenderForDecoration() => CreateMelLogger();
+        public void LogMessageInNestedScopes()
+        {
+            using (var _ = _logger.BeginScope("{ScopeKey1}", "scopeValue1"))
+            {
+                _logger.LogInformation("Outer Scope");
+
+                using (var __ = _logger.BeginScope("{ScopeKey1}", "scopeValue2"))
+                {
+                    _logger.LogInformation("Inner Scope");
+                }
+            }
+        }
 
         private void CreateMelLogger()
         {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/ILoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/ILoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -24,5 +24,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public void ConfigurePatternLayoutAppenderForDecoration();
         public void ConfigureJsonLayoutAppenderForDecoration();
 
+        public void  LogMessageInNestedScopes();
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/Log4NetLoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -134,6 +134,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 #endif
         }
 
+        public void LogMessageInNestedScopes()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     /// <summary>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -197,5 +197,13 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             CreateSingleLogMessageWithParam(message);
         }
 
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static void LogMessageInNestedScopes()
+        {
+            _log.LogMessageInNestedScopes();
+        }
+
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/MicrosoftLoggingLoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -103,6 +103,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
                 .CreateLogger();
 
             CreateMelLogger(LogLevel.Debug, serilogLogger);
+        }
+
+        public void LogMessageInNestedScopes()
+        {
+            using (var _ = logger.BeginScope("{ScopeKey1}", "scopeValue1"))
+            {
+                logger.LogInformation("Outer Scope");
+
+                using (var __ = logger.BeginScope("{ScopeKey1}", "scopeValue2"))
+                {
+                    logger.LogInformation("Inner Scope");
+                }
+            }
         }
 
         private void CreateMelLogger(LogLevel minimumLogLevel, Serilog.ILogger serilogLoggerImpl = null)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogExtensionsLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogExtensionsLoggingAdapter.cs
@@ -90,6 +90,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 
         }
 
+        public void LogMessageInNestedScopes()
+        {
+            using (var _ = logger.BeginScope("{ScopeKey1}", "scopeValue1"))
+            {
+                logger.LogInformation("Outer Scope");
+
+                using (var __ = logger.BeginScope("{ScopeKey1}", "scopeValue2"))
+                {
+                    logger.LogInformation("Inner Scope");
+                }
+            }
+        }
+
         private void CreateMelLogger(LogLevel minimumLogLevel)
         {
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NLogLoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -93,6 +93,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             };
 
             _log = _log = GetLogger(LogLevel.Debug, jsonLayout);
+        }
+
+        public void LogMessageInNestedScopes()
+        {
+            throw new NotImplementedException();
         }
 
         private Logger GetLogger(LogLevel minimumLogLevel, Layout layoutOverride = null)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogExtensionsLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogExtensionsLoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -90,6 +90,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         public void ConfigureJsonLayoutAppenderForDecoration()
         {
             CreateMelLogger(LogLevel.Debug, new JsonFormatter());
+        }
+
+        public void LogMessageInNestedScopes()
+        {
+            using (var _ = _logger.BeginScope("{ScopeKey1}", "scopeValue1"))
+            {
+                _logger.LogInformation("Outer Scope");
+
+                using (var __ = _logger.BeginScope("{ScopeKey1}", "scopeValue2"))
+                {
+                    _logger.LogInformation("Inner Scope");
+                }
+            }
         }
 
         private void CreateMelLogger(LogLevel minimumLogLevel) => CreateMelLogger(minimumLogLevel, null, null);

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -121,6 +121,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 #endif
         }
 
+        public void LogMessageInNestedScopes()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class ContextDataEnricher : ILogEventEnricher

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SerilogLoggingWebAdapter.cs
@@ -142,6 +142,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
             throw new NotImplementedException();
         }
 
+        public void LogMessageInNestedScopes()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class SerilogWebStartup

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SitecoreAdapter.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/SitecoreAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if NET48_OR_GREATER
@@ -114,6 +114,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
         {
             // TODO: Not supported?
             throw new System.NotImplementedException();
+        }
+
+        public void LogMessageInNestedScopes()
+        {
+            throw new NotImplementedException();
         }
 
         public void NoMessage()


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Fixes #2508 by modifying our logic for extracting context key/value pairs so that we retain the "innermost" value in cases where multiple contexts have the same key. 

Also updates Integration tests to verify this fix and adds an overload to `NewRelic.Agent.Extensions.Logging.ILogger` that allows an extension to report an exception in the same format that we use in the rest of the Agent.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
