### PR TITLE
chore: Remove temporary .NET 9 CI workarounds

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -167,12 +167,6 @@ jobs:
         with:
           vs-prerelease: true
 
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: List SDKS
         run: dotnet --list-sdks
         shell: powershell

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -77,12 +77,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: Build FullAgent.sln
         run: |
           Write-Host "dotnet build --force --configuration Release -p:AllowUnsafeBlocks=true ${{ env.fullagent_solution_path }}"
@@ -173,12 +167,6 @@ jobs:
         with:
           vs-prerelease: true
 
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: List SDKS
         run: dotnet --list-sdks
         shell: powershell
@@ -220,12 +208,6 @@ jobs:
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
         with:
           vs-prerelease: true
-
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
 
       - name: Build UnboundedIntegrationTests.sln
         run: |
@@ -392,12 +374,6 @@ jobs:
           choco install azure-functions-core-tools -y --params "'/x64'"
         shell: powershell
 
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: Run Integration Tests
         run: |
           if ($Env:enhanced_logging -eq $True) {
@@ -541,12 +517,6 @@ jobs:
 #          Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
 #          Start-CosmosDbEmulator
 #        shell: pwsh
-
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
 
       - name: Run Unbounded Integration Tests
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,12 +53,6 @@ jobs:
       with:
         languages: csharp
 
-    - name: Setup .NET 9 Preview
-      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-      with:
-        dotnet-version: '9.0.x'
-        dotnet-quality: 'preview'
-
     - name: Build .NET Agent Solution
       run: |
         dotnet build ${{ env.fullagent_solution_path }}

--- a/.github/workflows/run_linux_container_tests.yml
+++ b/.github/workflows/run_linux_container_tests.yml
@@ -77,11 +77,5 @@ jobs:
         run: |
           echo $INTEGRATION_TEST_SECRETS | dotnet user-secrets set --project ${{ env.integration_tests_shared_project }}
   
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: Build & Run Linux Container Integration Tests
         run: dotnet test ./tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj --framework net9.0

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -47,12 +47,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 9 Preview
-        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
-        with:
-          dotnet-version: '9.0.x'
-          dotnet-quality: 'preview'
-
       - name: Restore NuGet Packages
         run: dotnet restore
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,27 +1,3 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)\build\Versioning.targets" Condition="Exists('$(MSBuildThisFileDirectory)\build\Versioning.targets')" />
-  <!-- BEGIN workaround for https://github.com/dotnet/sdk/issues/43339; remove after updated to VS 17.12 or a future 17.11 patch -->
-  <Target Name="WorkaroundDotnetSdk43339" BeforeTargets="ResolvePackageAssets" Condition=" '$(MSBuildRuntimeType)' == 'Full' and $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))">
-    <PrimeSystemTextJson804 />
-  </Target>
-  <UsingTask
-    TaskName="PrimeSystemTextJson804"
-    TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-    <Task>
-      <Code Type="Fragment" Language="cs">
-<![CDATA[
-try
-{
-    System.Reflection.Assembly.LoadFrom(@"$(MicrosoftNETBuildTasksDirectoryRoot)\..\..\..\DotnetTools\dotnet-format\BuildHost-net472\System.Text.Json.dll");
-}
-catch
-{
-    // Best effort: if something moves in the SDK don't break the build.
-}
-]]>
-      </Code>
-    </Task>
-  </UsingTask>
-  <!-- END workaround for https://github.com/dotnet/sdk/issues/43339 -->
 </Project>


### PR DESCRIPTION
Remove temporary workarounds for building .NET 9 before GA.
