### PR TITLE
chore: Fix incorrect commands for custom container builds

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -20,8 +20,8 @@ From a Powershell command prompt in the same folder as this README file:
 docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
 docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
 
-docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseImage --tag fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 -push .
-docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.FedoraBaseImage --tag fedora-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 -push .
+docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseImage --tag dotnetreg.azurecr.io/fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.FedoraBaseImage --tag dotnetreg.azurecr.io/fedora-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
 ```
 
 4. Disable buildx in Docker Desktop


### PR DESCRIPTION
Corrects the README instructions for building the customer Alpine / Fedora images we use in container integration tests.