### PR TITLE
chore: Update latest tested versions of core tech libraries, 09/12/24

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.13" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.19" />
     <PackageReference Include="NewRelic.Agent.Api" Version="10.26.0" />
   </ItemGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/KafkaTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/KafkaTestApp.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     
     <PackageReference Include="Confluent.Kafka" Version="1.4.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageReference Include="Confluent.Kafka" Version="2.5.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Confluent.Kafka" Version="2.5.3" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup> <!-- retain alphabetical order please! -->
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.4" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.4" Condition="'$(TargetFramework)' == 'net8.0'" />
     
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net8.0'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -92,8 +92,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.16" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.16" Condition="'$(TargetFramework)' == 'net8.0'" />
 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves #2741 
Resolves #2742 
Resolves #2743 
Resolves #2744 

Note: some of the packages have gotten further updates since the core tech scanner (Dotty) ran on Monday, so the version each package was bumped to may be newer than specified in the associated issues.