### PR TITLE
fix: Fix potential race condition in AWS SDK, AWS Bedrock, and Elastisearch that could lead to an orphaned Transaction.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -165,6 +165,10 @@ namespace NewRelic.Agent.Api
         /// <summary>
         /// Detatches the transaction from each non-async active context storage. This is necessary when async tracking needs to continue but
         /// the primary context(s) the transaction may be stored can continue to persist, such as thread static or thread local storgage.
+        /// <para>
+        /// <b>Warning:</b> This method should only be called at the start of the transaction, before any other segments are created.
+        /// If called partway through the transaction, this can result in "Transaction was garbage collected without ever ending" errors.
+        /// </para>
         /// </summary>
         void DetachFromPrimary();
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
@@ -30,7 +30,6 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
             if (isAsync)
             {
                 transaction.AttachToAsync();
-                transaction.DetachFromPrimary(); //Remove from thread-local type storage
             }
 
             // Get the IRequestContext

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/InvokeModelAsyncWrapper.cs
@@ -40,7 +40,6 @@ namespace NewRelic.Providers.Wrapper.Bedrock
             if (instrumentedMethodCall.IsAsync)
             {
                 transaction.AttachToAsync();
-                transaction.DetachFromPrimary(); //Remove from thread-local type storage
             }
 
             dynamic invokeModelRequest = instrumentedMethodCall.MethodCall.MethodArguments[0];

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/RequestWrapper.cs
@@ -45,8 +45,6 @@ namespace NewRelic.Providers.Wrapper.Elasticsearch
             if (isAsync)
             {
                 transaction.AttachToAsync();
-                transaction.DetachFromPrimary(); //Remove from thread-local type storage
-
                 var parameterTypeNamesList = instrumentedMethodCall.InstrumentedMethodInfo.Method.ParameterTypeNames.Split(',');
                 if (parameterTypeNamesList[4] == "Elasticsearch.Net.IRequestParameters")
                 {


### PR DESCRIPTION
## Description

Discovered that calling ITransaction.DetachFromPrimary when in the middle of a transaction can result in `Transaction was garbage collected without ever ending` errors due to the AsyncLocal context being forward only and the other contexts being cleared.

Removed the call from AWS SDK, AWS Bedrock, and Elastisearch instrumentation where the call was made in the middle of transaction.  Left the method call in all other locations since it was done immediately after CreateTransaction was called.

Updated the summary for ITransaction.DetachFromPrimary to include a warning about this use case.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
