### PR TITLE
test: Unit Test TFM update, Integration Test workflow dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
           - "*"
     allow:
       - dependency-name: "coverlet.collector"
-      - dependency-name: "JustMock" # until we upgrade unit tests to target 4.8.1, we can' upgrade to the 20204 JustMock release
+      - dependency-name: "JustMock"
       - dependency-name: "Microsoft.NET.Test.Sdk"
       - dependency-name: "Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
       - dependency-name: "Microsoft.VisualStudio.Threading.Analyzers"

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -334,17 +334,19 @@ jobs:
           matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
           matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HttpClientInstrumentation' ||
           matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
-          matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables'
-
+          matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables' ||
+          matrix.namespace == 'RequestHeadersCapture.WCF' || matrix.namespace == 'WCF.Client.IIS.ASPDisabled' ||
+          matrix.namespace == 'WCF.Client.IIS.ASPEnabled' || matrix.namespace == 'WCF.Service.IIS.ASPDisabled' ||
+          matrix.namespace == 'WCF.Service.IIS.ASPEnabled'
         run: |
           Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
         shell: powershell
-        
-      # - name: Install dependencies
-      #   run: |
-      #     Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-      #     pip install aiohttp
-      #   shell: powershell
+
+      - name: Install aiohttp
+        if: matrix.namespace == 'DistributedTracing'
+        run: |
+          pip install aiohttp
+        shell: powershell
 
       - name: Install Azure Functions Core Tools
         if: matrix.namespace == 'AzureFunction'
@@ -456,23 +458,28 @@ jobs:
           New-ItemProperty -Path $registryPath -Name "Enabled" -Value "0" -PropertyType DWORD -Force
         shell: powershell
 
-      - name: Install dependencies
+      - name: Install HostableWebCore Feature
+        if: | # only install for the required namespaces
+          matrix.namespace == 'Couchbase' || matrix.namespace == 'MongoDB' || matrix.namespace == 'MsSql' || matrix.namespace == 'Oracle'
         run: |
-          # Write-Host "Installing HostableWebCore Feature"
-          # Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-          
-          if ("${{ matrix.namespace }}" -eq "Msmq") {
-            Write-Host "Installing Msmq Features"
-            Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
-            Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
-            Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
-          }
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+        shell: powershell
 
-          if ("${{ matrix.namespace }}" -eq "MsSql") {
-            Write-Host "Installing MSSQL CLI"
-            msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
-            Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
-          }
+      - name: Install MSMQ dependencies
+        if: matrix.namespace == 'Msmq'
+        run: |
+          Write-Host "Installing Msmq Features"
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Server -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-HTTP -All
+          Enable-WindowsOptionalFeature -Online -FeatureName MSMQ-Triggers -All
+        shell: powershell
+
+      - name: Install MsSql dependencies
+        if: matrix.namespace == 'MsSql'
+        run: |
+          Write-Host "Installing MSSQL CLI"
+          msiexec /i "${{ github.workspace }}\build\Tools\sqlncli.msi" IACCEPTSQLNCLILICENSETERMS=YES /quiet /qn /norestart
+          Start-Sleep 20 # Need to wait for install to finish -- takes only a few seconds, but we need to be sure.
         shell: powershell
 
       - name: Set up secrets

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -327,11 +327,11 @@ jobs:
           name: integrationtests
           # Should not need a path because the integration test artifacts are archived with the full directory structure
 
-      - name: Install dependencies
-        run: |
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
-          pip install aiohttp
-        shell: powershell
+      # - name: Install dependencies
+      #   run: |
+      #     Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+      #     pip install aiohttp
+      #   shell: powershell
 
       - name: Install Azure Functions Core Tools
         if: matrix.namespace == 'AzureFunction'
@@ -445,8 +445,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          Write-Host "Installing HostableWebCore Feature"
-          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+          # Write-Host "Installing HostableWebCore Feature"
+          # Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
           
           if ("${{ matrix.namespace }}" -eq "Msmq") {
             Write-Host "Installing Msmq Features"

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -327,6 +327,19 @@ jobs:
           name: integrationtests
           # Should not need a path because the integration test artifacts are archived with the full directory structure
 
+      - name: Install HostableWebCore Feature
+        if: | # only install for the required namespaces
+          matrix.namespace == 'AgentFeatures' || matrix.namespace == 'AgentLogs' || matrix.namespace == 'AgentMetrics' || matrix.namespace == 'BasicInstrumentation' || 
+          matrix.namespace == 'CatInbound' || matrix.namespace == 'CatOutbound' || matrix.namespace == 'CodeLevelMetrics' || matrix.namespace == 'CSP' || 
+          matrix.namespace == 'CustomAttributes' || matrix.namespace == 'CustomInstrumentation' || matrix.namespace == 'DataTransmission' || 
+          matrix.namespace == 'DistributedTracing' || matrix.namespace == 'Errors' || matrix.namespace == 'HttpClientInstrumentation' ||
+          matrix.namespace == 'Rejit.NetFramework' || matrix.namespace == 'RequestHandling' || matrix.namespace == 'RequestHeadersCapture.AspNet' ||
+          matrix.namespace == 'RequestHeadersCapture.AspNetCore' || matrix.namespace == 'RequestHeadersCapture.EnvironmentVariables'
+
+        run: |
+          Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore
+        shell: powershell
+        
       # - name: Install dependencies
       #   run: |
       #     Enable-WindowsOptionalFeature -Online -FeatureName IIS-HostableWebCore

--- a/tests/Agent/Benchmarking/Benchmarking/Benchmarking.csproj
+++ b/tests/Agent/Benchmarking/Benchmarking/Benchmarking.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net481</TargetFrameworks>
     <AssemblyName>Benchmarking</AssemblyName>
     <RootNamespace>Benchmarking</RootNamespace>
     <Description></Description>

--- a/tests/Agent/Benchmarking/BenchmarkingTests/BenchmarkingTests.csproj
+++ b/tests/Agent/Benchmarking/BenchmarkingTests/BenchmarkingTests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="MoreLinq" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/tests/Agent/Benchmarking/BenchmarkingTests/BenchmarkingTests.csproj
+++ b/tests/Agent/Benchmarking/BenchmarkingTests/BenchmarkingTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net481</TargetFrameworks>
     <RootNamespace>BenchmarkingTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.Core.BenchmarkingTests</AssemblyName>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>

--- a/tests/Agent/Benchmarking/ConcurrentBenchmarking/ConcurrentBenchmarking.csproj
+++ b/tests/Agent/Benchmarking/ConcurrentBenchmarking/ConcurrentBenchmarking.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net481</TargetFrameworks>
     <AssemblyName>ConcurrentBenchmarking</AssemblyName>
     <RootNamespace>ConcurrentBenchmarking</RootNamespace>
     <Description></Description>

--- a/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
+++ b/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20">

--- a/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
+++ b/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <RootNamespace>NewRelic.Agent.Tests.TestSerializationHelpers.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
+++ b/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net481</TargetFrameworks>
     <RootNamespace>NewRelic.Providers.CallStack.AsyncLocalTests</RootNamespace>
     <AssemblyName>NewRelic.Providers.CallStack.AsyncLocalTests</AssemblyName>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>

--- a/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
+++ b/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MoreLinq" Version="2.4.0" />

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <RootNamespace>CompositeTests</RootNamespace>
     <AssemblyName>NewRelic.Agent.Core.CompositeTests</AssemblyName>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
@@ -29,7 +29,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MoreLinq" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <RootNamespace>NewRelic.Agent.Core</RootNamespace>
     <AssemblyName>NewRelic.Agent.Core.UnitTest</AssemblyName>
     <DebugType>Full</DebugType>
@@ -28,12 +28,13 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net80'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Messaging" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
@@ -46,7 +47,7 @@
     <ProjectReference Include="..\..\NewRelic.Testing.Assertions\NewRelic.Testing.Assertions.csproj" />
     <ProjectReference Include="..\NewRelic.Agent.TestUtilities\NewRelic.Agent.TestUtilities.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <ProjectReference Include="$(RootProjectDirectory)\src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\AspNet\AspNet.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectionManagerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectionManagerTests.cs
@@ -81,7 +81,6 @@ namespace NewRelic.Agent.Core.DataTransport
             }
         }
 
-
         [Test]
         [TestCase("ForceRestartException")]
         [TestCase("HttpException")]

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <RootNamespace>Agent.Extensions.Tests</RootNamespace>
     <AssemblyName>NewRelic.Agent.Extensions.Tests</AssemblyName>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
@@ -25,7 +25,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0">

--- a/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net481;net8.0</TargetFrameworks>
     <RootNamespace>NewRelic.Agent.TestUtilities</RootNamespace>
     <AssemblyName>NewRelic.Agent.TestUtilities</AssemblyName>
   </PropertyGroup>
@@ -21,7 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="$(RootProjectDirectory)\src\Agent\NewRelic\Agent\Core\Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{A6AE0190-AEAB-4B3A-B671-95C2D5123BF9}</ProjectGuid>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AssemblyTitle>NewRelic.Testing.Assertions.UnitTests</AssemblyTitle>
     <Product>NewRelic.Testing.Assertions.UnitTests</Product>

--- a/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
+++ b/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
+    <PackageReference Include="JustMock" Version="2024.3.805.336" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MoreLinq" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
* Updates unit test projects to target .NET Framework 4.8.1 rather than 4.6.2
* Updates unit test projects to use the latest version of `JustMock` (previously we couldn't use the latest due to the TFM issue)
* Updates the `all_solutions` workflow to install the `HostableWebCore` and `aiohttp` dependencies only for the specific integration test namespaces that require those. Net effect is a reduction of 1-2 minutes execution time for each test that doesn't need either of those dependencies.