### PR TITLE
ci: Better Dependabot configuration for tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,14 +29,6 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: nuget
-    directory: /src/NewRelic.Core
-    schedule:
-      interval: weekly
-    groups:
-      nuget:
-        patterns:
-          - "*"
-  - package-ecosystem: nuget
     directory: /build
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,9 +52,9 @@ updates:
       nuget:
         patterns:
           - "*"
-  # Update a specific set of packages in the `tests` folder          
+  # Update a specific set of packages for integration tests
   - package-ecosystem: nuget
-    directory: /tests
+    directory: /tests/Agent/IntegrationTests
     schedule:
       interval: weekly
     groups:
@@ -62,10 +62,28 @@ updates:
         patterns:
           - "*"
     allow:
-      - dependency-name: "xunit*"
-      - dependency-name: "NUnit*"
       - dependency-name: "coverlet.collector"
       - dependency-name: "Microsoft.NET.Test.Sdk"
       - dependency-name: "Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
       - dependency-name: "Microsoft.VisualStudio.Threading.Analyzers"
+      - dependency-name: "NUnit*"
       - dependency-name: "Selenium*"
+      - dependency-name: "xunit*"
+  # Update a specific set of packages for unit tests (which are referenced in FullAgent.sln)
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    allow:
+      - dependency-name: "coverlet.collector"
+      - dependency-name: "JustMock"
+      - dependency-name: "Microsoft.NET.Test.Sdk"
+      - dependency-name: "Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
+      - dependency-name: "Microsoft.VisualStudio.Threading.Analyzers"
+      - dependency-name: "NUnit*"
+      - dependency-name: "Selenium*"
+      - dependency-name: "xunit*"


### PR DESCRIPTION
The [current Dependabot config was incorrect](https://github.com/newrelic/newrelic-dotnet-agent/network/updates/865576988), resulting in no update PRs for the limited set of NuGet packages we want to update in our Integration tests. 

I also added a rule to update the same limited set of packages in our unit test projects and removed the configuration for the (now deleted) NewRelic.Core project.