### PR TITLE
test: Move suppressed warnings closer to the integration test projects that generate them

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,10 +3,5 @@
     <LangVersion>default</LangVersion>
     <RootProjectDirectory>$(MSBuildThisFileDirectory)</RootProjectDirectory>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>
-      VSTHRD200, <!-- Use `Async` suffix for async methods -->
-      VSTHRD105, <!-- Avoid method overloads that assume `TaskScheduler.Current` -->
-      VSTHRD002 <!-- Avoid problematic synchronous waits -->
-    </NoWarn>
   </PropertyGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/Directory.Build.props
+++ b/tests/Agent/IntegrationTests/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>
+      VSTHRD200, <!-- Use `Async` suffix for async methods -->
+      VSTHRD105, <!-- Avoid method overloads that assume `TaskScheduler.Current` -->
+      VSTHRD002 <!-- Avoid problematic synchronous waits -->
+    </NoWarn>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Adds a new `Directory.Build.props` file at `tests\Agent\IntegrationTests` and takes out the warnings that were suppressed in the global `Directory.Build.props` file at the root of the repo. 

I looked at whether it would be possible to update the code so we don't get those warnings, but it would have been a lot of work for almost zero gain. The specific warnings that are being suppressed aren't serious enough to warrant code changes, especially not in our integration test apps.

Resolve #1924 