### PR TITLE
chore: Remove SharpZipLib, refactor data compression methods

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -55,7 +55,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <!--<PackageReference Include="SharpZipLib" Version="1.4.2" />-->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 
@@ -102,7 +102,7 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Autofac'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Google.Protobuf'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Grpc.Core.Api'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'ICSharpCode.SharpZipLib'" />
+      <!--<ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'ICSharpCode.SharpZipLib'" />-->
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Newtonsoft.Json'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'Serilog.Sinks.Async'" />
@@ -135,8 +135,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">20</ILRepackIncludeCount>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">17</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">19</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">16</ILRepackIncludeCount>
     </PropertyGroup>
 
     <Error Text="ILRepack of $(AssemblyName) ($(TargetFramework)) failed. A dependency is missing. Expected $(ILRepackIncludeCount) dependencies but found @(ILRepackInclude-&gt;Count())." Condition="@(ILRepackInclude-&gt;Count()) != $(ILRepackIncludeCount)" />

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Net;
+#if !NETFRAMEWORK
 using System.Net.Http;
-using System.Threading.Tasks;
+#endif
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
 using NewRelic.Agent.Extensions.Logging;
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClientWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClientWrapper.cs
@@ -1,5 +1,7 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#if !NETFRAMEWORK
 
 using System;
 using System.Net.Http;
@@ -14,3 +16,4 @@ namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
         TimeSpan Timeout { get; set; }
     }
 }
+#endif

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/Decompressor.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/Decompressor.cs
@@ -3,9 +3,8 @@
 
 
 using System.IO;
-using ICSharpCode.SharpZipLib.GZip;
-using ICSharpCode.SharpZipLib.Zip.Compression;
-using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
+using System.IO.Compression;
+using System.Text;
 
 namespace NewRelic.Agent.IntegrationTestHelpers
 {
@@ -13,28 +12,24 @@ namespace NewRelic.Agent.IntegrationTestHelpers
     {
         public static string DeflateDecompress(byte[] bytes)
         {
-            using (var memoryStream = new MemoryStream())
-            using (var inflaterStream = new InflaterInputStream(memoryStream, new Inflater()))
-            using (var streamReader = new StreamReader(inflaterStream))
+            using var compressedStream = new MemoryStream(bytes);
+            using var decompressedStream = new MemoryStream();
+            using (var deflateStream = new DeflateStream(compressedStream, CompressionMode.Decompress))
             {
-                memoryStream.Write(bytes, 0, bytes.Length);
-                memoryStream.Flush();
-                memoryStream.Position = 0;
-                return streamReader.ReadToEnd();
+                deflateStream.CopyTo(decompressedStream);
             }
+            return Encoding.UTF8.GetString(decompressedStream.ToArray());
         }
 
         public static string GzipDecompress(byte[] bytes)
         {
-            using (var memoryStream = new MemoryStream())
-            using (var inflaterStream = new GZipInputStream(memoryStream))
-            using (var streamReader = new StreamReader(inflaterStream))
+            using var compressedStream = new MemoryStream(bytes);
+            using var decompressedStream = new MemoryStream();
+            using (var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress))
             {
-                memoryStream.Write(bytes, 0, bytes.Length);
-                memoryStream.Flush();
-                memoryStream.Position = 0;
-                return streamReader.ReadToEnd();
+                gzipStream.CopyTo(decompressedStream);
             }
+            return Encoding.UTF8.GetString(decompressedStream.ToArray());
         }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/IntegrationTestHelpers.csproj
@@ -10,7 +10,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="xunit" version="2.9.0" />
     <PackageReference Include="xunit.assert" Version="2.9.0" />
     <PackageReference Include="xunit.core" Version="2.9.0" />

--- a/tests/Agent/Shared/TestSerializationHelpers/Models/TransactionTrace.cs
+++ b/tests/Agent/Shared/TestSerializationHelpers/Models/TransactionTrace.cs
@@ -6,9 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
-using ICSharpCode.SharpZipLib.Zip.Compression;
-using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -80,7 +79,7 @@ namespace NewRelic.Agent.Tests.TestSerializationHelpers.Models
                 var bytes = Convert.FromBase64String(compressedTraceData);
 
                 using (var memoryStream = new MemoryStream())
-                using (var inflaterStream = new InflaterInputStream(memoryStream, new Inflater()))
+                using (var inflaterStream = new DeflateStream(memoryStream, CompressionMode.Decompress))
                 using (var streamReader = new StreamReader(inflaterStream))
                 {
                     memoryStream.Write(bytes, 0, bytes.Length);

--- a/tests/Agent/Shared/TestSerializationHelpers/TestSerializationHelpers.csproj
+++ b/tests/Agent/Shared/TestSerializationHelpers/TestSerializationHelpers.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <!--<PackageReference Include="SharpZipLib" Version="1.4.2" />-->
   </ItemGroup>
 
 </Project>

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/DataCompressorTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/DataCompressorTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
-using ICSharpCode.SharpZipLib.GZip;
 using NUnit.Framework;
 
 namespace NewRelic.Agent.Core.DataTransport
@@ -64,15 +64,13 @@ namespace NewRelic.Agent.Core.DataTransport
 
         private static string DecompressGzip(byte[] compressedBytes)
         {
-            using (var memoryStream = new MemoryStream())
-            using (var inflaterStream = new GZipInputStream(memoryStream))
-            using (var streamReader = new StreamReader(inflaterStream, Encoding.UTF8))
+            using var compressedStream = new MemoryStream(compressedBytes);
+            using var decompressedStream = new MemoryStream();
+            using (var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress))
             {
-                memoryStream.Write(compressedBytes, 0, compressedBytes.Length);
-                memoryStream.Flush();
-                memoryStream.Position = 0;
-                return streamReader.ReadToEnd();
+                gzipStream.CopyTo(decompressedStream);
             }
+            return Encoding.UTF8.GetString(decompressedStream.ToArray());
         }
     }
 }


### PR DESCRIPTION
* Removes reference to `SharpZipLib` NuGet package
* Refactors `DataCompressor` to use `DeflateStream` and `GZipStream` (from `System.IO.Compression`) instead
* Updates unit tests
* Adds conditional compiling around a couple of `System.Net.Http` references that were missed in #2751 -- apparently, `SharpZipLib` included a transient reference to `System.Net.Http`, so we were still referencing that assembly even when we removed in the previous PR