### PR TITLE
Moving cloud SDK attributes to Segments

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -289,6 +289,7 @@ namespace NewRelic.Agent.Core.Attributes
                 .Create<object, object>(attribName, AttributeClassification.AgentAttributes)
                 .AppliesTo(AttributeDestinations.TransactionTrace)
                 .AppliesTo(AttributeDestinations.SpanEvent)
+                .WithConvert(x => x)
                 .Build(_attribFilter);
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/NoOpSegment.cs
@@ -61,6 +61,10 @@ namespace NewRelic.Agent.Core.Segments
         {
             return this;
         }
+        public ISpan AddCloudSdkAttribute(string key, object value)
+        {
+            return this;
+        }
 
         public ISpan SetName(string name)
         {

--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -449,6 +449,19 @@ namespace NewRelic.Agent.Core.Segments
             return this;
         }
 
+        public ISpan AddCloudSdkAttribute(string key, object value)
+        {
+            SpanAttributeValueCollection customAttribValues;
+            lock (_customAttribValuesSyncRoot)
+            {
+                customAttribValues = _customAttribValues ?? (_customAttribValues = new SpanAttributeValueCollection());
+            }
+
+            AttribDefs.GetCloudSdkAttribute(key).TrySetValue(customAttribValues, value);
+
+            return this;
+        }
+
         public ISpan SetName(string name)
         {
             SegmentNameOverride = name;

--- a/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
+++ b/src/Agent/NewRelic/Agent/Core/Transactions/Transaction.cs
@@ -1393,17 +1393,5 @@ namespace NewRelic.Agent.Core.Transactions
             var faasAttrib = _attribDefs.GetFaasAttribute(name);
             TransactionMetadata.UserAndRequestAttributes.TrySetValue(faasAttrib, value);
         }
-
-        public void AddCloudSdkAttribute(string name, object value)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                Log.Debug($"AddCloudSdkAttribute - Name cannot be null/empty");
-                return;
-            }
-
-            var cloudAttrib = _attribDefs.GetCloudSdkAttribute(name);
-            TransactionMetadata.UserAndRequestAttributes.TrySetValue(cloudAttrib, value);
-        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISpan.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ISpan.cs
@@ -11,6 +11,8 @@ namespace NewRelic.Agent.Api
     {
         ISpan AddCustomAttribute(string key, object value);
 
+        ISpan AddCloudSdkAttribute(string key, object value);
+
         ISpan SetName(string name);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Api/ITransaction.cs
@@ -315,7 +315,5 @@ namespace NewRelic.Agent.Api
         void AddLambdaAttribute(string name, object value);
 
         void AddFaasAttribute(string name, object value);
-
-        void AddCloudSdkAttribute(string name, object value);
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/RequestHandlers/LambdaInvokeRequestHandler.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/RequestHandlers/LambdaInvokeRequestHandler.cs
@@ -30,13 +30,13 @@ namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers
             return getResponse(task);
         }
 
-        private static void SetRequestIdIfAvailable(IAgent agent, ITransaction transaction, dynamic response)
+        private static void SetRequestIdIfAvailable(IAgent agent, ISegment segment, dynamic response)
         {
             try
             {
                 dynamic metadata = response.ResponseMetadata;
                 string requestId = metadata.RequestId;
-                transaction.AddCloudSdkAttribute("aws.requestId", requestId);
+                segment.AddCloudSdkAttribute("aws.requestId", requestId);
             }
             catch (Exception e)
             {
@@ -74,14 +74,14 @@ namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers
             }
             var segment = transaction.StartTransactionSegment(instrumentedMethodCall.MethodCall, "InvokeRequest");
 
-            transaction.AddCloudSdkAttribute("cloud.platform", "aws_lambda");
-            transaction.AddCloudSdkAttribute("aws.operation", "InvokeRequest");
-            transaction.AddCloudSdkAttribute("aws.region", builder.Region);
+            segment.AddCloudSdkAttribute("cloud.platform", "aws_lambda");
+            segment.AddCloudSdkAttribute("aws.operation", "InvokeRequest");
+            segment.AddCloudSdkAttribute("aws.region", builder.Region);
 
 
             if (!string.IsNullOrEmpty(arn))
             {
-                transaction.AddCloudSdkAttribute("cloud.resource_id", arn);
+                segment.AddCloudSdkAttribute("cloud.resource_id", arn);
             }
             else if (_reportBadInvocationName)
             {
@@ -101,7 +101,7 @@ namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers
                         {
                             transaction.NoticeError(responseTask.Exception);
                         }
-                        SetRequestIdIfAvailable(agent, transaction, GetTaskResult(responseTask));
+                        SetRequestIdIfAvailable(agent, segment, GetTaskResult(responseTask));
                     }
                     finally
                     {
@@ -115,7 +115,7 @@ namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers
                     onFailure: ex => segment.End(ex),
                     onSuccess: response =>
                     {
-                        SetRequestIdIfAvailable(agent, transaction, response);
+                        SetRequestIdIfAvailable(agent, segment, response);
                         segment.End();
                     }
                 );

--- a/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Transactions/TransactionTests.cs
@@ -591,35 +591,4 @@ public class TransactionTests
         // Assert
         Assert.That(result, Is.False);
     }
-    public void AddCloudSdkAttribute_SetAttributeInTransactionMetadata()
-    {
-        // Arrange
-        var key = "TestAttribute";
-        var value = "TestValue";
-
-        // Act
-        _transaction.AddCloudSdkAttribute(key, value);
-
-        // Assert
-        var allAttributeValuesDic = _transaction.TransactionMetadata.UserAndRequestAttributes.GetAllAttributeValuesDic();
-
-        var attributeValue = allAttributeValuesDic[key];
-        Assert.That(attributeValue, Is.EqualTo(value));
-    }
-
-    [TestCase("   ")]
-    [TestCase("")]
-    [TestCase(null)]
-    public void AddCloudSdkAttribute_DoesNotSetAttribute_WhenKeyIsBad(string key)
-    {
-        // Arrange
-        var value = "TestValue";
-
-        // Act
-        _transaction.AddCloudSdkAttribute(key, value);
-
-        // Assert
-        Assert.That(_transaction.TransactionMetadata.UserAndRequestAttributes.Count, Is.EqualTo(0));
-    }
-
 }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
@@ -217,6 +217,10 @@ namespace Agent.Extensions.Tests.Helpers
         {
             throw new NotImplementedException();
         }
+        public ISpan AddCloudSdkAttribute(string key, object value)
+        {
+            throw new NotImplementedException();
+        }
 
         public ISpan SetName(string name)
         {


### PR DESCRIPTION
Using this separate PR to discuss the pros and cons of moving the new Cloud SDK attributes out of Transaction metadata. The goal would be to support multiple AWS services per transaction.