### PR TITLE
chore: Log non-successful DataTransportResponseStatus during harvest

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
@@ -72,7 +72,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Custom Event harvest starting.");
+            Log.Finest("Custom Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> originalCustomEvents;
 
@@ -97,8 +97,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, customEvents);
             }
 
-            Log.Debug("Custom Event harvest finished.");
-
+            Log.Finest("Custom Event harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -120,7 +119,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportCustomEventsSent(customEvents.Count);
-                    Log.Debug("Successfully sent {count} custom events.", customEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(customEvents);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
@@ -72,7 +72,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Custom Event harvest starting.");
+            Log.Debug("Custom Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> originalCustomEvents;
 
@@ -97,7 +97,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, customEvents);
             }
 
-            Log.Finest($"Custom Event harvest finished. {eventCount} event(s) sent.");
+            Log.Debug("Custom Event harvest finished.");
 
         }
 
@@ -120,17 +120,21 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportCustomEventsSent(customEvents.Count);
+                    Log.Debug("Successfully sent {count} custom events.", customEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(customEvents);
+                    Log.Debug("Retaining {count} custom events.", customEvents.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                     var newSize = (int)(customEvents.Count * ReservoirReductionSizeMultiplier);
                     ReduceReservoirSize(newSize);
                     RetainEvents(customEvents);
+                    Log.Debug("Reservoir size reduced. Retaining {count} custom events.", customEvents.Count);
                     break;
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} custom events.", customEvents.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Error Event harvest starting.");
+            Log.Debug("Error Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> originalErrorEvents;
             ConcurrentList<ErrorEventWireModel> originalSyntheticsErrorEvents;
@@ -107,7 +107,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Finest($"Error Event harvest finished. {eventCount} event(s) sent.");
+            Log.Debug("Error Event harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -167,16 +167,20 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportErrorEventsSent(errorEvents.Count);
+                    Log.Debug("Successfully sent {count} error events.", errorEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(errorEvents);
+                    Log.Debug("Retaining {count} error events.", errorEvents.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                     ReduceReservoirSize((int)(errorEvents.Count * ReservoirReductionSizeMultiplier));
                     RetainEvents(errorEvents);
+                    Log.Debug("Reservoir size reduced. Retaining {count} error events.", errorEvents.Count);
                     break;
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} transaction events.", errorEvents.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Error Event harvest starting.");
+            Log.Finest("Error Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> originalErrorEvents;
             ConcurrentList<ErrorEventWireModel> originalSyntheticsErrorEvents;
@@ -107,7 +107,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Debug("Error Event harvest finished.");
+            Log.Finest("Error Event harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -167,7 +167,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportErrorEventsSent(errorEvents.Count);
-                    Log.Debug("Successfully sent {count} error events.", errorEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(errorEvents);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.Aggregators
         protected override void Harvest() => InternalHarvest();
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Error Trace harvest starting.");
+            Log.Finest("Error Trace harvest starting.");
 
             ICollection<ErrorTraceWireModel> errorTraceWireModels;
 
@@ -88,7 +88,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, errorTraceWireModels);
             }
 
-            Log.Debug("Error Trace harvest finished.");
+            Log.Finest("Error Trace harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -145,7 +145,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportErrorTracesSent(errorTraceWireModels.Count);
-                    Log.Debug("Successfully sent {count} error traces.", errorTraceWireModels.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     Retain(errorTraceWireModels);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorTraceAggregator.cs
@@ -65,7 +65,7 @@ namespace NewRelic.Agent.Core.Aggregators
         protected override void Harvest() => InternalHarvest();
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Error Trace harvest starting.");
+            Log.Debug("Error Trace harvest starting.");
 
             ICollection<ErrorTraceWireModel> errorTraceWireModels;
 
@@ -88,7 +88,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, errorTraceWireModels);
             }
 
-            Log.Finest($"Error Trace harvest finished. {traceCount} trace(s) sent.");
+            Log.Debug("Error Trace harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -145,13 +145,16 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportErrorTracesSent(errorTraceWireModels.Count);
+                    Log.Debug("Successfully sent {count} error traces.", errorTraceWireModels.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     Retain(errorTraceWireModels);
+                    Log.Debug("Retaining {count} error traces.", errorTraceWireModels.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} error traces.", errorTraceWireModels.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Log Event harvest starting.");
+            Log.Debug("Log Event harvest starting.");
 
             var originalLogEvents = GetAndResetLogEvents(GetReservoirSize());
             var aggregatedEvents = originalLogEvents.Where(node => node != null).Select(node => node.Data).ToList();
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Finest($"Log Event harvest finished. {eventCount} event(s) sent.");
+            Log.Debug("Log Event harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -155,16 +155,20 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportLoggingEventsSent(logEvents.Count);
+                    Log.Debug("Successfully sent {count} log events.", logEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(logEvents);
+                    Log.Debug("Retaining {count} log events.", logEvents.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                     ReduceReservoirSize((int)(logEvents.Count * ReservoirReductionSizeMultiplier));
                     RetainEvents(logEvents);
+                    Log.Debug("Reservoir size reduced. Retaining {count} log events.", logEvents.Count);
                     break;
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} log events.", logEvents.Count);
                     break;
             }
 

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -76,7 +76,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Log Event harvest starting.");
+            Log.Finest("Log Event harvest starting.");
 
             var originalLogEvents = GetAndResetLogEvents(GetReservoirSize());
             var aggregatedEvents = originalLogEvents.Where(node => node != null).Select(node => node.Data).ToList();
@@ -108,7 +108,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Debug("Log Event harvest finished.");
+            Log.Finest("Log Event harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -66,7 +66,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Metric harvest starting.");
+            Log.Finest("Metric harvest starting.");
 
             foreach (var source in _outOfBandMetricSources)
             {
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, metricsToSend);
             }
 
-            Log.Debug("Metric harvest finished.");
+            Log.Finest("Metric harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -103,7 +103,6 @@ namespace NewRelic.Agent.Core.Aggregators
             switch (responseStatus)
             {
                 case DataTransportResponseStatus.RequestSuccessful:
-                    Log.Debug("Successfully sent metrics.");
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainMetricData(unsuccessfulSendMetrics);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -66,7 +66,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Metric harvest starting.");
+            Log.Debug("Metric harvest starting.");
 
             foreach (var source in _outOfBandMetricSources)
             {
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, metricsToSend);
             }
 
-            Log.Finest($"Metric harvest finished. {metricCount} metric(s) sent.");
+            Log.Debug("Metric harvest finished.");
         }
 
         protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
@@ -98,18 +98,21 @@ namespace NewRelic.Agent.Core.Aggregators
 
         #endregion
 
-        private void HandleResponse(DataTransportResponseStatus responseStatus, IEnumerable<MetricWireModel> unsuccessfulSendMetrics)
+        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<MetricWireModel> unsuccessfulSendMetrics)
         {
             switch (responseStatus)
             {
                 case DataTransportResponseStatus.RequestSuccessful:
+                    Log.Debug("Successfully sent metrics.");
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainMetricData(unsuccessfulSendMetrics);
+                    Log.Debug("Retaining {count} metrics.", unsuccessfulSendMetrics.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} metrics.", unsuccessfulSendMetrics.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
@@ -107,7 +107,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Span Event harvest starting.");
+            Log.Debug("Span Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> spanEventsPriorityQueue;
 
@@ -132,7 +132,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, wireModels);
             }
 
-            Log.Finest($"Span Event harvest finished. {eventCount} event(s) sent.");
+            Log.Debug("Span Event harvest finished.");
         }
 
         private void ReduceReservoirSize(int newSize)
@@ -154,16 +154,20 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportSpanEventsSent(spanEvents.Count);
+                    Log.Debug("Successfully sent {count} span events.", spanEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(spanEvents);
+                    Log.Debug("Retaining {count} span events.", spanEvents.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                     ReduceReservoirSize((int)(spanEvents.Count * ReservoirReductionSizeMultiplier));
                     RetainEvents(spanEvents);
+                    Log.Debug("Reservoir size reduced. Retaining {count} span events.", spanEvents.Count);
                     break;
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} span events.", spanEvents.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
@@ -107,7 +107,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Span Event harvest starting.");
+            Log.Finest("Span Event harvest starting.");
 
             ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> spanEventsPriorityQueue;
 
@@ -132,7 +132,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, wireModels);
             }
 
-            Log.Debug("Span Event harvest finished.");
+            Log.Finest("Span Event harvest finished.");
         }
 
         private void ReduceReservoirSize(int newSize)
@@ -154,7 +154,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportSpanEventsSent(spanEvents.Count);
-                    Log.Debug("Successfully sent {count} span events.", spanEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(spanEvents);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceAggregator.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("SQL Trace harvest starting.");
+            Log.Debug("SQL Trace harvest starting.");
 
             IDictionary<long, SqlTraceWireModel> oldSqlTraces;
             lock (_sqlTraceLock)
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, slowestTraces);
             }
 
-            Log.Finest($"SQL Trace harvest finished. {traceCount} trace(s) sent.");
+            Log.Debug("SQL Trace harvest finished.");
         }
 
         private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<SqlTraceWireModel> traces)
@@ -83,13 +83,16 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportSqlTracesSent(traces.Count);
+                    Log.Debug("Successfully sent {count} SQL traces.", traces.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     Retain(traces);
+                    Log.Debug("Retaining {count} SQL traces.", traces.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                 case DataTransportResponseStatus.Discard:
                 default:
+                    Log.Debug("Discarding {count} SQL traces.", traces.Count);
                     break;
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceAggregator.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("SQL Trace harvest starting.");
+            Log.Finest("SQL Trace harvest starting.");
 
             IDictionary<long, SqlTraceWireModel> oldSqlTraces;
             lock (_sqlTraceLock)
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, slowestTraces);
             }
 
-            Log.Debug("SQL Trace harvest finished.");
+            Log.Finest("SQL Trace harvest finished.");
         }
 
         private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<SqlTraceWireModel> traces)
@@ -83,7 +83,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportSqlTracesSent(traces.Count);
-                    Log.Debug("Successfully sent {count} SQL traces.", traces.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     Retain(traces);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Transaction Event harvest starting.");
+            Log.Debug("Transaction Event harvest starting.");
 
             IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> originalTransactionEvents;
             ConcurrentList<TransactionEventWireModel> originalSyntheticsTransactionEvents;
@@ -104,7 +104,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Finest($"Transaction Event harvest finished. {eventCount} event(s) sent.");
+            Log.Debug("Transaction Event harvest finished.");
 
         }
 
@@ -150,17 +150,20 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportTransactionEventsSent(transactionEvents.Count);
+                    Log.Debug("Successfully sent {count} transaction events.", transactionEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(transactionEvents);
+                    Log.Debug("Retaining {count} transaction events.", transactionEvents.Count);
                     break;
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                     ReduceReservoirSize((int)(transactionEvents.Count * ReservoirReductionSizeMultiplier));
                     RetainEvents(transactionEvents);
+                    Log.Debug("Reservoir size reduced. Retaining {count} transaction events.", transactionEvents.Count);
                     break;
                 case DataTransportResponseStatus.Discard:
                 default:
-                    break;
+                    Log.Debug("Discarding {count} transaction events.", transactionEvents.Count); break;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
@@ -74,7 +74,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Transaction Event harvest starting.");
+            Log.Finest("Transaction Event harvest starting.");
 
             IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> originalTransactionEvents;
             ConcurrentList<TransactionEventWireModel> originalSyntheticsTransactionEvents;
@@ -104,7 +104,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, aggregatedEvents);
             }
 
-            Log.Debug("Transaction Event harvest finished.");
+            Log.Finest("Transaction Event harvest finished.");
 
         }
 
@@ -150,7 +150,6 @@ namespace NewRelic.Agent.Core.Aggregators
             {
                 case DataTransportResponseStatus.RequestSuccessful:
                     _agentHealthReporter.ReportTransactionEventsSent(transactionEvents.Count);
-                    Log.Debug("Successfully sent {count} transaction events.", transactionEvents.Count);
                     break;
                 case DataTransportResponseStatus.Retain:
                     RetainEvents(transactionEvents);

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
@@ -49,7 +49,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Debug("Transaction Trace harvest starting.");
+            Log.Finest("Transaction Trace harvest starting.");
 
             var traceSamples = _transactionCollectors
                 .Where(t => t != null)
@@ -71,7 +71,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, traceSamples);
             }
 
-            Log.Debug("Transaction Trace harvest finished.");
+            Log.Finest("Transaction Trace harvest finished.");
         }
 
         private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModelComponents> traceSamples)
@@ -79,7 +79,6 @@ namespace NewRelic.Agent.Core.Aggregators
             switch (responseStatus)
             {
                 case DataTransportResponseStatus.RequestSuccessful:
-                    Log.Debug("Successfully sent {count} transaction traces.", traceSamples.Count);
                     break;
 
                 case DataTransportResponseStatus.Retain:

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
@@ -49,7 +49,7 @@ namespace NewRelic.Agent.Core.Aggregators
 
         protected void InternalHarvest(string transactionId = null)
         {
-            Log.Finest("Transaction Trace harvest starting.");
+            Log.Debug("Transaction Trace harvest starting.");
 
             var traceSamples = _transactionCollectors
                 .Where(t => t != null)
@@ -71,7 +71,7 @@ namespace NewRelic.Agent.Core.Aggregators
                 HandleResponse(responseStatus, traceSamples);
             }
 
-            Log.Finest($"Transaction Trace harvest finished. {traceCount} trace(s) sent.");
+            Log.Debug("Transaction Trace harvest finished.");
         }
 
         private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModelComponents> traceSamples)
@@ -79,6 +79,7 @@ namespace NewRelic.Agent.Core.Aggregators
             switch (responseStatus)
             {
                 case DataTransportResponseStatus.RequestSuccessful:
+                    Log.Debug("Successfully sent {count} transaction traces.", traceSamples.Count);
                     break;
 
                 case DataTransportResponseStatus.Retain:
@@ -87,12 +88,13 @@ namespace NewRelic.Agent.Core.Aggregators
                     {
                         Collect(traceSample);
                     }
+                    Log.Debug("Retaining {count} transaction traces.", traceSamples.Count);
                     break;
 
                 case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
                 case DataTransportResponseStatus.Discard:
                 default:
-                    Log.Warn($"Discarding {traceSamples.Count} transaction traces due to collector response.");
+                    Log.Warn("Discarding {count} transaction traces.", traceSamples.Count);
                     break;
             }
         }


### PR DESCRIPTION
Adds logging in the `HandleResponse()` method of all aggregators to indicate whether data was sent successfully, retained or discarded.