### PR TITLE
Move init container release from lambda to GHA

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -200,6 +200,11 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Create release tags for Lambda and K8s Init Containers
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Create release tags for Lambda and K8s Init Containers
         run: |
           RELEASE_TITLE="New Relic .NET Agent ${AGENT_VERSION}.0"
           RELEASE_TAG="${AGENT_VERSION}.0_dotnet"

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -194,6 +194,11 @@ jobs:
     name: Create release tags
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          disable-sudo: true
+          egress-policy: audit
       - name: Create release tags for Lambda and K8s Init Containers
         run: |
           RELEASE_TITLE="New Relic .NET Agent ${AGENT_VERSION}.0"
@@ -205,5 +210,5 @@ jobs:
           echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GH_RELEASE_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
           AGENT_VERSION: "v${{ inputs.agent_version }}"

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -189,3 +189,21 @@ jobs:
         env:
           BUILD_PATH: ${{ github.workspace }}/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
           PUBLISH_PATH: ${{ github.workspace }}/publish
+
+  release-tags:
+    name: Create release tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release tags for Lambda and K8s Init Containers
+        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
+        with:
+          gh-cli-version: 2.63.2
+        run: |
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-lambda-layers - Releasing New Relic .NET Agent ${AGENT_VERSION}.0 with tag ${AGENT_VERSION}.0_dotnet"
+          gh create release "${AGENT_VERSION}.0_dotnet" -t "New Relic .NET Agent ${AGENT_VERSION}.0" --repo=newrelic/newrelic-lambda-layers
+          echo "newrelic/newrelic-agent-init-container - Releasing New Relic .NET Agent ${AGENT_VERSION}.0 with tag ${AGENT_VERSION}.0_dotnet"
+          gh create release "${AGENT_VERSION}.0_dotnet" -t "New Relic .NET Agent ${AGENT_VERSION}.0" --repo=newrelic/newrelic-agent-init-container
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.agent_version }}-1.x86_64"

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -195,15 +195,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release tags for Lambda and K8s Init Containers
-        uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
-        with:
-          gh-cli-version: 2.63.2
         run: |
+          RELEASE_TITLE="New Relic .NET Agent ${AGENT_VERSION}.0"
+          RELEASE_TAG="${AGENT_VERSION}.0_dotnet"
+          RELEASE_NOTES="Automated release for [.NET Agent ${AGENT_VERSION}](https://github.com/newrelic/newrelic-dotnet-agent/releases/tag/${AGENT_VERSION})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing New Relic .NET Agent ${AGENT_VERSION}.0 with tag ${AGENT_VERSION}.0_dotnet"
-          gh create release "${AGENT_VERSION}.0_dotnet" -t "New Relic .NET Agent ${AGENT_VERSION}.0" --repo=newrelic/newrelic-lambda-layers
-          echo "newrelic/newrelic-agent-init-container - Releasing New Relic .NET Agent ${AGENT_VERSION}.0 with tag ${AGENT_VERSION}.0_dotnet"
-          gh create release "${AGENT_VERSION}.0_dotnet" -t "New Relic .NET Agent ${AGENT_VERSION}.0" --repo=newrelic/newrelic-agent-init-container
+          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
         env:
           GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
-          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.agent_version }}-1.x86_64"
+          AGENT_VERSION: "v${{ inputs.agent_version }}"

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -200,11 +200,6 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Create release tags for Lambda and K8s Init Containers
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
-        with:
-          disable-sudo: true
-          egress-policy: audit
-      - name: Create release tags for Lambda and K8s Init Containers
         run: |
           RELEASE_TITLE="New Relic .NET Agent ${AGENT_VERSION}.0"
           RELEASE_TAG="${AGENT_VERSION}.0_dotnet"


### PR DESCRIPTION
## Description
We are getting rid of the internal [auto-layer-releases repo](https://source.datanerd.us/aws-lambda/auto-layer-releases/blob/master/app.py) and moving creating of the release tags into each agent's GHA deploy flow.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
