### PR TITLE
ci: Dotty Fixes

### DIFF
--- a/.github/workflows/scripts/nugetSlackNotifications/CsprojHandler.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/CsprojHandler.cs
@@ -36,9 +36,9 @@ namespace nugetSlackNotifications
 
                 foreach (var package in matchingPackages)
                 {
-                    if (package.VersionAsVersion < versionData.NewVersionAsVersion && package.Pin)
+                    if (package.VersionAsVersion < versionData.NewVersionAsVersion && !string.IsNullOrEmpty(versionData.IgnoreTfMs) && versionData.IgnoreTfMs.Split(",").Contains(package.TargetFramework))
                     {
-                        Log.Warning($"Not updating {package.Include} for {package.TargetFramework}, it is pinned to {package.Version}.  Manual verification recommended.");
+                        Log.Warning($"Not updating {package.Include} for {package.TargetFramework}, this TFM is ignored.  Manual verification recommended.");
                         continue;
                     }
 

--- a/.github/workflows/scripts/nugetSlackNotifications/NugetVersionData.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/NugetVersionData.cs
@@ -10,8 +10,10 @@ namespace nugetSlackNotifications
         public Version NewVersionAsVersion { get; set; }
         public string Url { get; set; }
         public DateTime PublishDate { get; set; }
+        public string IgnoreTfMs { get; }
 
-        public NugetVersionData(string packageName, string oldVersion, string newVersion, string url, DateTime publishDate)
+        public NugetVersionData(string packageName, string oldVersion, string newVersion, string url,
+            DateTime publishDate, string ignoreTfMs)
         {
             PackageName = packageName;
             OldVersion = oldVersion;
@@ -19,6 +21,7 @@ namespace nugetSlackNotifications
             NewVersionAsVersion = new Version(newVersion);
             Url = url;
             PublishDate = publishDate;
+            IgnoreTfMs = ignoreTfMs;
         }
     }
 }

--- a/.github/workflows/scripts/nugetSlackNotifications/PackageInfo.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/PackageInfo.cs
@@ -14,5 +14,7 @@ namespace nugetSlackNotifications
         public bool IgnoreMajor { get; set; }
         [JsonPropertyName("ignoreReason")]
         public string IgnoreReason {get; set;}
+        [JsonPropertyName("ignoreTFMs")]
+        public string IgnoreTFMs { get; set; }
     }
 }

--- a/.github/workflows/scripts/nugetSlackNotifications/PackageReference.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/PackageReference.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
@@ -33,8 +33,5 @@ namespace nugetSlackNotifications
                 return match.Success ? match.Value : null;
             }
         }
-
-        [XmlAttribute]
-        public bool Pin { get; set; }
     }
 }

--- a/.github/workflows/scripts/nugetSlackNotifications/Program.cs
+++ b/.github/workflows/scripts/nugetSlackNotifications/Program.cs
@@ -267,7 +267,7 @@ namespace nugetSlackNotifications
 
                 // create PR
                 var newPr = new NewPullRequest(commitMessage, branchName, "main");
-                newPr.Body = "Dotty updated the following for your convenience.\n\n" + updateLog + "\n\n**Don't forget to update the .NET Compatibility docs:docs: with the new versions!**\n";
+                newPr.Body = "Dotty updated the following for your convenience.\n\n" + updateLog + "\n\n**Don't forget to update the .NET Compatibility docs:memo: with the new versions!**\n";
                 var pullRequest = await ghClient.PullRequest.Create(Owner, Repo, newPr);
                 Log.Information($"Successfully created PR for {branchName} at {pullRequest.HtmlUrl}");
 

--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -122,10 +122,10 @@
         "packageName": "nservicebus"
     },
     {
-        "packageName": "orcacle.manageddataaccess"
+        "packageName": "oracle.manageddataaccess"
     },
     {
-        "packageName": "orcacle.manageddataaccess.core"
+        "packageName": "oracle.manageddataaccess.core"
     },
     {
         "packageName": "rabbitmq.client",

--- a/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
+++ b/.github/workflows/scripts/nugetSlackNotifications/packageInfo.json
@@ -119,7 +119,9 @@
         "packageName": "nlog.extensions.logging"
     },
     {
-        "packageName": "nservicebus"
+        "packageName": "nservicebus",
+        "ignoreTFMs": "net481",
+        "ignoreReason": "net481 doesn't support v9.x"
     },
     {
         "packageName": "oracle.manageddataaccess"


### PR DESCRIPTION
Updated Dotty PR creation logic to commit the changes to the new branch before creating a PR. Not sure why this was necessary now, but I'm assuming it's related to the OctoKit major version bump that was applied recently. 

Also added a config in `packageInfo.json` to allow updates for specific TFMs to be ignored (case in point: `NServiceBus` v9 isn't supported on `net481` but we still want to update the `net9.0` reference.)