### PR TITLE
test: Disable tests using deprecated AI models

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockTests.cs
@@ -21,7 +21,6 @@ where TFixture : ConsoleDynamicMethodFixture
         private string _prompt = "In one sentence, what is a large-language model?";
         private List<string> _bedrockModelsToTest = new List<string>
         {
-            "meta13",
             "amazonembed",
             "amazonexpress",
             "cohere",

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMAccountDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMAccountDisabledTests.cs
@@ -42,7 +42,7 @@ where TFixture : ConsoleDynamicMethodFixture
             _fixture.Initialize();
         }
 
-        [Fact]
+        //[Fact] // The model we were using that was marked as disabled is deprecated, so the test no longer works
         public void BedrockDisabledTest()
         {
             // Make sure it actually got called

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMApiTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/LLMApiTests.cs
@@ -50,7 +50,7 @@ where TFixture : ConsoleDynamicMethodFixture
             _fixture.Initialize();
         }
 
-        [Fact]
+        //[Fact] The Meta Llama models have been deprecated, so these tests need to be reworked
         public void BedrockApiTest()
         {
             bool found = false;


### PR DESCRIPTION
Llama 2 reached EOL today, and all calls using it fail. I'll add a ticket to come back and rework these tests.