### PR TITLE
ci: Update unit tests workflow to run on push to main

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -7,6 +7,13 @@ on:
       - "feature/**"
     paths-ignore:
       - ".github/**" # skip changes to the .github folder (workflows, etc.)
+
+  # needs to run on every push to main to keep CodeCov in sync
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**" # skip changes to the .github folder (workflows, etc.)
       
   # this workflow can be called from another workflow
   workflow_call:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - "feature/**"
+  
+  # needs to run on every push to main to keep CodeCov in sync
+  push:
+    branches:
+      - main
       
   workflow_dispatch: # allows for manual trigger
 


### PR DESCRIPTION
Updates `run_unit_tests.yml` so that the workflow runs on every push to `main`, which is required to keep CodeCov in sync and make the reports it generates more relevant. Also updates `build_profiler.yml` for the same reason.

I probably removed that trigger at some point in the past, in an attempt to minimize unnecessary workflow runs, but it looks like we actually need it. It was messages like this that clued me in:
![image](https://github.com/user-attachments/assets/d8d881e1-e5c6-441d-8ed6-4663135c66fd)
