### PR TITLE
test: Integration test regex updates

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string CustomEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""custom_event_data"" with : (.*)";
 
         // Collector responses
-        public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":{""agent_run_id""(.*)";
+        public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":(.*)";
         public const string ErrorResponseLogLinePrefixRegex = ErrorLogLinePrefixRegex + @"Request\(.{36}\): ";
 
         public const string ThreadProfileStartingLogLineRegex = InfoLogLinePrefixRegex + @"Starting a thread profiling session";
@@ -496,7 +496,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
             foreach (var match in matches)
             {
-                var json = "{ \"agent_run_id\"" + match;
+                var json = match;
                 json = json?.Trim('[', ']');
                 json = json.Remove(json.Length - 1); // remove the extra }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMDisabledAndServerSideHSMEnabledTests.cs
@@ -41,7 +41,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
             // 12/14/23 - the response status changed from "Gone" to "Conflict". If this test fails in the future, be alert for it possibly changing back.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/AspNetCoreLocalHSMEnabledAndServerSideHSMDisabledTests.cs
@@ -49,7 +49,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
             // 12/14/23 - the response status changed from "Gone" to "Conflict". If this test fails in the future, be alert for it possibly changing back.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerDisabled.cs
@@ -46,7 +46,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
             // 12/14/23 - the response status changed from "Gone" to "Conflict". If this test fails in the future, be alert for it possibly changing back.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/CSP/HighSecurityModeServerEnabled.cs
@@ -44,7 +44,7 @@ namespace NewRelic.Agent.IntegrationTests.CSP
         {
             // This test looks for the connect response body that was intended to be removed in P17, but was not.  If it does get removed this will fail.
             // 12/14/23 - the response status changed from "Gone" to "Conflict". If this test fails in the future, be alert for it possibly changing back.
-            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict with message {\"exception\":{\"message\":\"Account Security Violation: *?");
+            var notConnectedLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorResponseLogLinePrefixRegex + "Received HTTP status code Conflict *?");
             Assert.NotNull(notConnectedLogLine);
         }
     }


### PR DESCRIPTION
Updates a few regex patterns used in integration tests to be a little bit less selective. Discovered during testing of the pipeline control gateway endpoint. None of the changes causes any behavioral change in the integration tests.