### PR TITLE
feat: Improve serverless mode detection

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.25.1.10"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.27.0.15"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/InstrumentationConfigurationTest.cpp
@@ -956,7 +956,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             xmlSet->emplace(L"filename", L"<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 
             InstrumentationConfiguration instrumentation(xmlSet, nullptr);
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             Assert::IsFalse(instrumentationPoint == nullptr);
@@ -968,21 +968,21 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             xmlSet->emplace(L"filename", L"<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 
             InstrumentationConfiguration instrumentation(xmlSet, nullptr);
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::WrongMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyNamespace.MyClass:MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("::::::MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod::"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly:MyNamespace.MyClass:MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly/MyNamespace.MyClass/MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly_MyNamespace.MyClass_MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly MyNamespace.MyClass MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X(" MyAssembly::MyNamespace.MyClass:MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
-            instrumentation.AddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace .MyClass:: MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::WrongMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyNamespace.MyClass:MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("::::::MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X(":::MyMethod::"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly:MyNamespace.MyClass:MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly/MyNamespace.MyClass/MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly_MyNamespace.MyClass_MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly MyNamespace.MyClass MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X(" MyAssembly::MyNamespace.MyClass:MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace.MyClass::MyMethod"));
+            instrumentation.TryAddInstrumentationPointToCollectionFromEnvironment(_X("MyAssembly::MyNamespace .MyClass:: MyMethod"));
 
             auto instrumentationPoint = instrumentation.TryGetInstrumentationPoint(std::make_shared<MethodRewriter::Test::MockFunction>());
             Assert::IsFalse(instrumentationPoint == nullptr);


### PR DESCRIPTION
Modifies the Profiler to look for the `NEW_RELIC_LAMBDA_HANDLER` environment variable before looking for `_HANDLER`.  

If `NEW_RELIC_LAMBDA_HANDLER` isn't found or can't be parsed successfully, the profiler then looks for `_HANDLER` and applies the same parsing test. If neither variable exists or can be parsed correctly, serverless mode is not enabled.

Resolves #2659 