### PR TITLE
feat: Add config option for providing AWS account ID for linking

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -98,6 +98,8 @@ namespace NewRelic.Agent.Core.Config
         
         private configurationCodeLevelMetrics codeLevelMetricsField;
         
+        private configurationCloud cloudField;
+        
         private bool agentEnabledField;
         
         private bool rootAgentEnabledField;
@@ -121,6 +123,7 @@ namespace NewRelic.Agent.Core.Config
         /// </summary>
         public configuration()
         {
+            this.cloudField = new configurationCloud();
             this.codeLevelMetricsField = new configurationCodeLevelMetrics();
             this.processHostField = new configurationProcessHost();
             this.utilizationField = new configurationUtilization();
@@ -597,6 +600,18 @@ namespace NewRelic.Agent.Core.Config
             set
             {
                 this.codeLevelMetricsField = value;
+            }
+        }
+        
+        public configurationCloud cloud
+        {
+            get
+            {
+                return this.cloudField;
+            }
+            set
+            {
+                this.cloudField = value;
             }
         }
         
@@ -6009,6 +6024,79 @@ namespace NewRelic.Agent.Core.Config
         public virtual configurationCodeLevelMetrics Clone()
         {
             return ((configurationCodeLevelMetrics)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationCloud
+    {
+        
+        private configurationCloudAws awsField;
+        
+        /// <summary>
+        /// configurationCloud class constructor
+        /// </summary>
+        public configurationCloud()
+        {
+            this.awsField = new configurationCloudAws();
+        }
+        
+        public configurationCloudAws aws
+        {
+            get
+            {
+                return this.awsField;
+            }
+            set
+            {
+                this.awsField = value;
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationCloud object
+        /// </summary>
+        public virtual configurationCloud Clone()
+        {
+            return ((configurationCloud)(this.MemberwiseClone()));
+        }
+        #endregion
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
+    [System.SerializableAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="urn:newrelic-config")]
+    public partial class configurationCloudAws
+    {
+        
+        private string accountIdField;
+        
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string accountId
+        {
+            get
+            {
+                return this.accountIdField;
+            }
+            set
+            {
+                this.accountIdField = value;
+            }
+        }
+        
+        #region Clone method
+        /// <summary>
+        /// Create a clone of this configurationCloudAws object
+        /// </summary>
+        public virtual configurationCloudAws Clone()
+        {
+            return ((configurationCloudAws)(this.MemberwiseClone()));
         }
         #endregion
     }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -2025,6 +2025,30 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
+
+                <xs:element name="cloud" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Provide linking data needed for certain cloud services.
+                        </xs:documentation>
+                    </xs:annotation>
+
+                    <xs:complexType>
+                        <xs:all>
+                            <xs:element name="aws" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="accountId" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The AWS Account ID used by this application.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:all>
+                    </xs:complexType>
+                </xs:element>
             </xs:all>
 
             <xs:attribute name="agentEnabled" type="xs:boolean" default="true">

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2976,6 +2976,23 @@ namespace NewRelic.Agent.Core.Configuration
 
         #endregion
 
+        #region Cloud
+        private string _awsAccountId;
+        public string AwsAccountId
+        {
+            get
+            {
+                if (_awsAccountId != null)
+                {
+                    return _awsAccountId;
+                }
+                _awsAccountId = EnvironmentOverrides(_localConfiguration.cloud.aws.accountId, "NEW_RELIC_CLOUD_AWS_ACCOUNT_ID");
+
+                return _awsAccountId;
+            }
+        }
+        #endregion
+
         public static bool GetLoggingEnabledValue(IEnvironment environment, configurationLog localLogConfiguration)
         {
             return EnvironmentOverrides(environment, localLogConfiguration.enabled, "NEW_RELIC_LOG_ENABLED");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -711,6 +711,8 @@ namespace NewRelic.Agent.Core.Configuration
 
         public string AzureFunctionResourceIdWithFunctionName(string functionName) => _configuration.AzureFunctionResourceIdWithFunctionName(functionName);
 
+        [JsonIgnore]
+        public string AwsAccountId => _configuration.AwsAccountId;
 
         public IReadOnlyDictionary<string, string> GetAppSettings()
         {

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -231,5 +231,7 @@ namespace NewRelic.Agent.Configuration
         string AzureFunctionResourceIdWithFunctionName(string functionName);
 
         bool UtilizationDetectAzureFunction { get; }
+
+        string AwsAccountId { get; }
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4438,8 +4438,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             // Assert
             Assert.That(result, Is.EqualTo("some-service-name"));
         }
+        #endregion
 
-        #endregion Cloud
+        #region Cloud
         [Test]
         public void Cloud_Section_Parsing_And_Override()
         {
@@ -4507,8 +4508,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             config = GenerateConfigFromXml(xmlString);
             Assert.That(config.AwsAccountId, Is.EqualTo("444488881212"));
         }
-
-        #region
 
         #endregion
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4492,6 +4492,9 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             Assert.That(config.AwsAccountId, Is.EqualTo("444488881212"));
 
+            // A second call should use the cached value
+            Assert.That(config.AwsAccountId, Is.EqualTo("444488881212"));
+
             // If it exists in the config, the env variable should still override
             xmlString = """
             <?xml version="1.0"?>

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -359,6 +359,7 @@ namespace NewRelic.Agent.Core.Configuration
                 Assert.That(agentSettings.ServerlessFunctionName, Is.Null);
                 Assert.That(agentSettings.ServerlessFunctionVersion, Is.Null);
                 Assert.That(json, Is.EqualTo(expectedJson.Condense()));
+                Assert.That(agentSettings.AwsAccountId, Is.Empty);
             });
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -493,5 +493,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public string AzureFunctionResourceIdWithFunctionName(string functionName) => $"AzureFunctionResourceId/{functionName}";
 
         public string LoggingLevel => "info";
+
+        public string AwsAccountId => "";
     }
 }


### PR DESCRIPTION
Adds the ability to provide an AWS Account ID, which can be used to help link related entities.

This functionality is needed for multiple feature branches which is why I'm merging to `main` first, even though this won't be used yet.