### PR TITLE
test: Fix flaky CustomEventWireModelTests

### DIFF
--- a/tests/Agent/UnitTests/Core.UnitTest/CustomEvents/CustomEventWireModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/CustomEvents/CustomEventWireModelTests.cs
@@ -10,6 +10,7 @@ using NewRelic.Agent.Core.Transformers;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.TestUtilities;
 using System;
+using NewRelic.Agent.Core.JsonConverters;
 
 namespace NewRelic.Agent.Core.CustomEvents.Tests
 {
@@ -140,7 +141,7 @@ namespace NewRelic.Agent.Core.CustomEvents.Tests
             var customEvent = new CustomEventWireModel(.5f, attribVals);
 
             var serialized = JsonConvert.SerializeObject(customEvent);
-            var expectedSerialized = JsonConvert.SerializeObject(expectedSerialization);
+            var expectedSerialized = JsonConvert.SerializeObject(expectedSerialization, converters: [new EventAttributesJsonConverter()]);
 
             Assert.That(serialized, Is.Not.Null);
             Assert.That(serialized, Is.EqualTo(expectedSerialized));


### PR DESCRIPTION
Updated `CustomEvents_UserAttributes_AllAttributeTypesSerializeCorrectly()` (introduced yesterday) to make sure we use the same Jsonconverter for the "expected" serialization result. There was a slight difference in how `DateTime` values were being serialized without this change.