### PR TITLE
chore: Dotty / Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       github-actions:
         patterns:
@@ -30,7 +30,7 @@ updates:
       - /tests/Agent/IntegrationTests # will pick up container, integration and unbounded test solutions
       - / # will pick up FullAgent.sln which contains the unit tests
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       nuget-tests:
         patterns:

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -2,7 +2,7 @@ name: Check for new core technologies
 
 on:
   schedule:
-   - cron:  '0 10 * * 1' # Every Monday at 10:00 AM
+   - cron:  '0 10 1,15 * *' # On the 1st and 15th of every month at 10:00 AM UTC
   workflow_dispatch:
     inputs:
       daysToSearch:

--- a/.github/workflows/nuget_slack_notifications.yml
+++ b/.github/workflows/nuget_slack_notifications.yml
@@ -78,6 +78,6 @@ jobs:
             export DOTTY_TEST_MODE="True"
           fi
           cd ${{ env.scan-tool-publish-path }}
-          dotnet ./nugetSlackNotifications.dll ${{ env.nugets }}
+          dotnet ./nugetSlackNotifications.dll
         shell: bash
         

--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -30,10 +30,16 @@
         "packageName": "amazon.lambda.sqsevents"
     },
     {
-        "packageName": "awssdk.bedrockruntime"
+        "packageName": "awssdk.bedrockruntime",
+        "ignorePatch": true,
+        "ignoreMinor": false,
+        "ignoreReason": "frequent patch releases create too much noise"
     },
     {
-        "packageName": "awssdk.sqs"
+        "packageName": "awssdk.sqs",
+        "ignorePatch": true,
+        "ignoreMinor": false,
+        "ignoreReason": "frequent patch releases create too much noise"
     },
     {
         "packageName": "confluent.kafka"
@@ -99,7 +105,10 @@
         "packageName": "serilog.sinks.console"
     },
     {
-        "packageName": "stackexchange.redis"
+        "packageName": "stackexchange.redis",
+        "ignorePatch": true,
+        "ignoreMinor": false,
+        "ignoreReason": "frequent patch releases create too much noise"
     },
     {
         "packageName": "system.data.sqlclient"


### PR DESCRIPTION
A few changes, intended to reduce the burden of managing dependency updates:

* Dependabot will scan for github actions updates monthly instead of weekly
* Dependabot will scan for NuGet package updates for unit/integration tests monthly instead of weekly 
* Dotty will run on the 1st and 15th of the month instead of weekly on Mondays (note that it already uses the "last run" date as the starting timestamp for it's package searching, so we shouldn't miss any updates).
* Based on recent history, a few Dotty packages will now ignore patch version updates:
    * `AWSSDK.BedrockRuntime`
    * `AWSSDK.SQS`
    * `StackExchange.Redis`