### PR TITLE
test: Refactor "latest" integration test NuGet package references to a separate project

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -135,6 +135,7 @@ jobs:
 
     env:
       integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
+      mfaLatestPackages_project_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\SharedApplications\Common\MFALatestPackages\MFALatestPackages.csproj
 
     steps:
       - name: Checkout
@@ -159,12 +160,19 @@ jobs:
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
 
+      - name: Get list of NuGet packages used by MFALatestPackages project using dotnet list package
+        run: | 
+          dotnet list ${{ env.mfaLatestPackages_project_path }} package > ${{ github.workspace }}\mfaLatestPackages.txt
+          cat ${{ github.workspace }}\mfaLatestPackages.txt
+        shell: powershell
+
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: integrationtests
           path: |
             ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
+            ${{ github.workspace }}\mfaLatestPackages.txt
             ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
             ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
             !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -160,7 +160,7 @@ jobs:
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
 
-      - name: Get list of NuGet packages used by MFALatestPackages project using dotnet list package
+      - name: Get list of NuGet packages used by MFALatestPackages
         run: | 
           dotnet list ${{ env.mfaLatestPackages_project_path }} package > ${{ github.workspace }}\mfaLatestPackages.txt
           cat ${{ github.workspace }}\mfaLatestPackages.txt

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -135,7 +135,6 @@ jobs:
 
     env:
       integration_solution_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\IntegrationTests.sln
-      mfaLatestPackages_project_path: ${{ github.workspace }}\tests\Agent\IntegrationTests\SharedApplications\Common\MFALatestPackages\MFALatestPackages.csproj
 
     steps:
       - name: Checkout
@@ -160,19 +159,12 @@ jobs:
           MSBuild.exe -restore -m -p:Configuration=Release -p:DeployOnBuild=true -p:PublishProfile=LocalDeploy ${{ env.integration_solution_path }}
         shell: powershell
 
-      - name: Get list of NuGet packages used by MFALatestPackages
-        run: | 
-          dotnet list ${{ env.mfaLatestPackages_project_path }} package > ${{ github.workspace }}\mfaLatestPackages.txt
-          cat ${{ github.workspace }}\mfaLatestPackages.txt
-        shell: powershell
-
       - name: Archive Artifacts
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: integrationtests
           path: |
             ${{ github.workspace }}\test.runsettings  # Force the artifacts to use repo root as root of package.
-            ${{ github.workspace }}\mfaLatestPackages.txt
             ${{ github.workspace }}\tests\Agent\IntegrationTests\**\bin\**\*
             ${{ github.workspace }}\tests\Agent\IntegrationTests\**\Deploy\**\*
             !${{ github.workspace }}\tests\Agent\IntegrationTests\**\obj\**\*

--- a/tests/Agent/IntegrationTests/IntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/IntegrationTests.sln
@@ -183,6 +183,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializationHelpers", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializationHelpers.Test", "..\Shared\TestSerializationHelpers.Test\TestSerializationHelpers.Test.csproj", "{D33E155E-C7EC-49F1-AA24-B293A74F472D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MFALatestPackages", "SharedApplications\Common\MFALatestPackages\MFALatestPackages.csproj", "{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -417,6 +419,10 @@ Global
 		{D33E155E-C7EC-49F1-AA24-B293A74F472D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D33E155E-C7EC-49F1-AA24-B293A74F472D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D33E155E-C7EC-49F1-AA24-B293A74F472D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -472,6 +478,7 @@ Global
 		{8F7EBBC3-B22F-43AC-978E-2CD8AD7C02CF} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
 		{31DB04AF-2ED3-4379-98D7-7D02F38864F9} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
 		{472F6F9A-97E9-4DC3-9D70-AE79A20FA240} = {F0F6F2CE-8AE8-49E1-8EE9-A44B451EFC29}
+		{78C0CA57-4E16-4E3E-B0CF-E8C9259BA1F2} = {30CF078E-E531-441E-83AB-24AB9B1C179F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3830ABDF-4AEA-4D91-83A2-13F091D1DF5F}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -1,0 +1,92 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net481'" />
+    
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NServiceBus" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- Requires Serilog 3.1.1+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- Requires Serilog 3.1.1+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="NLog" Version="5.3.2" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <!-- Requires NLog 5.2.4+ -->
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
+    <PackageReference Include="RestSharp" Version="111.4.0" Condition="'$(TargetFramework)' == 'net481'" />
+
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+  </ItemGroup>
+
+</Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -5,87 +5,87 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="LibGit2Sharp" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="LibGit2Sharp" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
     
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net.Ext.Json" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
 
-    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="log4net" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="log4net.Ext.Json" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="npgsql" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="npgsql" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MySql.Data" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySql.Data" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MongoDB.Driver" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MongoDB.Driver" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MySqlConnector" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySqlConnector" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="StackExchange.Redis" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="StackExchange.Redis" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NEST" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NEST" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Elasticsearch.Net" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elasticsearch.Net" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Sinks.File" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.File" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="NServiceBus" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NServiceBus" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
 
-    <PackageReference Include="NLog" Version="5.3.2" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- Requires Serilog 3.1.1+ -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <PackageReference Include="NLog" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Requires NLog 5.2.4+ -->
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MassTransit" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MassTransit" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
-    <PackageReference Include="RestSharp" Version="111.4.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RestSharp" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
 
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -4,91 +4,90 @@
     <TargetFrameworks>net481;net8.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="LibGit2Sharp" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
+  <ItemGroup> <!-- retain alphabetical order please! -->
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.400" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.400" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="log4net" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net.Ext.Json" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <PackageReference Include="log4net" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="log4net.Ext.Json" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="MassTransit" Version="8.2.3" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MassTransit" Version="8.2.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="MySqlConnector" Version="2.3.7" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="NLog" Version="5.3.2" Condition="'$(TargetFramework)' == 'net481'" />
+    
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
     <!-- npgsql is on version 8, but we don't (currently) support it, so use the latest v7 release -->
     <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="MySql.Data" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MySql.Data" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="MongoDB.Driver" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MongoDB.Driver" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="MySqlConnector" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MySqlConnector" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="StackExchange.Redis" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="StackExchange.Redis" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="NEST" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NEST" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Elasticsearch.Net" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Elasticsearch.Net" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Serilog" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Serilog.AspNetCore" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
+    
     <!-- NServiceBus v9+ only supports .NET, so constraint FW target to the latest 8.x version -->
     <PackageReference Include="NServiceBus" Version="8.*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NServiceBus" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="NLog" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <!-- Requires NLog 5.2.4+ -->
-    <PackageReference Include="NLog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="MassTransit" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="MassTransit" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
-
+    <PackageReference Include="NServiceBus" Version="9.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
     <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
-    <PackageReference Include="RestSharp" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="RestSharp" Version="111.4.0" Condition="'$(TargetFramework)' == 'net481'" />
+    
+    <PackageReference Include="Serilog" Version="4.0.1" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog" Version="4.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -56,12 +56,12 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NServiceBus" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+
     <!-- Requires Serilog 3.1.1+ -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -17,8 +17,9 @@
     <PackageReference Include="log4net" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
-    <PackageReference Include="npgsql" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="npgsql" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <!-- npgsql is on version 8, but we don't (currently) support it, so use the latest v7 release -->
+    <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
@@ -56,6 +57,8 @@
     <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="RabbitMQ.Client" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
+    <!-- NServiceBus v9+ only supports .NET, so constraint FW target to the latest 8.x version -->
+    <PackageReference Include="NServiceBus" Version="8.*" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NServiceBus" Version="*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="Microsoft.Extensions.Logging" Version="*" Condition="'$(TargetFramework)' == 'net481'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -58,12 +58,12 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <!-- npgsql is on version 8, but we don't (currently) support it, so use the latest v7 release -->
-    <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="npgsql" Version="7.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <!-- npgsql is on version 8, but we don't (currently) support it -->
+    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <!-- NServiceBus v9+ only supports .NET, so constraint FW target to the latest 8.x version -->
-    <PackageReference Include="NServiceBus" Version="8.*" Condition="'$(TargetFramework)' == 'net481'" />
+    <!-- NServiceBus v9+ only supports .NET8+, so constraint FW target to the latest 8.x version -->
+    <PackageReference Include="NServiceBus" Version="8.2.2" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NServiceBus" Version="9.1.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     
     <PackageReference Include="RabbitMQ.Client" Version="6.8.1" Condition="'$(TargetFramework)' == 'net481'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -11,16 +11,12 @@
     <PackageReference Include="LibGit2Sharp" Version="0.24.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="LibGit2Sharp" Version="0.24.1" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="LibGit2Sharp" Version="0.28.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.320" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- log4net .NET framework references -->
     <PackageReference Include="log4net" Version="1.2.10" Condition="'$(TargetFramework)' == 'net462'" />
@@ -28,15 +24,11 @@
     <PackageReference Include="log4net.Ext.Json" Version="1.2.15.14586" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="log4net" Version="2.0.14" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- log4net .NET core references -->
     <PackageReference Include="log4net" Version="2.0.10" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.9.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="log4net" Version="2.0.16" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-
+    
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,11 +38,9 @@
     <PackageReference Include="npgsql" Version="4.0.14" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="npgsql" Version="5.0.18" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="npgsql" Version="6.0.11" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Postgres SQL .NET core references -->
     <PackageReference Include="npgsql" Version="4.1.13" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="npgsql" Version="7.0.7" Condition="'$(TargetFramework)' == 'net8.0'" />
     <!--System.Data.SqlClient (.NET Core/5+ only) -->
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <!--<PackageReference Include="System.Data.SqlClient" Version="4.8.6" Condition="'$(TargetFramework)' == 'net8.0'" />-->
@@ -60,21 +50,19 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19239.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.5" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySql.Data framework references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySql.Data" Version="8.0.15" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySql.Data" Version="8.0.30" Condition="'$(TargetFramework)' == 'net48'" />
     <!-- MySql.Data v8.0.33 is a breaking change for the agent and requires agent version 10.11.1 or greater -->
-    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySql.Data .NET/Core references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net6.0'" />
     <!-- MySql.Data v8.0.33 is a breaking change for the agent and requires agent version 10.11.1 or greater -->
-    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MongoDB.Driver .NET Framework references -->
     <!-- 2.3.0 is the oldest version we support, 2.17.1 is the newest version as of October 2022 -->
@@ -92,51 +80,42 @@
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySqlConnector" Version="1.3.13" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MySqlConnector" Version="2.1.2" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySqlConnector .NET/Core references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MySqlConnector" Version="2.3.6" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- StackExchange.Redis framework references -->
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.1.608" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.88" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net481'" />
     
     <!-- StackExchange.Redis .NET/Core references -->
     <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Elasticsearch NEST framework references -->
     <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NEST" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NEST" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elasticsearch NEST .NET/Core references -->
     <PackageReference Include="NEST" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Elasticsearch.Net framework references -->
     <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.3.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Elasticsearch.Net" Version="7.9.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elasticsearch.Net .NET/Core references -->
     <PackageReference Include="Elasticsearch.Net" Version="7.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- Elastic.Clients.Elasticsearch framework references - only actually testing oldest and newest -->
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.9" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Elastic.Clients.Elasticsearch .NET/Core references - only actually testing oldest and newest -->
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Serilog .NET framework references -->
     <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />
@@ -149,10 +128,6 @@
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(TargetFramework)' == 'net48'" />
 
-    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-
     <!-- There is only a Framework 4.8 version of Sitecore.Logging -->
     <PackageReference Include="Sitecore.Logging" Version="10.3.0" Condition="'$(TargetFramework)' == 'net48'" Aliases="Sitecore" />
     <PackageReference Include="Sitecore.Logging" Version="10.0.0" Condition="'$(TargetFramework)' == 'net481'" Aliases="Sitecore" />
@@ -164,12 +139,6 @@
     <PackageReference Include="Serilog" Version="2.8.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-
-    <PackageReference Include="Serilog" Version="4.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7">
       <NoWarn>NU1701</NoWarn>
@@ -203,16 +172,14 @@
     <PackageReference Include="RabbitMQ.Client" Version="3.6.9" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="RabbitMQ.Client" Version="4.1.3" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.0.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="RabbitMQ.Client" Version="5.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <PackageReference Include="NServiceBus" Version="5.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NServiceBus" Version="6.5.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NServiceBus" Version="8.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="NServiceBus" Version="9.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -227,24 +194,12 @@
     <!-- Requires Serilog 2.8.0+ -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net48'" />
 
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
     <!-- Requires Serilog 2.8.0+ -->
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-
-    <!-- Requires Serilog 3.1.1+ -->
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -255,13 +210,6 @@
     <PackageReference Include="NLog" Version="4.3.11" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NLog" Version="4.1.2" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NLog" Version="4.5.11" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="NLog" Version="5.3.2" Condition="'$(TargetFramework)' == 'net481'" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Requires NLog 5.2.4+ -->
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.4" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -277,9 +225,7 @@
     <PackageReference Include="MassTransit" Version="7.1.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MassTransit" Version="7.1.0" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MassTransit" Version="7.3.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="MassTransit" Version="7.3.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MassTransit" Version="8.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="MassTransit.AspNetCore" Version="7.1.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MassTransit.AspNetCore" Version="7.1.0" Condition="'$(TargetFramework)' == 'net471'" />
@@ -312,8 +258,6 @@
     <!-- Beginning with version 107.0.0 we rely on httpclient instrumentation to capture the appropriate
     data from RestSharp usage. -->
     <PackageReference Include="RestSharp" Version="107.3.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <!-- Latest version of RestSharp to test against. Relies on HttpClient instrumentation. -->
-    <PackageReference Include="RestSharp" Version="111.4.0" Condition="'$(TargetFramework)' == 'net481'" />
     
     <!-- Not testing these versions, but it simplfies the RestSharpExerciser class by not needing if directives -->
     <PackageReference Include="RestSharp" Version="106.6.10" Condition="'$(TargetFramework)' == 'net6.0'" />
@@ -325,15 +269,14 @@
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net481'" />
 
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.35" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />
     <ProjectReference Include="..\..\..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\MFALatestPackages\MFALatestPackages.csproj" Condition="'$(TargetFramework)' == 'net481' or '$(TargetFramework)' == 'net8.0'" />
     <ProjectReference Include="..\NetStandardTestLibrary\NetStandardTestLibrary.csproj" />
     <ProjectReference Include="..\SharedApplicationHelpers\SharedApplicationHelpers.csproj" />
   </ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -173,7 +173,6 @@
     <PackageReference Include="NServiceBus" Version="6.5.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NServiceBus" Version="8.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="NServiceBus" Version="[8.0,9.0)" Condition="'$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -51,7 +51,6 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.5" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MySql.Data framework references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net462'" />
@@ -62,19 +61,16 @@
     <!-- MySql.Data .NET/Core references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net6.0'" />
     <!-- MySql.Data v8.0.33 is a breaking change for the agent and requires agent version 10.11.1 or greater -->
-    <PackageReference Include="MySql.Data" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MongoDB.Driver .NET Framework references -->
     <!-- 2.3.0 is the oldest version we support, 2.17.1 is the newest version as of October 2022 -->
     <PackageReference Include="MongoDB.Driver" Version="2.3.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- MongoDB.Driver .NET/Core references -->
     <!-- Minimum version we can use with .NET core 3.0 or greater is 2.8.1, due to this bug: https://github.com/mongodb/mongo-csharp-driver/pull/372 -->
     <PackageReference Include="MongoDB.Driver" Version="2.8.1" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="MongoDB.Driver" Version="2.27.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <!-- MySqlConnector framework references -->
     <PackageReference Include="MySqlConnector" Version="1.0.1" Condition="'$(TargetFramework)' == 'net462'" />
@@ -115,7 +111,6 @@
 
     <!-- Elastic.Clients.Elasticsearch .NET/Core references - only actually testing oldest and newest -->
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" Condition="'$(TargetFramework)' == 'net481'" />
 
     <!-- Serilog .NET framework references -->
     <PackageReference Include="Serilog" Version="1.5.14" Condition="'$(TargetFramework)' == 'net462'" />
@@ -173,13 +168,12 @@
     <PackageReference Include="RabbitMQ.Client" Version="4.1.3" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="RabbitMQ.Client" Version="6.0.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="RabbitMQ.Client" Version="5.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.6.0" Condition="'$(TargetFramework)' == 'net481'" />
 
     <PackageReference Include="NServiceBus" Version="5.0.0" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="NServiceBus" Version="6.5.10" Condition="'$(TargetFramework)' == 'net471'" />
     <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="NServiceBus" Version="8.2.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="NServiceBus" Version="7.5.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NServiceBus" Version="[8.0,9.0)" Condition="'$(TargetFramework)' == 'net481'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests.sln
@@ -48,6 +48,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializationHelpers", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializationHelpers.Test", "..\Shared\TestSerializationHelpers.Test\TestSerializationHelpers.Test.csproj", "{06DC61C8-F4BF-47C5-8624-1F441E6C2A04}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MFALatestPackages", "SharedApplications\Common\MFALatestPackages\MFALatestPackages.csproj", "{C544A8F0-A222-42AF-91C8-9F556C293C11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{06DC61C8-F4BF-47C5-8624-1F441E6C2A04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06DC61C8-F4BF-47C5-8624-1F441E6C2A04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06DC61C8-F4BF-47C5-8624-1F441E6C2A04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C544A8F0-A222-42AF-91C8-9F556C293C11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C544A8F0-A222-42AF-91C8-9F556C293C11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C544A8F0-A222-42AF-91C8-9F556C293C11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C544A8F0-A222-42AF-91C8-9F556C293C11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -131,9 +137,10 @@ Global
 		{3E8423E9-1FBF-451F-8117-88CE3DADEF7F} = {129FF113-1F3A-4DAA-8D6F-287DF67A68FA}
 		{B64766CA-8731-493F-8417-61A70F783EB7} = {129FF113-1F3A-4DAA-8D6F-287DF67A68FA}
 		{F35861EC-9861-4776-AF51-9C2B7F1DBA5C} = {129FF113-1F3A-4DAA-8D6F-287DF67A68FA}
+		{C544A8F0-A222-42AF-91C8-9F556C293C11} = {129FF113-1F3A-4DAA-8D6F-287DF67A68FA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 		SolutionGuid = {656848E2-BFD2-4092-9328-C6CDF39B1274}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45;packages\EnterpriseLibrary.Data.6.0.1304.0\lib\NET45
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR extracts the latest (net481 and net8.0) package references in `MultiFunctionApplicationHelpers` to a separate project (`MFALatestPackages`) for easier maintenance. This also lays the groundwork for possible future automation of update PRs via Dotty.

Notes:
* All packages were updated to the latest version (except as noted below) and a docs PR will follow to update the compatibility docs to reflect these versions.
* NServiceBus v9.x only targets `net8.0`, so the `net481` build target continues to use the latest `"8.*"` version which is still maintained. The `net8.0` target uses the latest `"9.*"` version. Integration tests pass on v9.