### PR TITLE
fix: Better Lambda web request input parameter validation.

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -76,6 +76,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         // Serverless payloads
         public const string ServerlessPayloadLogLineRegex = FinestLogLinePrefixRegex + @"Serverless payload: (.*)";
 
+        // Invalid serverless web request
+        public const string InvalidServerlessWebRequestLogLineRegex = DebugLogLinePrefixRegex + @"Invalid or missing web request parameters. (.*)";
+
         public AgentLogBase(ITestOutputHelper testLogger)
         {
             _testLogger = testLogger;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayHttpApiV2ProxyRequestTest.cs
@@ -35,6 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequest();
                     _fixture.EnqueueAPIGatewayHttpApiV2ProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
                     _fixture.EnqueueMinimalAPIGatewayHttpApiV2ProxyRequest();
+                    _fixture.EnqueueInvalidAPIGatewayHttpApiV2ProxyRequest();
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 3);
                 }
             );
@@ -47,6 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
             var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
 
             Assert.Multiple(
+                // the fourth exerciser invocation should result in a NoOpDelegate, so there will only be 3 payloads
                 () => Assert.Equal(3, serverlessPayloads.Count),
                 // validate the first 2 payloads separately from the 3rd
                 () => Assert.All(serverlessPayloads.GetRange(0, 2), ValidateServerlessPayload),
@@ -54,6 +56,10 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 () => ValidateTraceHasNoParent(serverlessPayloads[0]),
                 () => ValidateTraceHasParent(serverlessPayloads[1])
                 );
+
+            // verify that the invalid request payload generated the expected log line
+            var logLines = _fixture.AgentLog.TryGetLogLines(AgentLogBase.InvalidServerlessWebRequestLogLineRegex);
+            Assert.Single(logLines);
         }
 
         private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaAPIGatewayRequestTest.cs
@@ -35,6 +35,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                     _fixture.EnqueueAPIGatewayProxyRequest();
                     _fixture.EnqueueAPIGatewayProxyRequestWithDTHeaders(TestTraceId, TestParentSpanId);
                     _fixture.EnqueueMinimalAPIGatewayProxyRequest();
+                    _fixture.EnqueueInvalidAPIGatewayProxyRequest();
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 3);
                 }
             );
@@ -47,6 +48,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
             var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
 
             Assert.Multiple(
+                // the fourth exerciser invocation should result in a NoOpDelegate, so there will only be 3 payloads
                 () => Assert.Equal(3, serverlessPayloads.Count),
                 // validate the first 2 payloads separately from the 3rd
                 () => Assert.All(serverlessPayloads.GetRange(0, 2), ValidateServerlessPayload),
@@ -54,6 +56,10 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 () => ValidateTraceHasNoParent(serverlessPayloads[0]),
                 () => ValidateTraceHasParent(serverlessPayloads[1])
                 );
+
+            // verify that the invalid request payload generated the expected log line
+            var logLines = _fixture.AgentLog.TryGetLogLines(AgentLogBase.InvalidServerlessWebRequestLogLineRegex);
+            Assert.Single(logLines);
         }
 
         private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaApplicationLoadBalancerRequestTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaApplicationLoadBalancerRequestTest.cs
@@ -34,6 +34,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
                 {
                     _fixture.EnqueueApplicationLoadBalancerRequest();
                     _fixture.EnqueueApplicationLoadBalancerRequestWithDTHeaders(TestTraceId, TestParentSpanId);
+                    _fixture.EnqueueInvalidLoadBalancerRequestyRequest();
                     _fixture.AgentLog.WaitForLogLines(AgentLogBase.ServerlessPayloadLogLineRegex, TimeSpan.FromMinutes(1), 2);
                 }
             );
@@ -46,11 +47,16 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.WebRequest
             var serverlessPayloads = _fixture.AgentLog.GetServerlessPayloads().ToList();
 
             Assert.Multiple(
+                // the third exerciser invocation should result in a NoOpDelegate, so there will only be 2 payloads
                 () => Assert.Equal(2, serverlessPayloads.Count),
                 () => Assert.All(serverlessPayloads, ValidateServerlessPayload),
                 () => ValidateTraceHasNoParent(serverlessPayloads[0]),
                 () => ValidateTraceHasParent(serverlessPayloads[1])
                 );
+
+            // verify that the invalid request payload generated the expected log line
+            var logLines = _fixture.AgentLog.TryGetLogLines(AgentLogBase.InvalidServerlessWebRequestLogLineRegex);
+            Assert.Single(logLines);
         }
 
         private void ValidateServerlessPayload(ServerlessPayload serverlessPayload)

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixture.cs
@@ -203,6 +203,19 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                                                """;
             EnqueueLambdaEvent(apiGatewayProxyRequestJson);
         }
+        
+        /// <summary>
+        /// An invalid payload to validate the fix for https://github.com/newrelic/newrelic-dotnet-agent/issues/2652
+        /// </summary>
+        public void EnqueueInvalidAPIGatewayHttpApiV2ProxyRequest()
+        {
+            var invalidApiGatewayHttpApiV2ProxyRequestJson = $$"""
+                                                      {
+                                                        "foo": "bar"
+                                                      }
+                                                      """;
+            EnqueueLambdaEvent(invalidApiGatewayHttpApiV2ProxyRequestJson);
+        }
     }
 
     public class LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayHttpApiV2ProxyRequestTriggerFixtureBase

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaAPIGatewayProxyRequestTriggerFixture.cs
@@ -166,6 +166,19 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                                                """;
             EnqueueLambdaEvent(apiGatewayProxyRequestJson);
         }
+
+        /// <summary>
+        /// An invalid payload to validate the fix for https://github.com/newrelic/newrelic-dotnet-agent/issues/2652
+        /// </summary>
+        public void EnqueueInvalidAPIGatewayProxyRequest()
+        {
+            var invalidApiGatewayProxyRequestJson = $$"""
+                                                     {
+                                                       "foo": "bar"
+                                                     }
+                                                     """;
+            EnqueueLambdaEvent(invalidApiGatewayProxyRequestJson);
+        }
     }
 
     public class LambdaAPIGatewayProxyRequestTriggerFixtureNet6 : LambdaAPIGatewayProxyRequestTriggerFixtureBase

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaApplicationLoadBalancerRequestTriggerFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaApplicationLoadBalancerRequestTriggerFixture.cs
@@ -93,6 +93,19 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                                                """;
             EnqueueLambdaEvent(ApplicationLoadBalancerRequestJson);
         }
+
+        /// <summary>
+        /// An invalid payload to validate the fix for https://github.com/newrelic/newrelic-dotnet-agent/issues/2652
+        /// </summary>
+        public void EnqueueInvalidLoadBalancerRequestyRequest()
+        {
+            var invalidLoadBalancerRequestJson = $$"""
+                                                      {
+                                                        "foo": "bar"
+                                                      }
+                                                      """;
+            EnqueueLambdaEvent(invalidLoadBalancerRequestJson);
+        }
     }
 
     public class LambdaApplicationLoadBalancerRequestTriggerFixtureNet6 : LambdaApplicationLoadBalancerRequestTriggerFixtureBase


### PR DESCRIPTION
Adds checking for required parameters (Http Method and Path) for Lambda web requests (`APIGatewayProxyRequest`, `APIGatewayHttpApiV2ProxyRequest` or `ApplicationLoadBalancerRequest`). 

If either or both are missing, we log a message (`Invalid or missing web request parameters. HttpMethod and Path are required for <request type>. Not instrumenting this function invocation.`) and return a NoOp Delegate. 

Resolves #2652 

