### PR TITLE
fix: Revert recent Profiler warning fixes

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -164,8 +164,8 @@ jobs:
       - name: Build Linux Profiler
         run: |
           cd ${{ env.profiler_path }}
-          docker-compose build build
-          docker-compose run build
+          docker compose build build
+          docker compose run build
         shell: bash
 
       - name: Move Profiler to staging folder

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -164,8 +164,8 @@ jobs:
       - name: Build Linux Profiler
         run: |
           cd ${{ env.profiler_path }}
-          docker compose build build
-          docker compose run build
+          docker-compose build build
+          docker-compose run build
         shell: bash
 
       - name: Move Profiler to staging folder

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.27.0.15"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.27.0.20"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Common/CorStandIn.h
+++ b/src/Agent/NewRelic/Profiler/Common/CorStandIn.h
@@ -3,8 +3,6 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 #pragma warning(push)
-// Since this isn't our code, we don't want to mess with it. These warnings can be safely ignored.
-#pragma warning(disable: 4458) // Scope hides class member with same name.
-#pragma warning(disable: 26495) // Uninitialized member variable, even if it's always set before use.
+#pragma warning(disable : 4458)
 #include <corhlpr.h>
 #pragma warning(pop)

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -47,10 +47,10 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             , _ignoreList(new IgnoreInstrumentationList())
         {
             try {
-                auto globalNewRelicConfigurationDocument = std::make_shared<rapidxml::xml_document<xchar_t>>();
-                globalNewRelicConfigurationDocument->parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(globalNewRelicConfiguration.c_str()));
+                rapidxml::xml_document<xchar_t> globalNewRelicConfigurationDocument;
+                globalNewRelicConfigurationDocument.parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(globalNewRelicConfiguration.c_str()));
 
-                auto globalNewRelicConfigurationNode = GetConfigurationNode(globalNewRelicConfigurationDocument);
+                auto globalNewRelicConfigurationNode  = GetConfigurationNode(globalNewRelicConfigurationDocument);
                 if (globalNewRelicConfigurationNode == nullptr) 
                 {
                     LogError(L"Unable to locate configuration node in the global newrelic.config file.");
@@ -58,13 +58,13 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                 }
 
                 auto appliedNewRelicConfigurationNode = globalNewRelicConfigurationNode;
-                auto localNewRelicConfigurationDocument = std::make_shared<rapidxml::xml_document<xchar_t>>();
 
                 if (localNewRelicConfiguration.second)
                 {
                     try
                     {
-                        localNewRelicConfigurationDocument->parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(localNewRelicConfiguration.first.c_str()));
+                        rapidxml::xml_document<xchar_t> localNewRelicConfigurationDocument;
+                        localNewRelicConfigurationDocument.parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(localNewRelicConfiguration.first.c_str()));
 
                         auto localNewRelicConfigurationNode = GetConfigurationNode(localNewRelicConfigurationDocument);
                         if (localNewRelicConfigurationNode == nullptr)
@@ -92,7 +92,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                 SetLogLevel(appliedNewRelicConfigurationNode);
                 SetInstrumentationData(appliedNewRelicConfigurationNode);
                 SetApplicationPools(appliedNewRelicConfigurationNode);
-                
+
             } catch (const rapidxml::parse_error& exception) {
                 // We log two separate error messages here because sometimes the logging macros hang when
                 // logging the "where" contents
@@ -196,15 +196,15 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             return _logLevel;
         }
 
-        bool GetConsoleLogging() const
+        bool GetConsoleLogging()
         {
             return _consoleLogging;
         }
-        bool GetLoggingEnabled() const
+        bool GetLoggingEnabled()
         {
             return _loggingEnabled;
         }
-        IgnoreInstrumentationListPtr GetIgnoreInstrumentationList() const
+        IgnoreInstrumentationListPtr GetIgnoreInstrumentationList()
         {
             return _ignoreList;
         }
@@ -224,9 +224,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
         std::shared_ptr<NewRelic::Profiler::Logger::IFileDestinationSystemCalls> _systemCalls;
         IgnoreInstrumentationListPtr _ignoreList;
 
-        rapidxml::xml_node<xchar_t>* GetConfigurationNode(const std::shared_ptr<rapidxml::xml_document<xchar_t>> document)
+        rapidxml::xml_node<xchar_t>* GetConfigurationNode(const rapidxml::xml_document<xchar_t>& document)
         {
-            auto configurationNode = document->first_node(_X("configuration"), 0, false);
+            auto configurationNode = document.first_node(_X("configuration"), 0, false);
             if (configurationNode == nullptr) {
                 return nullptr;
             }
@@ -294,7 +294,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             _logLevel = TryParseLogLevel(level);
         }
 
-        Logger::Level TryParseLogLevel(const xstring_t& logText) const
+        Logger::Level TryParseLogLevel(const xstring_t& logText)
         {
             if (Strings::AreEqualCaseInsensitive(logText, _X("off"))) {
                 return Logger::Level::LEVEL_ERROR;
@@ -423,8 +423,8 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             if (applicationConfiguration.empty())
                 return;
 
-            auto document = std::make_shared<rapidxml::xml_document<xchar_t>>();
-            document->parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(applicationConfiguration.c_str()));
+            rapidxml::xml_document<xchar_t> document;
+            document.parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(applicationConfiguration.c_str()));
             auto configurationNode = GetConfigurationNode(document);
 
             auto appSettingsNode = configurationNode->first_node(_X("appSettings"), 0, false);
@@ -468,7 +468,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
         static bool IsProcessInProcessList(const ProcessesPtr& processes, const xstring_t& processName)
         {
             // check the processes loaded from configuration
-            for (auto& validProcessName : *processes) {
+            for (auto validProcessName : *processes) {
                 if (Strings::EndsWith(processName, validProcessName)) {
                     return true;
                 }
@@ -498,7 +498,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             return isIis;
         }
 
-        bool ShouldInstrumentApplicationPool(const xstring_t& appPoolId) const
+        bool ShouldInstrumentApplicationPool(const xstring_t& appPoolId)
         {
             if (ApplicationPoolIsOnBlackList(appPoolId, _applicationPoolsBlackList)) {
                 LogInfo(_X("This application pool (") + appPoolId + _X(") is explicitly configured to NOT be instrumented."));

--- a/src/Agent/NewRelic/Profiler/Configuration/IgnoreInstrumentation.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/IgnoreInstrumentation.h
@@ -50,7 +50,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             }
 
         private:
-            bool Matches(xstring_t assembly, xstring_t className) const
+            bool Matches(xstring_t assembly, xstring_t className)
             {
                 if (!Strings::AreEqualCaseInsensitive(AssemblyName, assembly))
                 {

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -33,7 +33,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             , _foundServerlessInstrumentationPoint(false)
         {
             // pull instrumentation points from every xml string
-            for (auto& instrumentationXml : *instrumentationXmls)
+            for (auto instrumentationXml : *instrumentationXmls)
             {
                 try
                 {
@@ -64,13 +64,13 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             , _systemCalls(nullptr)
             , _foundServerlessInstrumentationPoint(false)
         {
-            for (auto& instrumentationPoint : *instrumentationPoints)
+            for (auto instrumentationPoint : *instrumentationPoints)
             {
                 AddInstrumentationPointToCollectionsIfNotIgnored(instrumentationPoint);
             }
         }
 
-        uint16_t GetInvalidFileCount() const
+        uint16_t GetInvalidFileCount()
         {
             return _invalidFileCount;
         }
@@ -100,7 +100,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             // We may have multiple matching instrumentation points that target different assembly versions. See if we can find one that meets
             // the version requirements
             AssemblyVersion foundVersion(function->GetAssemblyProps());
-            for (auto& instPoint : instPoints)
+            for (auto instPoint : instPoints)
             {
                 if ((instPoint->MinVersion != nullptr) && (foundVersion < *instPoint->MinVersion))
                 {
@@ -236,9 +236,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration
 
         void GetInstrumentationPoints(xstring_t instrumentationXml)
         {
-            auto document = std::make_shared<rapidxml::xml_document<xchar_t>>();
-            document->parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(instrumentationXml.c_str()));
-            auto extensionNode = document->first_node(_X("extension"), 0, false);
+            rapidxml::xml_document<xchar_t> document;
+            document.parse<rapidxml::parse_trim_whitespace | rapidxml::parse_normalize_whitespace>(const_cast<xchar_t*>(instrumentationXml.c_str()));
+            auto extensionNode = document.first_node(_X("extension"), 0, false);
             if (extensionNode == nullptr)
             {
                 LogWarn(L"extension node not found in instrumentation file. Please validate your instrumentation files against extensions/extension.xsd or contact New Relic support.");
@@ -405,7 +405,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             // if the ClassName includes multiple classes, we have to split this into multiple instrumentation points
             auto instrumentationPoints = SplitInstrumentationPointsOnClassNames(instrumentationPoint);
 
-            for (auto& iPoint : instrumentationPoints) {
+            for (auto iPoint : instrumentationPoints) {
 
                 // finally add the new instrumentation point(s) to our set of instrumentation points
                 // Note that there may be "duplicated" instrumentation points that target different assembly versions

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationPoint.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationPoint.h
@@ -52,7 +52,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
                 ParametersMatch(other);
         }
 
-        xstring_t ToString() const
+        xstring_t ToString()
         {
             if (Parameters == nullptr)
             {
@@ -63,7 +63,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             }
         }
 
-        xstring_t GetMatchKey() const
+        xstring_t GetMatchKey()
         {
             return Parameters == nullptr
                 ? GetMatchKey(AssemblyName, ClassName, MethodName)
@@ -82,7 +82,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
 
 
     private:
-        bool ParametersMatch(const InstrumentationPoint& other) const
+        bool ParametersMatch(const InstrumentationPoint& other)
         {
             // nullptr means no parameters attribute was supplied in configuration, suggesting that we should instrument all overloads
             if (this->Parameters == nullptr)

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ExceptionHandlerManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ExceptionHandlerManipulator.h
@@ -262,12 +262,12 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             // shift the original clauses up to the correct
             for (uint32_t i = 0; i < _originalExceptionClauseCount; ++i)
             {
-                auto& clause = _exceptionClauses[i];
+                auto clause = _exceptionClauses[i];
                 clause->ShiftOffsets(userCodeOffset);
             }
 
             // append the clauses
-            for (auto& clause : _exceptionClauses)
+            for (auto clause : _exceptionClauses)
             {
                 auto clauseBytes = clause->GetBytes();
                 bytes->insert(bytes->end(), clauseBytes->begin(), clauseBytes->end());
@@ -276,7 +276,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             return bytes;
         }
 
-        uint32_t GetOriginalExceptionClauseCount() const
+        uint32_t GetOriginalExceptionClauseCount()
         {
             return _originalExceptionClauseCount;
         }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h
@@ -350,7 +350,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             _instructions->Append(CEE_NEWARR, _X("[mscorlib]System.Object"));
             uint32_t index = 0;
 
-            for (auto& func : elementLoadLambdas)
+            for (auto func : elementLoadLambdas)
             {
                 auto nextIndex = index++;
                 // get an extra copy of the array (it will be popped off the stack each time we add an element to it)

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstructionSet.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstructionSet.h
@@ -403,7 +403,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
         void AppendTryEnd()
         {
-            auto& exception = _exceptionStack.top();
+            auto exception = _exceptionStack.top();
             if (exception->_tryLength != 0)
             {
                 LogError(L"Attempted to set try close on the same exception twice.");
@@ -414,7 +414,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
         void AppendCatchStart(uint32_t typeToken)
         {
-            auto& exception = _exceptionStack.top();
+            auto exception = _exceptionStack.top();
             if (exception->_handlerOffset != 0)
             {
                 LogError(L"Attempted to set catch start on the same exception twice.");
@@ -439,7 +439,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
         void AppendCatchEnd()
         {
-            auto& exception = _exceptionStack.top();
+            auto exception = _exceptionStack.top();
             if (exception->_handlerLength != 0)
             {
                 LogError(L"Attempted to set catch end on the same exception twice.");

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -16,10 +16,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     public:
         InstrumentFunctionManipulator(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings) : 
             FunctionManipulator(function), 
-            _instrumentationSettings(instrumentationSettings),
-            _userExceptionLocalIndex(0),
-            _resultLocalIndex(0),
-            _tracerLocalIndex(0)
+            _instrumentationSettings(instrumentationSettings)
         {
             if (_function->Preprocess()) {
                 Initialize();

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/MethodRewriter.h
@@ -54,7 +54,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
 
             auto instrumentationPoints = _instrumentationConfiguration->GetInstrumentationPoints();
 
-            for (auto& instrumentationPoint : *instrumentationPoints) {
+            for (auto instrumentationPoint : *instrumentationPoints) {
 
                 _instrumentedAssemblies->emplace(instrumentationPoint->AssemblyName);
                 _instrumentedFunctionNames->emplace(instrumentationPoint->MethodName);
@@ -74,7 +74,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
         std::set<Configuration::InstrumentationPointPtr> GetAssemblyInstrumentation(xstring_t assemblyName)
         {
             std::set<Configuration::InstrumentationPointPtr> set;
-            for (auto& instrumentationPoint : *_instrumentationConfiguration->GetInstrumentationPoints().get()) {
+            for (auto instrumentationPoint : *_instrumentationConfiguration->GetInstrumentationPoints().get()) {
                 if (assemblyName == instrumentationPoint->AssemblyName) {
                     set.emplace(instrumentationPoint);
                 }

--- a/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
+++ b/src/Agent/NewRelic/Profiler/ModuleInjector/ModuleInjector.h
@@ -10,7 +10,6 @@
 #include "../Logging/Logger.h"
 #include "../Sicily/Sicily.h"
 #include "IModule.h"
-#include "../Profiler/Exceptions.h"
 
 namespace NewRelic { namespace Profiler { namespace ModuleInjector
 {

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -574,7 +574,7 @@ namespace NewRelic { namespace Profiler {
         std::shared_ptr<std::map<xstring_t, Configuration::InstrumentationPointSetPtr>> GroupByAssemblyName(Configuration::InstrumentationPointSetPtr allInstrumentationPoints)
         {
             std::shared_ptr<std::map<xstring_t, Configuration::InstrumentationPointSetPtr>> instrumentationPointsByAssembly = std::make_shared<std::map<xstring_t, Configuration::InstrumentationPointSetPtr>>();
-            for (auto& point : *allInstrumentationPoints) {
+            for (auto point : *allInstrumentationPoints) {
                 Configuration::InstrumentationPointSetPtr instrumentationPoints;
                 auto it = instrumentationPointsByAssembly->find(point->AssemblyName);
 
@@ -632,7 +632,7 @@ namespace NewRelic { namespace Profiler {
 
             auto instrumentationXmls = GetInstrumentationXmlsFromDisk(_systemCalls);
             auto customXml = _customInstrumentation.GetCustomInstrumentationXml();
-            for (auto& xmlPair : *customXml) {
+            for (auto xmlPair : *customXml) {
                 (*instrumentationXmls)[xmlPair.first] = xmlPair.second;
             }
 
@@ -683,7 +683,7 @@ namespace NewRelic { namespace Profiler {
         {
             auto oldIter = instrumentationByAssembly->find(assemblyName);
             if (oldIter != instrumentationByAssembly->end()) {
-                auto& points = oldIter->second;
+                auto points = oldIter->second;
                 return GetMethodDefs(moduleId, points);
             }
 
@@ -789,15 +789,12 @@ namespace NewRelic { namespace Profiler {
                 ModuleID* moduleIds = new ModuleID[numberMethods];
                 mdMethodDef* methodIds = new mdMethodDef[numberMethods];
 
-#pragma warning(push)
-#pragma warning(disable : 6386) // Not possible to overrun the buffer since we're using the set size
                 int i = 0;
                 for (auto methodDef : *methodSet) {
                     moduleIds[i] = moduleId;
                     methodIds[i] = methodDef;
                     i++;
                 }
-#pragma warning(pop)
 
                 func(numberMethods, moduleIds, methodIds);
 
@@ -882,7 +879,7 @@ namespace NewRelic { namespace Profiler {
 
         bool _isCoreClr = false;
 
-        MethodRewriter::MethodRewriterPtr GetMethodRewriter() const
+        MethodRewriter::MethodRewriterPtr GetMethodRewriter()
         {
             return std::atomic_load(&_methodRewriter);
         }
@@ -945,7 +942,7 @@ namespace NewRelic { namespace Profiler {
 
             auto filePaths = GetXmlFilesInExtensionsDirectory(systemCalls);
 
-            for (auto& filePath : filePaths) {
+            for (auto filePath : filePaths) {
                 instrumentationXmls->emplace(filePath, ReadFile(filePath));
             }
 
@@ -1261,7 +1258,7 @@ namespace NewRelic { namespace Profiler {
             struct LANGANDCODEPAGE {
                 WORD wLanguage;
                 WORD wCodePage;
-            } *lpTranslate = nullptr;
+            } * lpTranslate;
 
             //xstring_t expectedProductName = _X("New Relic .NET CoreCLR Agent");
 
@@ -1280,7 +1277,7 @@ namespace NewRelic { namespace Profiler {
 
                     if (VerQueryValue(versionInfo, (LPTSTR)szSFI, (LPVOID*)&lpszBuf, &uLen)) {
                         if (expectedProductName == lpszBuf) {
-                            void* block = nullptr;
+                            void* block;
                             UINT blockSize;
                             if (VerQueryValue(versionInfo, L"\\", (LPVOID*)&block, &blockSize)) {
                                 auto fileInfo = (VS_FIXEDFILEINFO*)block;

--- a/src/Agent/NewRelic/Profiler/Profiler/CorTokenResolver.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorTokenResolver.h
@@ -42,7 +42,7 @@ namespace NewRelic { namespace Profiler
 
         xstring_t GetTypeStringsFromTypeSpec(uint32_t typeDefOrRefOrSpecToken)
         {
-            uint8_t* signature = 0;
+            uint8_t* signature;
             ULONG signatureLength;
             _metaDataImport->GetTypeSpecFromToken(typeDefOrRefOrSpecToken, (PCCOR_SIGNATURE*)(&signature), &signatureLength);
             

--- a/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorTokenizer.h
@@ -304,7 +304,7 @@ namespace NewRelic { namespace Profiler
 
         xstring_t ResolveAssemblyForType(xstring_t assemblyName, xstring_t fullQualifiedType)
         {
-            auto& coreAssembly = (*_typeNameToAssembly.get())[fullQualifiedType];
+            auto coreAssembly = (*_typeNameToAssembly.get())[fullQualifiedType];
             return coreAssembly.empty() ? assemblyName : coreAssembly;
         }
     };

--- a/src/Agent/NewRelic/Profiler/Profiler/Function.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Function.h
@@ -431,7 +431,7 @@ namespace NewRelic { namespace Profiler
             return _functionId;
         }
 
-        ModuleID GetModuleID() const
+        ModuleID GetModuleID()
         {
             return _moduleId;
         }
@@ -536,7 +536,7 @@ namespace NewRelic { namespace Profiler
         virtual ByteVectorPtr GetSignatureFromToken(mdToken token) override
         {
             ULONG signatureLength;
-            uint8_t* signature = 0;
+            uint8_t* signature;
             ThrowOnError(_metaDataImport->GetSigFromToken, token, (PCCOR_SIGNATURE*)&signature, &signatureLength);
             return std::make_shared<ByteVector>(signature, signature + signatureLength);
         }

--- a/src/Agent/NewRelic/Profiler/Profiler/FunctionHeaderInfo.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FunctionHeaderInfo.h
@@ -68,7 +68,7 @@ namespace NewRelic {
                     else if (info->instruction == CEE_SWITCH) {
                         counts.switchCount += 1;
                         const unsigned numberArms = ReadNumber(&bodyBytes[pos + 1], 4) & 0xFFFFFFFF;
-                        const unsigned numberBytesTable = (1 + static_cast<unsigned long long>(numberArms)) * sizeof(DWORD);
+                        const unsigned numberBytesTable = (1 + numberArms) * sizeof(DWORD);
                         const unsigned totalBytesInstruction = 1 + numberBytesTable;
                         pos += totalBytesInstruction;
                     }

--- a/src/Agent/NewRelic/Profiler/Profiler/OpCodes.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/OpCodes.h
@@ -96,16 +96,6 @@ namespace NewRelic {
             unsigned controlFlow;
             xstring_t name;
 
-            OpCode() :
-                instruction(0),
-                instructionSize(0),
-                arrayOffset(0),
-                operandSize(0),
-                totalSize(0),
-                controlFlow(0)
-                {}
-                
-
             void Reset(std::shared_ptr<OpCode> newOpCode)
             {
                 instruction = newOpCode->instruction;

--- a/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/SystemCalls.h
@@ -44,7 +44,7 @@ namespace NewRelic { namespace Profiler
 
         static std::unique_ptr<xstring_t> TryGetRegistryStringValue(HKEY rootKey, const xstring_t& path, const xstring_t& valueName)
         {
-            DWORD valueSize = 0;
+            DWORD valueSize;
             CRegKey key;
 
             // open the key

--- a/src/Agent/NewRelic/Profiler/Profiler/stdafx.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/stdafx.h
@@ -33,10 +33,7 @@
 
 
 // Profiler Header Files:
-#pragma warning(push)
-#pragma warning(disable: 26495) // Uninitialized member variable, even if it's always set before use
 #include <corhlpr.h>
-#pragma warning(pop)
 
 // Windows Header Files:
 #ifndef _WIN32_WINNT

--- a/src/Agent/NewRelic/Profiler/RapidXML/rapidxml.hpp
+++ b/src/Agent/NewRelic/Profiler/RapidXML/rapidxml.hpp
@@ -658,8 +658,6 @@ namespace rapidxml
             : m_name(0)
             , m_value(0)
             , m_parent(0)
-            , m_name_size(0)
-            , m_value_size(0)
         {
         }
 
@@ -809,9 +807,7 @@ namespace rapidxml
     
         //! Constructs an empty attribute with the specified type. 
         //! Consider using memory_pool of appropriate xml_document if allocating attributes manually.
-        xml_attribute() :
-            m_prev_attribute(nullptr),
-            m_next_attribute(nullptr)
+        xml_attribute()
         {
         }
 
@@ -906,10 +902,6 @@ namespace rapidxml
             : m_type(type)
             , m_first_node(0)
             , m_first_attribute(0)
-            , m_last_node(0)
-            , m_last_attribute(0)
-            , m_prev_sibling(0)
-            , m_next_sibling(0)
         {
         }
 

--- a/src/Agent/NewRelic/Profiler/SignatureParser/Types.h
+++ b/src/Agent/NewRelic/Profiler/SignatureParser/Types.h
@@ -475,7 +475,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
             stream += _type->ToString(tokenResolver);
             stream.push_back('[');
             bool first = true;
-            for (auto& genericArgumentType : *_genericArgumentTypes)
+            for (auto genericArgumentType : *_genericArgumentTypes)
             {
                 if (first) first = false;
                 else stream.push_back(',');
@@ -493,7 +493,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
             bytes->push_back(ELEMENT_TYPE_GENERICINST);
             bytes->insert(bytes->end(), typeBytes->begin(), typeBytes->end());
             bytes->insert(bytes->end(), compressedArgCount->begin(), compressedArgCount->end());
-            for (auto& argumentType : *_genericArgumentTypes)
+            for (auto argumentType : *_genericArgumentTypes)
             {
                 auto argumentTypeBytes = argumentType->ToBytes();
                 bytes->insert(bytes->end(), argumentTypeBytes->begin(), argumentTypeBytes->end());
@@ -801,11 +801,11 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
             _genericParamCount(genericParamCount)
         {}
 
-        xstring_t ToString(ITokenResolverPtr tokenResolver) const
+        xstring_t ToString(ITokenResolverPtr tokenResolver)
         {
             auto stream = xstring_t();
             bool firstParam = true;
-            for (auto& parameter : *_parameters)
+            for (auto parameter : *_parameters)
             {
                 if (firstParam) firstParam = false;
                 else stream.push_back(',');
@@ -836,7 +836,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
             auto returnTypeBytes = _returnType->ToBytes();
             bytes->insert(bytes->end(), returnTypeBytes->begin(), returnTypeBytes->end());
 
-            for (auto& parameter : *_parameters)
+            for (auto parameter : *_parameters)
             {
                 auto parameterBytes = parameter->ToBytes();
                 bytes->insert(bytes->end(), parameterBytes->begin(), parameterBytes->end());


### PR DESCRIPTION
We're seeing some instability in some customer applications that seems related to these recent Profiler changes: https://github.com/newrelic/newrelic-dotnet-agent/pull/2545
Reverting while we investigate.