### PR TITLE
test: More SQS tests

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
@@ -15,9 +15,9 @@ namespace AwsSdkTestApp.Controllers
     {
         private readonly ILogger<AwsSdkController> _logger = logger;
 
-        // GET: /AwsSdk/SQS_SendAndReceive?queueName=MyQueue
-        [HttpGet("SQS_SendAndReceive")]
-        public async Task SQS_SendAndReceive([Required]string queueName)
+        // GET: /AwsSdk/SQS_SendReceivePurge?queueName=MyQueue
+        [HttpGet("SQS_SendReceivePurge")]
+        public async Task SQS_SendReceivePurge([Required]string queueName)
         {
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
             
@@ -25,6 +25,8 @@ namespace AwsSdkTestApp.Controllers
 
             await awsSdkExerciser.SQS_SendMessage("Hello World!");
             await awsSdkExerciser.SQS_ReceiveMessage();
+            await awsSdkExerciser.SQS_SendMessageBatch(new[] { "Hello", "World" });
+            await awsSdkExerciser.SQS_PurgeQueue();
 
             await awsSdkExerciser.SQS_Teardown();
         }

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-awssdk.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-awssdk.yml
@@ -22,11 +22,11 @@
 
 services:
   localstack:
-    container_name: "localstack-main"
+    container_name: "localstack-containertest"
     image: localstack/localstack:stable
-    ports:
-      - "127.0.0.1:4566:4566"            # LocalStack Gateway
-      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+    expose: # ports are only available intneral to the service, not external so there's no chance for conflicts
+      - "4566"       # LocalStack Gateway
+      - "4510-4559"  # external services port range
     environment:
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
@@ -40,7 +40,7 @@ public class AwsSdkContainerSQSTestFixture : AwsSdkContainerTestFixtureBase
     {
         var address = $"http://localhost:{Port}/awssdk";
 
-        GetAndAssertStatusCode($"{address}/SQS_SendAndReceive?queueName={queueName}", System.Net.HttpStatusCode.OK);
+        GetAndAssertStatusCode($"{address}/SQS_SendReceivePurge?queueName={queueName}", System.Net.HttpStatusCode.OK);
     }
 
 }


### PR DESCRIPTION
* Adds `SendMessageBatch` and `PurgeQueue` calls to the SQS container tests
* Update docker-compose to make LocalStack ports internal  and to change the container name to avoid conflicts if running LocalStack in a separate service.