### PR TITLE
test: Use latest version of Lambda test tool (9.0)

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -23,7 +23,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
             string lambdaHandler, string lambdaName, string lambdaVersion, string lambdaExecutionEnvironment,
             bool setNewRelicLambdaHandlerEventVar) : base(remoteApplication)
         {
-            LambdaTestTool = new DotnetTool("Amazon.Lambda.TestTool-8.0", "lambda-test-tool-8.0", DestinationApplicationDirectoryPath);
+            LambdaTestTool = new DotnetTool("Amazon.Lambda.TestTool-9.0", "lambda-test-tool-9.0", DestinationApplicationDirectoryPath);
 
             if (string.IsNullOrWhiteSpace(newRelicLambdaHandler) && string.IsNullOrWhiteSpace(lambdaHandler))
             {


### PR DESCRIPTION
There's a [.NET 9 specific version of the Lambda test tool](https://www.nuget.org/packages/Amazon.Lambda.TestTool-9.0#readme-body-tab) that we install to run our Lambda integration tests. 

This PR updates our tooling to use that version. Don't know if it will make any difference at all in the recent Lambda test failures we've been seeing, but it can't hurt.