### PR TITLE
ci: for Lambda layer/K8s init container release, quote arguments that aren't single strings

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -205,10 +205,10 @@ jobs:
           RELEASE_TAG="${AGENT_VERSION}.0_dotnet"
           RELEASE_NOTES="Automated release for [.NET Agent ${AGENT_VERSION}](https://github.com/newrelic/newrelic-dotnet-agent/releases/tag/${AGENT_VERSION})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
-          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-lambda-layers - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-lambda-layers --notes="${RELEASE_NOTES}"
+          echo "newrelic/newrelic-agent-init-container - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-agent-init-container --notes="${RELEASE_NOTES}"
         env:
           GH_RELEASE_TOKEN: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
           AGENT_VERSION: "v${{ inputs.agent_version }}"


### PR DESCRIPTION
The post-deploy step for releasing the lambda layer and K8s init container failed for release 10.35.0: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/12918327015/job/36027065472

Given the error message: `stat Relic: no such file or directory`, I think the issue was that some of the arguments to `gh release create` need to be quoted because they contain whitespace, e.g. `--title="New Relic .NET Agent v10.35.0.0"`
