### PR TITLE
Feature work: Disable AspNetCore middleware wrapper

### DIFF
--- a/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/HttpTriggerFunctionUsingAspNetCorePipeline.cs
+++ b/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/HttpTriggerFunctionUsingAspNetCorePipeline.cs
@@ -10,6 +10,7 @@ namespace AzureFunctionApplication
 {
     public class HttpTriggerFunctionUsingAspNetCorePipeline
     {
+        private static bool _firstTime = true;
         private readonly ILogger<HttpTriggerFunctionUsingAspNetCorePipeline> _logger;
 
         public HttpTriggerFunctionUsingAspNetCorePipeline(ILogger<HttpTriggerFunctionUsingAspNetCorePipeline> logger)
@@ -18,9 +19,16 @@ namespace AzureFunctionApplication
         }
 
         [Function("HttpTriggerFunctionUsingAspNetCorePipeline")]
-        public IActionResult Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequest req)
+        public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequest req)
         {
             _logger.LogInformation("HttpTriggerFunctionUsingAspNetCorePipeline processed a request.");
+
+            if (_firstTime)
+            {
+                await Task.Delay(500); // to ensure that the first invocation gets sampled
+                _firstTime = false;
+            }
+
 
             return new OkObjectResult("Welcome to Azure Functions!");
         }


### PR DESCRIPTION
Disables the AspNetCore middleware wrapper (`NewRelic.Providers.Wrapper.AspNetCore6Plus.WrapPipelineMiddleware`) when running in Azure function mode, to prevent duplicate transactions from being created. 

Updates integration tests to add checking of transaction sample attributes.