### PR TITLE
tests: Skip testing deprecated non-async client methods in latest Elastic.Clients.Elasticsearch versions

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -188,7 +188,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void GenerateError()
+        public override async Task GenerateError()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ElasticsearchClientSettings(Address)
@@ -198,7 +198,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var client = new ElasticsearchClient(settings);
 
-            var response = _ = client.PingAsync().Result;
+            var response = _ = await client.PingAsync();
 
             if (response.IsSuccess())
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -47,7 +47,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task Connect()
+        public override async Task ConnectAsync()
         {
             var settings = new ElasticsearchClientSettings(Address)
                     .Authentication(new BasicAuthentication(Username, Password)).
@@ -188,7 +188,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task GenerateError()
+        public override async Task GenerateErrorAsync()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ElasticsearchClientSettings(Address)
@@ -198,7 +198,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var client = new ElasticsearchClient(settings);
 
-            var response = _ = await client.PingAsync();
+            var response = await client.PingAsync();
 
             if (response.IsSuccess())
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -47,7 +47,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Connect()
+        public override async Task Connect()
         {
             var settings = new ElasticsearchClientSettings(Address)
                     .Authentication(new BasicAuthentication(Username, Password)).
@@ -57,7 +57,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             // This isn't necessary but will log the response, which can help troubleshoot if
             // you're having connection errors
-            _ = _client.PingAsync().Result;
+            _ = await _client.PingAsync();
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -1,11 +1,13 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Non-async client methods are deprecated in the latest Elastic.Clients.Elasticsearch
+#if !NET481_OR_GREATER && !NET8_0_OR_GREATER
+#define SYNC_METHODS_OK
+#endif
+
 using System;
-using System.Collections.Generic;
-using System.Net;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Core.MSearch;
@@ -13,11 +15,15 @@ using Elastic.Clients.Elasticsearch.QueryDsl;
 using Elastic.Transport;
 using NewRelic.Agent.IntegrationTests.Shared;
 
+
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 {
     internal class ElasticsearchElasticClient : ElasticsearchTestClient
     {
         private ElasticsearchClient _client;
+
+        private const string NonAsyncDeprecationMessage = "Non-async methods are deprecated in the latest Elasticsearch clients.";
+
         protected override Uri Address
         {
             get
@@ -51,23 +57,23 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             // This isn't necessary but will log the response, which can help troubleshoot if
             // you're having connection errors
-#pragma warning disable CS0618 // obsolete usage is ok here
-            _client.Ping();
-#pragma warning restore CS0618
+            _ = _client.PingAsync().Result;
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Index()
         {
+#if SYNC_METHODS_OK
             var record = FlightRecord.GetSample();
-#pragma warning disable CS0618 // Type or member is obsolete
             var response = _client.Index(record, (IndexName)IndexName);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             if (!response.IsSuccess())
             {
                 throw new Exception($"Response was not successful. {response.ElasticsearchServerError}");
             }
+#else
+            throw new NotImplementedException(NonAsyncDeprecationMessage);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -86,7 +92,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void Search()
         {
-#pragma warning disable CS0618 // obsolete usage is ok here
+#if SYNC_METHODS_OK
             var response = _client.Search<FlightRecord>(s => s
                 .Index(IndexName)
                 .From(0)
@@ -97,9 +103,10 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                     )
                 )
             );
-#pragma warning restore CS0618
-
             AssertResponseIsSuccess(response);
+#else
+            throw new NotImplementedException(NonAsyncDeprecationMessage);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -124,13 +131,15 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void IndexMany()
         {
+#if SYNC_METHODS_OK
             var records = FlightRecord.GetSamples(3);
 
-#pragma warning disable CS0618 // Type or member is obsolete
             var response = _client.IndexMany(records, (IndexName)IndexName);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             AssertResponseIsSuccess(response);
+#else
+            throw new NotImplementedException(NonAsyncDeprecationMessage);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -148,26 +157,11 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public override void MultiSearch()
         {
-#if NET8_0_OR_GREATER || NET481_OR_GREATER
-            var req = new MultiSearchRequest
-            {
-                Searches =
-                [
-                    new SearchRequestItem(
-                        new MultisearchHeader { Indices = Infer.Index<FlightRecord>() },
-                        new MultisearchBody { From = 0, Query = new MatchAllQuery() }
-                    )
-                ]
-            };
-#pragma warning disable CS0618 // obsolete usage is ok here
-            var response = _client.MultiSearch<FlightRecord>(req);
-#pragma warning restore CS0618
-#else
-#pragma warning disable CS0618 // obsolete usage is ok here
+#if SYNC_METHODS_OK
             var response = _client.MultiSearch<FlightRecord>();
-#pragma warning restore CS0618
-#endif                        
-
+#else
+            throw new NotImplementedException(NonAsyncDeprecationMessage);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -204,9 +198,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var client = new ElasticsearchClient(settings);
 
-#pragma warning disable CS0618 // obsolete usage is ok here
-            var response = client.Ping();
-#pragma warning restore CS0618
+            var response = _ = client.PingAsync().Result;
 
             if (response.IsSuccess())
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -44,7 +44,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                         _client = new ElasticsearchElasticClient();
                         break;
                 }
-                await _client.Connect();
+                await _client.ConnectAsync();
             }
             else
             {
@@ -94,6 +94,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task GenerateError() => await _client.GenerateError();
+        public async Task GenerateErrorAsync() => await _client.GenerateErrorAsync();
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -94,6 +94,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void GenerateError() => _client.GenerateError();
+        public async Task GenerateError() => await _client.GenerateError();
     }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchExerciser.cs
@@ -27,7 +27,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         /// Sets the library to use for further actions
         /// </summary>
         /// <param name="client">ElasticsearchNet, NEST, or ElasticClients</param>
-        public void SetClient(string clientType)
+        public async Task SetClient(string clientType)
         {
             if (Enum.TryParse(clientType, out ClientType client))
             {
@@ -44,7 +44,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                         _client = new ElasticsearchElasticClient();
                         break;
                 }
-                _client.Connect();
+                await _client.Connect();
             }
             else
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -176,7 +176,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void GenerateError()
+        public override async Task GenerateError()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionSettings(Address).
@@ -186,7 +186,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             var client = new ElasticClient(settings);
 
-            var response = client.Ping();
+            var response = await client.PingAsync();
             if (response.IsValid)
             {
                 throw new Exception($"Response was successful but we expected an error. {response.ServerError}");

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -36,7 +36,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
          [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Connect()
+        public override async Task Connect()
         {
             var settings = new ConnectionSettings(Address).
                 BasicAuthentication(Username,Password).
@@ -46,7 +46,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
             // This isn't necessary but will log the response, which can help troubleshoot if
             // you're having connection errors
-            _client.Ping();
+            await _client.PingAsync();
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -36,7 +36,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
          [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task Connect()
+        public override async Task ConnectAsync()
         {
             var settings = new ConnectionSettings(Address).
                 BasicAuthentication(Username,Password).
@@ -176,7 +176,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task GenerateError()
+        public override async Task GenerateErrorAsync()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionSettings(Address).

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -36,13 +36,14 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void Connect()
+        public override async Task Connect()
         {
             var settings = new ConnectionConfiguration(Address)
                 .BasicAuthentication(Username, Password)
                 .RequestTimeout(TimeSpan.FromMinutes(2));
 
             _client = new ElasticLowLevelClient(settings);
+            await _client.PingAsync<StringResponse>();
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -36,7 +36,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task Connect()
+        public override async Task ConnectAsync()
         {
             var settings = new ConnectionConfiguration(Address)
                 .BasicAuthentication(Username, Password)
@@ -211,7 +211,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override async Task GenerateError()
+        public override async Task GenerateErrorAsync()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionConfiguration(Address)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -210,7 +210,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public override void GenerateError()
+        public override async Task GenerateError()
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionConfiguration(Address)
@@ -219,7 +219,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
                 .RequestTimeout(TimeSpan.FromMinutes(2));
 
             var client = new ElasticLowLevelClient(settings);
-            var response = client.Ping<StringResponse>();
+            var response = await client.PingAsync<StringResponse>();
 
             if (response.Success)
             {

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -28,7 +28,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         public ElasticsearchTestClient() { }
 
-        public abstract void Connect();
+        public abstract Task Connect();
 
         public abstract void Index();
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -46,7 +46,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         public abstract Task<long> MultiSearchAsync();
 
-        public abstract void GenerateError();
+        public abstract Task GenerateError();
     }
 
     public class FlightRecord

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchTestClient.cs
@@ -28,7 +28,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         public ElasticsearchTestClient() { }
 
-        public abstract Task Connect();
+        public abstract Task ConnectAsync();
 
         public abstract void Index();
 
@@ -46,7 +46,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
 
         public abstract Task<long> MultiSearchAsync();
 
-        public abstract Task GenerateError();
+        public abstract Task GenerateErrorAsync();
     }
 
     public class FlightRecord

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -65,6 +65,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             _fixture.AddCommand($"ElasticsearchExerciser SearchAsync");
             _fixture.AddCommand($"ElasticsearchExerciser IndexManyAsync");
             _fixture.AddCommand($"ElasticsearchExerciser MultiSearchAsync");
+            _fixture.AddCommand($"ElasticsearchExerciser GenerateErrorAsync");
 
             // Sync operations
             if (_syncMethodsOk )
@@ -75,7 +76,6 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
                 _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
 
             }
-            _fixture.AddCommand($"ElasticsearchExerciser GenerateError");
 
             _fixture.AddActions
             (
@@ -153,9 +153,9 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         }
 
         [Fact]
-        public void Error()
+        public void ErrorAsync()
         {
-            ValidateError("GenerateError");
+            ValidateError("GenerateErrorAsync");
         }
 
         private void ValidateError(string operationName)

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -34,6 +34,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         const string IndexName = "flights";
 
         protected readonly bool _syncMethodsOk;
+        const string SyncMethodSkipReason = "Synchronous methods are deprecated in latest Elastic.Clients.Elasticsearch";
 
 
         protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, ClientType clientType) : base(fixture)
@@ -99,40 +100,32 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             _fixture.Initialize();
         }
 
-        [Fact]
+        [SkippableFact]
         public void Index()
         {
-            if (_syncMethodsOk)
-            {
-                ValidateOperation("Index");
-            }
+            Skip.IfNot(_syncMethodsOk, SyncMethodSkipReason);
+            ValidateOperation("Index");
         }
 
-        [Fact]
+        [SkippableFact]
         public void Search()
         {
-            if (_syncMethodsOk)
-            {
-                ValidateOperation("Search");
-            }
+            Skip.IfNot(_syncMethodsOk, SyncMethodSkipReason);
+            ValidateOperation("Search");
         }
 
-        [Fact]
+        [SkippableFact]
         public void IndexMany()
         {
-            if (_syncMethodsOk)
-            {
-                ValidateOperation("IndexMany");
-            }
+            Skip.IfNot(_syncMethodsOk, SyncMethodSkipReason);
+            ValidateOperation("IndexMany");
         }
 
-        [Fact]
+        [SkippableFact]
         public void MultiSearch()
         {
-            if (_syncMethodsOk)
-            {
-                ValidateOperation("MultiSearch");
-            }
+            Skip.IfNot(_syncMethodsOk, SyncMethodSkipReason);
+            ValidateOperation("MultiSearch");
         }
 
         [Fact]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -33,12 +33,25 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
         const string IndexName = "flights";
 
+        protected readonly bool _syncMethodsOk;
+
 
         protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, ClientType clientType) : base(fixture)
         {
             _fixture = fixture;
             _fixture.TestLogger = output;
             _clientType = clientType;
+
+            // non-async methods are deprecated in the latest Elastic.Clients.Elasticsearch versions
+            if (_clientType != ClientType.ElasticClients ||
+                (_fixture.GetType() != typeof(ConsoleDynamicMethodFixtureCoreLatest) && _fixture.GetType() != typeof(ConsoleDynamicMethodFixtureFWLatest)))
+            {
+                _syncMethodsOk = true;
+            }
+            else
+            {
+                _syncMethodsOk = false;
+            }
 
             _host = GetHostFromElasticServer(_clientType);
 
@@ -53,10 +66,14 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
             _fixture.AddCommand($"ElasticsearchExerciser MultiSearchAsync");
 
             // Sync operations
-            _fixture.AddCommand($"ElasticsearchExerciser Index");
-            _fixture.AddCommand($"ElasticsearchExerciser Search");
-            _fixture.AddCommand($"ElasticsearchExerciser IndexMany");
-            _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
+            if (_syncMethodsOk )
+            {
+                _fixture.AddCommand($"ElasticsearchExerciser Index");
+                _fixture.AddCommand($"ElasticsearchExerciser Search");
+                _fixture.AddCommand($"ElasticsearchExerciser IndexMany");
+                _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
+
+            }
             _fixture.AddCommand($"ElasticsearchExerciser GenerateError");
 
             _fixture.AddActions
@@ -85,25 +102,37 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
         [Fact]
         public void Index()
         {
-            ValidateOperation("Index");
+            if (_syncMethodsOk)
+            {
+                ValidateOperation("Index");
+            }
         }
 
         [Fact]
         public void Search()
         {
-            ValidateOperation("Search");
+            if (_syncMethodsOk)
+            {
+                ValidateOperation("Search");
+            }
         }
 
         [Fact]
         public void IndexMany()
         {
-            ValidateOperation("IndexMany");
+            if (_syncMethodsOk)
+            {
+                ValidateOperation("IndexMany");
+            }
         }
 
         [Fact]
         public void MultiSearch()
         {
-            ValidateOperation("MultiSearch");
+            if (_syncMethodsOk)
+            {
+                ValidateOperation("MultiSearch");
+            }
         }
 
         [Fact]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <RootNamespace>NewRelic.Agent.UnboundedIntegrationTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.UnboundedIntegrationTests</AssemblyName>
@@ -58,6 +58,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
In the latest Elastic.Clients.Elasticsearch versions, non-async methods are deprecated.  We previously ignored the deprecation warnings and continued testing these methods.  This PR:

1. Uses preprocessor directives to avoid compiling the non-async methods in the latest ConsoleMF TFMs (net481 and net8.0), which are tied to the latest Elastic.Clients.Elasticsearch library versions.
2. Adds logic to the test code to skip testing the non-async methods for the latest version of Elastic.Clients.Elasticsearch
3. Modifies the `Connect` and `GenerateError` methods to be "async all the way" in order to use `PingSync()` instead of `Ping()` for those methods.

This also introduces the use of a 3rd-party library `XUnit.SkippableFact` to skip tests based on runtime conditions.  I wanted to be explicit that we were skipping test cases rather than just having them pass without actually testing anything.