### PR TITLE
chore: Update Azure Site Extension to include support for Azure Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ build/Linux/keys
 # Container Integration Tests
 /tests/Agent/IntegrationTests/LocalStack/volume
 /tests/Agent/IntegrationTests/ContainerApplications/volume/cache
+
+# Build artifacts
+/build/BuildArtifacts
+/build/_staging

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -175,17 +175,20 @@ function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath, $newRe
 	}
 }
 
-function RemoveXmlElement($file, $xPath)
+function RemoveXmlElements($file, $xPaths)
 {
     $xdoc = new-object System.Xml.XmlDocument
     $xdoc.load($file)
     $namespaceManager = new-object System.Xml.XmlNamespaceManager($xdoc.NameTable)
     $namespaceManager.AddNamespace("xdt", "http://schemas.microsoft.com/XML-Document-Transform")
 
-    $node = $xdoc.SelectSingleNode($xPath, $namespaceManager)
-    if ($node -ne $null)
+    foreach ($xPath in $xPaths)
     {
-        $node.ParentNode.RemoveChild($node)
+        $node = $xdoc.SelectSingleNode($xPath, $namespaceManager)
+        if ($node -ne $null)
+        {
+            $node.ParentNode.RemoveChild($node)
+        }
     }
     $xdoc.Save($file)
 }
@@ -385,7 +388,7 @@ try
         AddXmlElements $file $xPaths
 
         WriteToInstallLog "Removing <system.applicationHost> element from applicationHost.xdt"
-        RemoveXmlElement $file "/configuration/system.applicationHost"
+        RemoveXmlElements $file @("/configuration/system.applicationHost")
     }
 
 

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -386,11 +386,7 @@ try
         $file = resolve-path ".\applicationHost.xdt"
         WriteToInstallLog "Adding Azure Functions environment variables to applicationHost.xdt"
         AddXmlElements $file $xPaths
-
-        WriteToInstallLog "Removing <system.applicationHost> element from applicationHost.xdt"
-        RemoveXmlElements $file @("/configuration/system.applicationHost")
     }
-
 
 	$packageNames = @($nugetPackageForFrameworkApp, $nugetPackageForCoreApp)
 	$stagingFolders = @("NewRelicPackage", "NewRelicCorePackage")

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -175,19 +175,51 @@ function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath, $newRe
 	}
 }
 
-function RemoveXmlElements($file, $xPaths)
+function RemoveXmlElement($file, $xPath)
 {
-	$xdoc = new-object System.Xml.XmlDocument
-	$xdoc.load($file)
-	foreach ($xPath in $xPaths)
-	{
-		$elementToBeRemoved = $xdoc.SelectSingleNode($xPath)
-		if($elementToBeRemoved -ne $null)
-		{
-			$elementToBeRemoved.ParentNode.RemoveChild($elementToBeRemoved)
-		}
-	}
-	$xdoc.Save($file)
+    $xdoc = new-object System.Xml.XmlDocument
+    $xdoc.load($file)
+    $namespaceManager = new-object System.Xml.XmlNamespaceManager($xdoc.NameTable)
+    $namespaceManager.AddNamespace("xdt", "http://schemas.microsoft.com/XML-Document-Transform")
+
+    $node = $xdoc.SelectSingleNode($xPath, $namespaceManager)
+    if ($node -ne $null)
+    {
+        $node.ParentNode.RemoveChild($node)
+    }
+    $xdoc.Save($file)
+}
+
+function AddXmlElements($file, $xPaths)
+{
+    $xdoc = new-object System.Xml.XmlDocument
+    $xdoc.load($file)
+    $namespaceManager = new-object System.Xml.XmlNamespaceManager($xdoc.NameTable)
+    $namespaceManager.AddNamespace("xdt", "http://schemas.microsoft.com/XML-Document-Transform")
+
+    foreach ($xPath in $xPaths)
+    {
+        $newElement = $xdoc.CreateElement($xPath.Name)
+        foreach ($attribute in $xPath.Attributes.GetEnumerator())
+        {
+            if ($attribute.Key -like "xdt:*")
+            {
+                $newAttribute = $xdoc.CreateAttribute($attribute.Key, $namespaceManager.LookupNamespace("xdt"))
+            }
+            else
+            {
+                $newAttribute = $xdoc.CreateAttribute($attribute.Key)
+            }
+            $newAttribute.Value = $attribute.Value
+            $newElement.Attributes.Append($newAttribute)
+        }
+        $parentNode = $xdoc.SelectSingleNode($xPath.ParentPath, $namespaceManager)
+        if ($parentNode -ne $null)
+        {
+            $parentNode.AppendChild($newElement)
+        }
+    }
+    $xdoc.Save($file)
 }
 
 function CopyAgentInfo($agentInfoDestination)
@@ -341,6 +373,21 @@ try
 		$file = resolve-path(".\applicationHost.xdt")
 		RemoveXmlElements $file $xPaths
 	}
+
+    if ($env:FUNCTIONS_WORKER_RUNTIME -ne $null) # for Azure Functions, enable azure function mode and remove <system.applicationHost>
+    {
+        $xPaths = @(
+            @{ Name = "add"; Attributes = @{ name = "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"; value = "1"; "xdt:Locator" = "Match(name)"; "xdt:Transform" = "InsertIfMissing" }; ParentPath = "/configuration/system.webServer/runtime/environmentVariables" },
+            @{ Name = "add"; Attributes = @{ name = "NEW_RELIC_LOG_DIRECTORY"; value = "%HOME%\LogFiles\NewRelic"; "xdt:Locator" = "Match(name)"; "xdt:Transform" = "InsertIfMissing" }; ParentPath = "/configuration/system.webServer/runtime/environmentVariables" }
+        )
+        $file = resolve-path ".\applicationHost.xdt"
+        WriteToInstallLog "Adding Azure Functions environment variables to applicationHost.xdt"
+        AddXmlElements $file $xPaths
+
+        WriteToInstallLog "Removing <system.applicationHost> element from applicationHost.xdt"
+        RemoveXmlElement $file "/configuration/system.applicationHost"
+    }
+
 
 	$packageNames = @($nugetPackageForFrameworkApp, $nugetPackageForCoreApp)
 	$stagingFolders = @("NewRelicPackage", "NewRelicCorePackage")


### PR DESCRIPTION
Update the Azure Websites Site Extension Nuget package to detect when it's being added to an Azure Function. 

If the `FUNCTIONS_WORKER_RUNTIME` environment variable is detected, the extension adds `NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED=1` and `NEW_RELIC_LOG_DIRECTORY=%HOME%\LogFiles\NewRelic` to `applicationHost.xdt`.

With this change, the customer only needs to add the `NEW_RELIC_LICENSE_KEY` environment variable manually and the agent will "just work" in an Azure function. The `NEW_RELIC_AGENT_VERSION_OVERRIDE` environment variable is supported as usual.