### PR TITLE
chore: Updated a URL in the release notes template

### DIFF
--- a/build/ReleaseNotesBuilder/data.yml
+++ b/build/ReleaseNotesBuilder/data.yml
@@ -14,7 +14,7 @@ epilogue: |
   ### Updating your agent
 
   * Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
-  * If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).
+  * If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/apm/agents/net-agent/installation/update-net-agent/#updating_older_net).
 
   We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent).
   See the New Relic .NET agent [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy) for information about agent releases and support dates.

--- a/deploy/release_notes_template.md
+++ b/deploy/release_notes_template.md
@@ -24,4 +24,4 @@ This release is supported for one year after its release date. For a full list o
 ### Updating
 
 * Follow standard procedures to [update the .NET agent](https://docs.newrelic.com/docs/apm/agents/net-agent/installation/update-net-agent/).
-* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](https://docs.newrelic.com/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](https://docs.newrelic.com/docs/apm/agents/net-agent/installation/update-net-agent/#updating_older_net).


### PR DESCRIPTION
The docs team corrected this link in our last release notes PR. (I'm not sure why we have the same link in two different files, so I updated both. I'm assuming only the `data.yml` file is actually used when generating the release notes.)