### PR TITLE
fix: Preserve custom query name even if statement can't be parsed. (#2708)

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/ParsedSqlStatement.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/ParsedSqlStatement.cs
@@ -53,5 +53,10 @@ namespace NewRelic.Agent.Extensions.Parsing
         {
             return _asString;
         }
+
+        public ParsedSqlStatement CloneWithNewModel(string model)
+        {
+            return new ParsedSqlStatement(DatastoreVendor, model, Operation);
+        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/ParsedSqlStatement.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/ParsedSqlStatement.cs
@@ -53,10 +53,5 @@ namespace NewRelic.Agent.Extensions.Parsing
         {
             return _asString;
         }
-
-        public ParsedSqlStatement CloneWithNewModel(string model)
-        {
-            return new ParsedSqlStatement(DatastoreVendor, model, Operation);
-        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlParser.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlParser.cs
@@ -239,10 +239,8 @@ namespace NewRelic.Agent.Extensions.Parsing
                     }
                 }
 
-                // couldn't parse, return a default parsed statement
-                var parsedSqlStatement = _nullParsedStatementStore.GetOrAdd(datastoreVendor, x => new ParsedSqlStatement(datastoreVendor, null, null));
-                // but copy and override the model name if one was found
-                return !string.IsNullOrEmpty(explicitModel) ? parsedSqlStatement.CloneWithNewModel(explicitModel) : parsedSqlStatement;
+                // return a null statement with the model name if found, otherwise cache and return a null statement with no model name
+                return !string.IsNullOrEmpty(explicitModel) ? new ParsedSqlStatement(datastoreVendor, explicitModel, null) : _nullParsedStatementStore.GetOrAdd(datastoreVendor, x => new ParsedSqlStatement(datastoreVendor, null, null));
             };
         }
 

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlParserTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlParserTests.cs
@@ -254,6 +254,41 @@ namespace ParsingTests
                 Assert.That(parsedDatabaseStatement.ToString(), Is.EqualTo("dude - [dudeservice|getalldudes]/select"));
             });
         }
+
+        [Test]
+        public void SqlParserTest_PullNameFromComment_IfStatementCannotBeParsed()
+        {
+            var parsedDatabaseStatement = SqlParser.GetParsedDatabaseStatement(DatastoreVendor.MSSQL, CommandType.Text,
+                """
+                /* NewRelicQueryName: MyCustomQueryName */
+                
+                -- This is a full-line comment
+                SELECT
+                    (
+                        SELECT COUNT(*)
+                        FROM
+                            SomeTable
+                        WHERE
+                            SomeColumn = @SomeValue
+                    ) +
+                    (
+                        SELECT COUNT(*)
+                        FROM
+                            SomeOtherTable
+                        WHERE
+                            SomeOtherColumn = @SomeOtherValue
+                    );
+                """);
+
+            Assert.That(parsedDatabaseStatement, Is.Not.Null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsedDatabaseStatement.Model, Is.EqualTo("MyCustomQueryName"));
+
+                Assert.That(parsedDatabaseStatement.ToString(), Is.EqualTo("MyCustomQueryName/other"));
+            });
+        }
                 
 
         [Test]


### PR DESCRIPTION
The agent caches a "null parsed statement" per datastore vendor which is returned when parsing a SQL statement is unsuccessful.

This fix modifies that behavior in the case where a custom query name has been specified such that we return a new "null parsed statement", with the custom query name preserved. 

Includes unit test to verify.

Fixes #2708 