### PR TITLE
Remove references to System.Data.Odbc from wrapper and extensions

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Data.Odbc" Version="6.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
@@ -20,7 +21,7 @@ namespace NewRelic.Agent.Extensions.Parsing
         private const string NullQueryParameterValue = "Null";
 
         private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}");
-        private static Dictionary<string, DatastoreVendor> _vendorNameCache = new Dictionary<string, DatastoreVendor>();
+        private static ConcurrentDictionary<string, DatastoreVendor> _vendorNameCache = new ConcurrentDictionary<string, DatastoreVendor>();
 
         /// <summary>
         /// Gets the name of the datastore being used by a dbCommand.

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Globalization;
-using System.Data.Odbc;
+using System.Text.RegularExpressions;
 #if NETFRAMEWORK
 using System.Data.OleDb;
 #endif
@@ -19,6 +19,9 @@ namespace NewRelic.Agent.Extensions.Parsing
     {
         private const string NullQueryParameterValue = "Null";
 
+        private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}");
+        private static Dictionary<string, DatastoreVendor> _vendorNameCache = new Dictionary<string, DatastoreVendor>();
+
         /// <summary>
         /// Gets the name of the datastore being used by a dbCommand.
         /// </summary>
@@ -28,19 +31,33 @@ namespace NewRelic.Agent.Extensions.Parsing
         public static DatastoreVendor GetVendorName(IDbCommand command)
         {
 
-			// If this is an OdbcCommand, the only way to give the data store name is by looking at the connection driver
-
-			var odbcCommand = command as OdbcCommand;
-			if (odbcCommand != null && odbcCommand.Connection != null)
-				return ExtractVendorNameFromString(odbcCommand.Connection.Driver);
 #if NETFRAMEWORK
             // If this is an OleDbCommand, the only way to give the data store name is by looking at the connection provider
             var oleCommand = command as OleDbCommand;
-			if (oleCommand != null && oleCommand.Connection != null)
-				return ExtractVendorNameFromString(oleCommand.Connection.Provider);
+            if (oleCommand != null && oleCommand.Connection != null)
+                return ExtractVendorNameFromString(oleCommand.Connection.Provider);
 
 #endif
             return GetVendorName(command.GetType().Name);
+        }
+
+        public static DatastoreVendor GetVendorNameFromOdbcConnectionString(string connectionString)
+        {
+            // Example connection string: DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=MssqlPassw0rd;Encrypt=no;
+            if (_vendorNameCache.TryGetValue(connectionString, out DatastoreVendor vendor))
+            {
+                return vendor;
+            }
+
+            var match = _getDriverFromConnectionStringRegex.Match(connectionString);
+            if (match.Success)
+            {
+                var driver = match.Groups[1].Value;
+                vendor = ExtractVendorNameFromString(driver);
+                _vendorNameCache[connectionString] = vendor;
+                return vendor;
+            }
+            return DatastoreVendor.ODBC; // or maybe Other?
         }
 
         public static DatastoreVendor GetVendorName(string typeName)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/OdbcCommandWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/OdbcCommandWrapper.cs
@@ -23,8 +23,7 @@ namespace NewRelic.Providers.Wrapper.Sql
         public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
         {
             {
-                var odbcCommand = (IDbCommand)instrumentedMethodCall.MethodCall.InvocationTarget;
-                if (odbcCommand == null)
+                if (instrumentedMethodCall.MethodCall.InvocationTarget is not IDbCommand odbcCommand)
                 {
                     return Delegates.NoOp;
                 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Sql.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Sql/Sql.csproj
@@ -13,9 +13,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Data.Odbc" Version="6.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\NewRelic.Agent.Extensions\NewRelic.Agent.Extensions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Per team pairing last week, we should not add a reference to `System.Data.Odbc` to the `Sql` wrapper project nor the `Extensions` project with the helper code.

I initially went down a rabbit hole of using visibility bypasser to get the necessary data out of the `OdbcCommand` object.  However, I eventually realized that we can treat the `OdbcCommand` object as an `IDbCommand` interface type and get almost everything we need directly that way.  The one exception is the `Driver` string (needed to get the DatastoreVendor), which is not a part of the `IDbCommand` interface.  However, it can be easily parsed from the ODBC connection string (and cached based on the full connection string).