### PR TITLE
chore: Exclude pre-compiled modules from update_loaded_modules payload.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -28,8 +28,7 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 if (!TryGetAssemblyName(assembly, out var assemblyName))
                 {
-                    // no way to properly track this assembly
-                    continue;
+                    continue; // we don't want to report this assembly
                 }
 
                 var assemblyDetails = assembly.GetName();
@@ -71,11 +70,17 @@ namespace NewRelic.Agent.Core.WireModels
 
         private static bool TryGetAssemblyName(Assembly assembly, out string assemblyName)
         {
+            // We skip any assemblies that cannot be linked to a nuget package.
+
             try
             {
-                if (assembly.IsDynamic)
+                if (assembly.IsDynamic) // skip dynamic assemblies
                 {
-                    assemblyName = assembly.GetName().Name;
+                    assemblyName = null;
+                }
+                else if (assembly.GetName().Version.ToString() == "0.0.0.0") // skip assemblies that have a version of 0.0.0.0 - these are precompiled assemblies
+                {
+                    assemblyName = null;
                 }
                 else
                 {

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -14,6 +14,8 @@ namespace NewRelic.Agent.Core.WireModels
     [JsonConverter(typeof(LoadedModuleWireModelCollectionJsonConverter))]
     public class LoadedModuleWireModelCollection
     {
+        private static Version zeroedVersion = new Version("0.0.0.0");
+
         public List<LoadedModuleWireModel> LoadedModules { get; }
 
         private LoadedModuleWireModelCollection()
@@ -78,7 +80,7 @@ namespace NewRelic.Agent.Core.WireModels
                 {
                     assemblyName = null;
                 }
-                else if (assembly.GetName().Version.ToString() == "0.0.0.0") // skip assemblies that have a version of 0.0.0.0 - these are precompiled assemblies
+                else if (assembly.GetName().Version == zeroedVersion) // skip assemblies that have a version of 0.0.0.0 - these are precompiled assemblies
                 {
                     assemblyName = null;
                 }

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
@@ -26,7 +26,7 @@ namespace NewRelic.Agent.Core.Utilities
         [Test]
         public void LoadedModuleWireModelCollectionIsJsonSerializable()
         {
-            var expected = @"[""Jars"",[[""MyTestAssembly"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42"",""Implementation-Vendor"":""MyCompany"",""copyright"":""Copyright 2008""}]]]";
+            var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42"",""Implementation-Vendor"":""MyCompany"",""copyright"":""Copyright 2008""}]]]";
 
             var baseAssemblyName = new AssemblyName();
             baseAssemblyName.Name = BaseAssemblyName;
@@ -35,7 +35,6 @@ namespace NewRelic.Agent.Core.Utilities
 
             var baseTestAssembly = new TestAssembly();
             baseTestAssembly.SetAssemblyName = baseAssemblyName;
-            baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
             baseTestAssembly.SetLocation = BaseAssemblyPath;
             baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
@@ -52,7 +51,7 @@ namespace NewRelic.Agent.Core.Utilities
         [Test]
         public void LoadedModuleWireModelCollectionHandlesNulls()
         {
-            var expected = @"[""Jars"",[[""MyTestAssembly"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42""}]]]";
+            var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42""}]]]";
 
             var baseAssemblyName = new AssemblyName();
             baseAssemblyName.Name = BaseAssemblyName;
@@ -61,8 +60,8 @@ namespace NewRelic.Agent.Core.Utilities
 
             var baseTestAssembly = new TestAssembly();
             baseTestAssembly.SetAssemblyName = baseAssemblyName;
-            baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won't have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
+            baseTestAssembly.SetLocation = BaseAssemblyPath;
             baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(null));
             baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(null));
 

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
@@ -38,8 +38,8 @@ namespace NewRelic.Agent.Core.Utilities
             baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won'y have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
             baseTestAssembly.SetLocation = BaseAssemblyPath;
-            baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
-            baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
+            baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
+            baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
 
             var assemblies = new List<Assembly>();
             assemblies.Add(baseTestAssembly);
@@ -63,8 +63,8 @@ namespace NewRelic.Agent.Core.Utilities
             baseTestAssembly.SetAssemblyName = baseAssemblyName;
             baseTestAssembly.SetDynamic = true; // false uses on disk assembly and this won't have one.
             baseTestAssembly.SetHashCode = BaseHashCode;
-            baseTestAssembly.AddCustomAttribute(new AssemblyCompanyAttribute(null));
-            baseTestAssembly.AddCustomAttribute(new AssemblyCopyrightAttribute(null));
+            baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(null));
+            baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(null));
 
             var assemblies = new List<Assembly> { baseTestAssembly };
 

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
@@ -12,6 +12,7 @@ namespace NewRelic.Agent.Core.WireModels
     [TestFixture]
     public class LoadedModuleWireModelCollectionTests
     {
+        private const string BaseAssemblyNamespace = "MyTestAssembly";
         private const string BaseAssemblyName = "MyTestAssembly.dll";
 
         private string BaseAssemblyVersion;
@@ -38,7 +39,7 @@ namespace NewRelic.Agent.Core.WireModels
             BasePublicKey = "7075626C69636B6579746F6B656E";
 
             _baseAssemblyName = new AssemblyName();
-            _baseAssemblyName.Name = BaseAssemblyName;
+            _baseAssemblyName.Name = BaseAssemblyNamespace;
             _baseAssemblyName.Version = new Version(BaseAssemblyVersion);
             _baseAssemblyName.SetPublicKeyToken(Encoding.ASCII.GetBytes(BasePublicKeyToken));
 
@@ -57,8 +58,8 @@ namespace NewRelic.Agent.Core.WireModels
             _baseTestAssembly= null;
         }
 
-        [TestCase(BaseAssemblyName, true, ExpectedResult = 0)]
-        [TestCase(BaseAssemblyName, false, ExpectedResult = 1)]
+        [TestCase(BaseAssemblyNamespace, true, ExpectedResult = 0)]
+        [TestCase(BaseAssemblyNamespace, false, ExpectedResult = 1)]
         [TestCase(null, true, ExpectedResult = 0)]
         [TestCase(null, false, ExpectedResult = 0)]
         public int TryGetAssemblyName_UsingCollectionCount(string assemblyName, bool isDynamic)
@@ -125,7 +126,7 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
                 Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
-                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyName));
+                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
                 Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
                 Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
                 Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
@@ -185,7 +186,7 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
                 Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
-                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyName));
+                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
             });
             Assert.That(loadedModule.Data.ContainsKey("assemblyHashCode"), Is.False);
             Assert.Multiple(() =>
@@ -234,7 +235,7 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
                 Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
-                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyName));
+                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
                 Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
                 Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
             });
@@ -291,7 +292,7 @@ namespace NewRelic.Agent.Core.WireModels
             {
                 Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
                 Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
-                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyName));
+                Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
                 Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
             });
             Assert.That(loadedModule.Data.ContainsKey("publicKeyToken"), Is.False);


### PR DESCRIPTION
## Description

Our vulnerability management backend uses the assemblies from update_loaded_modules to locate which nuget packages the customer is using.  Pre-compiled assemblies are made from local files and are not part of any nuget package. Likewise, dynamically created assemblies are also not going to be found in nuget packages.

The Assembly type already have a property for IsDynamic that we can read, but there is no such property for pre-compiled assemblies (from [ASP.NET Precompilation](https://learn.microsoft.com/en-us/previous-versions/aspnet/bb398860(v=vs.100))).  I noticed that all of my test pre-compiled assemblies reported 0.0.0.0 as the version unlike any of the other assemblies in my apps.  While it is possible that non pre-compiled  assemblies could have a zerod version, such an assembly would not be useful when trying to link the assembly to a versioned nuget, which is what the data is supposed to enable. We will be using this to exclude assemblies.

The payload sent up via update_loaded_modules is not normally visible to customers.  The environment page for .NET still uses the data sent up during connect and it is not updated.

Changes:
- Excludes any "zerod" version assemblies since they are highly likely to be pre-compiled.
- Excludes assemblies marked as Assembly.IsDynamic = true
- Adds a pair of unit tests for the above
- Modifies the existing unit tests to take into account the changes in logic




# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
