### PR TITLE
fix: Update Profiler to check whether Azure function mode support is enabled

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.31.0.10"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.31.0.13"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -628,7 +628,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
 
         bool IsAzureFunctionModeEnabled() const
         {
-            auto azureFunctionModeEnabled = _systemCalls->TryGetEnvironmentVariable(_X("AZURE_FUNCTION_MODE_ENABLED"));
+            auto azureFunctionModeEnabled = _systemCalls->TryGetEnvironmentVariable(_X("NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"));
 
             if (azureFunctionModeEnabled == nullptr || azureFunctionModeEnabled->length() == 0) {
                 return false;

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -605,12 +605,10 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                 return false;
             }
 
-            // returns -1 if env var isn't specified at all
-            auto isAzureFunctionModeEnabled = IsAzureFunctionModeEnabled();
-
             if (IsAzureFunction())
             {
-                if (isAzureFunctionModeEnabled == 1) {
+                if (IsAzureFunctionModeEnabled()) // if not explicitly enabled, fall back to "legacy" behavior
+                {
                     auto retVal = ShouldInstrumentAzureFunction(processPath, appPoolId, commandLine);
                     if (retVal == 0) {
                         return false;
@@ -618,10 +616,6 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                     if (retVal == 1) {
                         return true;
                     }
-                }
-                else if (isAzureFunctionModeEnabled == 0)
-                {
-                    return false;
                 }
             }
 
@@ -632,12 +626,12 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             return true;
         }
 
-        int IsAzureFunctionModeEnabled() const
+        bool IsAzureFunctionModeEnabled() const
         {
             auto azureFunctionModeEnabled = _systemCalls->TryGetEnvironmentVariable(_X("AZURE_FUNCTION_MODE_ENABLED"));
 
             if (azureFunctionModeEnabled == nullptr || azureFunctionModeEnabled->length() == 0) {
-                return -1;
+                return false;
             }
 
             return Strings::AreEqualCaseInsensitive(*azureFunctionModeEnabled, _X("true")) || Strings::AreEqualCaseInsensitive(*azureFunctionModeEnabled, _X("1"));

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
@@ -74,7 +74,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
         }
 
         // tests to verify that "legacy" behavior (before azure function support) is retained.
-        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
+        // If NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
         // we should behave as if no azure function support has been added.
         TEST_METHOD(azure_function_should_behave_as_legacy_if_azure_function_mode_not_specified)
         {
@@ -94,7 +94,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
         }
 
         // tests to verify that "legacy" behavior (before azure function support) is retained.
-        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
+        // If NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
         // we should behave as if no azure function support has been added.
         TEST_METHOD(azure_function_should_behave_as_legacy_if_azure_function_mode_disabled)
         {
@@ -107,7 +107,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
-            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"0";
+            systemCalls->environmentVariables[L"NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"] = L"0";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -125,7 +125,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
-            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
+            systemCalls->environmentVariables[L"NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -143,7 +143,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
-            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
+            systemCalls->environmentVariables[L"NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -161,7 +161,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
-            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
+            systemCalls->environmentVariables[L"NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -179,7 +179,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
-            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
+            systemCalls->environmentVariables[L"NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
@@ -74,10 +74,9 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
         }
 
         // tests to verify that "legacy" behavior (before azure function support) is retained.
-        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set, we should behave as if
-        // no azure function support has been added.
-        // This can be removed when azure function support is enabled by default.
-        TEST_METHOD(should_instrument_azure_function_if_environment_variable_not_specified)
+        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
+        // we should behave as if no azure function support has been added.
+        TEST_METHOD(azure_function_should_behave_as_legacy_if_azure_function_mode_not_specified)
         {
             std::wstring configurationXml(L"\
     <?xml version=\"1.0\"?>\
@@ -94,7 +93,10 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsTrue(configuration.ShouldInstrument(L"functionsnethost.exe", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
         }
 
-        TEST_METHOD(should_not_instrument_azure_function_if_azure_function_mode_is_disabled)
+        // tests to verify that "legacy" behavior (before azure function support) is retained.
+        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set or is set to false,
+        // we should behave as if no azure function support has been added.
+        TEST_METHOD(azure_function_should_behave_as_legacy_if_azure_function_mode_disabled)
         {
             std::wstring configurationXml(L"\
     <?xml version=\"1.0\"?>\
@@ -109,7 +111,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
-            Assert::IsFalse(configuration.ShouldInstrument(L"functionsnethost.exe", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
+            Assert::IsTrue(configuration.ShouldInstrument(L"functionsnethost.exe", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
         }
 
         TEST_METHOD(should_not_instrument_azure_function_app_pool_id_in_commandline)

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
@@ -73,6 +73,45 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(configuration.ShouldInstrument(L"foo.exe", L"", L"", L"", false));
         }
 
+        // tests to verify that "legacy" behavior (before azure function support) is retained.
+        // If AZURE_FUNCTION_MODE_ENABLED environment variable is not set, we should behave as if
+        // no azure function support has been added.
+        // This can be removed when azure function support is enabled by default.
+        TEST_METHOD(should_instrument_azure_function_if_environment_variable_not_specified)
+        {
+            std::wstring configurationXml(L"\
+    <?xml version=\"1.0\"?>\
+    <configuration>\
+        <log level=\"deBug\"/>\
+    </configuration>\
+    ");
+
+            auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
+            systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+
+            Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
+
+            Assert::IsTrue(configuration.ShouldInstrument(L"functionsnethost.exe", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
+        }
+
+        TEST_METHOD(should_not_instrument_azure_function_if_azure_function_mode_is_disabled)
+        {
+            std::wstring configurationXml(L"\
+    <?xml version=\"1.0\"?>\
+    <configuration>\
+        <log level=\"deBug\"/>\
+    </configuration>\
+    ");
+
+            auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
+            systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"0";
+
+            Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
+
+            Assert::IsFalse(configuration.ShouldInstrument(L"functionsnethost.exe", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
+        }
+
         TEST_METHOD(should_not_instrument_azure_function_app_pool_id_in_commandline)
         {
             std::wstring configurationXml(L"\
@@ -84,6 +123,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -101,6 +141,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -118,6 +159,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
@@ -135,6 +177,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             auto systemCalls = std::make_shared<NewRelic::Profiler::Logger::Test::SystemCalls>();
             systemCalls->environmentVariables[L"FUNCTIONS_WORKER_RUNTIME"] = L"dotnet-isolated";
+            systemCalls->environmentVariables[L"AZURE_FUNCTION_MODE_ENABLED"] = L"true";
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 


### PR DESCRIPTION
Updates the Profiler to inspect the `NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED` environment variable. 

If the variable doesn't exist, we don't exclude any Azure function processes from instrumentation, which matches behavior prior to implementing Azure function support. 

If the variable does exist, Azure function mode is only enabled if the variable has a value of `1` or `true`.