### PR TITLE
ci: Update token for build_profiler workflow

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -372,6 +372,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
+            token: ${{ secrets.DOTNET_AGENT_GH_TOKEN}}
             commit-message: "chore: Update Profiler NuGet Package Reference to v${{ needs.package-and-deploy.outputs.package_version }}."
             title: "chore: Update Profiler NuGet Package Reference to v${{ needs.package-and-deploy.outputs.package_version }}"
             branch: profiler-nuget-updates/${{ github.ref_name }}

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -343,7 +343,6 @@ jobs:
     needs: package-and-deploy
     if: ${{ inputs.deploy }}
     permissions:
-      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Updates the token used by the `peter-evans/create-pull-request` action in `build_profiler.yml` to use our custom token instead of `GITHUB_TOKEN` - this change allows us to remove the `contents: write` permission that has been the subject of repeated [Code Scanning Alerts](https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/375).