### PR TITLE
fix: Refactor to eliminate usage of `.GetAwaiter().GetResult()` in Framework builds. (#2534)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _proxy = proxy;
         }
 
-        public abstract Task<IHttpResponse> SendAsync(IHttpRequest request);
+        public abstract IHttpResponse Send(IHttpRequest request);
 
         public virtual void Dispose()
         {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpContentWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpContentWrapper.cs
@@ -1,10 +1,9 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
 using System.IO;
 using System.Net.Http;
-using System.Threading.Tasks;
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
 
 namespace NewRelic.Agent.Core.DataTransport.Client
@@ -21,9 +20,9 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _httpContent = httpContent;
         }
 
-        public Task<Stream> ReadAsStreamAsync()
+        public Stream ReadAsStream()
         {
-            return _httpContent.ReadAsStreamAsync();
+            return _httpContent.ReadAsStreamAsync().GetAwaiter().GetResult();
         }
 
         public IHttpContentHeadersWrapper Headers => new HttpContentHeadersWrapper(_httpContent.Headers);

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpResponse.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
@@ -28,7 +28,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _httpResponseMessageWrapper = httpResponseMessageWrapper;
         }
 
-        public async Task<string> GetContentAsync()
+        public string GetContent()
         {
             try
             {
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                     return Constants.EmptyResponseBody;
                 }
 
-                var responseStream = await _httpResponseMessageWrapper.Content.ReadAsStreamAsync();
+                var responseStream = _httpResponseMessageWrapper.Content.ReadAsStream();
 
                 var contentTypeEncoding = _httpResponseMessageWrapper.Content.Headers.ContentEncoding;
                 if (contentTypeEncoding.Contains("gzip"))
@@ -48,7 +48,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 using (responseStream)
                 using (var reader = new StreamReader(responseStream, Encoding.UTF8))
                 {
-                    var responseBody = await reader.ReadLineAsync();
+                    var responseBody = reader.ReadLineAsync().GetAwaiter().GetResult();
 
                     if (responseBody != null)
                     {

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -8,6 +8,6 @@ namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
 {
     public interface IHttpClient : IDisposable
     {
-        Task<IHttpResponse> SendAsync(IHttpRequest request);
+        IHttpResponse Send(IHttpRequest request);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpContentWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpContentWrapper.cs
@@ -1,8 +1,7 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System.IO;
-using System.Threading.Tasks;
 
 namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
 {
@@ -12,7 +11,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
     /// </summary>
     public interface IHttpContentWrapper
     {
-        Task<Stream> ReadAsStreamAsync();
+        Stream ReadAsStream();
         IHttpContentHeadersWrapper Headers { get; }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpResponse.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -11,6 +11,6 @@ namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
     {
         bool IsSuccessStatusCode { get; }
         HttpStatusCode StatusCode { get; }
-        Task<string> GetContentAsync();
+        string GetContent();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if !NETFRAMEWORK
@@ -32,7 +32,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _httpClientWrapper = new HttpClientWrapper(httpClient, (int)configuration.CollectorTimeout);
         }
 
-        public override async Task<IHttpResponse> SendAsync(IHttpRequest request)
+        public override IHttpResponse Send(IHttpRequest request)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                     req.Content.Headers.Add(contentHeader.Key, contentHeader.Value);
                 }
 
-                var response = await _httpClientWrapper.SendAsync(req);
+                var response = _httpClientWrapper.SendAsync(req).GetAwaiter().GetResult();
 
                 var httpResponse = new HttpResponse(request.RequestGuid, response);
                 return httpResponse;

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRWebRequestClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRWebRequestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #if NETFRAMEWORK
@@ -25,7 +25,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _configuration = configuration;
         }
 
-        public override async Task<IHttpResponse> SendAsync(IHttpRequest request)
+        public override IHttpResponse Send(IHttpRequest request)
         {
             try
             {
@@ -61,12 +61,10 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                         throw new NullReferenceException("outputStream");
                     }
 
-                    // .ConfigureAwait(false) is required here for some reason
-                    await outputStream.WriteAsync(request.Content.PayloadBytes, 0, (int)_httpWebRequest.ContentLength).ConfigureAwait(false);
+                    outputStream.Write(request.Content.PayloadBytes, 0, (int)_httpWebRequest.ContentLength);
                 }
 
-                // .ConfigureAwait(false) is required here for some reason
-                var resp = (HttpWebResponse)await _httpWebRequest.GetResponseAsync().ConfigureAwait(false);
+                var resp = (HttpWebResponse)_httpWebRequest.GetResponse();
 
                 return new WebRequestClientResponse(request.RequestGuid, resp);
             }

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/WebRequestClientResponse.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/WebRequestClientResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 #if NETFRAMEWORK
 using System;
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _response = response;
         }
 
-        public Task<string> GetContentAsync()
+        public string GetContent()
         {
             try
             {
@@ -51,14 +51,14 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 using (var reader = new StreamReader(responseStream, Encoding.UTF8))
                 {
                     var responseBody = reader.ReadLine();
-                    return Task.FromResult(responseBody ?? Constants.EmptyResponseBody);
+                    return responseBody ?? Constants.EmptyResponseBody;
                 }
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Request({0}): Unable to parse response body.", _requestGuid);
 
-                return Task.FromResult(Constants.EmptyResponseBody);
+                return Constants.EmptyResponseBody;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/HttpCollectorWire.cs
@@ -62,9 +62,9 @@ namespace NewRelic.Agent.Core.DataTransport
                 foreach (var header in _requestHeadersMap)
                     request.Headers.Add(header.Key, header.Value);
 
-                using var response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                using var response = httpClient.Send(request);
 
-                var responseContent = response.GetContentAsync().GetAwaiter().GetResult();
+                var responseContent = response.GetContent();
 
                 if (!response.IsSuccessStatusCode)
                 {

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/HttpResponseTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/HttpResponseTests.cs
@@ -4,14 +4,12 @@
 #if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.IO;
 using System.IO.Compression;
 using Telerik.JustMock;
 using NUnit.Framework;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
 using Telerik.JustMock.Helpers;
 
@@ -40,30 +38,30 @@ namespace NewRelic.Agent.Core.DataTransport.Client
         }
 
         [Test]
-        public async Task GetContentAsync_ReturnsEmptyResponseBody_WhenContentIsNull()
+        public void GetContent_ReturnsEmptyResponseBody_WhenContentIsNull()
         {
             _mockHttpResponseMessage.Arrange(message => message.Content).Returns((IHttpContentWrapper)null);
 
-            var result = await _httpResponse.GetContentAsync();
+            var result = _httpResponse.GetContent();
 
             Assert.That(result, Is.EqualTo(Constants.EmptyResponseBody));
         }
 
         [Test]
-        public async Task GetContentAsync_ReturnsContent_WhenContentIsNotNull()
+        public void GetContent_ReturnsContent_WhenContentIsNotNull()
         {
             var mockContent = Mock.Create<IHttpContentWrapper>();
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(TestResponseBody));
             _mockHttpResponseMessage.Arrange(message => message.Content).Returns(mockContent);
-            mockContent.Arrange(content => content.ReadAsStreamAsync()).ReturnsAsync((Stream)stream);
+            mockContent.Arrange(content => content.ReadAsStream()).Returns(stream);
 
-            var result = await _httpResponse.GetContentAsync();
+            var result = _httpResponse.GetContent();
 
             Assert.That(result, Is.EqualTo(TestResponseBody));
         }
 
         [Test]
-        public async Task GetContentAsync_HandlesGzipDecompression_WhenContentEncodingIsGzip()
+        public void GetContent_HandlesGzipDecompression_WhenContentEncodingIsGzip()
         {
             var compressedStream = new MemoryStream();
             using (var gzipStream = new GZipStream(compressedStream, CompressionMode.Compress, true))
@@ -79,9 +77,9 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             var mockHeaders = Mock.Create<IHttpContentHeadersWrapper>();
             mockContent.Arrange(content => content.Headers).Returns(mockHeaders);
             mockHeaders.Arrange(headers => headers.ContentEncoding).Returns(new List<string> { "gzip" });
-            mockContent.Arrange(content => content.ReadAsStreamAsync()).ReturnsAsync((Stream)compressedStream);
+            mockContent.Arrange(content => content.ReadAsStream()).Returns(compressedStream);
 
-            var result = await _httpResponse.GetContentAsync();
+            var result = _httpResponse.GetContent();
 
             Assert.That(result, Is.EqualTo(TestResponseBody));
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientTests.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _mockHttpClientWrapper.Dispose();
         }
         [Test]
-        public async Task SendAsync_ReturnsResponse_WhenSendAsyncSucceeds()
+        public void Send_ReturnsResponse_WhenSendAsyncSucceeds()
         {
             // Arrange
             var request = CreateHttpRequest();
@@ -64,7 +64,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 .ReturnsAsync(mockHttpResponseMessage);
 
             // Act
-            var response = await _client.SendAsync(request);
+            var response = _client.Send(request);
 
             // Assert
             Assert.That(response, Is.Not.Null);
@@ -80,7 +80,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 .Throws<HttpRequestException>();
 
             // Act & Assert
-            Assert.ThrowsAsync<HttpRequestException>(() => _client.SendAsync(request));
+            Assert.Throws<HttpRequestException>(() => _client.Send(request));
         }
 
         private IHttpRequest CreateHttpRequest()

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
@@ -5,13 +5,10 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Threading.Tasks;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
 using NUnit.Framework;
 using Telerik.JustMock;
-using Telerik.JustMock.AutoMock.Ninject.Activation;
-using Telerik.JustMock.Helpers;
 
 namespace NewRelic.Agent.Core.DataTransport.Client
 {
@@ -52,7 +49,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
         }
 
         [Test]
-        public async Task SendAsync_ShouldReturnValidResponse_WhenWebRequestIsSuccessful()
+        public void Send_ShouldReturnValidResponse_WhenWebRequestIsSuccessful()
         {
             // Arrange
             var fakeResponse = Mock.Create<HttpWebResponse>();
@@ -65,7 +62,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             });
 
             // Act
-            var response = await _client.SendAsync(_request);
+            var response = _client.Send(_request);
 
             // Assert
             Assert.That(response, Is.Not.Null);
@@ -83,7 +80,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             });
 
             // Act & Assert
-            Assert.ThrowsAsync<NullReferenceException>(() => _client.SendAsync(_request));
+            Assert.Throws<NullReferenceException>(() => _client.Send(_request));
         }
 
         [Test]
@@ -100,10 +97,10 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             });
 
             // Act & Assert
-            Assert.ThrowsAsync<WebException>(() => _client.SendAsync(_request));
+            Assert.Throws<WebException>(() => _client.Send(_request));
         }
         [Test]
-        public async Task SendAsync_ReturnsResponse_WhenWebExceptionResponseIsNotNull()
+        public void Send_ReturnsResponse_WhenWebExceptionResponseIsNotNull()
         {
             // Arrange
             _client.SetHttpWebRequestFunc(uri =>
@@ -120,7 +117,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             });
 
             // Act
-            var response = await _client.SendAsync(_request);
+            var response = _client.Send(_request);
 
             // Assert
             Assert.That(response, Is.Not.Null);

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
@@ -57,7 +57,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             {
                 var mockWebRequest = Mock.Create<HttpWebRequest>();
                 Mock.Arrange(() => mockWebRequest.GetRequestStream()).Returns(new MemoryStream());
-                Mock.Arrange(() => mockWebRequest.GetResponseAsync()).ReturnsAsync((WebResponse)fakeResponse);
+                Mock.Arrange(() => mockWebRequest.GetResponse()).Returns((WebResponse)fakeResponse);
                 return mockWebRequest;
             });
 
@@ -92,7 +92,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 var mockWebRequest = Mock.Create<HttpWebRequest>();
                 Mock.Arrange(() => mockWebRequest.Address).Returns(new Uri("https://sometesthost.com"));
                 var webException = new WebException("testing");
-                Mock.Arrange(() => mockWebRequest.GetResponseAsync()).Throws(webException);
+                Mock.Arrange(() => mockWebRequest.GetResponse()).Throws(webException);
                 return mockWebRequest;
             });
 
@@ -112,7 +112,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
                 Mock.Arrange(() => mockHttpWebResponse.StatusCode).Returns(HttpStatusCode.BadRequest);
                 Mock.Arrange(() => mockHttpWebResponse.StatusDescription).Returns("Bad Request");
                 var webException = new WebException("testing", null, WebExceptionStatus.SendFailure,mockHttpWebResponse);
-                Mock.Arrange(() => mockWebRequest.GetResponseAsync()).Throws(webException);
+                Mock.Arrange(() => mockWebRequest.GetResponse()).Throws(webException);
                 return mockWebRequest;
             });
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/WebRequestClientResponseTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/WebRequestClientResponseTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
         }
 
         [Test]
-        public async Task GetContentAsync_ShouldReturnValidResponse_WhenResponseStreamIsNotNullAndNotGzipped()
+        public void GetContent_ShouldReturnValidResponse_WhenResponseStreamIsNotNullAndNotGzipped()
         {
             // Arrange
             var fakeStream = new MemoryStream(Encoding.UTF8.GetBytes("Test Response"));
@@ -41,28 +41,28 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             var webRequestClientResponse = new WebRequestClientResponse(_requestGuid, _response);
 
             // Act
-            var content = await webRequestClientResponse.GetContentAsync();
+            var content = webRequestClientResponse.GetContent();
 
             // Assert
             Assert.That(content, Is.EqualTo("Test Response"));
         }
 
         [Test]
-        public async Task GetContentAsync_ShouldReturnEmpty_WhenResponseStreamIsNull()
+        public void GetContent_ShouldReturnEmpty_WhenResponseStreamIsNull()
         {
             // Arrange
             Mock.Arrange(() => _response.GetResponseStream()).Returns(() => null);
             var webRequestClientResponse = new WebRequestClientResponse(_requestGuid, _response);
 
             // Act
-            var content = await webRequestClientResponse.GetContentAsync();
+            var content = webRequestClientResponse.GetContent();
 
             // Assert
             Assert.That(content, Is.EqualTo(Constants.EmptyResponseBody));
         }
 
         [Test]
-        public async Task GetContentAsync_ShouldReturnEmpty_WhenResponseHasException()
+        public void GetContent_ShouldReturnEmpty_WhenResponseHasException()
         {
             // Arrange
             var fakeStream = new ExceptionThrowingStream();
@@ -70,13 +70,13 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             var webRequestClientResponse = new WebRequestClientResponse(_requestGuid, _response);
 
             // Act
-            var content = await webRequestClientResponse.GetContentAsync();
+            var content = webRequestClientResponse.GetContent();
 
             // Assert
             Assert.That(content, Is.EqualTo(Constants.EmptyResponseBody));
         }
         [Test]
-        public async Task GetContentAsync_ShouldReturnEmpty_WhenResponseHeadersIsNull()
+        public void GetContent_ShouldReturnEmpty_WhenResponseHeadersIsNull()
         {
             // Arrange
             Mock.Arrange(() => _response.GetResponseStream()).Returns(new MemoryStream()); // Any dummy stream
@@ -84,14 +84,14 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             var webRequestClientResponse = new WebRequestClientResponse(_requestGuid, _response);
 
             // Act
-            var content = await webRequestClientResponse.GetContentAsync();
+            var content = webRequestClientResponse.GetContent();
 
             // Assert
             Assert.That(content, Is.EqualTo(Constants.EmptyResponseBody));
         }
 
         [Test]
-        public async Task GetContentAsync_ShouldReturnDecompressedResponse_WhenResponseIsGzipped()
+        public void GetContent_ShouldReturnDecompressedResponse_WhenResponseIsGzipped()
         {
             // Arrange
             var originalText = "Test GZIP Response";
@@ -102,7 +102,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             var webRequestClientResponse = new WebRequestClientResponse(_requestGuid, _response);
 
             // Act
-            var content = await webRequestClientResponse.GetContentAsync();
+            var content = webRequestClientResponse.GetContent();
 
             // Assert
             Assert.That(content, Is.EqualTo(originalText));

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/HttpCollectorWireTests.cs
@@ -59,10 +59,10 @@ namespace NewRelic.Agent.Core.DataTransport
             var mockHttpResponse = Mock.Create<IHttpResponse>();
             Mock.Arrange(() => mockHttpResponse.StatusCode).Returns(HttpStatusCode.OK);
             Mock.Arrange(() => mockHttpResponse.IsSuccessStatusCode).Returns(true);
-            Mock.Arrange(() => mockHttpResponse.GetContentAsync()).ReturnsAsync(expected);
+            Mock.Arrange(() => mockHttpResponse.GetContent()).Returns(expected);
 
             var mockHttpClient = Mock.Create<IHttpClient>();
-            Mock.Arrange(() => mockHttpClient.SendAsync(Arg.IsAny<IHttpRequest>())).ReturnsAsync(mockHttpResponse);
+            Mock.Arrange(() => mockHttpClient.Send(Arg.IsAny<IHttpRequest>())).Returns(mockHttpResponse);
 
             Mock.Arrange(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>(), Arg.IsAny<IConfiguration>())).Returns(mockHttpClient);
 
@@ -91,10 +91,10 @@ namespace NewRelic.Agent.Core.DataTransport
             var mockHttpResponse = Mock.Create<IHttpResponse>();
             Mock.Arrange(() => mockHttpResponse.StatusCode).Returns(HttpStatusCode.OK);
             Mock.Arrange(() => mockHttpResponse.IsSuccessStatusCode).Returns(true);
-            Mock.Arrange(() => mockHttpResponse.GetContentAsync()).ReturnsAsync(expected);
+            Mock.Arrange(() => mockHttpResponse.GetContent()).Returns(expected);
 
             var mockHttpClient = Mock.Create<IHttpClient>();
-            Mock.Arrange(() => mockHttpClient.SendAsync(Arg.IsAny<IHttpRequest>())).Throws(new HttpRequestException());
+            Mock.Arrange(() => mockHttpClient.Send(Arg.IsAny<IHttpRequest>())).Throws(new HttpRequestException());
 
             Mock.Arrange(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>(), Arg.IsAny<IConfiguration>())).Returns(mockHttpClient);
 
@@ -121,10 +121,10 @@ namespace NewRelic.Agent.Core.DataTransport
             var mockHttpResponse = Mock.Create<IHttpResponse>();
             Mock.Arrange(() => mockHttpResponse.StatusCode).Returns(HttpStatusCode.InternalServerError);
             Mock.Arrange(() => mockHttpResponse.IsSuccessStatusCode).Returns(false);
-            Mock.Arrange(() => mockHttpResponse.GetContentAsync()).ReturnsAsync(expected);
+            Mock.Arrange(() => mockHttpResponse.GetContent()).Returns(expected);
 
             var mockHttpClient = Mock.Create<IHttpClient>();
-            Mock.Arrange(() => mockHttpClient.SendAsync(Arg.IsAny<IHttpRequest>())).ReturnsAsync(mockHttpResponse);
+            Mock.Arrange(() => mockHttpClient.Send(Arg.IsAny<IHttpRequest>())).Returns(mockHttpResponse);
 
             Mock.Arrange(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>(), Arg.IsAny<IConfiguration>())).Returns(mockHttpClient);
 
@@ -153,10 +153,10 @@ namespace NewRelic.Agent.Core.DataTransport
             var mockHttpResponse = Mock.Create<IHttpResponse>();
             Mock.Arrange(() => mockHttpResponse.StatusCode).Returns(HttpStatusCode.OK);
             Mock.Arrange(() => mockHttpResponse.IsSuccessStatusCode).Returns(true);
-            Mock.Arrange(() => mockHttpResponse.GetContentAsync()).ReturnsAsync(expected);
+            Mock.Arrange(() => mockHttpResponse.GetContent()).Returns(expected);
 
             var mockHttpClient = Mock.Create<IHttpClient>();
-            Mock.Arrange(() => mockHttpClient.SendAsync(Arg.IsAny<IHttpRequest>())).ReturnsAsync(mockHttpResponse);
+            Mock.Arrange(() => mockHttpClient.Send(Arg.IsAny<IHttpRequest>())).Returns(mockHttpResponse);
 
             Mock.Arrange(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>(), Arg.IsAny<IConfiguration>())).Returns(mockHttpClient);
 
@@ -187,10 +187,10 @@ namespace NewRelic.Agent.Core.DataTransport
             var mockHttpResponse = Mock.Create<IHttpResponse>();
             Mock.Arrange(() => mockHttpResponse.StatusCode).Returns(HttpStatusCode.OK);
             Mock.Arrange(() => mockHttpResponse.IsSuccessStatusCode).Returns(true);
-            Mock.Arrange(() => mockHttpResponse.GetContentAsync()).ReturnsAsync(expected);
+            Mock.Arrange(() => mockHttpResponse.GetContent()).Returns(expected);
 
             var mockHttpClient = Mock.Create<IHttpClient>();
-            Mock.Arrange(() => mockHttpClient.SendAsync(Arg.IsAny<IHttpRequest>())).ReturnsAsync(mockHttpResponse);
+            Mock.Arrange(() => mockHttpClient.Send(Arg.IsAny<IHttpRequest>())).Returns(mockHttpResponse);
 
             Mock.Arrange(() => _httpClientFactory.CreateClient(Arg.IsAny<IWebProxy>(), Arg.IsAny<IConfiguration>())).Returns(mockHttpClient);
 


### PR DESCRIPTION
Refactors `HttpCollectorWire.Send()` to remove usage of `.GetAwaiter().GetResult()`, which required additional refactoring in `IHttpClient` and `IHttpContentWrapper`. 

With this change, there are now no usages of `.GetAwaiter().GetResult()` in code built for the .NET Framework target.

Resolves #2534 