### PR TITLE
fix: Incorrect string comparison in the profiler caused constructor instrumentation to fail on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,14 @@ tests/Agent/IntegrationTests/.vs/config/applicationhost.config
 .DS_Store
 
 # Local profiler build artificats
-src/Agent/_profilerBuild/*Debug
-src/Agent/NewRelic/Profiler/Profiler/VersionInfo.h
+/src/Agent/_profilerBuild/*Debug
+/src/Agent/NewRelic/Profiler/Profiler/VersionInfo.h
+/src/Agent/NewRelic/Profiler/CMakeFiles
+/src/Agent/NewRelic/Profiler/CMakeCache.txt
+/src/Agent/NewRelic/Profiler/cmake_install.cmake
+/src/Agent/NewRelic/Profiler/Makefile
+/src/Agent/_profilerBuild/x64-Release
+/src/Agent/_profilerBuild/x86-Release
 
 # Ignore any signing keys used in Linux packaging
 build/Linux/keys

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.34.0.10"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.34.0.14"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -55,7 +55,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             // some special name methods seem to give us trouble, but allow constructors to
             // be instrumented
             if (IsMdSpecialName(function->GetMethodAttributes()) &&
-                    !IsMdInstanceInitializerW(function->GetMethodAttributes(), function->GetFunctionName().c_str())) {
+                    !wcscmp(function->GetFunctionName().c_str(), _X(".ctor"))) {
                 LogError(L"Skipping SpecialName method: ", function->ToString());
                 return false;
             }

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -55,7 +55,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
             // some special name methods seem to give us trouble, but allow constructors to
             // be instrumented
             if (IsMdSpecialName(function->GetMethodAttributes()) &&
-                    !wcscmp(function->GetFunctionName().c_str(), _X(".ctor"))) {
+                    function->GetFunctionName() != _X(".ctor")) {
                 LogError(L"Skipping SpecialName method: ", function->ToString());
                 return false;
             }


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The profiler is supposed to allow instrumentation of constructors, but we found that the string comparison operator being used didn't work correctly under Linux. This PR changes the comparison to use a cross-platform version of `wcscmp()` instead.

Fixes #2918 

# Author Checklist
- [x] Unit tests, Integration tests, and Unbounded tests completed
- [x] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [x] Perform code review
- [x] Pull request was adequately tested (new/existing tests, performance tests)
