### PR TITLE
chore(deps): Bump Serilog packages to latest version for net481 and net8.0 targets

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -95,6 +95,10 @@ jobs:
                  rabbitmq.client
                  restsharp
                  serilog
+                 serilog.extensions.logging
+                 serilog.aspnetcore
+                 serilog.sinks.file
+                 serilog.sinks.console
                  stackexchange.redis
                  system.data.sqlclient"
                  

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -149,9 +149,9 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net48'" />
 
-    <PackageReference Include="Serilog" Version="3.1.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- There is only a Framework 4.8 version of Sitecore.Logging -->
     <PackageReference Include="Sitecore.Logging" Version="10.3.0" Condition="'$(TargetFramework)' == 'net48'" Aliases="Sitecore" />
@@ -165,11 +165,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'net6.0'" />
 
-    <PackageReference Include="Serilog" Version="3.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7">
       <NoWarn>NU1701</NoWarn>
@@ -230,8 +230,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <!-- Requires Serilog 2.9.0+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- Requires Serilog 3.1.1+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
@@ -243,8 +243,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <!-- Requires Serilog 2.9.0+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <!-- Requires Serilog 3.1.1+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup> <!-- Versions below 4.5 did not support netstandard 2.0 -->


### PR DESCRIPTION
Updates Serilog packages to latest version for the net481 and net8.0 build targets. These should have been caught by Dotty but were missed somehow. 

Also updates Dotty config to scan for additional serilog package updates.