### PR TITLE
fix: Remove usage of non-thread safe HashSet in AwsSdk pipeline wrappers. (#2855)

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AwsSdkPipelineWrapper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
 namespace NewRelic.Providers.Wrapper.AwsSdk
@@ -12,7 +13,7 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
         public bool IsTransactionRequired => true;
 
         private const string WrapperName = "AwsSdkPipelineWrapper";
-        private static HashSet<string> _unsupportedRequestTypes = new();
+        private static ConcurrentHashSet<string> _unsupportedRequestTypes = new();
 
         public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
         {
@@ -54,8 +55,11 @@ namespace NewRelic.Providers.Wrapper.AwsSdk
                 return SQSRequestHandler.HandleSQSRequest(instrumentedMethodCall, agent, transaction, request, isAsync, executionContext);
             }
 
-            if (_unsupportedRequestTypes.Add(requestType)) // log once per unsupported request type
+            if (!_unsupportedRequestTypes.Contains(requestType))  // log once per unsupported request type
+            {                
                 agent.Logger.Debug($"AwsSdkPipelineWrapper: Unsupported request type: {requestType}. Returning NoOp delegate.");
+                _unsupportedRequestTypes.Add(requestType);
+            }
 
             return Delegates.NoOp;
         }


### PR DESCRIPTION
Use `ConcurrentHashSet<T>` instead of `HashSet<T>` in AWSSdk wrapper to resolve a threading issue. 

Resolves #2855. Replaces #2856.

Co-authored-by: Gideon @gjunge 