### PR TITLE
chore: Update Dotty project and package lists, other fixes

### DIFF
--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -68,7 +68,8 @@ namespace nugetSlackNotifications
                 catch (Exception ex)
                 {
                     Log.Error(ex, $"Caught exception while checking {package.PackageName} for updates.");
-                    await SendSlackNotification($"Dotty: caught exception while checking {package.PackageName} for updates: {ex}");
+                    if (!_testMode)
+                        await SendSlackNotification($"Dotty: caught exception while checking {package.PackageName} for updates: {ex}");
                 }
             }
 

--- a/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
+++ b/.github/workflows/scripts/nugetSlackNotifications/nugetSlackNotifications.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Nuget.Protocol" Version="6.11.1" />
+    <PackageReference Include="Nuget.Protocol" Version="6.12.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +23,10 @@
     <None Update="projectInfo.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -42,6 +42,9 @@
         "ignoreReason": "frequent patch releases create too much noise"
     },
     {
+        "packageName": "awssdk.dynamodbv2"
+    },
+    {
         "packageName": "confluent.kafka"
     },
     {
@@ -54,11 +57,29 @@
         "ignoreReason": "frequent patch releases create too much noise"
     },
     {
+        "packageName": "enyimmemcachedcore"
+    },
+    {
         "packageName": "log4net",
         "ignorePatch": true,
         "ignoreMinor": true,
         "ignoreMajor": true,
         "ignoreReason": "Breaking major update. See https://github.com/newrelic/newrelic-dotnet-agent/issues/2764"
+    },
+    {
+        "packageName": "microsoft.azure.functions.worker"
+    },
+    {
+        "packageName": "microsoft.azure.functions.worker.extensions.http"
+    },
+    {
+        "packageName": "microsoft.azure.functions.worker.extensions.http.aspnetcore"
+    },
+    {
+        "packageName": "microsoft.azure.functions.worker.extensions.storage.queues"
+    },
+    {
+        "packageName": "microsoft.azure.functions.worker.sdk"
     },
     {
         "packageName": "microsoft.extensions.logging"
@@ -86,9 +107,12 @@
         "packageName": "nest"
     },
     {
+        "packageName": "newrelic.agent.api"
+    },
+    {
         "packageName": "nlog"
     },
-    {   
+    {
         "packageName": "nservicebus"
     },
     {

--- a/.github/workflows/scripts/nugetSlackNotifications/projectInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/projectInfo.json
@@ -1,5 +1,23 @@
 [
     {
         "projectFile": "tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/AzureFunctionApplication.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/Applications/LambdaSelfExecutingAssembly/LambdaSelfExecutingAssembly.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/KafkaTestApp.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/MemcachedTestApp.csproj"
+    },
+    {
+        "projectFile": "tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/SmokeTestApp.csproj"
     }
 ]

--- a/build/NugetValidator/NugetValidator.csproj
+++ b/build/NugetValidator/NugetValidator.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.11.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.12.1" />
     <PackageReference Include="YamlDotNet" Version="16.2.0" />
   </ItemGroup>
 

--- a/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+++ b/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Protocol" Version="6.11.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.12.1" />
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />


### PR DESCRIPTION
* Updates list of projects that Dotty monitors, as well as the list of packages
* Fixes a bug in Dotty where multi-line `<PackageReference>` elements in csproj files weren't parsed correctly
* Updates some NuGet packages that had vulnerabilities, as reported by the .NET 9 updated version of nuget.exe.