### PR TITLE
test: Force terminate helper processes still running at dispose time

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
@@ -182,7 +182,7 @@ public class ContainerApplication : RemoteApplication
         WaitForAppServerToStartListening(RemoteProcess, captureStandardOutput);
     }
 
-    public override void Shutdown()
+    public override void Shutdown(bool force = false)
     {
         if (!IsRunning)
         {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/AzureFuncTool.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/AzureFuncTool.cs
@@ -157,7 +157,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             WaitForAppServerToStartListening(RemoteProcess, captureStandardOutput);
         }
 
-        public override void Shutdown()
+        public override void Shutdown(bool force = false)
         {
             base.Shutdown();
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/DotnetTool.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/DotnetTool.cs
@@ -178,7 +178,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             }
         }
 
-        public override void Shutdown()
+        public override void Shutdown(bool force = false)
         {
             if (!IsRunning)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplication.cs
@@ -325,10 +325,23 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             RemoteProcess.StandardInput.WriteLine(commandText);
         }
 
-        public virtual void Shutdown()
+        public virtual void Shutdown(bool force = false)
         {
             if (!IsRunning)
             {
+                return;
+            }
+
+            if (force)
+            {
+                try
+                {
+                    RemoteProcess.Kill();
+                }
+                catch
+                {
+                    // ignored
+                }
                 return;
             }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -379,7 +379,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
         public virtual void Dispose()
         {
-            RemoteApplication.Shutdown();
+            RemoteApplication.Shutdown(true);
             RemoteApplication.Dispose();
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteConsoleApplication.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteConsoleApplication.cs
@@ -43,7 +43,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             // This may cause us trouble in the future.
         }
 
-        public override void Shutdown()
+        public override void Shutdown(bool force = false)
         {
             if (RemoteProcess is null)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
@@ -156,7 +156,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public override void Dispose()
         {
-            MockNewRelicApplication.Shutdown();
+            MockNewRelicApplication.Shutdown(true);
             MockNewRelicApplication.Dispose();
             base.Dispose();
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinRemotingFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/OwinRemotingFixture.cs
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures
 
         public override void Dispose()
         {
-            OwinRemotingServerApplication.Shutdown();
+            OwinRemotingServerApplication.Shutdown(true);
             OwinRemotingServerApplication.Dispose();
             base.Dispose();
         }


### PR DESCRIPTION
An intermittent integration test failure I've noticed: if a `RemoteProcess` is hung, we can still send it shutdown signals without getting an error back, so we never force it to close. Then when we make our final attempt to shut it down in `Dispose`, it throws because the test logger is no longer available.