### PR TITLE
chore: Update latest tested versions of core tech, week of 2024-09-16

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.19" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.20" />
     <PackageReference Include="NewRelic.Agent.Api" Version="10.26.0" />
   </ItemGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup> <!-- retain alphabetical order please! -->
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.4" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.4" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.8" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.8" Condition="'$(TargetFramework)' == 'net8.0'" />
     
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net8.0'" />
@@ -53,8 +53,8 @@
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NEST" Version="7.17.5" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <PackageReference Include="NLog" Version="5.3.3" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NLog" Version="5.3.3" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NLog" Version="5.3.4" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="NLog" Version="5.3.4" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" Condition="'$(TargetFramework)' == 'net8.0'" />
@@ -65,7 +65,7 @@
     
     <!-- NServiceBus v9+ only supports .NET8+, so constraint FW target to the latest 8.x version -->
     <PackageReference Include="NServiceBus" Version="8.2.2" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="NServiceBus" Version="9.1.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="NServiceBus" Version="9.2.2" Condition="'$(TargetFramework)' == 'net8.0'" />
 
     
     <!-- modern oracle only supports net472+ and net6.0+ -->

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="log4net" Version="3.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="3.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net8.0'" />
     
-    <PackageReference Include="log4net" Version="3.0.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net" Version="3.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net8.0'" />
     
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net8.0'" />


### PR DESCRIPTION
Resolves #2762 
Resolves #2763
Resolves #2765 
Resolves #2766 
Resolves #2767 

Note: this no longer addresses the issue numbered 2764, which is a major version bump of log4net.  This change broke some tests and will need additional troubleshooting and testing.
