### PR TITLE
chore: Update multiverse scanner solution to .NET 8

### DIFF
--- a/.github/workflows/multiverse_run.yml
+++ b/.github/workflows/multiverse_run.yml
@@ -30,8 +30,8 @@ jobs:
     env:
       multiverse_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting
       multiverse_solution: ${{ github.workspace }}/tests/Agent/MultiverseTesting/MultiverseTesting.sln
-      multiverse_consolescanner_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ConsoleScanner/bin/Release/netcoreapp3.1
-      multiverse_reportbuilder_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ReportBuilder/bin/Release/netcoreapp3.1
+      multiverse_consolescanner_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ConsoleScanner/bin/Release/net8.0
+      multiverse_reportbuilder_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ReportBuilder/bin/Release/net8.0
       MVS_XML_PATH: ${{ github.workspace }}/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper
 
     steps:
@@ -60,11 +60,6 @@ jobs:
           echo "dotnet build ${{ env.multiverse_solution }} --configuration Release"
           dotnet build ${{ env.multiverse_solution }} --configuration Release
         shell: bash
-
-      - name: Setup .NET Core 3.1.100
-        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
-        with:
-          dotnet-version: '3.1.100'
 
       - name: Run ConsoleScanner
         run: |
@@ -96,8 +91,8 @@ jobs:
     env:
       multiverse_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting
       multiverse_solution: ${{ github.workspace }}/tests/Agent/MultiverseTesting/MultiverseTesting.sln
-      multiverse_consolescanner_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ConsoleScanner/bin/Release/netcoreapp3.1
-      multiverse_reportbuilder_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ReportBuilder/bin/Release/netcoreapp3.1
+      multiverse_consolescanner_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ConsoleScanner/bin/Release/net8.0
+      multiverse_reportbuilder_path: ${{ github.workspace }}/tests/Agent/MultiverseTesting/ReportBuilder/bin/Release/net8.0
       MVS_XML_PATH: ${{ github.workspace }}/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper
 
     steps:
@@ -105,11 +100,6 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           egress-policy: audit 
-
-      - name: Setup .NET Core 3.1.100
-        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
-        with:
-          dotnet-version: '3.1.100'
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/tests/Agent/MultiverseTesting/ConsoleScanner/ConsoleScanner.csproj
+++ b/tests/Agent/MultiverseTesting/ConsoleScanner/ConsoleScanner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>NewRelic.Agent.ConsoleScanner</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Agent/MultiverseTesting/MultiverseScanner/MultiverseScanner.csproj
+++ b/tests/Agent/MultiverseTesting/MultiverseScanner/MultiverseScanner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>NewRelic.Agent.MultiverseScanner</RootNamespace>
   </PropertyGroup>
 

--- a/tests/Agent/MultiverseTesting/ReportBuilder/Program.cs
+++ b/tests/Agent/MultiverseTesting/ReportBuilder/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 
@@ -6,15 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using NewRelic.Agent.MultiverseScanner.Reporting;
 
 namespace ReportBuilder
 {
-	class Program
-	{
-		static void Main(string[] args)
-		{
+    class Program
+    {
+        static void Main(string[] args)
+        {
             if (args.Length != 3 || string.IsNullOrWhiteSpace(args[0]) || string.IsNullOrWhiteSpace(args[1]))
             {
                 Console.WriteLine("ERROR Missing argument: Must supply agent version, path to report, and an output path.");
@@ -112,5 +111,5 @@ namespace ReportBuilder
 
             return overview;
         }
-	}
+    }
 }

--- a/tests/Agent/MultiverseTesting/ReportBuilder/ReportBuilder.csproj
+++ b/tests/Agent/MultiverseTesting/ReportBuilder/ReportBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Why not .NET 9?  I didn't want to deal with temporarily configuring the CI to install the .NET 9 SDK.  Going with an LTS version of .NET and we can bump it to .NET 10 next year.