### PR TITLE
chore: Add docker ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,19 @@ updates:
       github-actions:
         patterns:
           - "*"
-            
+
+  - package-ecosystem: docker
+    directories: 
+      - "/src/Agent/NewRelic/Profiler/linux"
+      - "/build/**/"
+      - "/deploy/**/"
+    schedule:
+      interval: monthly
+    groups:
+      docker:
+        patterns:
+          - "*"
+          
   # We do not scan anything in the /src/Agent/NewRelic/Agent/Extensions folder, as those projects
   # intentionally reference old versions of the Nuget packages they instrument.
   - package-ecosystem: nuget


### PR DESCRIPTION
Adds a specific set of folders for Dependabot scanning in the Docker ecosystem, with a monthly schedule. 

If the recommendations turn out to be unhelpful, we can back this change out later.
