### PR TITLE
SQS: Rework distributed trace tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -477,6 +477,23 @@ namespace NewRelic.Agent.Core
             _customEventTransformer.Transform(eventType, attributes, transaction.Priority);
         }
 
+        public IEnumerable<string> GetConfiguredDTHeaders()
+        {
+            List<string> headers = [];
+            if (_configurationService.Configuration.DistributedTracingEnabled)
+            {
+                headers.Add(Constants.TraceParentHeaderKey);
+                headers.Add(Constants.TraceStateHeaderKey);
+
+                if (!_configurationService.Configuration.ExcludeNewrelicHeader)
+                {
+                    headers.Add(Constants.DistributedTracePayloadKeyAllLower);
+                }
+            }
+
+            return headers;
+        }
+
         public ISimpleSchedulingService SimpleSchedulingService
         {
             get { return _simpleSchedulingService; }

--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -477,7 +477,7 @@ namespace NewRelic.Agent.Core
             _customEventTransformer.Transform(eventType, attributes, transaction.Priority);
         }
 
-        public IEnumerable<string> GetConfiguredDTHeaders()
+        public List<string> GetConfiguredDTHeaders()
         {
             List<string> headers = [];
             if (_configurationService.Configuration.DistributedTracingEnabled)

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -1224,7 +1224,7 @@
                         <xs:attribute name="excludeNewrelicHeader" type="xs:boolean" default="false">
                             <xs:annotation>
                                 <xs:documentation>
-                                    Set this to true to disable adding of the newrelic header to outgoing requests.  It is disabled by default.
+                                    Set this to true to exclude the newrelic header from outgoing requests.  It is included by default.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -51,5 +51,7 @@ namespace NewRelic.Agent.Api.Experimental
         ISimpleSchedulingService SimpleSchedulingService { get; }
 
         void RecordLlmEvent(string eventType, IDictionary<string, object> attributes);
+
+        IEnumerable<string> GetConfiguredDTHeaders();
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/Experimental/IAgentExperimental.cs
@@ -52,6 +52,6 @@ namespace NewRelic.Agent.Api.Experimental
 
         void RecordLlmEvent(string eventType, IDictionary<string, object> attributes);
 
-        IEnumerable<string> GetConfiguredDTHeaders();
+        List<string> GetConfiguredDTHeaders();
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
@@ -112,10 +112,10 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
                 }
             }
 
-            // modify the request to ask for DT headers in the response message attributes
+            // modify the request to ask for DT headers in the response message attributes.
+            // we can't know which header(s) the message might contain, so we have to ask for all of them
             if (action == MessageBrokerAction.Consume)
             {
-                // TODO: update the distributed trace API to give the set of headers to accept based on current configuration
                 if (request.MessageAttributeNames == null)
                     request.MessageAttributeNames = new List<string>();
 
@@ -123,7 +123,6 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
                 request.MessageAttributeNames.Add(W3C_TRACESTATE_HEADER);
                 request.MessageAttributeNames.Add(W3C_TRACEPARENT_HEADER);
             }
-
 
             if (isAsync)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
@@ -115,6 +115,7 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
             // modify the request to ask for DT headers in the response message attributes
             if (action == MessageBrokerAction.Consume)
             {
+                // TODO: update the distributed trace API to give the set of headers to accept based on current configuration
                 if (request.MessageAttributeNames == null)
                     request.MessageAttributeNames = new List<string>();
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
@@ -36,6 +36,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
             var awsCredentials = new Amazon.Runtime.BasicAWSCredentials("dummy", "dummy");
             var config = new AmazonSQSConfig
             {
+                //ServiceURL = "http://localhost:4566",
                 ServiceURL = "http://localstack-containertest:4566",
                 AuthenticationRegion = "us-west-2"
             };

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
@@ -7,7 +7,6 @@ using System;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using System.Linq;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace AwsSdkTestApp.AwsSdkExerciser
@@ -36,7 +35,6 @@ namespace AwsSdkTestApp.AwsSdkExerciser
             var awsCredentials = new Amazon.Runtime.BasicAWSCredentials("dummy", "dummy");
             var config = new AmazonSQSConfig
             {
-                //ServiceURL = "http://localhost:4566",
                 ServiceURL = "http://localstack-containertest:4566",
                 AuthenticationRegion = "us-west-2"
             };
@@ -64,7 +62,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
                 QueueUrl = _sqsQueueUrl
             });
         }
-        public async Task<string> SQS_Initialize(string queueName)
+        public async Task<string> SQS_InitializeAsync(string queueName)
         {
             if (_sqsQueueUrl != null)
             {
@@ -76,7 +74,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
             return _sqsQueueUrl;
         }
 
-        public async Task SQS_Teardown()
+        public async Task SQS_TeardownAsync()
         {
             if (_sqsQueueUrl == null)
             {
@@ -88,7 +86,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task SQS_SendMessage(string message)
+        public async Task SQS_SendMessageAsync(string message)
         {
             if (_sqsQueueUrl == null)
             {
@@ -99,7 +97,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task<IEnumerable<Message>> SQS_ReceiveMessage(int maxMessagesToReceive = 1)
+        public async Task<IEnumerable<Message>> SQS_ReceiveMessageAsync(int maxMessagesToReceive = 1)
         {
             if (_sqsQueueUrl == null)
             {
@@ -134,7 +132,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
 
         // send message batch
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task SQS_SendMessageBatch(string[] messages)
+        public async Task SQS_SendMessageBatchAsync(string[] messages)
         {
             if (_sqsQueueUrl == null)
             {
@@ -157,7 +155,7 @@ namespace AwsSdkTestApp.AwsSdkExerciser
 
         // purge the queue
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public async Task SQS_PurgeQueue()
+        public async Task SQS_PurgeQueueAsync()
         {
             if (_sqsQueueUrl == null)
             {

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AWSSDK.SQS" Version="3.7.301.23" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="10.26.0" />
   </ItemGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
@@ -1,7 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
@@ -33,24 +32,24 @@ namespace AwsSdkTestApp.Controllers
 
         // GET: /AwsSdk/SQS_SendReceivePurge?queueName=MyQueue
         [HttpGet("SQS_SendReceivePurge")]
-        public async Task SQS_SendReceivePurge([Required]string queueName)
+        public async Task SQS_SendReceivePurgeAsync([Required]string queueName)
         {
             _logger.LogInformation("Starting SQS_SendReceivePurge for {Queue}", queueName);
 
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
             
-            await awsSdkExerciser.SQS_Initialize(queueName);
+            await awsSdkExerciser.SQS_InitializeAsync(queueName);
 
-            await awsSdkExerciser.SQS_SendMessage("Hello World!");
-            await awsSdkExerciser.SQS_ReceiveMessage();
+            await awsSdkExerciser.SQS_SendMessageAsync("Hello World!");
+            await awsSdkExerciser.SQS_ReceiveMessageAsync();
 
             var messages = new[] { "Hello", "World" };
-            await awsSdkExerciser.SQS_SendMessageBatch(messages);
-            await awsSdkExerciser.SQS_ReceiveMessage(messages.Length);
+            await awsSdkExerciser.SQS_SendMessageBatchAsync(messages);
+            await awsSdkExerciser.SQS_ReceiveMessageAsync(messages.Length);
 
-            await awsSdkExerciser.SQS_PurgeQueue();
+            await awsSdkExerciser.SQS_PurgeQueueAsync();
 
-            await awsSdkExerciser.SQS_Teardown();
+            await awsSdkExerciser.SQS_TeardownAsync();
 
             _logger.LogInformation("Finished SQS_SendReceivePurge for {Queue}", queueName);
         }
@@ -62,11 +61,11 @@ namespace AwsSdkTestApp.Controllers
         /// <returns></returns>
         // GET: /AwsSdk/SQS_InitializeQueue?queueName=MyQueue
         [HttpGet("SQS_InitializeQueue")]
-        public async Task<string> SQS_InitializeQueue([Required]string queueName)
+        public async Task<string> SQS_InitializeQueueAsync([Required]string queueName)
         {
             _logger.LogInformation("Initializing queue {Queue}", queueName);
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
-            var queueUrl = await awsSdkExerciser.SQS_Initialize(queueName);
+            var queueUrl = await awsSdkExerciser.SQS_InitializeAsync(queueName);
             _logger.LogInformation("Queue {Queue} initialized with URL {QueueUrl}", queueName, queueUrl);
             return queueUrl;
         }
@@ -79,13 +78,13 @@ namespace AwsSdkTestApp.Controllers
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
             awsSdkExerciser.SQS_SetQueueUrl(messageQueueUrl);
 
-            await awsSdkExerciser.SQS_SendMessage(message);
+            await awsSdkExerciser.SQS_SendMessageAsync(message);
             _logger.LogInformation("Message {Message} sent to {Queue}", message, messageQueueUrl);
         }
 
         // GET: /AwsSdk/SQS_SendMessageBatchToQueue?messageQueueUrl=MyQueue
         [HttpGet("SQS_ReceiveMessageFromQueue")]
-        public async Task<IEnumerable<Message>> SQS_ReceiveMessageFromQueue([Required]string messageQueueUrl)
+        public async Task<IEnumerable<Message>> SQS_ReceiveMessageFromQueueAsync([Required]string messageQueueUrl)
         {
             _logger.LogInformation("Requesting a message from {Queue}", messageQueueUrl);
             await _requestQueue.QueueRequestAsync(messageQueueUrl);
@@ -97,13 +96,13 @@ namespace AwsSdkTestApp.Controllers
 
         // GET: /AwsSdk/SQS_SendMessageBatchToQueue?messageQueueUrl=MyQueue
         [HttpGet("SQS_DeleteQueue")]
-        public async Task SQS_DeleteQueue([Required]string messageQueueUrl)
+        public async Task SQS_DeleteQueueAsync([Required]string messageQueueUrl)
         {
             _logger.LogInformation("Deleting queue {Queue}", messageQueueUrl);
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
             awsSdkExerciser.SQS_SetQueueUrl(messageQueueUrl);
 
-            await awsSdkExerciser.SQS_Teardown();
+            await awsSdkExerciser.SQS_TeardownAsync();
             _logger.LogInformation("Queue {Queue} deleted", messageQueueUrl);
         }
     }

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkController.cs
@@ -72,7 +72,7 @@ namespace AwsSdkTestApp.Controllers
 
         // GET: /AwsSdk/SQS_SendMessageToQueue?message=Hello&messageQueueUrl=MyQueue
         [HttpGet("SQS_SendMessageToQueue")]
-        public async Task SQS_SendMessageToQueue([Required]string message, [Required]string messageQueueUrl)
+        public async Task SQS_SendMessageToQueueAsync([Required]string message, [Required]string messageQueueUrl)
         {
             _logger.LogInformation("Sending message {Message} to {Queue}", message, messageQueueUrl);
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Program.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Program.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSReceiverService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSReceiverService.cs
@@ -1,0 +1,14 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public interface ISQSReceiverService
+    {
+        Task<IEnumerable<Message>> ReceiveAMessageAsync(string queueUrl);
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSRequestQueue.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSRequestQueue.cs
@@ -1,0 +1,15 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public interface ISQSRequestQueue
+    {
+        Task QueueRequestAsync(string queueUrl);
+
+        Task<string> DequeueAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSResponseQueue.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/ISQSResponseQueue.cs
@@ -1,0 +1,17 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public interface ISQSResponseQueue
+    {
+        Task QueueResponseAsync(IEnumerable<Message> messages);
+
+        Task<IEnumerable<Message>> DequeueAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSReceiverService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSReceiverService.cs
@@ -59,7 +59,7 @@ namespace AwsSdkTestApp.SQSBackgroundService
             using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
             awsSdkExerciser.SQS_SetQueueUrl(queueUrl);
             _logger.LogInformation("Receiving a message from {Queue}", queueUrl);
-            var messages = await awsSdkExerciser.SQS_ReceiveMessage();
+            var messages = await awsSdkExerciser.SQS_ReceiveMessageAsync();
             _logger.LogInformation("Received a message from {Queue}; queuing a response", queueUrl);
             await _responseQueue.QueueResponseAsync(messages);
             _logger.LogInformation("Finished processing request for {Queue}", queueUrl);

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSReceiverService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSReceiverService.cs
@@ -1,0 +1,69 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using AwsSdkTestApp.AwsSdkExerciser;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NewRelic.Api.Agent;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public class SQSReceiverService : BackgroundService
+    {
+        private readonly ILogger<SQSReceiverService> _logger;
+        private readonly ISQSRequestQueue _requestQueue;
+        private readonly ISQSResponseQueue _responseQueue;
+        private CancellationToken _stoppingToken;
+
+        public SQSReceiverService(ILogger<SQSReceiverService> logger, ISQSRequestQueue requestQueue, ISQSResponseQueue responseQueue)
+        {
+            _logger = logger;
+            _requestQueue = requestQueue;
+            _responseQueue = responseQueue;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _stoppingToken = stoppingToken;
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    _logger.LogInformation("Waiting for a request to receive a message");
+                    var queueUrl = await _requestQueue.DequeueAsync(stoppingToken);
+                    var messages = await ProcessRequestAsync(queueUrl);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation("Cancellation requested. Shutting down SQSReceiverService");
+                }
+
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "An error occurred while processing a request");
+                    throw;
+                }
+            }
+        }
+
+        [Transaction]
+        private async Task<IEnumerable<Message>> ProcessRequestAsync(string queueUrl)
+        {
+            _logger.LogInformation("Received a request to receive a message from {Queue}", queueUrl);
+            using var awsSdkExerciser = new AwsSdkExerciser.AwsSdkExerciser(AwsSdkTestType.SQS);
+            awsSdkExerciser.SQS_SetQueueUrl(queueUrl);
+            _logger.LogInformation("Receiving a message from {Queue}", queueUrl);
+            var messages = await awsSdkExerciser.SQS_ReceiveMessage();
+            _logger.LogInformation("Received a message from {Queue}; queuing a response", queueUrl);
+            await _responseQueue.QueueResponseAsync(messages);
+            _logger.LogInformation("Finished processing request for {Queue}", queueUrl);
+            return messages;
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSRequestQueue.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSRequestQueue.cs
@@ -1,0 +1,33 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public class SQSRequestQueue : ISQSRequestQueue
+    {
+        private readonly Channel<string> _requestQueue;
+
+        public SQSRequestQueue()
+        {
+            var options = new BoundedChannelOptions(1)
+            {
+                FullMode = BoundedChannelFullMode.Wait
+            };
+            _requestQueue = Channel.CreateBounded<string>(options);
+        }
+
+        public async Task QueueRequestAsync(string queueUrl)
+        {
+            await _requestQueue.Writer.WriteAsync(queueUrl);
+        }
+
+        public async Task<string> DequeueAsync(CancellationToken cancellationToken)
+        {
+            return await _requestQueue.Reader.ReadAsync(cancellationToken);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSResponseQueue.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/SQSBackgroundService/SQSResponseQueue.cs
@@ -1,0 +1,35 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+
+namespace AwsSdkTestApp.SQSBackgroundService
+{
+    public class SQSResponseQueue : ISQSResponseQueue
+    {
+        private readonly Channel<IEnumerable<Message>> _responseQueue;
+
+        public SQSResponseQueue()
+        {
+            var options = new BoundedChannelOptions(1)
+            {
+                FullMode = BoundedChannelFullMode.Wait
+            };
+            _responseQueue = Channel.CreateBounded<IEnumerable<Message>>(options);
+        }
+
+        public async Task QueueResponseAsync(IEnumerable<Message> messages)
+        {
+            await _responseQueue.Writer.WriteAsync(messages);
+        }
+
+        public async Task<IEnumerable<Message>> DequeueAsync(CancellationToken cancellationToken)
+        {
+            return await _responseQueue.Reader.ReadAsync(cancellationToken);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests.sln
@@ -4,6 +4,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ContainerIntegrationTests", "ContainerIntegrationTests\ContainerIntegrationTests.csproj", "{3B33858F-A8CF-44FE-B1A6-9308254C0019}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0EECB18A-4350-4D17-AB0D-F7647B4E3B58} = {0EECB18A-4350-4D17-AB0D-F7647B4E3B58}
+		{1F7402D8-E345-480C-BBA6-6313A1DEEB23} = {1F7402D8-E345-480C-BBA6-6313A1DEEB23}
+		{70731828-AFC8-4262-9076-3FB39E224D10} = {70731828-AFC8-4262-9076-3FB39E224D10}
+		{FBA07795-8066-4641-88E5-05DD272D333A} = {FBA07795-8066-4641-88E5-05DD272D333A}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTestHelpers", "IntegrationTestHelpers\IntegrationTestHelpers.csproj", "{1A7589F4-614C-47BA-8163-E42A6863BC13}"
 EndProject
@@ -26,7 +32,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KafkaTestApp", "ContainerAp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.Testing.Assertions", "..\NewRelic.Testing.Assertions\NewRelic.Testing.Assertions.csproj", "{C0ADF41E-F8B8-4ECA-828F-F578E09B17A9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AwsSdkTestApp", "ContainerApplications\AwsSdkTestApp\AwsSdkTestApp.csproj", "{70731828-AFC8-4262-9076-3FB39E224D10}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AwsSdkTestApp", "ContainerApplications\AwsSdkTestApp\AwsSdkTestApp.csproj", "{70731828-AFC8-4262-9076-3FB39E224D10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NewRelic.Agent.ContainerIntegrationTests.Applications;
 using NewRelic.Agent.ContainerIntegrationTests.Fixtures;
@@ -50,6 +51,7 @@ public class AwsSdkContainerSQSTestFixture : AwsSdkContainerTestFixtureBase
         var queueUrl =  GetString($"{address}/SQS_InitializeQueue?queueName={queueName}");
 
         GetAndAssertStatusCode($"{address}/SQS_SendMessageToQueue?message=Hello&messageQueueUrl={queueUrl}", System.Net.HttpStatusCode.OK);
+
         var messagesJson = GetString($"{address}/SQS_ReceiveMessageFromQueue?messageQueueUrl={queueUrl}");
 
         GetAndAssertStatusCode($"{address}/SQS_DeleteQueue?messageQueueUrl={queueUrl}", System.Net.HttpStatusCode.OK);

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
@@ -17,7 +17,6 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
 
     private readonly string _testQueueName = $"TestQueue-{Guid.NewGuid()}";
     private readonly string _metricScope1 = "WebTransaction/MVC/AwsSdk/SQS_SendReceivePurge/{queueName}";
-    private string _messagesJson;
 
     public AwsSdkSQSTest(AwsSdkContainerSQSTestFixture fixture, ITestOutputHelper output) : base(fixture)
     {
@@ -42,7 +41,7 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
                 _fixture.Delay(5);
 
                 _fixture.ExerciseSQS_SendReceivePurge(_testQueueName);
-                _messagesJson = _fixture.ExerciseSQS_SendAndReceiveInSeparateTransactions(_testQueueName);
+                _fixture.ExerciseSQS_SendAndReceiveInSeparateTransactions(_testQueueName);
 
                 _fixture.Delay(15);
 
@@ -71,7 +70,7 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
 
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 3},
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 2, metricScope = _metricScope1},
-            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSReceiverService/ProcessRequestAsync"},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
 
             new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName}", callCount = 1},
             new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName}", callCount = 1, metricScope = _metricScope1},

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
@@ -15,8 +15,10 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
 {
     private readonly AwsSdkContainerSQSTestFixture _fixture;
 
-    private readonly string _testQueueName = $"TestQueue-{Guid.NewGuid()}";
+    private readonly string _testQueueName1 = $"TestQueue1-{Guid.NewGuid()}";
+    private readonly string _testQueueName2 = $"TestQueue2-{Guid.NewGuid()}";
     private readonly string _metricScope1 = "WebTransaction/MVC/AwsSdk/SQS_SendReceivePurge/{queueName}";
+    private readonly string _metricScope2 = "WebTransaction/MVC/AwsSdk/SQS_SendMessageToQueue/{message}/{messageQueueUrl}";
 
     public AwsSdkSQSTest(AwsSdkContainerSQSTestFixture fixture, ITestOutputHelper output) : base(fixture)
     {
@@ -32,7 +34,7 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
                 configModifier.EnableDistributedTrace();
                 configModifier.ConfigureFasterMetricsHarvestCycle(15);
                 configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
-                configModifier.ConfigureFasterTransactionTracesHarvestCycle(20);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
                 configModifier.LogToConsole();
 
             },
@@ -40,11 +42,10 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
             {
                 _fixture.Delay(5);
 
-                _fixture.ExerciseSQS_SendReceivePurge(_testQueueName);
-                _fixture.ExerciseSQS_SendAndReceiveInSeparateTransactions(_testQueueName);
+                _fixture.ExerciseSQS_SendReceivePurge(_testQueueName1);
+                _fixture.ExerciseSQS_SendAndReceiveInSeparateTransactions(_testQueueName2);
 
-                _fixture.Delay(15);
-
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
 
                 // shut down the container and wait for the agent log to see it
@@ -63,53 +64,62 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
 
         var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName}", callCount = 3}, // SendMessage and SendMessageBatch
-            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName}", callCount = 2, metricScope = _metricScope1},
-            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName}", callCount = 1, metricScope = "WebTransaction/MVC/AwsSdk/SQS_SendMessageToQueue/{message}/{messageQueueUrl}"},
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName1}", callCount = 2}, // SendMessage and SendMessageBatch
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName1}", callCount = 2, metricScope = _metricScope1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName1}", callCount = 2},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName1}", callCount = 2, metricScope = _metricScope1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName1}", callCount = 1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName1}", callCount = 1, metricScope = _metricScope1},
 
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName2}", callCount = 1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName2}", callCount = 1, metricScope = _metricScope2},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName2}", callCount = 1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName2}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
 
-            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 3},
-            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 2, metricScope = _metricScope1},
-            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
-
-            new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName}", callCount = 1},
-            new() { metricName = $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName}", callCount = 1, metricScope = _metricScope1},
         };
 
-        var sendMessageTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope1);
-
-        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_metricScope1);
-        var expectedTransactionTraceSegments = new List<string>
+        var sendReceivePurgeTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope1);
+        var sendReceivePurgeTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_metricScope1);
+        var sendReceivePurgeExpectedTransactionTraceSegments = new List<string>
         {
-            $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName}",
-            $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}",
-            $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName}"
+            $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName1}",
+            $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName1}",
+            $"MessageBroker/SQS/Queue/Purge/Named/{_testQueueName1}"
         };
 
         Assertions.MetricsExist(expectedMetrics, metrics);
         NrAssert.Multiple(
-            () => Assert.True(sendMessageTransactionEvent != null, "sendMessageTransactionEvent should not be null"),
-            () => Assert.True(transactionSample != null, "transactionSample should not be null"),
-            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+            () => Assert.True(sendReceivePurgeTransactionEvent != null, "sendReceivePurgeTransactionEvent should not be null"),
+            () => Assert.True(sendReceivePurgeTransactionSample != null, "sendReceivePurgeTransactionSample should not be null"),
+            () => Assertions.TransactionTraceSegmentsExist(sendReceivePurgeExpectedTransactionTraceSegments, sendReceivePurgeTransactionSample)
+        );
+
+        var sendMessageToQueueTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope2);
+        var receiveMessageTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync");
+        NrAssert.Multiple(
+            () => Assert.True(sendMessageToQueueTransactionEvent != null, "sendMessageToQueueTransactionEvent should not be null"),
+            () => Assert.True(receiveMessageTransactionEvent != null, "receiveMessageTransactionEvent should not be null")
         );
 
         // verify that distributed trace worked as expected -- the last produce span should have the same traceId and parentId as the last consume span
-        var queueProduce = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName}";
-        var queueConsume = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName}";
+        var queueProduce = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName2}";
+        var queueConsume = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName2}";
 
         var spans = _fixture.AgentLog.GetSpanEvents().ToList();
         var produceSpan = spans.LastOrDefault(s => s.IntrinsicAttributes["name"].Equals(queueProduce));
         var consumeSpan = spans.LastOrDefault(s => s.IntrinsicAttributes["name"].Equals(queueConsume));
+        var processRequestSpan = spans.LastOrDefault(s => s.IntrinsicAttributes["name"].Equals("OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"));
 
         NrAssert.Multiple(
-            () => Assert.NotNull(produceSpan),
-            () => Assert.NotNull(consumeSpan),
+            () => Assert.True(produceSpan != null, "produceSpan should not be null"),
+            () => Assert.True(consumeSpan != null, "consumeSpan should not be null"),
+            () => Assert.True(processRequestSpan != null, "processRequestSpan should not be null"),
             () => Assert.True(produceSpan!.IntrinsicAttributes.ContainsKey("traceId")),
-            () => Assert.True(produceSpan!.IntrinsicAttributes.ContainsKey("parentId")),
+            () => Assert.True(produceSpan!.IntrinsicAttributes.ContainsKey("guid")),
             () => Assert.True(consumeSpan!.IntrinsicAttributes.ContainsKey("traceId")),
-            () => Assert.True(consumeSpan!.IntrinsicAttributes.ContainsKey("parentId")),
+            () => Assert.True(processRequestSpan!.IntrinsicAttributes.ContainsKey("parentId")),
             () => Assert.Equal(produceSpan!.IntrinsicAttributes["traceId"], consumeSpan!.IntrinsicAttributes["traceId"]),
-            () => Assert.Equal(produceSpan!.IntrinsicAttributes["parentId"], consumeSpan!.IntrinsicAttributes["parentId"])
+            () => Assert.Equal(produceSpan!.IntrinsicAttributes["guid"], processRequestSpan!.IntrinsicAttributes["parentId"])
         );
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdkTests.cs
@@ -76,6 +76,7 @@ public class AwsSdkSQSTest : NewRelicIntegrationTest<AwsSdkContainerSQSTestFixtu
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName2}", callCount = 1},
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName2}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
 
+            new () { metricName = "Supportability/TraceContext/Accept/Success", callCount = 1}, // only one accept should occur (from the SQSReceiverService/ProcessRequestAsync transaction)
         };
 
         var sendReceivePurgeTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope1);

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
@@ -47,7 +47,7 @@ namespace Agent.Extensions.Tests.Helpers
             };
 
             // Act
-            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest);
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate"]);
 
             // Assert
             Assert.That(sendMessageRequest.MessageAttributes, Has.Count.EqualTo(3));
@@ -74,7 +74,7 @@ namespace Agent.Extensions.Tests.Helpers
             }
 
             // Act
-            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest);
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate"]);
 
             // Assert
             if (dtHeadersShouldBeAdded)

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
@@ -47,7 +47,7 @@ namespace Agent.Extensions.Tests.Helpers
             };
 
             // Act
-            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate"]);
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, 2);
 
             // Assert
             Assert.That(sendMessageRequest.MessageAttributes, Has.Count.EqualTo(3));
@@ -74,7 +74,7 @@ namespace Agent.Extensions.Tests.Helpers
             }
 
             // Act
-            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate", "newrelic"]);
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, 3);
 
             // Assert
             if (dtHeadersShouldBeAdded)

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
@@ -74,7 +74,7 @@ namespace Agent.Extensions.Tests.Helpers
             }
 
             // Act
-            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate"]);
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, ["traceparent", "tracestate", "newrelic"]);
 
             // Assert
             if (dtHeadersShouldBeAdded)


### PR DESCRIPTION
Reworks the SQS container test app to use a background service to receive messages, rather than directly receiving them from an API endpoint. The solution is (mildly) convoluted, but works well. 

Updated tests to verify the trace id and parent id match in the produce and consume sides.