### PR TITLE
test: Fix lambda smoke test flicker.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
@@ -23,6 +23,14 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
 
             _fixture = fixture;
             _fixture.TestLogger = output;
+
+            _fixture.AdditionalSetupConfiguration = () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ForceTransactionTraces();
+            };
+
             _fixture.Actions(
                 exerciseApplication: () =>
                 {
@@ -51,8 +59,8 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
                 () => Assert.NotNull(serverlessPayload.Telemetry.MetricsPayload),
                 () => Assert.NotNull(serverlessPayload.Telemetry.TransactionEventsPayload),
                 () => Assert.NotNull(serverlessPayload.Telemetry.SpanEventsPayload),
+                () => Assert.NotNull(serverlessPayload.Telemetry.TransactionTracePayload),
                 () => Assert.Null(serverlessPayload.Telemetry.SqlTracePayload),
-                () => Assert.Null(serverlessPayload.Telemetry.TransactionTracePayload),
                 () => Assert.Null(serverlessPayload.Telemetry.ErrorTracePayload),
                 () => Assert.Null(serverlessPayload.Telemetry.ErrorEventsPayload),
                 () => Assert.Equal(_expectedTransactionName, serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single().IntrinsicAttributes["name"])

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -14,6 +14,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
     public class LambdaTestToolFixture : RemoteApplicationFixture
     {
         public DotnetTool LambdaTestTool { get; set; }
+        public Action AdditionalSetupConfiguration { get; set; }
 
         public LambdaTestToolFixture(RemoteApplication remoteApplication, string newRelicLambdaHandler, string lambdaHandler, string lambdaName, string lambdaVersion, string lambdaExecutionEnvironment) : base(remoteApplication)
         {
@@ -40,6 +41,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
 
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");
+
+                    AdditionalSetupConfiguration?.Invoke();
 
                     if (LambdaTestTool.IsRunning)
                     {


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The lambda smoke tests will sometimes fail when the lambda method runs long enough to trigger a transaction trace when the test doesn't expect a transaction trace to be generated. In this PR we are flipping the logic around to ensure that a transaction trace is generated, and verify that it is included in the payload.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
