### PR TITLE
fix: Remove .NET Standard libraries from .NET Framework target

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -55,7 +55,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <!-- 1.3.3 is the latest package of SharpZipLib that still has a .NET Framework target. Later versions
+    only have a .NET Standard target -->
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</RootNamespace>
     <AssemblyName>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</AssemblyName>
     <Description>Microsoft.Extensions.Logging Wrapper Provider for New Relic .NET Agent</Description>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/MicrosoftExtensionsLogging/MicrosoftExtensionsLogging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</RootNamespace>
     <AssemblyName>NewRelic.Providers.Wrapper.MicrosoftExtensionsLogging</AssemblyName>
     <Description>Microsoft.Extensions.Logging Wrapper Provider for New Relic .NET Agent</Description>
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #2898. See the linked Jira ticket for an analysis of potentially affected libraries.