### PR TITLE
test: Update Oracle server image, restore unbounded tests

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -388,8 +388,7 @@ jobs:
             MySql,
             NServiceBus,
             NServiceBus5,
-            # Disabling Oracle temporarily
-            #Oracle,
+            Oracle,
             Postgres,
             RabbitMq,
             Redis,

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
 
     cosmosdb:
@@ -95,7 +94,7 @@ services:
         container_name: MssqlServer
 
     oracle:
-        build: ./oracle
+        image: container-registry.oracle.com/database/free:23.4.0.0-lite
         shm_size: 1g
         ports:
             - "1521:1521"

--- a/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/oracle/Dockerfile
@@ -1,1 +1,0 @@
-FROM newrelic/test-oracle-db:11.2.0.2-xe


### PR DESCRIPTION
* Updates our unbounded services configuration to use the [free Oracle 23ai](https://www.oracle.com/database/free/) container image
* Updates the all_solutions workflow to restore Oracle namespace in the unbounded tests project

The updated services config was deployed to our test EC2 instance and Github secrets were updated appropriately.