### PR TITLE
Fix: remove usage of non-thread safe HashSet in AwsSdk pipeline wrappers

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
@@ -13,7 +13,7 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
         public bool IsTransactionRequired => true;
 
         private const string WrapperName = "AwsSdkPipelineWrapper";
-        private ConcurrentHashSet<string> _unsupportedRequestTypes = new();
+        private static ConcurrentHashSet<string> _unsupportedRequestTypes = new();
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/SQSRequestHandler.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/SQSRequestHandler.cs
@@ -9,13 +9,14 @@ using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.AwsSdk;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Reflection;
+using NewRelic.Agent.Extensions.Collections;
 
 namespace NewRelic.Providers.Wrapper.AwsSdk
 {
     internal static class SQSRequestHandler
     {
         private static readonly ConcurrentDictionary<Type, Func<object, object>> _getRequestResponseFromGeneric = new();
-        private static readonly HashSet<string> _unsupportedSQSRequestTypes = [];
+        private static readonly ConcurrentHashSet<string> _unsupportedSQSRequestTypes = [];
 
         public static AfterWrappedMethodDelegate HandleSQSRequest(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction, dynamic request, bool isAsync, dynamic executionContext)
         {
@@ -35,9 +36,11 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
                     action = MessageBrokerAction.Purge;
                     break;
                 default:
-                    if (_unsupportedSQSRequestTypes.Add(requestType)) // log once per unsupported request type
+                    if (!_unsupportedSQSRequestTypes.Contains(requestType))  // log once per unsupported request type
+                    {
                         agent.Logger.Debug($"AwsSdkPipelineWrapper: SQS Request type {requestType} is not supported. Returning NoOp delegate.");
-
+                        _unsupportedSQSRequestTypes.Add(requestType);
+                    }
                     return Delegates.NoOp;
             }
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Fixes issue found in #2855. Instead of using the `HashSet<string>` we use the `ConcurrentHashSet<string>`, similar as being used in `NewRelic.Providers.Wrappers.AwsLambda.HandlerMethodWrapper`.

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
