### PR TITLE
test: Upgrade to XUnit 2.9.0, fix some test failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,4 @@ updates:
       - dependency-name: "Microsoft.VisualStudio.Threading.Analyzers"
       - dependency-name: "NUnit*"
       - dependency-name: "Selenium*"
-# Enable xunit after we fix the v2.9.0 upgrade blocker https://github.com/newrelic/newrelic-dotnet-agent/issues/2684
-#      - dependency-name: "xunit*"
+      - dependency-name: "xunit*"

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.8.0">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -164,15 +164,12 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             var timeout = timeoutOrZero ?? TimeSpan.Zero;
 
-            //_testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Waiting for expression: {regularExpression}. Duration: {timeout.TotalSeconds:N0} seconds. Minimum count: {minimumCount}");
-
             var timeTaken = Stopwatch.StartNew();
             do
             {
                 var matches = TryGetLogLines(regularExpression).ToList();
                 if (matches.Count >= minimumCount)
                 {
-                    //_testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Matched expression: {regularExpression} in {timeTaken.Elapsed.TotalSeconds:N1}s.");
                     return matches;
                 }
 
@@ -180,7 +177,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             } while (timeTaken.Elapsed < timeout);
 
             var message = $"{Timestamp} Log line did not appear a minimum of {minimumCount} times within {timeout.TotalSeconds:N0} seconds.  Expected line expression: {regularExpression}";
-            //_testLogger?.WriteLine(message);
             throw new Exception(message);
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -88,9 +88,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public abstract IEnumerable<string> GetFileLines();
 
-        public string GetAccountId(TimeSpan? timeoutOrZero = null)
+        public string GetAccountId()
         {
-            var reportingAppLink = GetReportingAppLink(timeoutOrZero);
+            var reportingAppLink = GetReportingAppLink();
             var reportingAppUri = new Uri(reportingAppLink);
             var accountId = reportingAppUri.Segments[2];
             if (accountId == null)
@@ -98,9 +98,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return accountId.TrimEnd('/');
         }
 
-        public string GetApplicationId(TimeSpan? timeoutOrZero = null)
+        public string GetApplicationId()
         {
-            var reportingAppLink = GetReportingAppLink(timeoutOrZero);
+            var reportingAppLink = GetReportingAppLink();
             var reportingAppUri = new Uri(reportingAppLink);
             var applicationId = reportingAppUri.Segments[4];
             if (applicationId == null)
@@ -108,15 +108,19 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             return applicationId.TrimEnd('/');
         }
 
-        public string GetCrossProcessId(TimeSpan? timeoutOrZero = null)
+        public string GetCrossProcessId()
         {
             return $@"{GetAccountId()}#{GetApplicationId()}";
         }
 
-        public string GetReportingAppLink(TimeSpan? timeoutOrZero = null)
+        private string GetReportingAppLink()
         {
-            var match = WaitForLogLine(AgentReportingToLogLineRegex, timeoutOrZero);
-            return match.Groups[1].Value;        }
+            var match = TryGetLogLine(AgentReportingToLogLineRegex);
+            if (!match.Success || match.Groups.Count < 2)
+                throw new Exception("Could not find reporting app link in log file.");
+
+            return match.Groups[1].Value;
+        }
 
         public void WaitForConnect(TimeSpan? timeoutOrZero = null)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -115,8 +115,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public string GetReportingAppLink(TimeSpan? timeoutOrZero = null)
         {
-            var match = WaitForLogLine(AgentReportingToLogLineRegex, timeoutOrZero);
-            return match.Groups[1].Value;
+            var match = TryGetLogLine(AgentReportingToLogLineRegex);
+            return match.Success ? match.Groups[1].Value : null;
         }
 
         public void WaitForConnect(TimeSpan? timeoutOrZero = null)
@@ -164,7 +164,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             var timeout = timeoutOrZero ?? TimeSpan.Zero;
 
-            _testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Waiting for expression: {regularExpression}. Duration: {timeout.TotalSeconds:N0} seconds. Minimum count: {minimumCount}");
+            //_testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Waiting for expression: {regularExpression}. Duration: {timeout.TotalSeconds:N0} seconds. Minimum count: {minimumCount}");
 
             var timeTaken = Stopwatch.StartNew();
             do
@@ -172,7 +172,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 var matches = TryGetLogLines(regularExpression).ToList();
                 if (matches.Count >= minimumCount)
                 {
-                    _testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Matched expression: {regularExpression} in {timeTaken.Elapsed.TotalSeconds:N1}s.");
+                    //_testLogger?.WriteLine($"{Timestamp} WaitForLogLines  Matched expression: {regularExpression} in {timeTaken.Elapsed.TotalSeconds:N1}s.");
                     return matches;
                 }
 
@@ -180,7 +180,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             } while (timeTaken.Elapsed < timeout);
 
             var message = $"{Timestamp} Log line did not appear a minimum of {minimumCount} times within {timeout.TotalSeconds:N0} seconds.  Expected line expression: {regularExpression}";
-            _testLogger?.WriteLine(message);
+            //_testLogger?.WriteLine(message);
             throw new Exception(message);
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -115,9 +115,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public string GetReportingAppLink(TimeSpan? timeoutOrZero = null)
         {
-            var match = TryGetLogLine(AgentReportingToLogLineRegex);
-            return match.Success ? match.Groups[1].Value : null;
-        }
+            var match = WaitForLogLine(AgentReportingToLogLineRegex, timeoutOrZero);
+            return match.Groups[1].Value;        }
 
         public void WaitForConnect(TimeSpan? timeoutOrZero = null)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
@@ -11,9 +11,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="xunit" version="2.8.0" />
-    <PackageReference Include="xunit.assert" Version="2.8.0" />
-    <PackageReference Include="xunit.core" Version="2.8.0" />
+    <PackageReference Include="xunit" version="2.9.0" />
+    <PackageReference Include="xunit.assert" Version="2.9.0" />
+    <PackageReference Include="xunit.core" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Shared\TestSerializationHelpers\TestSerializationHelpers.csproj" />

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -42,11 +42,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Selenium.Support" Version="4.17.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.8.0" />
-    <PackageReference Include="xunit.core" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.8.0">
+    <PackageReference Include="xunit.assert" Version="2.9.0" />
+    <PackageReference Include="xunit.core" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -51,9 +51,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="CouchbaseNetClient" Version="2.3.8" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
-    <PackageReference Include="xunit" version="2.8.0" />
-    <PackageReference Include="xunit.assert" Version="2.8.0" />
-    <PackageReference Include="xunit.core" Version="2.8.0" />
+    <PackageReference Include="xunit" version="2.9.0" />
+    <PackageReference Include="xunit.assert" Version="2.9.0" />
+    <PackageReference Include="xunit.core" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
+++ b/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
@@ -11,11 +11,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.8.0" />
-    <PackageReference Include="xunit.core" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.8.0">
+    <PackageReference Include="xunit.assert" Version="2.9.0" />
+    <PackageReference Include="xunit.core" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR does the following:
* Re-applies the XUnit 2.9.0 upgrade to all integration test projects
* Modifies `AgentLogBase.GetReportingAppLink()` to use `TryGetLogLine()` instead of `WaitForLogLine()`
* Removes logging that I added in [this commit](https://github.com/newrelic/newrelic-dotnet-agent/commit/cbf4248c1a61c3741dbaf533d4d4793c8ebafd13#diff-6f30640a5ec218e443bcbf334bb43947f57e9f10a1af059525d16eddc5ef3df8R160) several months ago.

These fixes should address the `System.InvalidOperationException : There is no currently active test.` errors we started seeing after the previous upgrade attempt. 

Fixes #2684 (probably...)