### PR TITLE
test: Fix name collision on archive test results step

### DIFF
--- a/.github/workflows/run_linux_container_tests.yml
+++ b/.github/workflows/run_linux_container_tests.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Archive test results
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-            name: ContainerTestResults
+            name: ContainerTestResults-amd64
             path: ${{ env.test_results_path }} # Directory containing files to upload
           
 
@@ -150,5 +150,5 @@ jobs:
       - name: Archive test results
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-            name: ContainerTestResults
+            name: ContainerTestResults-arm64
             path: ${{ env.test_results_path }} # Directory containing files to upload


### PR DESCRIPTION
I forgot that artifacts require unique names. Oops.