### PR TITLE
feat: Set application name via command line with the .msi installer

### DIFF
--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -172,6 +172,7 @@ SPDX-License-Identifier: Apache-2.0
     <CustomAction Id="SaveDeferredCustomActionData" DllEntry="SaveDeferredCustomActionData" Execute="immediate" Return="check" BinaryRef="CustomActionsDll" />
     <CustomAction Id="MigrateConfiguration" DllEntry="MigrateConfiguration" Execute="deferred" Impersonate="no" Return="check" BinaryRef="CustomActionsDll" />
     <CustomAction Id="SetLicenseKey" DllEntry="SetLicenseKey" Execute="deferred" Impersonate="no" Return="check" BinaryRef="CustomActionsDll" />
+    <CustomAction Id="SetAppName" DllEntry="SetAppName" Execute="deferred" Impersonate="no" Return="check" BinaryRef="CustomActionsDll" />
     <CustomAction Id="CleanupPreviousInstall" DllEntry="CleanupPreviousInstall" Execute="deferred" Impersonate="no" Return="check" BinaryRef="CustomActionsDll" />
     <CustomAction Id="RestartIis" DllEntry="RestartIis" Impersonate="yes" BinaryRef="CustomActionsDll" />
     <CustomAction Id="CloseStatusMonitor" DllEntry="CloseStatusMonitor" Impersonate="yes" BinaryRef="CustomActionsDll" />

--- a/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
+++ b/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
@@ -142,7 +142,7 @@ namespace InstallerActions
                 //    return ActionResult.Success;
                 //}
 
-                var existingAppName = applicationNameNode.Value;
+                var existingAppName = applicationNameNode.InnerText;
                 if (existingAppName == null)
                 {
                     session.Log("Application name value not found on /configuration/application/name node.  Application name not set.");
@@ -150,7 +150,7 @@ namespace InstallerActions
                 }
                 session.Log("Application name value found in /configuration/application/name node.");
 
-                applicationNameNode.Value = appName;
+                applicationNameNode.InnerText = appName;
                 session.Log("Application name set to " + appName);
 
                 document.Save(session.CustomActionData["NETAGENTCOMMONFOLDER"] + @"\newrelic.config");

--- a/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
+++ b/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
@@ -127,7 +127,7 @@ namespace InstallerActions
                 var useAppPoolNaming = session.CustomActionData["NR_USE_APP_POOL_NAMING"].Equals(bool.TrueString, StringComparison.CurrentCultureIgnoreCase)
                     || session.CustomActionData["NR_USE_APP_POOL_NAMING"].Equals("1");
 
-                session.Log($"appName={appName}, useAppPoolNaming={useAppPoolNaming}");
+                session.Log($"SetAppName: appName={appName}, useAppPoolNaming={useAppPoolNaming}");
                 if (string.IsNullOrEmpty(appName) && !useAppPoolNaming)
                 {
                     session.Log("NR_APP_NAME was not set or was set to an empty string, and NR_USE_APP_POOL_NAMING was not set or was not set to true. Application name not modified.");
@@ -173,19 +173,10 @@ namespace InstallerActions
                 if (applicationNameNode == null)
                 {
                     session.Log("Unable to locate existing /configuration/application/name node in newrelic.config, creating a new one.");
-                    var newNameNode = document.CreateElement("name");
-                    newNameNode.Attributes.RemoveAll(); // to remove the 'xmlns' attr that was automatically added
+                    var newNameNode = document.CreateElement("name", "urn:newrelic-config");
                     applicationNameNode = applicationNode.AppendChild(newNameNode);
                 }
                 session.Log("/configuration/application/name node found or created in newrelic.config");
-
-                var existingAppName = applicationNameNode.InnerText;
-                if (existingAppName == null)
-                {
-                    session.Log("Application name value not found on /configuration/application/name node. Application name not set.");
-                    return ActionResult.Success;
-                }
-                session.Log("Application name value found in /configuration/application/name node.");
 
                 applicationNameNode.InnerText = appName;
                 session.Log("Application name set to " + appName);


### PR DESCRIPTION
This PR:
1. Enables setting the application name (in the global `newrelic.config` file) with the command line parameter `NR_APP_NAME` when using the .msi installer.
2. Enables setting the global `newrelic.config` to use application pool naming (see https://docs.newrelic.com/docs/apm/agents/net-agent/configuration/name-your-net-application/#app-pool) by setting the command line parameter `NR_USE_APP_POOL_NAMING="True"` when using the .msi installer.

Examples:

To set the application name at install time:
`msiexec.exe /i C:\path\to\NewRelicAgent_x64_10.28.0.0.msi /qb NR_APP_NAME="My Application Name"`

To configure the agent to use app pool naming at install time:
`msiexec.exe /i C:\path\to\NewRelicAgent_x64_10.28.0.0.msi /qb NR_USE_APP_POOL_NAMING="True"`

Notes and cautions:

1. Setting the app pool naming option takes precedence over setting the application name, i.e. if both `NR_APP_NAME` and `NR_USE_APP_POOL_NAMING` are supplied on the msiexec command line (and NR_USE_APP_POOL_NAMING is set to "True"), then the NR_APP_NAME will be ignored.
2. Valid "true" values for `NR_USE_APP_POOL_NAMING` are any string equal to "True" with a case-insensitive comparison, or "1".  Any other values will be treated as "false".
3. Setting `NR_APP_NAME` to an empty string is equivalent to not setting it at all; the existing application name will not be updated.
4. For troubleshooting, enable msi logging by adding the following to the msiexec parameters: `/l*v C:\path\to\logfile`.  The file is overwritten with each msiexec invocation.

