### PR TITLE
ci: Change to docker compose v2 due to GH deprecations.

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -559,8 +559,8 @@ jobs:
           fi
 
           cd ${{ github.workspace }}/build/Linux
-          docker-compose build build_rpm
-          docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
+          docker compose build build_rpm
+          docker compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
         shell: bash
 
       - name: Archive RPM Package Artifacts
@@ -612,8 +612,8 @@ jobs:
           fi
 
           cd ${{ github.workspace }}/build/Linux
-          docker-compose build build_deb
-          docker-compose run -e AGENT_VERSION=$agentVersion build_deb
+          docker compose build build_deb
+          docker compose run -e AGENT_VERSION=$agentVersion build_deb
         shell: bash
 
       - name: Archive Debian Package Artifacts

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -164,8 +164,8 @@ jobs:
       - name: Build Linux Profiler
         run: |
           cd ${{ env.profiler_path }}
-          docker-compose build build
-          docker-compose run build
+          docker compose build build
+          docker compose run build
         shell: bash
 
       - name: Move Profiler to staging folder

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -139,6 +139,7 @@ jobs:
 
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
+      CORECLR_NEWRELIC_HOME: ${{ github.workspace }}/src/Agent/NewRelic/newrelichome_x64_coreclr_linux # not used but required by Profiler/docker-compose.yml
 
     steps:
       # intentionally disabled for this job, when enabled it causes a failure in the Build Linux Profiler step

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -422,12 +422,12 @@ jobs:
           cd ${{ github.workspace }}/deploy/linux/
           find . -name "*.bash" |xargs chmod a+x
           find . -type f |xargs dos2unix
-          docker-compose build
+          docker compose build
           if [ "${{ inputs.deploy }}" == "true" ] ; then
-            docker-compose run deploy_packages
+            docker compose run deploy_packages
           else
             echo "Input:deploy was not true.  The following deploy command was not run:"
-            echo "docker-compose run deploy_packages"
+            echo "docker compose run deploy_packages"
           fi
         shell: bash
 

--- a/build/Linux/linux_packaging.md
+++ b/build/Linux/linux_packaging.md
@@ -4,15 +4,15 @@ The Linux CoreCLR agent can be packaged into .rpm (for Red Hat/Centos/Oracle/SUS
 
 1. From Visual Studio, build the FullAgent solution, `Release` or `Debug` depending on your needs.
 2. In Powershell, from `build/Linux`:
-      1. `docker-compose build`
-      2. `docker-compose run build_rpm`
-      3. `docker-compose run build_deb`
+      1. `docker compose build`
+      2. `docker compose run build_rpm`
+      3. `docker compose run build_deb`
 
 Optional: sign the .rpm
 
-1. `docker-compose run -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm`
+1. `docker compose run -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm`
 
 You can do ad hoc testing inside containers using the `test_debian` and/or `test_centos` services and `bash`.
 
-     docker-compose run test_debian bash
-     docker-compose run test_centos bash
+     docker compose run test_debian bash
+     docker compose run test_centos bash

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -79,16 +79,16 @@ Write-Host "===================================="
 Write-Host "Executing Linux builds in Docker for Agent Version: $agentVersion"
 Push-Location "$rootDirectory\build\Linux"
 # Build the docker images
-docker-compose build
+docker compose build
 # Build the Debian package
-docker-compose run -e AGENT_VERSION=$agentVersion build_deb
+docker compose run -e AGENT_VERSION=$agentVersion build_deb
 # Build the RPM package, signing it if a key was supplied
 if (!($gpgKeyPath -eq "")) {
     New-Item keys -Type Directory -Force
     Copy-Item $gpgKeyPath .\keys\gpg.tar.bz2 -Force
-    docker-compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
+    docker compose run -e AGENT_VERSION=$agentVersion -e GPG_KEYS=/keys/gpg.tar.bz2 build_rpm
 } else {
-    docker-compose run -e AGENT_VERSION=$agentVersion build_rpm
+    docker compose run -e AGENT_VERSION=$agentVersion build_rpm
 }
 Pop-Location
 Write-Host "===================================="

--- a/deploy/linux/README.md
+++ b/deploy/linux/README.md
@@ -32,11 +32,11 @@ To deploy the .rpm and .deb packages for a particular release version (e.g. 10.0
 
 5. Build the Docker container:
 
-        docker-compose build
+        docker compose build
 
 6. Run the deploy (or rollback) process:
 
-        docker-compose run deploy_packages
+        docker compose run deploy_packages
 
 Note that the scripts in ./deploy_scripts came from the PHP agent team and have a lot of logic in them to support their particular build/test/release processes, 
 not all of which we are using.  However, since we are sharing the same public package sources with the PHP agent, anything this script does needs to be cautious 

--- a/src/Agent/NewRelic/Profiler/build/scripts/build_linux.ps1
+++ b/src/Agent/NewRelic/Profiler/build/scripts/build_linux.ps1
@@ -11,11 +11,11 @@ Write-Host "********"
 $baseProfilerPath = (Get-Item (Split-Path $script:MyInvocation.MyCommand.Path)).parent.parent.FullName
 Push-Location "$baseProfilerPath"
 
-Write-Host "docker-compose build build"
-docker-compose build build
+Write-Host "docker compose build build"
+docker compose build build
 
-Write-Host "docker-compose run build"
-docker-compose run build
+Write-Host "docker compose run build"
+docker compose run build
 
 if ($LastExitCode -ne 0) {
     exit $LastExitCode

--- a/tests/Agent/IntegrationTests/UnboundedServices/README.md
+++ b/tests/Agent/IntegrationTests/UnboundedServices/README.md
@@ -16,21 +16,21 @@ Note: while not a hard requirement, the containers will perform better if you us
 * This folder has Dockerfiles that set up Linux containerized services and can be used with Docker Desktop's WSL2 backend. Developers should use these containers in their system to run unbounded integration tests.
 
 * All commands below should be run from a shell (we've tested Powershell and "git-bash") in the same location as this README.
-* Before Docker containers can be used the first time, they need to be built by executing `docker-compose build`.
+* Before Docker containers can be used the first time, they need to be built by executing `docker compose build`.
 
 ### All
 
 To run all services:
 
-`docker-compose up`
+`docker compose up`
 
 If you don't want to follow the output of the services, you can run them in the background (detached) like this:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 To stop the services:
 
-`docker-compose down`
+`docker compose down`
 
 **Note**: launching all of the services takes a lot of time (as much as 15 minutes in our testing) and a lot of system resources.  Unless you need to run all of the unbounded integration tests (e.g. if you've made a change to a core part of the test framework as opposed to an individual test or piece of instrumentation) it is not recommended to do this.
 
@@ -38,7 +38,7 @@ To stop the services:
 
 It is generally best to only the the service for the tests you happen to be working on at the time (see note above).  To run a single service, execute the following:
 
-`docker-compose up <service>`
+`docker compose up <service>`
 
 See the docker-compose.yml file for the names of the services provided.
 

--- a/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
+++ b/tests/Agent/IntegrationTests/UnboundedServices/unbounded-services-control.ps1
@@ -20,7 +20,7 @@ Param(
 Function StartUnboundedServices([string] $scriptPath) {
     Push-Location "$scriptPath"
     Write-Host "Launching docker services"
-    docker-compose up -d
+    docker compose up -d
     Write-Host "Waiting $StartDelaySeconds seconds for services to be ready"
     Start-Sleep $StartDelaySeconds #TODO: something smarter than this
     Pop-Location
@@ -28,7 +28,7 @@ Function StartUnboundedServices([string] $scriptPath) {
 
 Function StopUnboundedServices([string] $scriptPath) {
     Push-Location "$scriptPath"
-    docker-compose down
+    docker compose down
     Pop-Location
 }
 


### PR DESCRIPTION
## Description

Migrate all our workflows and scripts to use docker compose v2.  See issue linked below for details about the change.

Relates to actions/runner-images#9692

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
