### PR TITLE
ODBC integration tests

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.Extensions.Parsing
     {
         private const string NullQueryParameterValue = "Null";
 
-        private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}", RegexOptions.IgnoreCase);
+        private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static ConcurrentDictionary<string, DatastoreVendor> _vendorNameCache = new ConcurrentDictionary<string, DatastoreVendor>();
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Extensions.Parsing
                 _vendorNameCache[connectionString] = vendor;
                 return vendor;
             }
-            return DatastoreVendor.ODBC; // or maybe Other?
+            return DatastoreVendor.ODBC;
         }
 
         public static DatastoreVendor GetVendorName(string typeName)

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Parsing/SqlWrapperHelper.cs
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.Extensions.Parsing
     {
         private const string NullQueryParameterValue = "Null";
 
-        private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}");
+        private static Regex _getDriverFromConnectionStringRegex = new Regex(@"DRIVER\=\{(.+?)\}", RegexOptions.IgnoreCase);
         private static ConcurrentDictionary<string, DatastoreVendor> _vendorNameCache = new ConcurrentDictionary<string, DatastoreVendor>();
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.Extensions.Parsing
 
         public static DatastoreVendor GetVendorNameFromOdbcConnectionString(string connectionString)
         {
-            // Example connection string: DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=MssqlPassw0rd;Encrypt=no;
+            // Example connection string: DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;
             if (_vendorNameCache.TryGetValue(connectionString, out DatastoreVendor vendor))
             {
                 return vendor;

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -94,9 +94,12 @@
     
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    
+
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" Condition="'$(TargetFramework)' == 'net9.0'" />
+
+    <PackageReference Include="System.Data.Odbc" Version="9.0.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="System.Data.Odbc" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
 
   </ItemGroup>
 </Project>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/MultiFunctionApplicationHelpers.csproj
@@ -48,6 +48,12 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" Condition="'$(TargetFramework)' == 'net48'" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" Condition="'$(TargetFramework)' == 'net8.0'" />
 
+    <!--System.Data.Odbc-->
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" Condition="'$(TargetFramework)' == 'net462'" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" Condition="'$(TargetFramework)' == 'net471'" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+
     <!-- MySql.Data framework references -->
     <PackageReference Include="MySql.Data" Version="6.10.7" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="MySql.Data" Version="8.0.15" Condition="'$(TargetFramework)' == 'net471'" />

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataExerciser.cs
@@ -14,13 +14,15 @@ using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 using System.Threading;
 using System.Data.OleDb;
-using System.Data.Odbc;
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
 {
     [Library]
     public class SystemDataExerciser : MsSqlExerciserBase
     {
+
+        private static string _connectionString = MsSqlConfiguration.MsSqlConnectionString;
+
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -28,7 +30,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var teamMembers = new List<string>();
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
@@ -78,7 +80,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var teamMembers = new List<string>();
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 await connection.OpenAsync();
 
@@ -127,7 +129,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var teamMembers = new List<string>();
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
@@ -159,7 +161,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var teamMembers = new List<string>();
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 await connection.OpenAsync();
 
@@ -195,7 +197,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         private int ExecuteParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
         {
             EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             using (var command = new SqlCommand(procedureName, connection))
             {
                 connection.Open();
@@ -210,39 +212,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
                 }
 
                 return command.ExecuteNonQuery();
-            }
-        }
-
-        [LibraryMethod]
-        [Transaction]
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        public void MsSqlParameterizedStoredProcedureUsingOdbcDriver(string procedureNameWith, string procedureNameWithout)
-        {
-            ExecuteParameterizedStoredProcedureUsingOdbcDriver(procedureNameWith, true);
-            ExecuteParameterizedStoredProcedureUsingOdbcDriver(procedureNameWithout, false);
-        }
-
-        private void ExecuteParameterizedStoredProcedureUsingOdbcDriver(string procedureName, bool paramsWithAtSign)
-        {
-            EnsureProcedure(procedureName, DbParameterData.OdbcMsSqlParameters);
-
-            var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
-
-            using (var connection = new OdbcConnection(MsSqlOdbcConfiguration.MsSqlOdbcConnectionString))
-            using (var command = new OdbcCommand($"{{call {procedureName}({parameterPlaceholder})}}", connection))
-            {
-                connection.Open();
-                command.CommandType = CommandType.StoredProcedure;
-                foreach (var parameter in DbParameterData.OdbcMsSqlParameters)
-                {
-                    var paramName = paramsWithAtSign
-                        ? parameter.ParameterName
-                        : parameter.ParameterName.TrimStart('@');
-
-                    command.Parameters.Add(new OdbcParameter(paramName, parameter.Value)); ;
-                }
-
-                command.ExecuteNonQuery();
             }
         }
 
@@ -280,7 +249,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         [LibraryMethod]
         public void CreateTable(string tableName)
         {
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
@@ -297,7 +266,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var dropTableSql = string.Format(DropPersonTableMsSql, tableName);
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
@@ -313,7 +282,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var dropProcedureSql = string.Format(DropProcedureSql, procedureName);
 
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             {
                 connection.Open();
 
@@ -334,7 +303,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
         {
             var parameters = string.Join(", ", dbParameters.Select(x => $"{x.ParameterName} {x.DbTypeName}"));
             var statement = string.Format(CreateProcedureStatement, procedureName, parameters);
-            using (var connection = new SqlConnection(MsSqlConfiguration.MsSqlConnectionString))
+            using (var connection = new SqlConnection(_connectionString))
             using (var command = new SqlCommand(statement, connection))
             {
                 connection.Open();

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataOdbcExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/MsSql/SystemDataOdbcExerciser.cs
@@ -182,36 +182,6 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql
             return string.Join(",", teamMembers);
         }
 
-        //[LibraryMethod]
-        //[Transaction]
-        //[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        //public void MsSqlParameterizedStoredProcedure(string procedureNameWith, string procedureNameWithout)
-        //{
-        //    ExecuteParameterizedStoredProcedure(procedureNameWith, true);
-        //    ExecuteParameterizedStoredProcedure(procedureNameWithout, false);
-        //}
-
-        //private int ExecuteParameterizedStoredProcedure(string procedureName, bool paramsWithAtSign)
-        //{
-        //    EnsureProcedure(procedureName, DbParameterData.MsSqlParameters);
-        //    using (var connection = new OdbcConnection(_connectionString))
-        //    using (var command = new OdbcCommand(procedureName, connection))
-        //    {
-        //        connection.Open();
-        //        command.CommandType = CommandType.StoredProcedure;
-        //        foreach (var parameter in DbParameterData.MsSqlParameters)
-        //        {
-        //            var paramName = paramsWithAtSign
-        //                ? parameter.ParameterName
-        //                : parameter.ParameterName.TrimStart('@');
-
-        //            command.Parameters.Add(new OdbcParameter(paramName, parameter.Value));
-        //        }
-
-        //        return command.ExecuteNonQuery();
-        //    }
-        //}
-
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName },
                 new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
-            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
             };
 
             var expectedTransactionTraceSegments = new List<string>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
             _fixture = fixture;
             _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedureUsingOdbcDriver";
+            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/OdbcParameterizedStoredProcedure";
 
             _tableName = Utilities.GenerateTableName();
             var procedureName = Utilities.GenerateProcedureName();
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
 
             _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedureUsingOdbcDriver {_procNameWith} {_procNameWithout}");
+            _fixture.AddCommand($"{excerciserName} OdbcParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
             _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
 
             _fixture.AddActions
@@ -78,23 +78,23 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1 },
+                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
             };
 
             var expectedTransactionTraceSegments = new List<string>
             {
-                $"Datastore/statement/Other/{expectedSqlStatementWith}/ExecuteProcedure",
-                $"Datastore/statement/Other/{expectedSqlStatementWithout}/ExecuteProcedure"
+                $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
+                $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure"
             };
 
             var expectedQueryParametersWith = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
             var expectedQueryParametersWithout = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
 
-            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Other/{expectedSqlStatementWith}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
-            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Other/{expectedSqlStatementWithout}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
+            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
+            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
 
             var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
             {
@@ -102,14 +102,14 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
                 {
                     TransactionName = _expectedTransactionName,
                     Sql = $"{{call {_procNameWith}({parameterPlaceholder})}}",
-                    DatastoreMetricName = $"Datastore/statement/Other/{expectedSqlStatementWith}/ExecuteProcedure",
+                    DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
                     QueryParameters = expectedQueryParametersWith
                 },
                 new Assertions.ExpectedSqlTrace
                 {
                     TransactionName = _expectedTransactionName,
                     Sql = $"{{call {_procNameWithout}({parameterPlaceholder})}}",
-                    DatastoreMetricName = $"Datastore/statement/Other/{expectedSqlStatementWithout}/ExecuteProcedure",
+                    DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure",
                     QueryParameters = expectedQueryParametersWithout
                 }
 
@@ -138,16 +138,26 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
         }
     }
 
-    // Only tests for System.Data in .NET Framework for ODBC, since the OdbcCommandWrapper is .NET Framework only,
-    // and the instrumentation.xml only matches System.Data as of 2022-10-20
     [NetFrameworkTest]
-    public class MsSqlStoredProcedureUsingOdbcDriverTests : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(
                   fixture: fixture,
                   output: output,
-                  excerciserName: "SystemDataExerciser")
+                  excerciserName: "SystemDataOdbcExerciser")
+        {
+        }
+    }
+
+    [NetCoreTest]
+    public class MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(
+                  fixture: fixture,
+                  output: output,
+                  excerciserName: "SystemDataOdbcExerciser")
         {
         }
     }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlWrapperHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Parsing/SqlWrapperHelperTests.cs
@@ -26,7 +26,7 @@ namespace ParsingTests
         [TestCase("Oracle", ExpectedResult = DatastoreVendor.Oracle)]
         [TestCase("PostgreSQL", ExpectedResult = DatastoreVendor.Postgres)]
         [TestCase("IBMDB2", ExpectedResult = DatastoreVendor.IBMDB2)]
-        public DatastoreVendor GetVendorName_ReturnsCorrectHost_IfOleDbConnectionProviderContainsKnownHost(
+        public DatastoreVendor GetVendorName_ReturnsCorrectVendor_IfOleDbConnectionProviderContainsKnownProvider(
             string provider)
         {
             var command = new OleDbCommand
@@ -45,7 +45,7 @@ namespace ParsingTests
         [TestCase("NpgsqlCommand", ExpectedResult = DatastoreVendor.Postgres)]
         [TestCase("DB2Command", ExpectedResult = DatastoreVendor.IBMDB2)]
         public DatastoreVendor
-            GetVendorName_ReturnsCorrectHost(string typeName)
+            GetVendorName_ReturnsCorrectVendor(string typeName)
         {
             return SqlWrapperHelper.GetVendorName(typeName);
         }
@@ -80,6 +80,20 @@ namespace ParsingTests
             var datastoreName = SqlWrapperHelper.GetVendorName(command);
 
             Assert.That(datastoreName, Is.EqualTo(DatastoreVendor.Other));
+        }
+
+        [Test]
+        [TestCase("DRIVER={SQL Server Native Client 11.0};Server=127.0.0.1;Database=NewRelic;Trusted_Connection=no;UID=sa;PWD=password;Encrypt=no;", ExpectedResult = DatastoreVendor.MSSQL)]
+        [TestCase("Driver={MySQL ODBC 5.2 UNICODE Driver};Server=localhost;Database=myDataBase;User=myUsername;Password=myPassword;Option=3;", ExpectedResult = DatastoreVendor.MySQL)]
+        [TestCase("Driver={Microsoft ODBC for Oracle};Server=myServerAddress;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.Oracle)]
+        [TestCase("Driver={Oracle in OraClient11g_home1};Dbq=myTNSServiceName;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.Oracle)]
+        [TestCase("Driver={PostgreSQL UNICODE};Server=IP address;Port=5432;Database=myDataBase;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.Postgres)]
+        [TestCase("Driver={IBM DB2 ODBC DRIVER};Database=myDataBase;Hostname=myServerAddress;Port=1234;Protocol=TCPIP;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.IBMDB2)]
+        [TestCase("Driver={Amazon Redshift ODBC Driver (x64)};Database=myDataBase;Hostname=myServerAddress;Port=1234;Protocol=TCPIP;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.ODBC)]
+        [TestCase("Driver={MyCoolDb ODBC DRIVER};Database=myDataBase;Hostname=myServerAddress;Port=1234;Protocol=TCPIP;Uid=myUsername;Pwd=myPassword;", ExpectedResult = DatastoreVendor.ODBC)]
+        public DatastoreVendor GetVendorNameFromOdbcConnectionString_ReturnsExpectedVendor(string connectionString)
+        {
+            return SqlWrapperHelper.GetVendorNameFromOdbcConnectionString(connectionString);
         }
 
         public class UnknownDbCommand : IDbCommand


### PR DESCRIPTION
Update the MSSQL integration tests to test the ODBC instrumentation.

* A new `SystemDataOdbcExerciser` is added to exercise the ODBC instrumentation
* The existing `MsSqlTests` are updated to test the ODBC instrumentation
* The existing `MsSqlStoredProcedureUsingOdbcDriverTests` are updated to use the new ODBC exerciser, and account for some changes

Things to note:
* The ODBC instrumentation does not instrument `Connect{Async}` or the DB read iteration methods.  The test logic accounts for this.
* The DB vendor for ODBC is no longer `Other`, but whatever DB we can detect as the underlying destination based on the connection string, in this case `MSSQL`

