### PR TITLE
chore: Update nuget.exe to latest, update .nuspec files

### DIFF
--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -7,8 +7,8 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/newrelic/newrelic-dotnet-agent</projectUrl>
-    <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
     <icon>images\icon.png</icon>
+    <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Make sure you go to New Relic first to sign up and get your license key at https://newrelic.com. Performance monitoring will never be the same after you do!  
             The package is available through your NuGet package manager and on the web at https://nuget.org/packages/NewRelic.Agent

--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -7,8 +7,8 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/newrelic/newrelic-dotnet-agent</projectUrl>
-    <icon>images\icon.png</icon>
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
+    <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Make sure you go to New Relic first to sign up and get your license key at https://newrelic.com. Performance monitoring will never be the same after you do!  
             The package is available through your NuGet package manager and on the web at https://nuget.org/packages/NewRelic.Agent

--- a/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
+++ b/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
@@ -7,7 +7,7 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api</projectUrl>
-    <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
+    <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The New Relic .NET Agent API supports custom error and metric reporting, and custom transaction parameters. If the agent is not installed or is disabled, method invocations of this API will have no effect. You can find more information about the NewRelic.Agent.Api at https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.</description>

--- a/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
+++ b/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
@@ -7,7 +7,7 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/newrelic/nuget-azure-cloud-services</projectUrl>
-    <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
+    <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Make sure you go to New Relic first to sign up and get your key at https://newrelic.com. Performance monitoring will never be the same after you do!  

--- a/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
@@ -7,7 +7,7 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</projectUrl>
-    <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
+    <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>

--- a/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
@@ -7,7 +7,7 @@
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</projectUrl>
-    <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
+    <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>


### PR DESCRIPTION
A few things that came up during my attempt to integrate SourceLink - these aren't critical updates but will improve the appearance of our packages on Nuget. 

* Updates `nuget.exe` to the most recent version (6.10)
* Updates the `.nuspec` files to add a `<repository>` element and remove the (deprecated) `iconUrl` element