### PR TITLE
ci:Migrate runner types from windows-2019 to windows-2022.

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -180,7 +180,7 @@ jobs:
     needs: [get-release-info, get-external-artifacts]
     if: ${{ inputs.downloadsite }}
     name: Deploy MSI to Download Site
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
       - name: Download Deploy Artifacts
@@ -256,7 +256,7 @@ jobs:
     needs: get-external-artifacts
     if: ${{ inputs.nuget }}
     name: Deploy Agent to NuGet
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       nuget_source: https://www.nuget.org

--- a/.github/workflows/deploy_siteextension.yml
+++ b/.github/workflows/deploy_siteextension.yml
@@ -22,7 +22,7 @@ jobs:
 
   deploy-nuget:
     name: Deploy to NuGet
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       nuget_source: https://www.nuget.org


### PR DESCRIPTION
## Description

Windows Server 2019 reached its initial servicing EOL date on Jan 9, 2024.  We need to migrate the two workflows off that version to windows-2022 or windows-latest.  I prefer us to be pinned to a specific version of windows, so I moved the two workflows to windows-2022.

There shouldn't be an impact from the change, however these are deploy scripts so we won't be 100% sure until the next release.

Resolves #2752 

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
