### PR TITLE
feat: Use Lambda function name if application name is not set

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -18,6 +18,7 @@ namespace NewRelic.Agent.Core.Config
         bool AgentEnabled { get; }
         string AgentEnabledAt { get; }
         ILogConfig LogConfig { get; }
+        string ServerlessFunctionName { get; }
     }
 
     /// <summary>
@@ -88,6 +89,8 @@ namespace NewRelic.Agent.Core.Config
         /// </summary>
         public bool ServerlessModeEnabled { get; private set; }
 
+        public string ServerlessFunctionName { get; private set; }
+
         /// <summary>
         /// Gets the debug startup delay in seconds. This is used primarily for debugging of AWS Lambda functions.
         /// </summary>
@@ -126,17 +129,18 @@ namespace NewRelic.Agent.Core.Config
 
         private bool CheckServerlessModeEnabled(configuration localConfiguration)
         {
+            // We may need this later even if we don't use it now.
+            ServerlessFunctionName = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
+
             // according to the spec, environment variable takes precedence over config file
             var serverlessModeEnvVariable = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");
-
             if (serverlessModeEnvVariable.TryToBoolean(out var enabledViaEnvVariable))
             {
                 return enabledViaEnvVariable;
             }
 
             // env variable is not set, check for function name
-            var awsLambdaFunctionName = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
-            if (!string.IsNullOrEmpty(awsLambdaFunctionName))
+            if (!string.IsNullOrEmpty(ServerlessFunctionName))
                 return true;
 
             // fall back to config file

--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -19,6 +19,7 @@ namespace NewRelic.Agent.Core.Config
         string AgentEnabledAt { get; }
         ILogConfig LogConfig { get; }
         string ServerlessFunctionName { get; }
+        string ServerlessFunctionVersion { get; }
     }
 
     /// <summary>
@@ -91,6 +92,8 @@ namespace NewRelic.Agent.Core.Config
 
         public string ServerlessFunctionName { get; private set; }
 
+        public string ServerlessFunctionVersion { get; private set; }
+
         /// <summary>
         /// Gets the debug startup delay in seconds. This is used primarily for debugging of AWS Lambda functions.
         /// </summary>
@@ -129,8 +132,9 @@ namespace NewRelic.Agent.Core.Config
 
         private bool CheckServerlessModeEnabled(configuration localConfiguration)
         {
-            // We may need this later even if we don't use it now.
+            // We may need these later even if we don't use it now.
             ServerlessFunctionName = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
+            ServerlessFunctionVersion = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_VERSION");
 
             // according to the spec, environment variable takes precedence over config file
             var serverlessModeEnvVariable = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -276,7 +276,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (ServerlessModeEnabled)
                 {
-                    string name = GetLambdaFunctionName();
+                    string name = _bootstrapConfiguration.ServerlessFunctionName;
                     if (!string.IsNullOrEmpty(name))
                     {
                         Log.Info("Application name from Lambda Function Name.");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -41,8 +41,6 @@ namespace NewRelic.Agent.Core.Configuration
         private const int MaxExptectedErrorConfigEntries = 50;
         private const int MaxIgnoreErrorConfigEntries = 50;
 
-        private const string DefaultAppNameInConfigFile = "My Application"; // The name in our default newrelic.config file
-
         private static long _currentConfigurationVersion;
         private readonly IEnvironment _environment = new EnvironmentMock();
         private readonly IProcessStatic _processStatic = new ProcessStatic();

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -312,8 +312,6 @@ namespace NewRelic.Agent.Core.Configuration
             throw new Exception("An application name must be provided");
         }
 
-        private string GetLambdaFunctionName() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME");
-
         private string GetAppPoolId()
         {
             var appPoolId = _environment.GetEnvironmentVariable("APP_POOL_ID");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -201,6 +201,10 @@ namespace NewRelic.Agent.Core.Configuration
 
         public bool ServerlessModeEnabled => _bootstrapConfiguration.ServerlessModeEnabled;
 
+        public string ServerlessFunctionName => _bootstrapConfiguration.ServerlessFunctionName;
+
+        public string ServerlessFunctionVersion => _bootstrapConfiguration.ServerlessFunctionVersion;
+
         private string _agentLicenseKey;
         public virtual string AgentLicenseKey
         {
@@ -272,17 +276,13 @@ namespace NewRelic.Agent.Core.Configuration
                 return appName.Split(StringSeparators.Comma);
             }
 
-            if (ApplicationNameIsBlankOrDefault())
+            if (ServerlessModeEnabled)
             {
-                if (ServerlessModeEnabled)
+                if (!string.IsNullOrEmpty(ServerlessFunctionName))
                 {
-                    string name = _bootstrapConfiguration.ServerlessFunctionName;
-                    if (!string.IsNullOrEmpty(name))
-                    {
-                        Log.Info("Application name from Lambda Function Name.");
-                        _applicationNamesSource = "Environment Variable (AWS_LAMBDA_FUNCTION_NAME)";
-                        return new List<string> { name };
-                    }
+                    Log.Info("Application name from Lambda Function Name.");
+                    _applicationNamesSource = "Environment Variable (AWS_LAMBDA_FUNCTION_NAME)";
+                    return new List<string> { ServerlessFunctionName };
                 }
             }
 
@@ -313,9 +313,6 @@ namespace NewRelic.Agent.Core.Configuration
 
             throw new Exception("An application name must be provided");
         }
-
-        private bool ApplicationNameIsBlankOrDefault() => (_localConfiguration.application.name.Count == 0) ||
-            ((_localConfiguration.application.name.Count == 1) && (_localConfiguration.application.name[0] == DefaultAppNameInConfigFile));
 
         private string GetLambdaFunctionName() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME");
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -39,6 +39,12 @@ namespace NewRelic.Agent.Core.Configuration
         public bool ServerlessModeEnabled => _configuration.ServerlessModeEnabled;
 
         [JsonIgnore]
+        public string ServerlessFunctionName => _configuration.ServerlessFunctionName;
+
+        [JsonIgnore]
+        public string ServerlessFunctionVersion => _configuration.ServerlessFunctionVersion;
+
+        [JsonIgnore]
         public string AgentLicenseKey => _configuration.AgentLicenseKey;
 
         [JsonProperty("agent.license_key.configured")]

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -15,6 +15,8 @@ namespace NewRelic.Agent.Configuration
         string AgentEnabledAt { get; }
 
         bool ServerlessModeEnabled { get; }
+        string ServerlessFunctionName { get; }
+        string ServerlessFunctionVersion { get; }
 
         string AgentLicenseKey { get; }
         IEnumerable<string> ApplicationNames { get; }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -48,10 +48,10 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 return false;
             }
 
-            public void Validate(string fallbackName)
+            public void Validate(string fallbackName1, string fallbackName2, string versionFallback)
             {
-                ValidateName(fallbackName);
-                ValidateVersion();
+                ValidateName(fallbackName1, fallbackName2);
+                ValidateVersion(versionFallback);
             }
 
             private void SetName(object lambdaContext)
@@ -60,11 +60,11 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 FunctionName = functionNameGetter(lambdaContext);
             }
 
-            private void ValidateName(string fallbackName)
+            private void ValidateName(string fallback1, string fallback2)
             {
                 if (string.IsNullOrEmpty(_functionDetails.FunctionName))
                 {
-                    FunctionName = System.Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME") ?? fallbackName;
+                    FunctionName = fallback1 ?? fallback2;
                 }
             }
 
@@ -74,11 +74,11 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 FunctionVersion = functionVersionGetter(lambdaContext);
             }
 
-            private void ValidateVersion()
+            private void ValidateVersion(string fallback)
             {
                 if (string.IsNullOrEmpty(FunctionVersion))
                 {
-                    FunctionVersion = System.Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION") ?? "$LATEST";
+                    FunctionVersion = fallback ?? "$LATEST";
                 }
             }
 
@@ -200,7 +200,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
                 }
             }
 
-            _functionDetails.Validate(instrumentedMethodCall.MethodCall.Method.MethodName);
+            _functionDetails.Validate(agent.Configuration.ServerlessFunctionName, instrumentedMethodCall.MethodCall.Method.MethodName, agent.Configuration.ServerlessFunctionVersion);
 
             if (!_functionDetails.HasContext())
             {

--- a/tests/Agent/UnitTests/Core.UnitTest/Config/BootstrapConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Config/BootstrapConfigurationTests.cs
@@ -33,6 +33,8 @@ namespace NewRelic.Agent.Core.Config
                 Assert.That(config.AgentEnabledAt, Is.EqualTo("Default value"));
                 Assert.That(config.DebugStartupDelaySeconds, Is.EqualTo(0));
                 Assert.That(config.ServerlessModeEnabled, Is.False);
+                Assert.That(config.ServerlessFunctionName, Is.Null);
+                Assert.That(config.ServerlessFunctionVersion, Is.Null);
             });
         }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -13,6 +13,7 @@ using NewRelic.Agent.Core.SharedInterfaces.Web;
 using NewRelic.Testing.Assertions;
 using NUnit.Framework;
 using Telerik.JustMock;
+using Telerik.JustMock.Expectations.Abstraction;
 using Telerik.JustMock.Helpers;
 
 namespace NewRelic.Agent.Core.Configuration.UnitTest
@@ -2075,9 +2076,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _runTimeConfig.ApplicationNames = new List<string>();
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
 
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
@@ -2096,9 +2097,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _runTimeConfig.ApplicationNames = new List<string>();
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
 
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
@@ -2117,9 +2118,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _runTimeConfig.ApplicationNames = new List<string>();
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
 
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
@@ -2138,9 +2139,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _runTimeConfig.ApplicationNames = new List<string>();
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
 
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
@@ -2159,10 +2160,10 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _runTimeConfig.ApplicationNames = new List<string>();
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_APP_NAME")).Returns("My App Name");
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
 
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2133,6 +2133,27 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (NEW_RELIC_APP_NAME)"))
             );
         }
+
+        [Test]
+        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfBlank()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("");
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string> { "My Application" };
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("My Application")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
+            );
+        }
         #endregion ApplicationNames
 
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2069,7 +2069,111 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             );
         }
 
+        [Test]
+        public void ApplicationNamesUsesLambdaFunctionNameIfBlank()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
 
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string>();
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyFunc")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (AWS_LAMBDA_FUNCTION_NAME)"))
+            );
+        }
+
+        [Test]
+        public void ApplicationNamesUsesLambdaFunctionNameIfDefault()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string> { "My Application" };
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyFunc")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (AWS_LAMBDA_FUNCTION_NAME)"))
+            );
+        }
+
+        [Test]
+        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfConfigSet()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string> { "MyOverrideName" };
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyOverrideName")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
+            );
+        }
+
+        [Test]
+        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfMultipleNamesSet()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string> { "My Application", "My Other Name" };
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(2)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("My Application")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
+            );
+        }
+
+        [Test]
+        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfEnvVarSet()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("NEW_RELIC_APP_NAME")).Returns("My App Name");
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("MyFunc");
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
+
+            _localConfig.application.name = new List<string> { "My Application" };
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("My App Name")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (NEW_RELIC_APP_NAME)"))
+            );
+        }
         #endregion ApplicationNames
 
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2077,6 +2077,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
             Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
+            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionVersion).Returns("2");
             //Sets to default return null for all calls unless overriden by later arrange.
             Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
 
@@ -2087,6 +2088,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             NrAssert.Multiple(
                 () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
                 () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyFunc")),
+                () => Assert.That(_defaultConfig.ServerlessFunctionVersion, Is.EqualTo("2")),
                 () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Environment Variable (AWS_LAMBDA_FUNCTION_NAME)"))
             );
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -2113,48 +2113,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfConfigSet()
-        {
-            _runTimeConfig.ApplicationNames = new List<string>();
-
-            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
-            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
-            //Sets to default return null for all calls unless overriden by later arrange.
-            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
-
-            _localConfig.application.name = new List<string> { "MyOverrideName" };
-
-            NrAssert.Multiple(
-                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
-                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyOverrideName")),
-                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
-            );
-        }
-
-        [Test]
-        public void ApplicationNamesDoesNotUseLambdaFunctionNameIfMultipleNamesSet()
-        {
-            _runTimeConfig.ApplicationNames = new List<string>();
-
-            Mock.Arrange(() => _bootstrapConfiguration.ServerlessModeEnabled).Returns(true);
-            Mock.Arrange(() => _bootstrapConfiguration.ServerlessFunctionName).Returns("MyFunc");
-            //Sets to default return null for all calls unless overriden by later arrange.
-            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
-
-            _localConfig.application.name = new List<string> { "My Application", "My Other Name" };
-
-            NrAssert.Multiple(
-                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(2)),
-                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("My Application")),
-                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
-            );
-        }
-
-        [Test]
         public void ApplicationNamesDoesNotUseLambdaFunctionNameIfEnvVarSet()
         {
             _runTimeConfig.ApplicationNames = new List<string>();

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -355,6 +355,8 @@ namespace NewRelic.Agent.Core.Configuration
                 Assert.That(agentSettings.AgentEnabledAt, Is.Not.Null);
                 Assert.That(agentSettings.ServerlessModeEnabled, Is.False);
                 Assert.That(agentSettings.LoggingLevel, Is.Not.Null);
+                Assert.That(agentSettings.ServerlessFunctionName, Is.Null);
+                Assert.That(agentSettings.ServerlessFunctionVersion, Is.Null);
                 Assert.That(json, Is.EqualTo(expectedJson.Condense()));
             });
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -18,6 +18,10 @@ namespace NewRelic.Agent.Core.DataTransport
 
         public bool ServerlessModeEnabled  => false;
 
+        public string ServerlessFunctionName => null;
+
+        public string ServerlessFunctionVersion => null;
+
         public string AgentLicenseKey => "AgentLicenseKey";
 
         public IEnumerable<string> ApplicationNames => new[] { "name1", "name2", "name3" };


### PR DESCRIPTION
Changes the default behavior in Serverless mode to use the function name rather than "My Application" if no name is set.

Unit tests included.