### PR TITLE
test: Set finest-level logging in ExpectedErrorTests for troubleshooting flickers

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
@@ -36,6 +36,7 @@ namespace NewRelic.Agent.IntegrationTests.Errors
                     configModifier.AddExpectedStatusCodes("410-450")
                     .AddExpectedErrorMessages("System.Exception", new List<string> { "test exception"})
                     .AddExpectedErrorClasses(new List<string> { "AspNetCoreMvcBasicRequestsApplication.Controllers.CustomExceptionClass" });
+                    configModifier.SetLogLevel("finest");
                 },
                 exerciseApplication: () =>
                 {


### PR DESCRIPTION
Need a bit more detail in the logs to figure out why ExpectedErrorTests sometimes fails