### PR TITLE
feat: Update CosmosDB instrumentation to support latest version

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/CosmosDb/Instrumentation.xml
@@ -15,5 +15,10 @@ SPDX-License-Identifier: Apache-2.0
 			<exactMethodMatcher methodName="ExecuteItemQueryAsync" parameters="System.String,Microsoft.Azure.Documents.ResourceType,Microsoft.Azure.Documents.OperationType,System.Guid,Microsoft.Azure.Cosmos.FeedRange,Microsoft.Azure.Cosmos.QueryRequestOptions,Microsoft.Azure.Cosmos.Query.Core.SqlQuerySpec,System.String,System.Boolean,System.Int32,Microsoft.Azure.Cosmos.Tracing.ITrace,System.Threading.CancellationToken" />
 			</match>
 		</tracerFactory>
+    <tracerFactory name="ExecuteItemQueryAsyncWrapper">
+      <match assemblyName="Microsoft.Azure.Cosmos.Client" className="Microsoft.Azure.Cosmos.CosmosQueryClientCore">
+        <exactMethodMatcher methodName="ExecuteItemQueryAsync" parameters="System.String,Microsoft.Azure.Documents.ResourceType,Microsoft.Azure.Documents.OperationType,Microsoft.Azure.Cosmos.FeedRange,Microsoft.Azure.Cosmos.QueryRequestOptions,Microsoft.Azure.Cosmos.Query.Core.AdditionalRequestHeaders,Microsoft.Azure.Cosmos.Query.Core.SqlQuerySpec,System.String,System.Int32,Microsoft.Azure.Cosmos.Tracing.ITrace,System.Threading.CancellationToken" />
+      </match>
+    </tracerFactory>
 	</instrumentation>
 </extension>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.8" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.403.8" Condition="'$(TargetFramework)' == 'net8.0'" />
     
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -184,6 +184,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -183,7 +183,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -251,11 +251,19 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
         }
     }
 
+    [NetFrameworkTest]
+    public class CosmosDBTestsFW462 : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public CosmosDBTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
 
     [NetFrameworkTest]
-    public class CosmosDBTestsFW : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class CosmosDBTestsFWLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public CosmosDBTestsFW(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public CosmosDBTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
@@ -263,12 +271,20 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
 
 
     [NetCoreTest]
-    public class CosmosDBTestsCore : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    public class CosmosDBTestsCoreOldest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
     {
-        public CosmosDBTestsCore(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        public CosmosDBTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
 
+    [NetCoreTest]
+    public class CosmosDBTestsCoreLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public CosmosDBTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
 }


### PR DESCRIPTION
## Description

Updates CosmosDB instrumentation to support the latest version (3.43.0). There was a change in the signature of the method we instrument for database queries somewhere between 3.23.0 and 3.43.0. 

Includes integration tests for both the old and new version.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
