### PR TITLE
test: log4net v3 support

### DIFF
--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -60,11 +60,7 @@
         "packageName": "enyimmemcachedcore"
     },
     {
-        "packageName": "log4net",
-        "ignorePatch": true,
-        "ignoreMinor": true,
-        "ignoreMajor": true,
-        "ignoreReason": "Breaking major update. See https://github.com/newrelic/newrelic-dotnet-agent/issues/2764"
+        "packageName": "log4net"
     },
     {
         "packageName": "microsoft.azure.functions.worker"

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" Condition="'$(TargetFramework)' == 'net9.0'" />
     
-    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net" Version="2.0.17" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="log4net" Version="3.0.3" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net" Version="3.0.3" Condition="'$(TargetFramework)' == 'net9.0'" />
     
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="log4net.Ext.Json" Version="3.0.3" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="log4net.Ext.Json" Version="3.0.3" Condition="'$(TargetFramework)' == 'net9.0'" />
     
     <PackageReference Include="MassTransit" Version="8.2.5" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="MassTransit" Version="8.2.5" Condition="'$(TargetFramework)' == 'net9.0'" />


### PR DESCRIPTION
Updates NuGet packages to test log4net v3.0.3, removes Dotty exclusions.

Closes #2764 