### PR TITLE
chore: `Dispose()` refactoring

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -57,8 +57,8 @@ namespace NewRelic.Agent.Core.AgentHealth
 
         public override void Dispose()
         {
-            base.Dispose();
             _scheduler.StopExecuting(LogPeriodicReport);
+            base.Dispose();
         }
 
         private void LogPeriodicReport()
@@ -78,7 +78,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 }
             }
             var message = events.Count > 0 ? string.Join(", ", events) : "No events";
-            Log.Info($"In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
+            Log.Info($"AgentHealthReporter: In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
         }
 
         public void ReportSupportabilityCountMetric(string metricName, long count = 1)

--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -395,7 +395,7 @@ namespace NewRelic.Agent.Core
 
             try
             {
-                Log.Debug("Starting the shutdown process for the .NET Agent.");
+                Log.Info("Starting the shutdown process for the .NET Agent.");
 
                 AgentInitializer.OnExit -= ProcessExit;
 
@@ -408,15 +408,17 @@ namespace NewRelic.Agent.Core
 
                 Log.Debug("Shutting down public agent services...");
                 StopServices();
-                Log.Info("The New Relic .NET Agent v{0} has shutdown (pid {1}) on app domain '{2}'", AgentInstallConfiguration.AgentVersion, AgentInstallConfiguration.ProcessId, AgentInstallConfiguration.AppDomainAppVirtualPath ?? AgentInstallConfiguration.AppDomainName);
             }
             catch (Exception e)
             {
-                Log.Debug(e, "Shutdown error");
+                Log.Info(e, "Unexpected exception during agent shutdown");
             }
             finally
             {
+                Log.Debug("Shutting down internal agent services...");
                 Dispose();
+
+                Log.Info("The New Relic .NET Agent v{Version} has shutdown (pid {pid}) on app domain '{appDomain}'", AgentInstallConfiguration.AgentVersion, AgentInstallConfiguration.ProcessId, AgentInstallConfiguration.AppDomainAppVirtualPath ?? AgentInstallConfiguration.AppDomainName);
                 Serilog.Log.CloseAndFlush();
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
@@ -82,8 +82,8 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _scheduler.StopExecuting(Harvest);
+            base.Dispose();
         }
 
     }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
@@ -43,8 +43,9 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _readerWriterLockSlim.Dispose();
+
+            base.Dispose();
         }
 
         protected override TimeSpan HarvestCycle => _configuration.CustomEventsHarvestCycle;

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
@@ -51,8 +51,8 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _readerWriterLock.Dispose();
+            base.Dispose();
         }
 
         public override void Collect(ErrorEventWireModel errorEventWireModel)

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
@@ -39,8 +39,8 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _readerWriterLock.Dispose();
+            base.Dispose();
         }
 
         protected override TimeSpan HarvestCycle => _configuration.ErrorTracesHarvestCycle;

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -45,11 +45,6 @@ namespace NewRelic.Agent.Core.Aggregators
         protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
         protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
 
-        public override void Dispose()
-        {
-            base.Dispose();
-        }
-
         public override void Collect(LogEventWireModel loggingEventWireModel)
         {
             _agentHealthReporter.ReportLoggingEventCollected();

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
@@ -67,8 +67,8 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _readerWriterLockSlim.Dispose();
+            base.Dispose();
         }
 
         public override void Collect(ISpanEventWireModel wireModel)

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
@@ -49,8 +49,8 @@ namespace NewRelic.Agent.Core.Aggregators
 
         public override void Dispose()
         {
-            base.Dispose();
             _readerWriterLock.Dispose();
+            base.Dispose();
         }
 
         public override void Collect(TransactionEventWireModel transactionEventWireModel)

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRWebRequestClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRWebRequestClient.cs
@@ -82,11 +82,6 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             }
         }
 
-        public override void Dispose()
-        {
-            base.Dispose();
-        }
-
         // for unit testing only
         public void SetHttpWebRequestFunc(Func<Uri, HttpWebRequest> getHttpWebRequestFunc )
         {

--- a/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentContainer.cs
+++ b/src/Agent/NewRelic/Agent/Core/DependencyInjection/AgentContainer.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Agent.Core.DependencyInjection
 
         // use the scope instead of the container to resolve instances. This allows us to replace registrations in a new scope for unit testing
         private ILifetimeScope _scope;
-        private bool _disposedValue;
+        private bool _disposed;
         private readonly Dictionary<Type, object> _registrationsToReplace = new Dictionary<Type, object>();
 
         public AgentContainer()
@@ -102,7 +102,7 @@ namespace NewRelic.Agent.Core.DependencyInjection
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposedValue)
+            if (!_disposed)
             {
                 if (disposing)
                 {
@@ -113,7 +113,7 @@ namespace NewRelic.Agent.Core.DependencyInjection
                     _container = null;
                 }
 
-                _disposedValue = true;
+                _disposed = true;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Samplers/AbstractSampler.cs
+++ b/src/Agent/NewRelic/Agent/Core/Samplers/AbstractSampler.cs
@@ -32,8 +32,8 @@ namespace NewRelic.Agent.Core.Samplers
 
         public override void Dispose()
         {
-            base.Dispose();
             Stop();
+            base.Dispose();
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)

--- a/src/Agent/NewRelic/Agent/Core/Samplers/GCSamplerNetCore.cs
+++ b/src/Agent/NewRelic/Agent/Core/Samplers/GCSamplerNetCore.cs
@@ -127,10 +127,11 @@ namespace NewRelic.Agent.Core.Samplers
 
         public override void Dispose()
         {
-            base.Dispose();
             _listener?.StopListening();
             _listener?.Dispose();
             _listener = null;
+
+            base.Dispose();
         }
     }
 

--- a/src/Agent/NewRelic/Agent/Core/Samplers/ThreadStatsSampler.cs
+++ b/src/Agent/NewRelic/Agent/Core/Samplers/ThreadStatsSampler.cs
@@ -77,12 +77,13 @@ namespace NewRelic.Agent.Core.Samplers
 
         public override void Dispose()
         {
-            base.Dispose();
             _listener?.StopListening();
 #if NETFRAMEWORK // calling .Dispose() in .NET 7 explodes. No idea why.
                 _listener?.Dispose();
 #endif
             _listener = null;
+
+            base.Dispose();
         }
     }
 

--- a/src/Agent/NewRelic/Agent/Core/SharedInterfaces/PerformanceCounterProxy.cs
+++ b/src/Agent/NewRelic/Agent/Core/SharedInterfaces/PerformanceCounterProxy.cs
@@ -17,8 +17,7 @@ namespace NewRelic.Agent.Core.SharedInterfaces
 
     public class PerformanceCounterProxy : IPerformanceCounterProxy
     {
-        private readonly PerformanceCounter _counter;
-        private bool _counterIsDisposed = false;
+        private PerformanceCounter _counter;
 
         public PerformanceCounterProxy(string categoryName, string counterName, string instanceName)
         {
@@ -32,10 +31,10 @@ namespace NewRelic.Agent.Core.SharedInterfaces
 
         public void Dispose()
         {
-            if (_counter != null && !_counterIsDisposed)
+            if (_counter != null)
             {
                 _counter.Dispose();
-                _counterIsDisposed = true;
+                _counter = null;
             }
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/Time/Scheduler.cs
+++ b/src/Agent/NewRelic/Agent/Core/Time/Scheduler.cs
@@ -202,10 +202,7 @@ namespace NewRelic.Agent.Core.Time
 
                 foreach (var timer in _recurringTimers.Values)
                 {
-                    if (timer != null)
-                    {
-                        timer.Dispose();
-                    }
+                    timer?.Dispose();
                 }
                 _recurringTimers.Clear();
             }
@@ -219,8 +216,7 @@ namespace NewRelic.Agent.Core.Time
             public void Dispose()
             {
                 var timer = Timer;
-                if (timer != null)
-                    timer.Dispose();
+                timer?.Dispose();
             }
         }
     }


### PR DESCRIPTION
Minor refactoring of our Dispose() pattern to ensure that any base-class `Dispose()` method is called *after* the derived class has cleaned up its own resources. Should have zero impact on agent functionality; this is primarily a cosmetic change. 

Also removed a couple of unnecessary `Dispose()` overrides and modified a couple of log messages. The final "agent has been shutdown" message will only show in the logs when everything else related to shutdown is complete; failure to observe that message is an indicator that the shutdown process did not complete for some reason. 

Resolves #2795 