### PR TITLE
chore: disable Docker ecosystem in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,18 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: docker
-    directories: 
-      - "/src/Agent/NewRelic/Profiler/linux"
-      - "/build/**/"
-      - "/deploy/**/"
-    schedule:
-      interval: monthly
-    groups:
-      docker:
-        patterns:
-          - "*"
+# Docker can't be updated until we modernize the profiler build process
+#  - package-ecosystem: docker
+#    directories: 
+#      - "/src/Agent/NewRelic/Profiler/linux"
+#      - "/build/**/"
+#      - "/deploy/**/"
+#    schedule:
+#      interval: monthly
+#    groups:
+#      docker:
+#        patterns:
+#          - "*"
           
   # We do not scan anything in the /src/Agent/NewRelic/Agent/Extensions folder, as those projects
   # intentionally reference old versions of the Nuget packages they instrument.


### PR DESCRIPTION
It turns out we can't update any of our Dockerfile dependencies until we modernize the Profiler build. Commenting out that section for now; we can revisit once the profiler build is updated.
