### PR TITLE
chore: For netstandard2.0, use HttpClient in VendorHttpApiRequestor.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
@@ -3,9 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using NewRelic.Agent.Extensions.Logging;
+
+#if NETFRAMEWORK
 using System.IO;
 using System.Net;
-using NewRelic.Agent.Extensions.Logging;
+#else
+using System.Net.Http;
+#endif
 
 namespace NewRelic.Agent.Core.Utilization
 {
@@ -14,6 +19,16 @@ namespace NewRelic.Agent.Core.Utilization
         private const int WebReqeustTimeout = 1000;
 
         public virtual string CallVendorApi(Uri uri, string method, string vendorName, IEnumerable<string> headers = null)
+        {
+#if NETFRAMEWORK
+            return CallWithWebRequest(uri, method, vendorName, headers);
+#else
+            return CallWithHttpClient(uri, method, vendorName, headers);
+#endif
+        }
+
+#if NETFRAMEWORK
+        private string CallWithWebRequest(Uri uri, string method, string vendorName, IEnumerable<string> headers = null)
         {
             try
             {
@@ -66,5 +81,55 @@ namespace NewRelic.Agent.Core.Utilization
                 return null;
             }
         }
+#else
+        // create a static HttpClient for use across all the vendor API calls
+        private static readonly HttpClient httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromMilliseconds(WebReqeustTimeout)
+        };
+
+        private string CallWithHttpClient(Uri uri, string method, string vendorName, IEnumerable<string> headers = null)
+        {
+            try
+            {
+                var request = new HttpRequestMessage
+                {
+                    RequestUri = uri,
+                    Method = new HttpMethod(method)
+                };
+
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        var separatorIndex = header.IndexOf(": ");
+                        if (separatorIndex > -1)
+                        {
+                            var headerName = header.Substring(0, separatorIndex).Trim();
+                            var headerValue = header.Substring(separatorIndex + 2).Trim(); // +2 to skip past ": "
+                            request.Headers.TryAddWithoutValidation(headerName, headerValue);
+                        }
+                    }
+                }
+
+                var response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                if (!response.IsSuccessStatusCode)
+                {
+                    var statusCode = response.StatusCode;
+                    var statusDescription = response.ReasonPhrase ?? string.Empty;
+                    // intentionally not passing the exception parameter here
+                    Log.Debug("CallVendorApi ({0}) failed with WebException with status: {1}; message: {2}", vendorName, statusCode, statusDescription);
+                }
+
+                return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                // intentionally not passing the exception parameter here
+                Log.Debug($"CallVendorApi ({{0}}) failed: {ex.Message}", vendorName);
+                return null;
+            }
+        }
+#endif
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorHttpApiRequestor.cs
@@ -82,11 +82,12 @@ namespace NewRelic.Agent.Core.Utilization
             }
         }
 #else
-        // create a static HttpClient for use across all the vendor API calls
-        private static readonly HttpClient httpClient = new HttpClient
-        {
-            Timeout = TimeSpan.FromMilliseconds(WebReqeustTimeout)
-        };
+        private static readonly Lazy<HttpClient> httpClient = new Lazy<HttpClient>(() =>
+            new HttpClient
+            {
+                Timeout = TimeSpan.FromMilliseconds(WebReqeustTimeout)
+            });
+
 
         private string CallWithHttpClient(Uri uri, string method, string vendorName, IEnumerable<string> headers = null)
         {
@@ -112,7 +113,7 @@ namespace NewRelic.Agent.Core.Utilization
                     }
                 }
 
-                var response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                var response = httpClient.Value.SendAsync(request).GetAwaiter().GetResult();
                 if (!response.IsSuccessStatusCode)
                 {
                     var statusCode = response.StatusCode;


### PR DESCRIPTION
## Description

For netstandard2.0, use HttpClient in VendorHttpApiRequestor.  Uses directives to switch between builds types.  No additional tests were needed.

Manual validation of changes was successful.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
