### PR TITLE
feat: Add support for using Sitecore.Logging and log4net together

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Log4NetLogging/Instrumentation.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
       </match>
     </tracerFactory>
     <!-- Sitecore uses an old fork of log4net with the same namespace -->
-    <tracerFactory name="log4net">
+    <tracerFactory name="SitecoreLogging">
       <match assemblyName="Sitecore.Logging" className="log4net.Repository.Hierarchy.Logger">
         <exactMethodMatcher methodName="CallAppenders" />
       </match>


### PR DESCRIPTION
A customer attempted to use Sitecore.Logging and log4net in the same application. Sitecore.Logging uses an old fork of log4net that has different properties, and the instrumentation was not built to handle both at once. The wrapper would throw errors and eventually be disabled. Now they will work side by side.

This also adds the ability to run integration tests on multiple loggers at once, in case we run into other similar logging conflicts in the future.