### PR TITLE
Clean up POC

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/StringsHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/StringsHelper.cs
@@ -119,5 +119,34 @@ namespace NewRelic.Agent.Extensions.Parsing
 
             return value;
         }
+
+        public static string ToSnakeCase(this string text)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+            if (text.Length < 2)
+            {
+                return text.ToLowerInvariant();
+            }
+            var sb = new StringBuilder();
+            sb.Append(char.ToLowerInvariant(text[0]));
+            for (int i = 1; i < text.Length; ++i)
+            {
+                char c = text[i];
+                if (char.IsUpper(c))
+                {
+                    sb.Append('_');
+                    sb.Append(char.ToLowerInvariant(c));
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/DynamoDbRequestHandler.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/DynamoDbRequestHandler.cs
@@ -1,107 +1,30 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NewRelic.Agent.Api;
-using NewRelic.Agent.Extensions.AwsSdk;
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
-using NewRelic.Reflection;
-using static System.Collections.Specialized.BitVector32;
 
 namespace NewRelic.Providers.Wrapper.AwsSdk
 {
     internal static class DynamoDbRequestHandler
     {
 
+        private static Dictionary<string,string> _operationNameCache = new Dictionary<string,string>();
+
         public static AfterWrappedMethodDelegate HandleDynamoDbRequest(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction, dynamic request, bool isAsync, dynamic executionContext)
         {
-            var requestType = request.GetType().Name;
+            var requestType = request.GetType().Name as string;
 
             string model;
             string operation;
-            switch (requestType)
-            {
-                case "CreateGlobalTableRequest":
-                case "CreateTableRequest":
-                    operation = "create_table";
-                    break;
-                case "DeleteTableRequest":
-                    operation = "delete_table";
-                    break;
-                case "DeleteItemRequest":
-                    operation = "delete_item";
-                    break;
-                case "TransactGetItemsRequest":
-                case "BatchGetItemRequest":
-                case "GetItemRequest":
-                    operation = "get_item";
-                    break;
-                case "PutItemRequest":
-                    operation = "put_item";
-                    break;
-                case "QueryRequest":
-                    operation = "query";
-                    break;
-                case "ScanRequest":
-                    operation = "scan";
-                    break;
-                case "UpdateItemRequest":
-                    operation = "update_item";
-                    break;
-                /* All other request types
-                case "DescribeEndpointsRequest":
-                case "DescribeTableRequest":
-                case "DescribeExportRequest":
-                case "ExportTableToPointInTimeRequest":
-                case "ListImportsRequest":
-                case "BatchExecuteStatementRequest":
-                case "DeleteResourcePolicyRequest":
-                case "DescribeImportRequest":
-                case "UpdateGlobalTableRequest":
-                case "ListGlobalTablesRequest":
-                case "DescribeTableReplicaAutoScalingRequest":
-                case "ListBackupsRequest":
-                case "ExecuteStatementRequest":
-                case "DescribeContinuousBackupsRequest":
-                case "UpdateContributorInsightsRequest":
-                case "TagResourceRequest":
-                case "ImportTableRequest":
-                case "DescribeContributorInsightsRequest":
-                case "EnableKinesisStreamingDestinationRequest":
-                case "DescribeGlobalTableSettingsRequest":
-                case "UpdateTableReplicaAutoScalingRequest":
-                case "UntagResourceRequest":
-                case "GetResourcePolicyRequest":
-                case "DeleteBackupRequest":
-                case "UpdateTimeToLiveRequest":
-                case "RestoreTableToPointInTimeRequest":
-                case "DescribeTimeToLiveRequest":
-                case "UpdateContinuousBackupsRequest":
-                case "DisableKinesisStreamingDestinationRequest":
-                case "ListContributorInsightsRequest":
-                case "ListTagsOfResourceRequest":
-                case "DescribeBackupRequest":
-                case "DescribeKinesisStreamingDestinationRequest":
-                case "UpdateKinesisStreamingDestinationRequest":
-                case "BatchWriteItemRequest":
-                case "ListExportsRequest":
-                case "RestoreTableFromBackupRequest":
-                case "DescribeLimitsRequest":
-                case "ListTablesRequest":
-                case "PutResourcePolicyRequest":
-                case "UpdateGlobalTableSettingsRequest":
-                case "CreateBackupRequest":
-                case "TransactWriteItemsRequest":
-                case "ExecuteTransactionRequest":
-                */
-                default:
-                    operation = "other";
-                    break;
-            }
+
+            // PutItemRequest => put_item,
+            // CreateTableRequest => create_table, etc.
+            operation = GetOperationNameFromRequestType(requestType);
+
             // Even though there is no common interface they all implement, every Request type I checked
             // has a TableName property
             model = request.TableName;
@@ -111,6 +34,17 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
                 Delegates.GetAsyncDelegateFor<Task>(agent, segment)
                 :
                 Delegates.GetDelegateFor(segment);
+        }
+
+        private static string GetOperationNameFromRequestType(string requestType)
+        {
+            if (_operationNameCache.ContainsKey(requestType))
+            {
+                return _operationNameCache[requestType];
+            }
+            var operationName = requestType.Replace("Request", string.Empty).ToSnakeCase();
+            _operationNameCache.Add(requestType, operationName);
+            return operationName;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/MemcachedHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Memcached/MemcachedHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Parsing;
-using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
 
 namespace NewRelic.Providers.Wrapper.Memcached
@@ -27,7 +26,7 @@ namespace NewRelic.Providers.Wrapper.Memcached
         {
             if (_hasGetServerFailed)
             {
-                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), null, -1, null);
+                return new ConnectionInfo(null, -1, null);
             }
 
             try
@@ -67,13 +66,13 @@ namespace NewRelic.Providers.Wrapper.Memcached
                 _portGetter ??= VisibilityBypasser.Instance.GeneratePropertyAccessor<int>(endpointType, "Port");
                 int? port = _portGetter(endpoint);
 
-                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), address, port.HasValue ? port.Value : -1, null);
+                return new ConnectionInfo(address, port.HasValue ? port.Value : -1, null);
             }
             catch (Exception exception)
             {
                 agent.Logger.Warn(exception, "Unable to get Memcached server address/port, likely to due to type differences. Server address/port will not be available.");
                 _hasGetServerFailed = true;
-                return new ConnectionInfo(DatastoreVendor.Memcached.ToKnownName(), null, -1, null);
+                return new ConnectionInfo(null, -1, null);
             }
         }
     }


### PR DESCRIPTION
The only real change is that instead of using a switch statement to convert request type names like "PutItemRequest" and "CreateTableRequest" to operation names like `put_item` and `create_table`, instead use a formula of "remove the trailing `Request` and then convert PascalCase to snake_case".

There was also a minor merge conflict in the new Memcache instrumentation which was created after the original POC was done.