### PR TITLE
chore: Update all xunit(assert,core) references to 2.9.2

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.0">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
@@ -174,10 +174,10 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 
 
                 //Cannot determine async-fire and forget because it will probably throw an error, but can determine what it starts with
-                () => Assert.NotEmpty(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/AF-", StringComparison.OrdinalIgnoreCase))),
+                () => Assert.True(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/AF-", StringComparison.OrdinalIgnoreCase)).Count() > 0),
 
                 //Cannot determine sync-fire and forget because it will probably throw an error, but can determine what it starts with
-                () => Assert.NotEmpty(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/SF-", StringComparison.OrdinalIgnoreCase))),
+                () => Assert.True(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/SF-", StringComparison.OrdinalIgnoreCase)).Count() > 0),
 
                 //There shouldn't be any OtherTransactions because no instrumentation has been applied instructing
                 //the agent to create another transaction.

--- a/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/BasicInstrumentation/WebApiAsyncForceNewTransactionTests.cs
@@ -174,10 +174,10 @@ namespace NewRelic.Agent.IntegrationTests.BasicInstrumentation
 
 
                 //Cannot determine async-fire and forget because it will probably throw an error, but can determine what it starts with
-                () => Assert.True(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/AF-", StringComparison.OrdinalIgnoreCase)).Count() > 0),
+                () => Assert.Contains(metrics, x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/AF-", StringComparison.OrdinalIgnoreCase)),
 
                 //Cannot determine sync-fire and forget because it will probably throw an error, but can determine what it starts with
-                () => Assert.True(metrics.Where(x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/SF-", StringComparison.OrdinalIgnoreCase)).Count() > 0),
+                () => Assert.Contains(metrics, x => x.MetricSpec.Name.StartsWith("WebTransaction/FireAndForgetTests/SF-", StringComparison.OrdinalIgnoreCase)),
 
                 //There shouldn't be any OtherTransactions because no instrumentation has been applied instructing
                 //the agent to create another transaction.

--- a/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
@@ -42,11 +42,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Selenium.Support" Version="4.17.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.17.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Include="xunit.assert" Version="2.9.0" />
-    <PackageReference Include="xunit.core" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.0">
+    <PackageReference Include="xunit.assert" Version="2.9.2" />
+    <PackageReference Include="xunit.core" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
@@ -51,9 +51,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="CouchbaseNetClient" Version="2.3.8" />
     <PackageReference Include="Oracle.ManagedDataAccess" Version="12.1.2400" />
-    <PackageReference Include="xunit" version="2.9.0" />
-    <PackageReference Include="xunit.assert" Version="2.9.0" />
-    <PackageReference Include="xunit.core" Version="2.9.0" />
+    <PackageReference Include="xunit" version="2.9.2" />
+    <PackageReference Include="xunit.assert" Version="2.9.2" />
+    <PackageReference Include="xunit.core" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fix a build problem in our integration tests caused by an incomplete update of xunit package references by Dependabot (🤖 🙅) 