### PR TITLE
ci: Update RPM dockerfile to hack around mirrorlist EOL

### DIFF
--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -2,6 +2,12 @@ FROM rpmbuild/centos7
 
 USER root
 ADD Image-ExifTool-12.28.tar.gz /exiftool
+
+# temporary workaround until we can move to a non-centos7 base image
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \ 
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+    
 RUN yum --assumeyes install dos2unix rpm-sign expect perl-ExtUtils-MakeMaker
 
 # Install exiftool


### PR DESCRIPTION
Updates RPM dockerfile to adjust urls for yum repos as per https://serverfault.com/a/1161847. This is a temporary fix until we can rebuild the RPM packaging process.