### PR TITLE
ci: Run markdown link check once a month instead of daily

### DIFF
--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -2,7 +2,7 @@ name: Check Markdown links
 
 on: 
   schedule:
-    - cron: "0 9 * * 1-5" # run once a day, M-F
+    - cron: '0 0 1 * *' # run once a month on the first
   workflow_dispatch:
 
 # only allow one instance of this workflow to be running per PR or branch, cancels any that are already running


### PR DESCRIPTION
Updates the schedule for `markdowncheck.yml` to run once a month. There's really no reason to run it daily, and by running just once a month, we can subscribe the team Slack channel to notifications for that workflow so that I'm not the only one who gets notified when it fails... ;-) 