### PR TITLE
fix: Fix syntax error in `setenv.sh`

### DIFF
--- a/build/Linux/build/common/setenv.sh
+++ b/build/Linux/build/common/setenv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$CORECLR_NEWRELIC_HOME" ]; && [ -z "$CORECLR_NEW_RELIC_HOME" ]; then
+if [ -z "$CORECLR_NEWRELIC_HOME" ] && [ -z "$CORECLR_NEW_RELIC_HOME" ]; then
     echo "CORECLR_NEWRELIC_HOME is undefined"
 else
     NRHOME=${CORECLR_NEWRELIC_HOME:-${CORECLR_NEW_RELIC_HOME}}


### PR DESCRIPTION
Fixes a syntax error that was introduced in #2852. 

Resolves #2863
