### PR TITLE
fix: Prevent NullReferenceExeption on APIGatewayProxyRequest

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Lambda/LambdaEventHelpers.cs
@@ -292,7 +292,8 @@ public static class LambdaEventHelpers
             transaction.SetUri(webReqEvent.Path);
         }
 
-        transaction.SetRequestParameters(webReqEvent.QueryStringParameters);
+        if (webReqEvent.QueryStringParameters != null)
+            transaction.SetRequestParameters(webReqEvent.QueryStringParameters);
     }
 
     private static TransportType GetDistributedTransportType(string forwardedProto)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
@@ -34,6 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 {
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequest();
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
+                    _fixture.EnqueueMinimalAPIGatewayHttpApiV2ProxyRequest();
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
                 }
             );
@@ -46,8 +47,10 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
             var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
 
             Assert.Multiple(
-                () => Assert.Equal(2, serverlessPayloads.Count),
-                () => Assert.All(serverlessPayloads, ValidateServerlessPayload),
+                () => Assert.Equal(3, serverlessPayloads.Count),
+                // validate the first 2 payloads separately from the 3rd
+                () => Assert.All(serverlessPayloads.GetRange(0, 2), ValidateServerlessPayload),
+                () => ValidateMinimalRequestPayload(serverlessPayloads[2]),
                 () => ValidateTraceHasNoParent(serverlessPayloads[0]),
                 () => ValidateTraceHasParent(serverlessPayloads[1])
                 );
@@ -76,6 +79,34 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 { "request.uri", "/path/to/resource" },
                 { "request.parameters.parameter1", "value1,value2" },
                 { "request.parameters.parameter2", "value" },
+                { "http.statusCode", 200 },
+                { "response.status", "200" },
+                { "response.headers.content-type", "application/json" },
+                { "response.headers.content-length", "12345" }
+            };
+
+            Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
+        }
+
+        private void ValidateMinimalRequestPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId",
+                "host.displayName"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.eventType", "apiGateway" },
+                {"request.method", "POST" },
+                {"request.uri", "/path/to/resource" },
                 { "http.statusCode", 200 },
                 { "response.status", "200" },
                 { "response.headers.content-type", "application/json" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
@@ -35,7 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequest();
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
                     _fixture.EnqueueMinimalAPIGatewayHttpApiV2ProxyRequest();
-                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 3);
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
@@ -34,6 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 {
                     _fixture.EnqueueAPIGatewayProxyRequest();
                     _fixture.EnqueueAPIGatewayProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
+                    _fixture.EnqueueMinimalAPIGatewayProxyRequest();
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
                 }
             );
@@ -46,8 +47,10 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
             var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
 
             Assert.Multiple(
-                () => Assert.Equal(2, serverlessPayloads.Count),
-                () => Assert.All(serverlessPayloads, ValidateServerlessPayload),
+                () => Assert.Equal(3, serverlessPayloads.Count),
+                // validate the first 2 payloads separately from the 3rd
+                () => Assert.All(serverlessPayloads.GetRange(0, 2), ValidateServerlessPayload),
+                () => ValidateMinimalRequestPayload(serverlessPayloads[2]),
                 () => ValidateTraceHasNoParent(serverlessPayloads[0]),
                 () => ValidateTraceHasParent(serverlessPayloads[1])
                 );
@@ -97,7 +100,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 expectedAgentAttributeValues.Add("response.status", "200");
                 expectedAgentAttributeValues.Add("response.headers.content-type", "application/json");
                 expectedAgentAttributeValues.Add("response.headers.content-length", "12345");
-            };
+            }
 
             Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
 
@@ -110,6 +113,34 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                     { "http.statusCode", "response.status", "response.headers.content-type", "response.headers.content-length" };
                 Assertions.TransactionEventDoesNotHaveAttributes(unexpectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
             }
+        }
+
+        private void ValidateMinimalRequestPayload(ServerlessPayload serverlessPayload)
+        {
+            var transactionEvent = serverlessPayload.Telemetry.TransactionEventsPayload.TransactionEvents.Single();
+
+            var expectedAgentAttributes = new[]
+            {
+                "aws.lambda.arn",
+                "aws.requestId",
+                "host.displayName"
+            };
+
+            var expectedAgentAttributeValues = new Dictionary<string, object>
+            {
+                { "aws.lambda.eventSource.eventType", "apiGateway" },
+                {"request.method", "POST" },
+                {"request.uri", "/path/to/resource" },
+                { "http.statusCode", 200 },
+                { "response.status", "200" },
+                { "response.headers.content-type", "application/json" },
+                { "response.headers.content-length", "12345" }
+            };
+
+            Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
+
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributes, TransactionEventAttributeType.Agent, transactionEvent);
+            Assertions.TransactionEventHasAttributes(expectedAgentAttributeValues, TransactionEventAttributeType.Agent, transactionEvent);
         }
 
         private void ValidateTraceHasNoParent(ServerlessPayload serverlessPayload)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
@@ -131,11 +131,15 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 { "aws.lambda.eventSource.eventType", "apiGateway" },
                 {"request.method", "POST" },
                 {"request.uri", "/path/to/resource" },
-                { "http.statusCode", 200 },
-                { "response.status", "200" },
-                { "response.headers.content-type", "application/json" },
-                { "response.headers.content-length", "12345" }
             };
+
+            if (!_returnsStream) // stream response type won't have response attributes
+            {
+                expectedAgentAttributeValues.Add("http.statusCode", 200);
+                expectedAgentAttributeValues.Add("response.status", "200");
+                expectedAgentAttributeValues.Add("response.headers.content-type", "application/json");
+                expectedAgentAttributeValues.Add("response.headers.content-length", "12345");
+            }
 
             Assert.Equal(_expectedTransactionName, transactionEvent.IntrinsicAttributes["name"]);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
@@ -35,7 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                     _fixture.EnqueueAPIGatewayProxyRequest();
                     _fixture.EnqueueAPIGatewayProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
                     _fixture.EnqueueMinimalAPIGatewayProxyRequest();
-                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 3);
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
@@ -181,6 +181,28 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                                                """;
             EnqueueLambdaEvent(apiGatewayProxyRequestJson);
         }
+
+        /// <summary>
+        /// A minimal payload to validate the fix for https://github.com/newrelic/newrelic-dotnet-agent/issues/2528
+        /// </summary>
+        public void EnqueueMinimalAPIGatewayHttpApiV2ProxyRequest()
+        {
+            var apiGatewayProxyRequestJson = $$"""
+                                               {
+                                                 "version": "2.0",
+                                                 "routeKey": "$default",
+                                                 "rawPath": "/path/to/resource",
+                                                 "requestContext": {
+                                                   "http": {
+                                                     "method": "POST",
+                                                     "path": "/path/to/resource"
+                                                   }
+                                                 },
+                                                 "body": "{\"test\":\"body\"}"
+                                               }
+                                               """;
+            EnqueueLambdaEvent(apiGatewayProxyRequestJson);
+        }
     }
 
     public class LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
@@ -151,6 +151,21 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                                                """;
             EnqueueLambdaEvent(apiGatewayProxyRequestJson);
         }
+
+        /// <summary>
+        /// A minimal payload to validate the fix for https://github.com/newrelic/newrelic-dotnet-agent/issues/2528
+        /// </summary>
+        public void EnqueueMinimalAPIGatewayProxyRequest()
+        {
+            var apiGatewayProxyRequestJson = $$"""
+                                               {
+                                                 "body": "{\"test\":\"body\"}",
+                                                 "path": "/path/to/resource",
+                                                 "httpMethod": "POST"
+                                               }
+                                               """;
+            EnqueueLambdaEvent(apiGatewayProxyRequestJson);
+        }
     }
 
     public class LambdaAPIGatewayProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

This fixes a null reference exception that could occur when a minimal JSON payload was sent to to a Lambda function that take an `APIGatewayProxyRequest` or `APIGatewayHttpApiV2ProxyRequest`.

Includes integration tests to validate the fix.

Fixes #2528

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
