### PR TITLE
chore: Update core tech version scan tool dependencies

### DIFF
--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -30,6 +30,7 @@ jobs:
     
     env:
       scan-tool-path: ${{ github.workspace }}/.github/workflows/scripts/nugetSlackNotifications
+      scan-tool-publish-path: ${{ github.workspace }}/publish
 
     steps:
       - name: Harden Runner
@@ -46,7 +47,7 @@ jobs:
         run: |
           cd ${{ env.scan-tool-path }}
           dotnet add nugetSlackNotifications.csproj package NewRelic.Agent
-          dotnet build
+          dotnet publish -o ${{ env.scan-tool-publish-path }}
 
       - name: Check for updates to core technology packages
         run: |
@@ -56,7 +57,7 @@ jobs:
           if [ "${{ inputs.testMode }}" == "true" ]; then
             export DOTTY_TEST_MODE="True"
           fi
-          cd ${{ env.scan-tool-path }}/bin/Debug/net6.0
+          cd ${{ env.scan-tool-publish-path }}
           dotnet ./nugetSlackNotifications.dll ${{ env.nugets }}
         shell: bash
 
@@ -64,9 +65,9 @@ jobs:
             DOTTY_WEBHOOK: ${{ secrets.SLACK_NUGET_NOTIFICATIONS_WEBHOOK }}
             DOTTY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             CORECLR_ENABLE_PROFILING: 1
-            CORECLR_NEWRELIC_HOME: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic
+            CORECLR_NEWRELIC_HOME: ${{ env.scan-tool-publish-path }}/newrelic
             CORECLR_PROFILER: "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
-            CORECLR_PROFILER_PATH: ${{ env.scan-tool-path }}/bin/Debug/net6.0/newrelic/libNewRelicProfiler.so
+            CORECLR_PROFILER_PATH: ${{ env.scan-tool-publish-path }}/newrelic/libNewRelicProfiler.so
             NEW_RELIC_APP_NAME: Dotty
             NEW_RELIC_HOST: staging-collector.newrelic.com
             NEW_RELIC_LICENSE_KEY: ${{ secrets.STAGING_LICENSE_KEY }}

--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -1,4 +1,4 @@
-﻿using NewRelic.Api.Agent;
+using NewRelic.Api.Agent;
 using Octokit;
 using Serilog;
 using System;

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Api" Version="10.3.0" />
-    <PackageReference Include="Octokit" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.25.1" />
+    <PackageReference Include="Octokit" Version="12.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR:

1. Fixes a bug in recent runs of this tool by updating to the latest Oktokit
2. Upgrades the tool to net8.0
3. Updates other dependencies
4. Updates the workflow to publish the tool and run from that location rather than hardcoding the output path including the .NET version TFM

Here's a successful run of the workflow from this branch: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/9503813056/job/26195081810
