### PR TITLE
fix: SQS instrumentation could cause InvalidOperationException #2645

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/SQSRequestHandler.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/SQSRequestHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.AwsSdk;

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExerciser/AwsSdkExerciser.cs
@@ -104,12 +104,18 @@ namespace AwsSdkTestApp.AwsSdkExerciser
                 throw new InvalidOperationException("Queue URL is not set. Call SQS_Initialize or SQS_SetQueueUrl first.");
             }
 
+            List<string> messageAttributeNames = ["All"];
+
             var response = await _amazonSqsClient.ReceiveMessageAsync(new ReceiveMessageRequest
             {
                 QueueUrl = _sqsQueueUrl,
                 MaxNumberOfMessages = maxMessagesToReceive,
-                MessageAttributeNames = ["All"]
+                MessageAttributeNames = messageAttributeNames
             });
+
+
+            if (messageAttributeNames.Count != 1)
+                throw new Exception("Expected messageAttributeNames to have a single element");
 
             foreach (var message in response.Messages)
             {

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerTestFixtures.cs
@@ -41,6 +41,8 @@ public class AwsSdkContainerSQSTestFixture : AwsSdkContainerTestFixtureBase
     {
         var address = $"http://localhost:{Port}/awssdk";
 
+        // The exerciser will return a 500 error if the `RequestMessage.MessageAttributeNames` collection is modified by our instrumentation.
+        // See https://github.com/newrelic/newrelic-dotnet-agent/pull/2646 
         GetAndAssertStatusCode($"{address}/SQS_SendReceivePurge?queueName={queueName}", System.Net.HttpStatusCode.OK);
     }
 


### PR DESCRIPTION
Modifies SQS instrumentation to clone the existing `ReceiveMessageRequest.MessageAttributeNames` collection prior to adding our distributed trace headers to the collection. 

Fixes #2645, where the customer was re-using the same source collection on each new `ReceiveMessageRequest` instance.