### PR TITLE
chore: Add supportabililty metric when Azure Function mode is enabled

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -812,6 +812,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             ReportIfGCSamplerV2IsEnabled();
             ReportIfAwsAccountIdProvided();
             ReportIfAgentControlHealthEnabled();
+            ReportIfAzureFunctionModeIsEnabled();
         }
 
         public void CollectMetrics()
@@ -981,6 +982,14 @@ namespace NewRelic.Agent.Core.AgentHealth
             if (!string.IsNullOrEmpty(_configuration.AwsAccountId))
             {
                 ReportSupportabilityCountMetric(MetricNames.SupportabilityAwsAccountIdProvided);
+            }
+        }
+
+        private void ReportIfAzureFunctionModeIsEnabled()
+        {
+            if (_configuration.AzureFunctionModeEnabled && _configuration.AzureFunctionModeDetected)
+            {
+                ReportSupportabilityCountMetric(MetricNames.SupportabilityAzureFunctionModeEnabled);
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNames.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNames.cs
@@ -839,6 +839,7 @@ namespace NewRelic.Agent.Core.Metrics
         public const string SupportabilityIgnoredInstrumentation = SupportabilityDotnetPs + "IgnoredInstrumentation";
         public const string SupportabilityGCSamplerV2Enabled = SupportabilityDotnetPs + "GCSamplerV2/Enabled";
         public const string SupportabilityAwsAccountIdProvided = SupportabilityDotnetPs + "AwsAccountId/Config";
+        public const string SupportabilityAzureFunctionModeEnabled = SupportabilityDotnetPs + "AzureFunctionMode/Enabled";
 
         #endregion Supportability
 


### PR DESCRIPTION
Adds `Supportability/Dotnet/AzureFunctionMode/Enabled` metric when Azure Function mode is enabled and the agent is running in an Azure Function.