### PR TITLE
ci: Build RPM on Ubuntu

### DIFF
--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -1,19 +1,12 @@
 
 
-FROM ubuntu:jammy
+FROM ubuntu:noble-20240605@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-# git + root certificates to checkout builder code
     git ca-certificates \
-# rpm; to build rpm
     rpm \
-# gnupg2; to sign packages
     gnupg2 \
-# python3 and python3-gnupg; to import signing key
-    python3 python3-gnupg \
     dos2unix \
-    expect \
-    # for extracting the GPG key from the tar.bz2 file
     dtrx \ 
 # save on final image size
  && rm -rf /var/lib/apt/lists/*

--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3 python3-gnupg \
     dos2unix \
     expect \
+    # for extracting the GPG key from the tar.bz2 file
+    dtrx \ 
 # save on final image size
  && rm -rf /var/lib/apt/lists/*
 

--- a/build/Linux/build/rpm/Dockerfile
+++ b/build/Linux/build/rpm/Dockerfile
@@ -1,17 +1,30 @@
-FROM rpmbuild/centos7
 
-USER root
-ADD Image-ExifTool-12.28.tar.gz /exiftool
 
-# temporary workaround until we can move to a non-centos7 base image
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \ 
-    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-    
-RUN yum --assumeyes install dos2unix rpm-sign expect perl-ExtUtils-MakeMaker
+FROM ubuntu:jammy
 
-# Install exiftool
-RUN cd /exiftool/Image-ExifTool-12.28; \
-perl Makefile.PL; \
-make; \
-make install
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# git + root certificates to checkout builder code
+    git ca-certificates \
+# rpm; to build rpm
+    rpm \
+# gnupg2; to sign packages
+    gnupg2 \
+# python3 and python3-gnupg; to import signing key
+    python3 python3-gnupg \
+    dos2unix \
+    expect \
+# save on final image size
+ && rm -rf /var/lib/apt/lists/*
+
+# Install New Relic's public key to verify RPM signature
+RUN apt-get update && apt-get install -y --no-install-recommends \
+# wget to download New Relic's public key
+    wget \
+ && wget -O /tmp/newrelic-public.gpg https://download.newrelic.com/548C16BF.gpg \
+ && rpm --import /tmp/newrelic-public.gpg \
+# cleanup temporary state to save on final image size
+ && apt-get autoremove -y wget \
+ && rm -rf /var/lib/apt/lists/*
+
+ # Install exiftool
+RUN git clone https://github.com/exiftool/exiftool.git

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -18,20 +18,7 @@ function sign_rpm {
 %_gpgbin /usr/bin/gpg
 MACROS
 
-    # create an expect script to run the sign command
-    # this is necessary because the sign tool asks for a passphrase
-    cat << EXPECT | tee sign.expect
-#!/usr/bin/expect -f
-set timeout -1
-spawn rpm --addsign $rpm_file
-expect "Enter pass phrase:"
-send -- "\r"
-expect eof
-EXPECT
-
-    # run the expect script
-    chmod a+x sign.expect
-    ./sign.expect
+    rpm --addsign $rpm_file
 }
 
 PACKAGE_NAME='newrelic-dotnet-agent'

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -5,7 +5,7 @@ set -e # Halt the build script on any error
 function sign_rpm {
     rpm_file="$1"
     # unpack the tarball, rename it and set perms
-    dtrx "$GPG_KEYS"
+    dtrx --one here "$GPG_KEYS"
     mv gpg-conf "$HOME/.gnupg"
     chown root:root "$HOME/.gnupg"
     chmod 0700 "$HOME/.gnupg"

--- a/build/Linux/build/rpm/build.sh
+++ b/build/Linux/build/rpm/build.sh
@@ -5,7 +5,7 @@ set -e # Halt the build script on any error
 function sign_rpm {
     rpm_file="$1"
     # unpack the tarball, rename it and set perms
-    tar -jxvf "$GPG_KEYS"
+    dtrx "$GPG_KEYS"
     mv gpg-conf "$HOME/.gnupg"
     chown root:root "$HOME/.gnupg"
     chmod 0700 "$HOME/.gnupg"

--- a/build/Linux/docker-compose.yml
+++ b/build/Linux/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
     build_deb: 
         build: ./build/deb 


### PR DESCRIPTION
Modifies the RPM build process to use Ubuntu instead of CentOS. Surprisingly, only a few minor changes were required. 

Successful CI run: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/9943833300/job/27468784640?pr=2627

Verified by pulling latest Fedora docker image, copying the .rpm file from the build artifact to the container and running `rpm -i` on it. 