### PR TITLE
chore: Ensure all `using System.Net.Http;` are conditionally compiled

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/HttpClientBase.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Net;
+#if !NETFRAMEWORK
 using System.Net.Http;
-using System.Threading.Tasks;
+#endif
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
 using NewRelic.Agent.Extensions.Logging;
 

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClientWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/Interfaces/IHttpClientWrapper.cs
@@ -1,6 +1,7 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#if !NETFRAMEWORK
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -14,3 +15,4 @@ namespace NewRelic.Agent.Core.DataTransport.Client.Interfaces
         TimeSpan Timeout { get; set; }
     }
 }
+#endif


### PR DESCRIPTION
Minor cleanup to place the last few `using System.Net.Http;` lines behind conditional compilation for non-NETFRAMEWORK build targets. 