### PR TITLE
chore: Add ignoreMajor config to Dotty

### DIFF
--- a/.github/workflows/scripts/nugetSlackNotifications/PackageInfo.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/PackageInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace nugetSlackNotifications
 {
@@ -10,6 +10,8 @@ namespace nugetSlackNotifications
         public bool IgnorePatch { get; set; }
         [JsonPropertyName("ignoreMinor")]
         public bool IgnoreMinor { get; set; }
+        [JsonPropertyName("ignoreMajor")]
+        public bool IgnoreMajor { get; set; }
         [JsonPropertyName("ignoreReason")]
         public string IgnoreReason {get; set;}
     }

--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -131,7 +131,7 @@ namespace nugetSlackNotifications
             // check publish date
             if (latest.Published >= searchTime)
             {
-                if (previous != null && (package.IgnorePatch || package.IgnoreMinor))
+                if (previous != null && (package.IgnorePatch || package.IgnoreMinor || package.IgnoreMajor))
                 {
                     var previousVersion = previous.Identity.Version;
                     var latestVersion = latest.Identity.Version;
@@ -151,6 +151,14 @@ namespace nugetSlackNotifications
                         if (previousVersion.Major == latestVersion.Major)
                         {
                             Log.Information($"Package {packageName} ignores Minor version updates; the Major version ({latestVersion.Major}) has not been updated.");
+                            return;
+                        }
+                    }
+                    if (package.IgnoreMajor)
+                    {
+                        if (previousVersion.Major != latestVersion.Major)
+                        {
+                            Log.Information($"Package {packageName} ignores Major version updates.");
                             return;
                         }
                     }

--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -54,7 +54,11 @@
         "ignoreReason": "frequent patch releases create too much noise"
     },
     {
-        "packageName": "log4net"
+        "packageName": "log4net",
+        "ignorePatch": true,
+        "ignoreMinor": true,
+        "ignoreMajor": true,
+        "ignoreReason": "Breaking major update. See https://github.com/newrelic/newrelic-dotnet-agent/issues/2764"
     },
     {
         "packageName": "microsoft.extensions.logging"
@@ -66,7 +70,11 @@
         "packageName": "microsoft.net.http"
     },
     {
-        "packageName": "mongodb.driver"
+        "packageName": "mongodb.driver",
+        "ignorePatch": true,
+        "ignoreMinor": true,
+        "ignoreMajor": true,
+        "ignoreReason": "Breaking since at least 2.25.0. See https://new-relic.atlassian.net/browse/NR-281915"
     },
     {
         "packageName": "mysql.data"


### PR DESCRIPTION
Minor update to Dotty that adds an `ignoreMajor` property to `packageInfo.json`. 

Modifies `log4net` and `MongoDB.Driver` to set that new flag since both have breaking changes that we can't incorporate at present.