### PR TITLE
feat: Add support for the EnyimMemcachedCore client.

### DIFF
--- a/FullAgent.sln
+++ b/FullAgent.sln
@@ -215,9 +215,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestSerializationHelpers.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AwsSdk", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\AwsSdk\AwsSdk.csproj", "{37262C22-6A3A-4AD7-AB78-3853D2B2931D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureFunction", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\AzureFunction\AzureFunction.csproj", "{338AD83A-ED68-438A-8FB1-E93A3AE87EA8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureFunction", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\AzureFunction\AzureFunction.csproj", "{338AD83A-ED68-438A-8FB1-E93A3AE87EA8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PublicApiChangeTests", "tests\Agent\UnitTests\PublicApiChangeTests\PublicApiChangeTests.csproj", "{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PublicApiChangeTests", "tests\Agent\UnitTests\PublicApiChangeTests\PublicApiChangeTests.csproj", "{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Memcached", "src\Agent\NewRelic\Agent\Extensions\Providers\Wrapper\Memcached\Memcached.csproj", "{5D74E5C5-9BA3-423B-86F7-14C2D1A14661}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -461,6 +463,10 @@ Global
 		{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D74E5C5-9BA3-423B-86F7-14C2D1A14661}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D74E5C5-9BA3-423B-86F7-14C2D1A14661}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D74E5C5-9BA3-423B-86F7-14C2D1A14661}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D74E5C5-9BA3-423B-86F7-14C2D1A14661}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -531,10 +537,11 @@ Global
 		{37262C22-6A3A-4AD7-AB78-3853D2B2931D} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
 		{338AD83A-ED68-438A-8FB1-E93A3AE87EA8} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
 		{A8F6EFEA-1C31-4461-A7B4-25C30D954EE2} = {E5B988C0-5D19-407E-8210-71FFB90C579A}
+		{5D74E5C5-9BA3-423B-86F7-14C2D1A14661} = {5E86E10A-C38F-48CB-ADE9-67B22BB2F50A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {D8B98070-6B8E-403C-A07F-A3F2E4A3A3D0}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35
+		SolutionGuid = {D8B98070-6B8E-403C-A07F-A3F2E4A3A3D0}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = FullAgent.vsmdi

--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -59,6 +59,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsLambda.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsSdk.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AzureFunction.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Memcached.dll",
             };
 
             var wrapperXmls = new[]
@@ -86,6 +87,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsLambda.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsSdk.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml",
             };
 
             ExtensionXsd = $@"{SourceHomeBuilderPath}\extensions\extension.xsd";

--- a/build/ArtifactBuilder/FrameworkAgentComponents.cs
+++ b/build/ArtifactBuilder/FrameworkAgentComponents.cs
@@ -66,6 +66,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Bedrock.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsSdk.dll",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AzureFunction.dll",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Memcached.dll",
             };
 
             var wrapperXmls = new[]
@@ -107,6 +108,7 @@ namespace ArtifactBuilder
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Bedrock.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AwsSdk.Instrumentation.xml",
                 $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml",
+                $@"{SourceHomeBuilderPath}\extensions\NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml",
             };
 
             ExtensionXsd = $@"{SourceHomeBuilderPath}\extensions\extension.xsd";

--- a/src/Agent/MsiInstaller/Installer/Product.wxs
+++ b/src/Agent/MsiInstaller/Installer/Product.wxs
@@ -401,6 +401,9 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="AzureFunctionWrapperComponent" Guid="{949893C5-0212-447A-88A3-DDE3638DDC6E}">
         <File Id="AzureFunctionWrapperFile" Name="NewRelic.Providers.Wrapper.AzureFunction.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.AzureFunction.dll" />
       </Component>
+      <Component Id="MemcachedWrapperComponent" Guid="{2FF15179-BBEB-460C-A145-10F20C0CAD07}">
+        <File Id="MemcachednWrapperFile" Name="NewRelic.Providers.Wrapper.Memcached.dll" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Memcached.dll" />
+      </Component>
     </ComponentGroup>
 
     <ComponentGroup Id="CoreNewRelic.Agent.Extensions" Directory="CoreProgramFilesExtensionsFolder">
@@ -475,6 +478,9 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreAzureFunctionWrapperComponent" Guid="{6DC23A07-4063-462E-B43A-532D6F810AFE}">
         <File Id="CoreAzureFunctionWrapperFile" Name="NewRelic.Providers.Wrapper.AzureFunction.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.AzureFunction.dll" />
+      </Component>
+      <Component Id="CoreMemcachedWrapperComponent" Guid="{1D7D04A1-24D5-4716-B7CB-EACB21D66D7D}">
+        <File Id="CoreMemcachedWrapperFile" Name="NewRelic.Providers.Wrapper.Memcached.dll" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Memcached.dll" />
       </Component>
    </ComponentGroup>
 
@@ -591,6 +597,9 @@ SPDX-License-Identifier: Apache-2.0
       <Component Id="AzureFunctionInstrumentationComponent" Guid="{0D802289-3B47-4D94-8907-285FFD2779AB}">
         <File Id="AzureFunctionInstrumentationFile" Name="NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml" />
       </Component>
+      <Component Id="MemcachedInstrumentationComponent" Guid="{065F899F-4942-43C6-9589-538C432E3E4D}">
+        <File Id="MemcachedInstrumentationFile" Name="NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)\extensions\NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml" />
+      </Component>
    </ComponentGroup>
 
     <ComponentGroup Id="CoreNewRelic.Agent.Extensions.Instrumentation" Directory="CoreExtensionsFolder">
@@ -662,6 +671,9 @@ SPDX-License-Identifier: Apache-2.0
       </Component>
       <Component Id="CoreAzureFunctionInstrumentationComponent" Guid="{BF3BEE66-A563-4A59-ADEC-65C3381C582E}">
         <File Id="CoreAzureFunctionInstrumentationFile" Name="NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.AzureFunction.Instrumentation.xml"/>
+      </Component>
+      <Component Id="CoreMemcachedInstrumentationComponent" Guid="{5A78488A-837C-4CA5-BD20-4A1ED734C085}">
+        <File Id="CoreMemcachedInstrumentationFile" Name="NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml" KeyPath="yes" Source="$(var.HomeFolderPath)_coreclr\extensions\NewRelic.Providers.Wrapper.Memcached.Instrumentation.xml"/>
       </Component>
     </ComponentGroup>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
@@ -30,7 +30,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
                 transaction.AttachToAsync();
             }
 
-            // Internally, the key is used to determine what server to read from, in a multi-server environment.
+            // Internally, the key is used to determine what server to read from in a multi-server environment.
             // Without a key, we can't determine the server, so we can't determine the connection info.
 
             ParsedSqlStatement parsedStatement;
@@ -79,7 +79,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
                 agent);
 
             var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, parsedStatement, connectionInfo, isLeaf: true);
-            segment.AddCustomAttribute("key", key); // node also stores the key - not required!
+            segment.AddCustomAttribute("key", key); // Storing the key is optional, but could be useful and we already have it.
 
             if (instrumentedMethodCall.IsAsync)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
@@ -13,16 +13,13 @@ namespace NewRelic.Providers.Wrapper.Memcached
     public class EnyimMemcachedCoreWrapper : IWrapper
     {
         private const string ModelName = "cache";
-
-        public string[] WrapperNames = new string[] { "EnyimMemcachedCoreWrapper" };
+        private const string WrapperName = "EnyimMemcachedCoreWrapper";
 
         public bool IsTransactionRequired => true;
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
-            var canWrap = WrapperNames.Contains(methodInfo.RequestedWrapperName, StringComparer.OrdinalIgnoreCase);
-
-            return new CanWrapResponse(canWrap);
+            return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
         }
 
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
@@ -1,0 +1,97 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+
+namespace NewRelic.Providers.Wrapper.Memcached
+{
+    public class EnyimMemcachedCoreWrapper : IWrapper
+    {
+        public string[] WrapperNames = new string[] { "EnyimMemcachedCoreWrapper" };
+
+        public bool IsTransactionRequired => true;
+
+        public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
+        {
+            var canWrap = WrapperNames.Contains(methodInfo.RequestedWrapperName, StringComparer.OrdinalIgnoreCase);
+
+            return new CanWrapResponse(canWrap);
+        }
+
+        public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+        {
+            if (instrumentedMethodCall.IsAsync)
+            {
+                transaction.AttachToAsync();
+            }
+
+            // Internally, the key is used to determine what server to read from, in a multi-server environment.
+            // Without a key, we can't determine the server, so we can't determine the connection info.
+
+            ParsedSqlStatement parsedStatement;
+            string key;
+
+            // Operation is the first argument in all cases, Key is the second argument
+            if (instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformStore")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformStoreAsync")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformMutate")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformMutateAsync")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformConcatenate"))
+            {
+                key = instrumentedMethodCall.MethodCall.MethodArguments[1].ToString();
+                parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
+                    key,
+                    instrumentedMethodCall.MethodCall.MethodArguments[0].ToString());
+            }
+            // Operation is always Get, Key is the first argument
+            else if (instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformTryGet")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("PerformGet")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("GetAsync"))
+            {
+                key = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
+                parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
+                    key,
+                    "Get");
+            }
+            // Operation is always Remove, Key is the first argument
+            else if (instrumentedMethodCall.MethodCall.Method.MethodName.Equals("Remove")
+                || instrumentedMethodCall.MethodCall.Method.MethodName.Equals("RemoveAsync"))
+            {
+                key = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
+                parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
+                    key,
+                    "Remove");
+            }
+            // Should not happen
+            else
+            {
+                return Delegates.NoOp;
+            }
+
+            var connectionInfo = MemcachedHelpers.GetConnectionInfo(
+                key,
+                instrumentedMethodCall.MethodCall.InvocationTarget,
+                agent);
+
+            var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, parsedStatement, connectionInfo, isLeaf: true);
+            segment.AddCustomAttribute("key", key); // node also stores the key - not required!
+
+            if (instrumentedMethodCall.IsAsync)
+            {
+                return Delegates.GetAsyncDelegateFor<Task>(
+                    agent,
+                    segment);
+            }
+
+            return Delegates.GetDelegateFor(
+                onFailure: (ex) => segment.End(ex),
+                onComplete: () => segment.End()
+            );
+        }
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/EnyimMemcachedCoreWrapper.cs
@@ -12,6 +12,8 @@ namespace NewRelic.Providers.Wrapper.Memcached
 {
     public class EnyimMemcachedCoreWrapper : IWrapper
     {
+        private const string ModelName = "cache";
+
         public string[] WrapperNames = new string[] { "EnyimMemcachedCoreWrapper" };
 
         public bool IsTransactionRequired => true;
@@ -45,7 +47,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
             {
                 key = instrumentedMethodCall.MethodCall.MethodArguments[1].ToString();
                 parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
-                    key,
+                    ModelName,
                     instrumentedMethodCall.MethodCall.MethodArguments[0].ToString());
             }
             // Operation is always Get, Key is the first argument
@@ -55,7 +57,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
             {
                 key = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
                 parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
-                    key,
+                    ModelName,
                     "Get");
             }
             // Operation is always Remove, Key is the first argument
@@ -64,7 +66,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
             {
                 key = instrumentedMethodCall.MethodCall.MethodArguments[0].ToString();
                 parsedStatement = new ParsedSqlStatement(DatastoreVendor.Memcached,
-                    key,
+                    ModelName,
                     "Remove");
             }
             // Should not happen
@@ -79,7 +81,6 @@ namespace NewRelic.Providers.Wrapper.Memcached
                 agent);
 
             var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, parsedStatement, connectionInfo, isLeaf: true);
-            segment.AddCustomAttribute("key", key); // Storing the key is optional, but could be useful and we already have it.
 
             if (instrumentedMethodCall.IsAsync)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 <extension xmlns="urn:newrelic-extension">
   <instrumentation>
 
+    <!--Supports all MemcachedClient and "DistributedCache" methods, except MultiX methods.-->
     <tracerFactory name="EnyimMemcachedCoreWrapper">
 
       <!--MemcachedClient<T> calls into MemcachedClient-->

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Copyright 2020 New Relic Corporation. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+<extension xmlns="urn:newrelic-extension">
+  <instrumentation>
+
+    <tracerFactory name="EnyimMemcachedCoreWrapper">
+
+      <!--MemcachedClient<T> calls into MemcachedClient-->
+      <!--DistributedCache is just MemcachedClient, not a separate class-->
+      <match assemblyName="EnyimMemcachedCore" className="Enyim.Caching.MemcachedClient">
+        <!--Add/Async, Set/Async, Replace/Async, Store/Async, Cas-->
+        <exactMethodMatcher methodName="PerformStore" parameters="Enyim.Caching.Memcached.StoreMode,System.String,System.Object,System.UInt32,System.UInt64&amp;,System.Int32&amp;" />
+        <exactMethodMatcher methodName="PerformStoreAsync" />
+
+        <!--Get > TryGet > PerformTryGet-->
+        <!--GetWithCas > TryGetWithCas > PerformTryGet-->
+        <!--GetWithCas<T> > TryGetWithCas > PerformTryGet-->
+        <exactMethodMatcher methodName="PerformTryGet" />
+
+        <!--Get<T>-->
+        <exactMethodMatcher methodName="PerformGet" />
+
+        <!--GetValueAsync-->
+        <exactMethodMatcher methodName="GetAsync" parameters="System.String" />
+
+        <!--Increment, Decrement, CasMutate-->
+        <exactMethodMatcher methodName="PerformMutate" parameters="Enyim.Caching.Memcached.MutationMode,System.String,System.UInt64,System.UInt64,System.UInt32,System.UInt64&amp;" />
+
+        <!--TouchAsync-->
+        <exactMethodMatcher methodName="PerformMutateAsync" />
+
+        <!--Append, Prepend(-->
+        <exactMethodMatcher methodName="PerformConcatenate" />
+        
+        <exactMethodMatcher methodName="Remove" />
+        <exactMethodMatcher methodName="RemoveAsync" />
+      </match>
+    </tracerFactory>
+
+  </instrumentation>
+</extension>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Instrumentation.xml
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
         <!--TouchAsync-->
         <exactMethodMatcher methodName="PerformMutateAsync" />
 
-        <!--Append, Prepend(-->
+        <!--Append, Prepend-->
         <exactMethodMatcher methodName="PerformConcatenate" />
         
         <exactMethodMatcher methodName="Remove" />

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Memcached.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/Memcached.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <RootNamespace>NewRelic.Providers.Wrapper.Memcached</RootNamespace>
+    <AssemblyName>NewRelic.Providers.Wrapper.Memcached</AssemblyName>
+    <Description>Memcached Wrapper Provider for New Relic .NET Agent</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Instrumentation.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/MemcachedHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/MemcachedHelpers.cs
@@ -1,0 +1,66 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Reflection;
+
+namespace NewRelic.Providers.Wrapper.Memcached
+{
+    public class MemcachedHelpers
+    {
+        private static bool _hasGetServerFailed = false;
+        private const string AssemblyName = "EnyimMemcachedCore";
+        private static Func<object, object> _transformerGetter;
+        private static Func<object, string, string> _transformMethod;
+        private static Func<object, object> _poolGetter;
+        private static Func<object, string, object> _locateMethod;
+        private static Func<object, object> _endpointGetter;
+        private static Func<object, object> _addressGetter;
+        private static Func<object, int> _portGetter;
+
+        public static ConnectionInfo GetConnectionInfo(string key, object target, IAgent agent)
+        {
+            if (_hasGetServerFailed)
+            {
+                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), null, -1, null);
+            }
+
+            try
+            {
+                var targetType = target.GetType();
+                _transformerGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(targetType, "KeyTransformer");
+                var transformer = _transformerGetter(target);
+
+                _transformMethod ??= VisibilityBypasser.Instance.GenerateOneParameterMethodCaller<string, string>(AssemblyName, transformer.GetType().FullName, "Transform");
+                var hashedKey = _transformMethod(transformer, key);
+
+                _poolGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(targetType, "Pool");
+                var pool = _poolGetter(target);
+
+                _locateMethod ??= VisibilityBypasser.Instance.GenerateOneParameterMethodCaller<string, object>(AssemblyName, pool.GetType().FullName, "Enyim.Caching.Memcached.IServerPool.Locate");
+                var node = _locateMethod(pool, hashedKey);
+
+                _endpointGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(node.GetType(), "EndPoint");
+                var endpoint = _endpointGetter(node);
+
+                var endpointType = endpoint.GetType();
+                _addressGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(endpointType, "Address");
+                var address = _addressGetter(endpoint).ToString();
+
+                _portGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<int>(endpointType, "Port");
+                int? port = _portGetter(endpoint);
+
+                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), address, port.HasValue ? port.Value : -1, null);
+            }
+            catch (Exception exception)
+            {
+                agent.Logger.Warn(exception, "Unable to get Memcached server address/port, likely to due to type differences. Server address/port will not be available.");
+                _hasGetServerFailed = true;
+                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), null, -1, null);
+            }
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPost.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPost.cs
@@ -1,0 +1,11 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace MemcachedTestApp
+{
+    public class BlogPost
+    {
+        public string Title { get; set; }
+        public string Body { get; set; }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPostService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPostService.cs
@@ -1,0 +1,35 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+namespace MemcachedTestApp
+{
+    public class BlogPostService : IBlogPostService
+    {
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async Task<Dictionary<string, List<BlogPost>>> GetRecent(int itemCount)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            var dict = new Dictionary<string, List<BlogPost>>();
+
+            var posts = new List<BlogPost>();
+            for (int i = 0; i < itemCount; i++)
+            {
+                posts.Add(
+                    new BlogPost
+                    {
+                        Title = "Hello World" + itemCount,
+                        Body = "EnyimCachingCore" + itemCount
+                    });
+            }
+
+
+            dict.Add(DateTime.Today.ToString("yyyy-MM-dd"), posts);
+
+            return dict;
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPostService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/BlogPostService.cs
@@ -1,20 +1,16 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 
 namespace MemcachedTestApp
 {
     public class BlogPostService : IBlogPostService
     {
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        public async Task<Dictionary<string, List<BlogPost>>> GetRecent(int itemCount)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        public Dictionary<string, List<BlogPost>> GetRecent(int itemCount)
         {
             var dict = new Dictionary<string, List<BlogPost>>();
-
             var posts = new List<BlogPost>();
             for (int i = 0; i < itemCount; i++)
             {
@@ -26,9 +22,7 @@ namespace MemcachedTestApp
                     });
             }
 
-
             dict.Add(DateTime.Today.ToString("yyyy-MM-dd"), posts);
-
             return dict;
         }
     }

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Controllers/MemcachedController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Controllers/MemcachedController.cs
@@ -1,8 +1,8 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Enyim.Caching;
 using Microsoft.AspNetCore.Mvc;
@@ -61,12 +61,12 @@ namespace MemcachedTestApp.Controllers
             var posts = await _memcachedClient.GetValueOrCreateAsync(
                 cacheKey,
                 cacheSeconds,
-                async () => await _blogPostService.GetRecent(2));
+                async () => await Task.FromResult(_blogPostService.GetRecent(2)));
         }
 
         private void Get()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("Get", value, 600);
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -76,7 +76,7 @@ namespace MemcachedTestApp.Controllers
 
         private void GetGen()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("GetGen", value, 600);
 
             var posts = _memcachedClient.Get<object>("GetGen");
@@ -105,7 +105,7 @@ namespace MemcachedTestApp.Controllers
 
         private void Increment()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("Increment", value, 600);
 
             var posts = _memcachedClient.Increment("Increment", 1, 1, 1);
@@ -113,7 +113,7 @@ namespace MemcachedTestApp.Controllers
 
         private void Decrement()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("Decrement", value, 600);
 
             var posts = _memcachedClient.Decrement("Decrement", 1, 1, 1);
@@ -122,7 +122,7 @@ namespace MemcachedTestApp.Controllers
 #if NET8_0
         private async Task TouchAsync()
         {
-            var value = await _blogPostService.GetRecent(2);
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("TouchAsync", value, 600);
 
             var posts = await _memcachedClient.TouchAsync("TouchAsync", DateTime.Now.AddDays(5));
@@ -131,7 +131,7 @@ namespace MemcachedTestApp.Controllers
         // This is not instrumented
         private void GetMany()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("GetMany", value, 600);
 
             var keys = new List<string> { "GetMany" };
@@ -141,7 +141,7 @@ namespace MemcachedTestApp.Controllers
         // This is not instrumented
         private async Task GetManyAsync()
         {
-            var value = await _blogPostService.GetRecent(2);
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("GetManyAsync", value, 600);
 
             var keys = new List<string> { "GetManyAsync" };
@@ -150,7 +150,7 @@ namespace MemcachedTestApp.Controllers
 
         private void Remove()
         {
-            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("Remove", value, 600);
 
             var posts = _memcachedClient.Remove("Remove");
@@ -158,7 +158,7 @@ namespace MemcachedTestApp.Controllers
 
         private async Task RemoveAsync()
         {
-            var value = await _blogPostService.GetRecent(2);
+            var value = _blogPostService.GetRecent(2);
             _memcachedClient.Add("RemoveAsync", value, 600);
 
             var posts = await _memcachedClient.RemoveAsync("RemoveAsync");

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Controllers/MemcachedController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Controllers/MemcachedController.cs
@@ -1,0 +1,167 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Enyim.Caching;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace MemcachedTestApp.Controllers
+{
+    [ApiController]
+    [Route("Memcached")]
+    public class MemcachedController : ControllerBase
+    {
+        private readonly IMemcachedClient _memcachedClient;
+        private readonly IBlogPostService _blogPostService;
+        private readonly ILogger<MemcachedController> _logger;
+
+        public MemcachedController(IMemcachedClient memcachedClient, IBlogPostService blogPostService, ILogger<MemcachedController> logger)
+        {
+            _memcachedClient = memcachedClient;
+            _blogPostService = blogPostService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [Route("testallmethods")]
+        public async Task<string> TestAllMethods()
+        {
+            FlushAll();
+            await GetValueOrCreateAsync();
+            Get();
+            GetGen();
+            await GetAsync();
+            await GetAsyncGen();
+            Increment();
+            Decrement();
+#if NET8_0
+            await TouchAsync();
+#endif
+            GetMany();
+            await GetManyAsync();
+            Remove();
+            await RemoveAsync();
+
+            return "Complete";
+        }
+
+        private void FlushAll()
+        {
+            _memcachedClient.FlushAll();
+        }
+
+        private async Task GetValueOrCreateAsync()
+        {
+            var cacheKey = "GetValueOrCreateAsync";
+            var cacheSeconds = 600;
+
+            var posts = await _memcachedClient.GetValueOrCreateAsync(
+                cacheKey,
+                cacheSeconds,
+                async () => await _blogPostService.GetRecent(2));
+        }
+
+        private void Get()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("Get", value, 600);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var posts = _memcachedClient.Get("Get");
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        private void GetGen()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("GetGen", value, 600);
+
+            var posts = _memcachedClient.Get<object>("GetGen");
+        }
+
+        private async Task GetAsync()
+        {
+            var value = _blogPostService.GetRecent(2);
+            _memcachedClient.Add("GetAsync", value, 600);
+#pragma warning disable CS0618 // Type or member is obsolete
+#if NET6_0
+            var posts = await _memcachedClient.GetAsync<object>("GetAsync");
+#elif NET8_0
+            var posts = await _memcachedClient.GetAsync("GetAsync");
+#endif
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        private async Task GetAsyncGen()
+        {
+            var value = _blogPostService.GetRecent(2);
+            _memcachedClient.Add("GetAsyncGen", value, 600);
+
+            var posts = await _memcachedClient.GetAsync<object>("GetAsyncGen");
+        }
+
+        private void Increment()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("Increment", value, 600);
+
+            var posts = _memcachedClient.Increment("Increment", 1, 1, 1);
+        }
+
+        private void Decrement()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("Decrement", value, 600);
+
+            var posts = _memcachedClient.Decrement("Decrement", 1, 1, 1);
+        }
+
+#if NET8_0
+        private async Task TouchAsync()
+        {
+            var value = await _blogPostService.GetRecent(2);
+            _memcachedClient.Add("TouchAsync", value, 600);
+
+            var posts = await _memcachedClient.TouchAsync("TouchAsync", DateTime.Now.AddDays(5));
+        }
+#endif
+        // This is not instrumented
+        private void GetMany()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("GetMany", value, 600);
+
+            var keys = new List<string> { "GetMany" };
+            var posts = _memcachedClient.Get<object>(keys);
+        }
+
+        // This is not instrumented
+        private async Task GetManyAsync()
+        {
+            var value = await _blogPostService.GetRecent(2);
+            _memcachedClient.Add("GetManyAsync", value, 600);
+
+            var keys = new List<string> { "GetManyAsync" };
+            var posts = await _memcachedClient.GetAsync<object>(keys);
+        }
+
+        private void Remove()
+        {
+            var value = _blogPostService.GetRecent(2).GetAwaiter().GetResult();
+            _memcachedClient.Add("Remove", value, 600);
+
+            var posts = _memcachedClient.Remove("Remove");
+        }
+
+        private async Task RemoveAsync()
+        {
+            var value = await _blogPostService.GetRecent(2);
+            _memcachedClient.Add("RemoveAsync", value, 600);
+
+            var posts = await _memcachedClient.RemoveAsync("RemoveAsync");
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Dockerfile
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Dockerfile
@@ -1,0 +1,57 @@
+ARG DISTRO_TAG
+FROM --platform=amd64 mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+WORKDIR /app
+EXPOSE 80
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y aspnetcore-runtime-6.0
+
+
+# build image is always amd64 (to match the runner architecture), even though the target architecture may be arm64
+FROM --platform=amd64 mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+RUN apt-get update \
+    && apt-get install -y wget \
+    && wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y dotnet-sdk-6.0
+WORKDIR /src
+COPY ["MemcachedTestApp/MemcachedTestApp.csproj", "MemcachedTestApp/"]
+ARG APP_DOTNET_VERSION
+RUN dotnet restore "MemcachedTestApp/MemcachedTestApp.csproj" -p:TargetFramework=net${APP_DOTNET_VERSION}
+
+COPY . .
+WORKDIR "/src/MemcachedTestApp"
+RUN dotnet build "MemcachedTestApp.csproj" -c Release -o /app/build --self-contained --os linux --framework net${APP_DOTNET_VERSION}
+
+
+FROM build AS publish
+ARG APP_DOTNET_VERSION
+RUN dotnet publish "MemcachedTestApp.csproj" -c Release -o /app/publish --self-contained --os linux --framework net${APP_DOTNET_VERSION}
+
+
+FROM base AS final
+
+# Enable the agent
+ARG NEW_RELIC_HOST
+ARG NEW_RELIC_LICENSE_KEY
+ARG NEW_RELIC_APP_NAME
+
+ENV CORECLR_ENABLE_PROFILING=1 \
+CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
+CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
+NEW_RELIC_HOST=${NEW_RELIC_HOST} \
+NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY} \
+NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME} \
+NEWRELIC_LOG_DIRECTORY=/app/logs
+
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+ENTRYPOINT ["dotnet", "MemcachedTestApp.dll"]

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/IBlogPostService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/IBlogPostService.cs
@@ -1,0 +1,13 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MemcachedTestApp
+{
+    public interface IBlogPostService
+    {
+        Task<Dictionary<string, List<BlogPost>>> GetRecent(int itemCount);
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/IBlogPostService.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/IBlogPostService.cs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace MemcachedTestApp
 {
     public interface IBlogPostService
     {
-        Task<Dictionary<string, List<BlogPost>>> GetRecent(int itemCount);
+        Dictionary<string, List<BlogPost>> GetRecent(int itemCount);
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/MemcachedTestApp.csproj
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/MemcachedTestApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>.</DockerfileContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <PackageReference Include="EnyimMemcachedCore" Version="2.1.9" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="EnyimMemcachedCore" Version="3.2.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Program.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Program.cs
@@ -1,0 +1,52 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.IO;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MemcachedTestApp
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            // Add services to the container.
+            builder.Services.AddControllers();
+            builder.Services.AddSingleton<IBlogPostService, BlogPostService>();
+            builder.Services.AddEnyimMemcached(options => options.AddServer("memcached-server", 11211));
+
+            // listen to any ip on port 80 for http
+            IPEndPoint ipEndPointHttp = new IPEndPoint(IPAddress.Any, 80);
+            builder.WebHost.UseUrls($"http://{ipEndPointHttp}");
+
+            var app = builder.Build();
+
+            // Configure the HTTP request pipeline.
+            app.UseAuthorization();
+            app.MapControllers();
+
+            await app.StartAsync();
+
+            CreatePidFile();
+
+            await app.WaitForShutdownAsync();
+        }
+
+        public static void CreatePidFile()
+        {
+            var pidFileNameAndPath = Path.Combine(Environment.GetEnvironmentVariable("NEWRELIC_LOG_DIRECTORY"), "containerizedapp.pid");
+            var pid = Environment.ProcessId;
+            using var file = File.CreateText(pidFileNameAndPath);
+            file.WriteLine(pid);
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/appsettings.Development.json
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/appsettings.json
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
@@ -1,0 +1,56 @@
+# The following must be set either in environment variables or via a .env file in the same folder as this file:
+#
+# AGENT_PATH      host path to the Agent linux home folder - will map to /usr/local/newrelic-dotnet-agent in the container
+# LOG_PATH        host path for Agent logfile output - will map to /app/logs in the container
+# DISTRO_TAG      distro tag for build, not including the architecture suffix - possible values 8.0-bookworm-slim, 8.0-alpine, 8.0-jammy
+# TARGET_ARCH     the target architecture for the build and run -- either amd64 or arm64
+# PORT            external port for the smoketest API
+# CONTAINER_NAME  The name for the container
+# PLATFORM        The platform that the service runs on -- linux/amd64 or linux/arm64/v8
+# DOTNET_VERSION  The dotnet version number to use (8.0, etc)
+# TEST_DOCKERFILE The path and dockerfile to use for the service.
+#
+# NEW_RELIC_KAFKA_TOPIC
+# 
+# and the usual suspects:
+# NEW_RELIC_LICENSE_KEY
+# NEW_RELIC_HOST
+# NEW_RELIC_APP_NAME
+#
+#
+# To build and run, execute `docker compose -f <path to docker-compose.yml> up` 
+# Alternatively, set COMPOSE_FILE environment variable to the path and omit the -f parameter
+
+services:
+    LinuxSmokeTestApp:
+        container_name: ${CONTAINER_NAME}
+        image: ${CONTAINER_NAME}
+        platform: ${PLATFORM}
+        build:
+            context: .
+            dockerfile: ${TEST_DOCKERFILE}
+            args:
+                DISTRO_TAG: ${DISTRO_TAG}
+                TARGET_ARCH: ${TARGET_ARCH}
+                NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
+                NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
+                NEW_RELIC_HOST: ${NEW_RELIC_HOST}
+                DOTNET_VERSION: ${DOTNET_VERSION}
+                APP_DOTNET_VERSION: ${APP_DOTNET_VERSION}
+        ports:
+          - "${PORT}:80"
+        volumes:
+          - ${AGENT_PATH}:/usr/local/newrelic-dotnet-agent # AGENT_PATH from .env, points to newrelichome_linux_x64
+          - ${LOG_PATH}:/app/logs # LOG_PATH from .env, should be a folder unique to this run of the smoketest app           
+        depends_on:
+            - memcached-server
+
+    memcached-server:
+        image: memcached:1.6.31
+
+
+networks:
+    default:
+        driver: bridge
+        driver_opts:
+          com.docker.network.bridge.enable_icc: "true"

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
@@ -22,7 +22,7 @@
 # Alternatively, set COMPOSE_FILE environment variable to the path and omit the -f parameter
 
 services:
-    LinuxSmokeTestApp:
+    MemcachedTestApp:
         container_name: ${CONTAINER_NAME}
         image: ${CONTAINER_NAME}
         platform: ${PLATFORM}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests.sln
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_docker", "_docker", "{FB10
 	ProjectSection(SolutionItems) = preProject
 		ContainerApplications\docker-compose-awssdk.yml = ContainerApplications\docker-compose-awssdk.yml
 		ContainerApplications\docker-compose-kafka.yml = ContainerApplications\docker-compose-kafka.yml
+		ContainerApplications\docker-compose-memcached.yml = ContainerApplications\docker-compose-memcached.yml
 		ContainerApplications\docker-compose.yml = ContainerApplications\docker-compose.yml
 	EndProjectSection
 EndProject
@@ -33,6 +34,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewRelic.Testing.Assertions", "..\NewRelic.Testing.Assertions\NewRelic.Testing.Assertions.csproj", "{C0ADF41E-F8B8-4ECA-828F-F578E09B17A9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AwsSdkTestApp", "ContainerApplications\AwsSdkTestApp\AwsSdkTestApp.csproj", "{70731828-AFC8-4262-9076-3FB39E224D10}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemcachedTestApp", "ContainerApplications\MemcachedTestApp\MemcachedTestApp.csproj", "{3D46F286-A19A-4942-8E3F-8999E953A6F2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -72,6 +75,10 @@ Global
 		{70731828-AFC8-4262-9076-3FB39E224D10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70731828-AFC8-4262-9076-3FB39E224D10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70731828-AFC8-4262-9076-3FB39E224D10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D46F286-A19A-4942-8E3F-8999E953A6F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D46F286-A19A-4942-8E3F-8999E953A6F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D46F286-A19A-4942-8E3F-8999E953A6F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D46F286-A19A-4942-8E3F-8999E953A6F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,6 +88,7 @@ Global
 		{FB10922F-3CC6-4497-AF53-DF6808380258} = {84D70574-4AC7-4EA7-AE52-832C3531E082}
 		{1F7402D8-E345-480C-BBA6-6313A1DEEB23} = {84D70574-4AC7-4EA7-AE52-832C3531E082}
 		{70731828-AFC8-4262-9076-3FB39E224D10} = {84D70574-4AC7-4EA7-AE52-832C3531E082}
+		{3D46F286-A19A-4942-8E3F-8999E953A6F2} = {84D70574-4AC7-4EA7-AE52-832C3531E082}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB230433-D05D-4A1F-951B-CC14F47BBF42}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
@@ -19,7 +19,7 @@ public abstract class MemcachedTestFixtureBase : RemoteApplicationFixture
         string dockerfile,
         string dotnetVersion,
         string dockerComposeFile = "docker-compose-memcached.yml") :
-        base(new ContainerApplication(distroTag, containerArchitecture, dotnetVersion, dockerfile, dockerComposeFile))
+        base(new ContainerApplication(distroTag, containerArchitecture, dotnetVersion, dockerfile, dockerComposeFile, "MemcachedTestApp"))
     {
         DotnetVer = dotnetVersion;
     }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
@@ -1,0 +1,57 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading.Tasks;
+using NewRelic.Agent.ContainerIntegrationTests.Applications;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+
+namespace NewRelic.Agent.ContainerIntegrationTests.Fixtures;
+
+public abstract class MemcachedTestFixtureBase : RemoteApplicationFixture
+{
+    protected override int MaxTries => 1;
+    public readonly string DotnetVer;
+
+    protected MemcachedTestFixtureBase(
+        string distroTag,
+        ContainerApplication.Architecture containerArchitecture,
+        string dockerfile,
+        string dotnetVersion,
+        string dockerComposeFile = "docker-compose-memcached.yml") :
+        base(new ContainerApplication(distroTag, containerArchitecture, dotnetVersion, dockerfile, dockerComposeFile))
+    {
+        DotnetVer = dotnetVersion;
+    }
+
+    public virtual void ExerciseApplication()
+    {
+        var address = $"http://localhost:{Port}/memcached/";
+        GetAndAssertStatusCode(address + "testallmethods", System.Net.HttpStatusCode.OK);
+    }
+
+    public void Delay(int seconds)
+    {
+        Task.Delay(TimeSpan.FromSeconds(seconds)).GetAwaiter().GetResult();
+    }
+}
+
+public class MemcachedDotNet6TestFixture : MemcachedTestFixtureBase
+{
+    private const string Dockerfile = "MemcachedTestApp/Dockerfile";
+    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
+    private const string DistroTag = "bookworm-slim";
+    private const string DotnetVersion = "6.0";
+
+    public MemcachedDotNet6TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }
+}
+
+public class MemcachedDotNet8TestFixture : MemcachedTestFixtureBase
+{
+    private const string Dockerfile = "MemcachedTestApp/Dockerfile";
+    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
+    private const string DistroTag = "bookworm-slim";
+    private const string DotnetVersion = "8.0";
+
+    public MemcachedDotNet8TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }
+}

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
@@ -62,26 +62,12 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
             var datastoreOperationMemcachedTouch = "Datastore/operation/Memcached/Touch";
             var datastoreOperationMemcachedRemove = "Datastore/operation/Memcached/Remove";
 
-            var datastoreStatementMemcachedGetValueOrCreateAsyncGet = "Datastore/statement/Memcached/GetValueOrCreateAsync/Get";
-            var datastoreStatementMemcachedGetValueOrCreateAsyncAdd = "Datastore/statement/Memcached/GetValueOrCreateAsync/Add";
-            var datastoreStatementMemcachedGetAdd = "Datastore/statement/Memcached/Get/Add";
-            var datastoreStatementMemcachedGetGet = "Datastore/statement/Memcached/Get/Get";
-            var datastoreStatementMemcachedGetGenAdd = "Datastore/statement/Memcached/GetGen/Add";
-            var datastoreStatementMemcachedGetGenGet = "Datastore/statement/Memcached/GetGen/Get";
-            var datastoreStatementMemcachedGetAsyncAdd = "Datastore/statement/Memcached/GetAsync/Add";
-            var datastoreStatementMemcachedGetAsyncGet = "Datastore/statement/Memcached/GetAsync/Get";
-            var datastoreStatementMemcachedGetAsyncGenAdd = "Datastore/statement/Memcached/GetAsyncGen/Add";
-            var datastoreStatementMemcachedGetAsyncGenGet = "Datastore/statement/Memcached/GetAsyncGen/Get";
-            var datastoreStatementMemcachedIncrementAdd = "Datastore/statement/Memcached/Increment/Add";
-            var datastoreStatementMemcachedIncrementIncrement = "Datastore/statement/Memcached/Increment/Increment";
-            var datastoreStatementMemcachedDecrementAdd = "Datastore/statement/Memcached/Decrement/Add";
-            var datastoreStatementMemcachedDecrementDecrement = "Datastore/statement/Memcached/Decrement/Decrement";
-            var datastoreStatementMemcachedTouchAsyncAdd = "Datastore/statement/Memcached/TouchAsync/Add";
-            var datastoreStatementMemcachedTouchAsyncTouch = "Datastore/statement/Memcached/TouchAsync/Touch";
-            var datastoreStatementMemcachedRemoveAdd = "Datastore/statement/Memcached/Remove/Add";
-            var datastoreStatementMemcachedRemoveRemove = "Datastore/statement/Memcached/Remove/Remove";
-            var datastoreStatementMemcachedRemoveAsyncAdd = "Datastore/statement/Memcached/RemoveAsync/Add";
-            var datastoreStatementMemcachedRemoveAsyncRemove = "Datastore/statement/Memcached/RemoveAsync/Remove";
+            var datastoreStatementMemcachedGet = "Datastore/statement/Memcached/cache/Get";
+            var datastoreStatementMemcachedAdd = "Datastore/statement/Memcached/cache/Add";
+            var datastoreStatementMemcachedIncrement = "Datastore/statement/Memcached/cache/Increment";
+            var datastoreStatementMemcachedDecrement = "Datastore/statement/Memcached/cache/Decrement";
+            var datastoreStatementMemcachedTouch = "Datastore/statement/Memcached/cache/Touch";
+            var datastoreStatementMemcachedRemove = "Datastore/statement/Memcached/cache/Remove";
 
             var transactionName = "WebTransaction/MVC/Memcached/TestAllMethods";
 
@@ -94,43 +80,15 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
                 new() { metricName = datastoreOperationMemcachedDecrement, callCount = 1 },
                 new() { metricName = datastoreOperationMemcachedRemove, callCount = 2 },
 
-                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncGet, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetGet, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetGenAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetGenGet, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetAsyncAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGet, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGenAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGenGet, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedIncrementAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedIncrementIncrement, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedDecrementAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedDecrementDecrement, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedRemoveAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedRemoveRemove, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedRemoveAsyncAdd, callCount = 1 },
-                new() { metricName = datastoreStatementMemcachedRemoveAsyncRemove, callCount = 1 },
-
-                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncGet, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetGet, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetGenAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetGenGet, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetAsyncAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGet, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGenAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedGetAsyncGenGet, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedIncrementAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedIncrementIncrement, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedDecrementAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedDecrementDecrement, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedRemoveAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedRemoveRemove, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedRemoveAsyncAdd, callCount = 1, metricScope = transactionName },
-                new() { metricName = datastoreStatementMemcachedRemoveAsyncRemove, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGet, callCount = 5 },
+                new() { metricName = datastoreStatementMemcachedIncrement, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedDecrement, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedRemove, callCount = 2 },
+                
+                new() { metricName = datastoreStatementMemcachedGet, callCount = 5, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedIncrement, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedDecrement, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedRemove, callCount = 2, metricScope = transactionName },
             };
 
             if (_fixture.DotnetVer == "6.0")
@@ -140,6 +98,8 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
                 expectedMetrics.Add(new() { metricName = datastoreMemcachedAll, callCount = 20 });
                 expectedMetrics.Add(new() { metricName = datastoreMemcachedAllOther, callCount = 20 });
                 expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedAdd, callCount = 11 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedAdd, callCount = 11 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedAdd, callCount = 11, metricScope = transactionName });
             }
             else if (_fixture.DotnetVer == "8.0")
             {
@@ -149,10 +109,10 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
                 expectedMetrics.Add(new() { metricName = datastoreMemcachedAllOther, callCount = 22 });
                 expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedAdd, callCount = 12 });
                 expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedTouch, callCount = 1 });
-                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncAdd, callCount = 1 });
-                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncTouch, callCount = 1 });
-                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncAdd, callCount = 1, metricScope = transactionName });
-                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncTouch, metricScope = transactionName });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedAdd, callCount = 12 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedAdd, callCount = 12, metricScope = transactionName });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouch, callCount = 1 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouch, callCount = 1, metricScope = transactionName });
             }
             else
             {

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
@@ -1,0 +1,188 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using NewRelic.Agent.ContainerIntegrationTests.Fixtures;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using NewRelic.Testing.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.ContainerIntegrationTests.Tests
+{
+    public abstract class LinuxMemcachedTest<T> : NewRelicIntegrationTest<T> where T : MemcachedTestFixtureBase
+    {
+        private readonly T _fixture;
+
+        protected LinuxMemcachedTest(T fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.TestLogger = output;
+
+            _fixture.Actions(setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                    configModifier.SetLogLevel("debug");
+                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                    configModifier.LogToConsole();
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.Delay(15); // wait long enough to ensure memcached
+                    _fixture.ExerciseApplication();
+
+                    _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+
+                    // shut down the container and wait for the agent log to see it
+                    _fixture.ShutdownRemoteApplication();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromSeconds(10));
+                });
+
+            _fixture.Initialize();
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var datastoreAll = "Datastore/all";
+            var datastoreAllOther = "Datastore/allWeb";
+            var datastoreMemcachedAll = "Datastore/Memcached/all";
+            var datastoreMemcachedAllOther = "Datastore/Memcached/allWeb";
+
+            var datastoreOperationMemcachedGet = "Datastore/operation/Memcached/Get";
+            var datastoreOperationMemcachedAdd = "Datastore/operation/Memcached/Add";
+            var datastoreOperationMemcachedIncrement = "Datastore/operation/Memcached/Increment";
+            var datastoreOperationMemcachedDecrement = "Datastore/operation/Memcached/Decrement";
+            var datastoreOperationMemcachedTouch = "Datastore/operation/Memcached/Touch";
+            var datastoreOperationMemcachedRemove = "Datastore/operation/Memcached/Remove";
+
+            var datastoreStatementMemcachedGetValueOrCreateAsyncGet = "Datastore/statement/Memcached/GetValueOrCreateAsync/Get";
+            var datastoreStatementMemcachedGetValueOrCreateAsyncAdd = "Datastore/statement/Memcached/GetValueOrCreateAsync/Add";
+            var datastoreStatementMemcachedGetAdd = "Datastore/statement/Memcached/Get/Add";
+            var datastoreStatementMemcachedGetGet = "Datastore/statement/Memcached/Get/Get";
+            var datastoreStatementMemcachedGetGenAdd = "Datastore/statement/Memcached/GetGen/Add";
+            var datastoreStatementMemcachedGetGenGet = "Datastore/statement/Memcached/GetGen/Get";
+            var datastoreStatementMemcachedGetAsyncAdd = "Datastore/statement/Memcached/GetAsync/Add";
+            var datastoreStatementMemcachedGetAsyncGet = "Datastore/statement/Memcached/GetAsync/Get";
+            var datastoreStatementMemcachedGetAsyncGenAdd = "Datastore/statement/Memcached/GetAsyncGen/Add";
+            var datastoreStatementMemcachedGetAsyncGenGet = "Datastore/statement/Memcached/GetAsyncGen/Get";
+            var datastoreStatementMemcachedIncrementAdd = "Datastore/statement/Memcached/Increment/Add";
+            var datastoreStatementMemcachedIncrementIncrement = "Datastore/statement/Memcached/Increment/Increment";
+            var datastoreStatementMemcachedDecrementAdd = "Datastore/statement/Memcached/Decrement/Add";
+            var datastoreStatementMemcachedDecrementDecrement = "Datastore/statement/Memcached/Decrement/Decrement";
+            var datastoreStatementMemcachedTouchAsyncAdd = "Datastore/statement/Memcached/TouchAsync/Add";
+            var datastoreStatementMemcachedTouchAsyncTouch = "Datastore/statement/Memcached/TouchAsync/Touch";
+            var datastoreStatementMemcachedRemoveAdd = "Datastore/statement/Memcached/Remove/Add";
+            var datastoreStatementMemcachedRemoveRemove = "Datastore/statement/Memcached/Remove/Remove";
+            var datastoreStatementMemcachedRemoveAsyncAdd = "Datastore/statement/Memcached/RemoveAsync/Add";
+            var datastoreStatementMemcachedRemoveAsyncRemove = "Datastore/statement/Memcached/RemoveAsync/Remove";
+
+            var transactionName = "WebTransaction/MVC/Memcached/TestAllMethods";
+
+            var metrics = _fixture.AgentLog.GetMetrics();
+
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new() { metricName = datastoreOperationMemcachedGet, callCount = 5 },
+                new() { metricName = datastoreOperationMemcachedIncrement, callCount = 1 },
+                new() { metricName = datastoreOperationMemcachedDecrement, callCount = 1 },
+                new() { metricName = datastoreOperationMemcachedRemove, callCount = 2 },
+
+                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncGet, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetGet, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetGenAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetGenGet, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetAsyncAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGet, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGenAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGenGet, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedIncrementAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedIncrementIncrement, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedDecrementAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedDecrementDecrement, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedRemoveAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedRemoveRemove, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedRemoveAsyncAdd, callCount = 1 },
+                new() { metricName = datastoreStatementMemcachedRemoveAsyncRemove, callCount = 1 },
+
+                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncGet, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetValueOrCreateAsyncAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetGet, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetGenAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetGenGet, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetAsyncAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGet, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGenAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedGetAsyncGenGet, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedIncrementAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedIncrementIncrement, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedDecrementAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedDecrementDecrement, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedRemoveAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedRemoveRemove, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedRemoveAsyncAdd, callCount = 1, metricScope = transactionName },
+                new() { metricName = datastoreStatementMemcachedRemoveAsyncRemove, callCount = 1, metricScope = transactionName },
+            };
+
+            if (_fixture.DotnetVer == "6.0")
+            {
+                expectedMetrics.Add(new() { metricName = datastoreAll, callCount = 20 });
+                expectedMetrics.Add(new() { metricName = datastoreAllOther, callCount = 20 });
+                expectedMetrics.Add(new() { metricName = datastoreMemcachedAll, callCount = 20 });
+                expectedMetrics.Add(new() { metricName = datastoreMemcachedAllOther, callCount = 20 });
+                expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedAdd, callCount = 11 });
+            }
+            else if (_fixture.DotnetVer == "8.0")
+            {
+                expectedMetrics.Add(new() { metricName = datastoreAll, callCount = 22 });
+                expectedMetrics.Add(new() { metricName = datastoreAllOther, callCount = 22 });
+                expectedMetrics.Add(new() { metricName = datastoreMemcachedAll, callCount = 22 });
+                expectedMetrics.Add(new() { metricName = datastoreMemcachedAllOther, callCount = 22 });
+                expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedAdd, callCount = 12 });
+                expectedMetrics.Add(new() { metricName = datastoreOperationMemcachedTouch, callCount = 1 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncAdd, callCount = 1 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncTouch, callCount = 1 });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncAdd, callCount = 1, metricScope = transactionName });
+                expectedMetrics.Add(new() { metricName = datastoreStatementMemcachedTouchAsyncTouch, metricScope = transactionName });
+            }
+            else
+            {
+                Assert.Fail("Unexpected .NET version in Memcache.");
+            }
+
+            // The address can change from system to system
+            // Datastore/instance/Memcached/<address>/11211
+            var instanceMetric = metrics.FirstOrDefault(m =>
+                m.MetricSpec.Name.StartsWith("Datastore/instance/Memcached/")
+                && m.MetricSpec.Name.EndsWith("/11211"));
+
+            NrAssert.Multiple(
+                () => Assertions.MetricsExist(expectedMetrics, metrics),
+                () => Assert.NotNull(instanceMetric)
+            );
+        }
+    }
+
+    public class MemcachedDotNet6Test : LinuxMemcachedTest<MemcachedDotNet6TestFixture>
+    {
+        public MemcachedDotNet6Test(MemcachedDotNet6TestFixture fixture, ITestOutputHelper output) : base(fixture, output)
+        {
+        }
+    }
+
+    public class MemcachedDotNet8Test : LinuxMemcachedTest<MemcachedDotNet8TestFixture>
+    {
+        public MemcachedDotNet8Test(MemcachedDotNet8TestFixture fixture, ITestOutputHelper output) : base(fixture, output)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Adds support for EnyimMemcachedCore versions 2.X and 3.X with nearly all methods except MultiGet methods, sync and async.
- Adds ContainerIntegration tests: (I expect these will change when net9.0 releases)
  - net8.0 with EnyimMemcachedCore  v2.1.9
  - net6.0 with EnyimMemcachedCore  v3.2.2

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
