### PR TITLE
fix: Update excluded processes for Azure Linux App Service

### DIFF
--- a/.github/workflows/multiverse_run.yml
+++ b/.github/workflows/multiverse_run.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
 
       - name: Setup .NET Core 3.1.100
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
         with:
           dotnet-version: '3.1.100'
 
@@ -107,7 +107,7 @@ jobs:
           egress-policy: audit 
 
       - name: Setup .NET Core 3.1.100
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
         with:
           dotnet-version: '3.1.100'
 

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.33.1.3"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.33.1.6"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -564,7 +564,11 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             //If it contains MsBuild, it is a build command and should not be profiled.
             bool isMsBuildInvocation = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("MSBuild.dll"));
             bool isKudu = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("Kudu.Services.Web")) ||
-                            NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("kuduagent.dll"));
+                          // kuduagent.dll is a new version of kudu (maybe KuduLite) in recent versions of Linux Azure App Services
+                          NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("kuduagent.dll"));
+            // DiagServer is a short-lived process that seems to be invoked every 5 minutes in recent versions of Linux Azure App Services.
+            bool isDiagServer = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("./DiagServer"));
+
 
             std::vector<xstring_t> out;
             Tokenize(commandLine, out);
@@ -601,7 +605,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                 }
             }
 
-            if (isMsBuildInvocation || isKudu) {
+            if (isMsBuildInvocation || isKudu || isDiagServer) {
                 LogInfo(L"This process will not be instrumented. Command line identified as invalid invocation for instrumentation");
                 return false;
             }

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -563,7 +563,8 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
         {
             //If it contains MsBuild, it is a build command and should not be profiled.
             bool isMsBuildInvocation = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("MSBuild.dll"));
-            bool isKudu = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("Kudu.Services.Web"));
+            bool isKudu = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("Kudu.Services.Web")) ||
+                            NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("kuduagent.dll"));
 
             std::vector<xstring_t> out;
             Tokenize(commandLine, out);

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ShouldInstrumentTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ShouldInstrumentTest.cpp
@@ -41,6 +41,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("app1.exe | dotnet run"), isCoreClr));
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("dotnet Kudu.Services.Web.dll"), isCoreClr));
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("/opt/Kudu/Kudu.Services.Web"), isCoreClr));
+            Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("/appservice/dotnet/dotnet /appservice/kuduagent/kuduagent.dll"), isCoreClr));
 
             Assert::IsTrue(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("dotnetXexe restore"), isCoreClr));
             Assert::IsTrue(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("\"c:\\program files\\dotnet.exe\"run"), isCoreClr));

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ShouldInstrumentTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ShouldInstrumentTest.cpp
@@ -42,6 +42,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("dotnet Kudu.Services.Web.dll"), isCoreClr));
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("/opt/Kudu/Kudu.Services.Web"), isCoreClr));
             Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("/appservice/dotnet/dotnet /appservice/kuduagent/kuduagent.dll"), isCoreClr));
+            Assert::IsFalse(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("./DiagServer"), isCoreClr));
 
             Assert::IsTrue(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("dotnetXexe restore"), isCoreClr));
             Assert::IsTrue(configuration.ShouldInstrument(processPath, L"", appPoolId, _X("\"c:\\program files\\dotnet.exe\"run"), isCoreClr));


### PR DESCRIPTION
Updates the Profiler to exclude `kuduagent.dll` and `DiagServer` processes from instrumentation. These are both part of the most recent Azure Linux App Services deployments and should not be instrumented.

Verified correct behavior in an Azure Linux app service:
```
[Trace] 2024-11-04 18:05:16 Checking to see if we should instrument this process. 
[Info ] 2024-11-04 18:05:16 Command line: /appservice/dotnet/dotnet /appservice/kuduagent/kuduagent.dll 
[Info ] 2024-11-04 18:05:16 This process will not be instrumented. Command line identified as invalid invocation for instrumentation 
[Info ] 2024-11-04 18:05:16 This process should not be instrumented, unloading profiler.
```

Resolves #2871 