### PR TITLE
fix: Add Azure Function app name prefix to `faas.name` attribute in Azure Function transactions.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -271,11 +271,11 @@ namespace NewRelic.Agent.Core.Configuration
                 return appName.Split(StringSeparators.Comma);
             }
 
-            if (AzureFunctionModeDetected && AzureFunctionModeEnabled && !string.IsNullOrEmpty(AzureFunctionServiceName))
+            if (AzureFunctionModeDetected && AzureFunctionModeEnabled && !string.IsNullOrEmpty(AzureFunctionAppName))
             {
                 Log.Info("Application name from Azure Function site name.");
                 _applicationNamesSource = "Azure Function";
-                return new List<string> { AzureFunctionServiceName };
+                return new List<string> { AzureFunctionAppName };
             }
 
             appName = _environment.GetEnvironmentVariable("RoleName");
@@ -2185,7 +2185,7 @@ namespace NewRelic.Agent.Core.Configuration
                     return string.Empty;
                 }
 
-                return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{(string.IsNullOrEmpty(AzureFunctionServiceName) ? "unknown" : AzureFunctionServiceName)}";
+                return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{(string.IsNullOrEmpty(AzureFunctionAppName) ? "unknown" : AzureFunctionAppName)}";
             }
         }
 
@@ -2245,7 +2245,7 @@ namespace NewRelic.Agent.Core.Configuration
             }
         }
 
-        public string AzureFunctionServiceName => _environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+        public string AzureFunctionAppName => _environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
         #endregion
 
         #endregion

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -713,7 +713,7 @@ namespace NewRelic.Agent.Core.Configuration
         public string AzureFunctionSubscriptionId => _configuration.AzureFunctionSubscriptionId;
 
         [JsonIgnore]
-        public string AzureFunctionServiceName => _configuration.AzureFunctionServiceName;
+        public string AzureFunctionAppName => _configuration.AzureFunctionAppName;
 
         public string AzureFunctionResourceIdWithFunctionName(string functionName) => _configuration.AzureFunctionResourceIdWithFunctionName(functionName);
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -229,7 +229,7 @@ namespace NewRelic.Agent.Configuration
         string AzureFunctionResourceGroupName { get; }
         string AzureFunctionRegion { get; }
         string AzureFunctionSubscriptionId { get; }
-        string AzureFunctionServiceName { get; }
+        string AzureFunctionAppName { get; }
         string AzureFunctionResourceIdWithFunctionName(string functionName);
 
         bool UtilizationDetectAzureFunction { get; }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/InvokeFunctionAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/InvokeFunctionAsyncWrapper.cs
@@ -76,7 +76,7 @@ public class InvokeFunctionAsyncWrapper : IWrapper
         }
 
         transaction.AddFaasAttribute("cloud.resource_id", agent.Configuration.AzureFunctionResourceIdWithFunctionName(functionDetails.FunctionName));
-        transaction.AddFaasAttribute("faas.name", functionDetails.FunctionName);
+        transaction.AddFaasAttribute("faas.name", $"{agent.Configuration.AzureFunctionAppName}/{functionDetails.FunctionName}");
         transaction.AddFaasAttribute("faas.trigger", functionDetails.Trigger);
         transaction.AddFaasAttribute("faas.invocation_id", functionDetails.InvocationId);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionHttpTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionHttpTriggerTests.cs
@@ -149,7 +149,7 @@ public abstract class AzureFunctionHttpTriggerTestsBase<TFixture> : NewRelicInte
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("cloud.resource_id", out var cloudResourceIdValue));
             Assert.Equal("/subscriptions/subscription_id/resourceGroups/my_resource_group/providers/Microsoft.Web/sites/IntegrationTestAppName/functions/HttpTriggerFunctionUsingSimpleInvocation", cloudResourceIdValue);
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("faas.name", out var faasNameValue));
-            Assert.Equal("HttpTriggerFunctionUsingSimpleInvocation", faasNameValue);
+            Assert.Equal("IntegrationTestAppName/HttpTriggerFunctionUsingSimpleInvocation", faasNameValue);
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("faas.trigger", out var faasTriggerValue));
             Assert.Equal("http", faasTriggerValue);
 
@@ -284,7 +284,7 @@ public abstract class AzureFunctionHttpTriggerTestsBase<TFixture> : NewRelicInte
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("cloud.resource_id", out var cloudResourceIdValue));
             Assert.Equal("/subscriptions/subscription_id/resourceGroups/my_resource_group/providers/Microsoft.Web/sites/IntegrationTestAppName/functions/HttpTriggerFunctionUsingAspNetCorePipeline", cloudResourceIdValue);
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("faas.name", out var faasNameValue));
-            Assert.Equal("HttpTriggerFunctionUsingAspNetCorePipeline", faasNameValue);
+            Assert.Equal("IntegrationTestAppName/HttpTriggerFunctionUsingAspNetCorePipeline", faasNameValue);
             Assert.True(firstTransaction.IntrinsicAttributes.TryGetValue("faas.trigger", out var faasTriggerValue));
             Assert.Equal("http", faasTriggerValue);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
@@ -58,7 +58,7 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
         {
             { "faas.coldStart", true},
             //new("faas.invocation_id", "test_invocation_id"), This one is a random guid, not something we can specifically look for
-            { "faas.name", "QueueTriggerFunction" },
+            { "faas.name", "IntegrationTestAppName/QueueTriggerFunction" },
             { "faas.trigger", "datasource" },
             { "cloud.resource_id", "/subscriptions/subscription_id/resourceGroups/my_resource_group/providers/Microsoft.Web/sites/IntegrationTestAppName/functions/QueueTriggerFunction" }
         };
@@ -92,7 +92,7 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
             Assert.True(transaction.IntrinsicAttributes.TryGetValue("cloud.resource_id", out var cloudResourceIdValue));
             Assert.Equal("/subscriptions/subscription_id/resourceGroups/my_resource_group/providers/Microsoft.Web/sites/IntegrationTestAppName/functions/QueueTriggerFunction", cloudResourceIdValue);
             Assert.True(transaction.IntrinsicAttributes.TryGetValue("faas.name", out var faasNameValue));
-            Assert.Equal("QueueTriggerFunction", faasNameValue);
+            Assert.Equal("IntegrationTestAppName/QueueTriggerFunction", faasNameValue);
             Assert.True(transaction.IntrinsicAttributes.TryGetValue("faas.trigger", out var faasTriggerValue));
             Assert.Equal("datasource", faasTriggerValue);
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4436,7 +4436,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("WEBSITE_SITE_NAME")).Returns("some-service-name");
 
             // Act
-            var result = _defaultConfig.AzureFunctionServiceName;
+            var result = _defaultConfig.AzureFunctionAppName;
 
             // Assert
             Assert.That(result, Is.EqualTo("some-service-name"));

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -492,7 +492,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public string AzureFunctionResourceGroupName => "AzureFunctionResourceGroupName";
         public string AzureFunctionRegion => "AzureFunctionRegion";
         public string AzureFunctionSubscriptionId => "AzureFunctionSubscriptionId";
-        public string AzureFunctionServiceName => "AzureFunctionServiceName";
+        public string AzureFunctionAppName => "AzureFunctionServiceName";
         public string AzureFunctionResourceIdWithFunctionName(string functionName) => $"AzureFunctionResourceId/{functionName}";
 
         public string LoggingLevel => "info";


### PR DESCRIPTION
Update the `faas.name` attribute on Azure Function transactions to include the Azure Function app name as a prefix. This change is for consistency with [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/faas/#faas-name) for this attribute. 

The `faas.name` attribute will now have the format `{azure_function_app_name}/{function_name}` where it previously contained only `{function_name}`. 

Also renamed the related config property to better reflect that it is the Azure Function app name.