### PR TITLE
fix: Improve error handling in AWS account ID parsing logic

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AmazonServiceClientWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/AmazonServiceClientWrapper.cs
@@ -11,6 +11,8 @@ namespace NewRelic.Providers.Wrapper.AwsSdk;
 
 public class AmazonServiceClientWrapper : IWrapper
 {
+    private bool _disableServiceClientWrapper;
+
     private const int LRUCapacity = 100;
     // cache the account id per instance of AmazonServiceClient.Config
     public static LRUCache<WeakReferenceKey<object>, string> AwsAccountIdByClientConfigCache = new(LRUCapacity);
@@ -27,30 +29,79 @@ public class AmazonServiceClientWrapper : IWrapper
 
     public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
     {
+        if (_disableServiceClientWrapper) // something bad happened on a previous call, so we're disabling this wrapper
+            return Delegates.NoOp;
+
         object client = instrumentedMethodCall.MethodCall.InvocationTarget;
 
         var weakReferenceKey = new WeakReferenceKey<object>(client);
-        if (AmazonServiceClientInstanceCache.Contains(weakReferenceKey)) // don't do anything if we've already seen this client instance
+
+        // don't do anything if we've already seen this client instance -- the account ID is cached already
+        if (AmazonServiceClientInstanceCache.Contains(weakReferenceKey)) 
             return Delegates.NoOp;
 
+        // add this client instance to cache so we don't process it again
         AmazonServiceClientInstanceCache.Add(weakReferenceKey);
 
-        string awsAccountId;
+        // retrieve and cache the account id
+        string awsAccountId = null;
         try
         {
             // get the AWSCredentials parameter
-            dynamic awsCredentials = instrumentedMethodCall.MethodCall.MethodArguments[0];
+            if (instrumentedMethodCall.MethodCall.MethodArguments.Length > 0)
+            {
+                dynamic awsCredentials = instrumentedMethodCall.MethodCall.MethodArguments[0];
+                if (awsCredentials != null)
+                {
+                    dynamic immutableCredentials = awsCredentials.GetCredentials();
+                    if (immutableCredentials != null)
+                    {
+                        string accessKey = immutableCredentials.AccessKey;
 
-            dynamic immutableCredentials = awsCredentials.GetCredentials();
-            string accessKey = immutableCredentials.AccessKey;
+                        if (!string.IsNullOrEmpty(accessKey))
+                        {
+                            try
+                            {
+                                // convert the access key to an account id
+                                awsAccountId = AwsAccountIdDecoder.GetAccountId(accessKey);
+                            }
+                            catch (Exception e)
+                            {
+                                agent.Logger.Debug(e, "Unexpected exception parsing AWS Account ID from AccessKey.");
+                            }
+                        }
+                        else
+                            agent.Logger.Debug("Unable to parse AWS Account ID from AWSCredentials because AccessKey was null.");
+                    }
+                    else
+                        agent.Logger.Debug("Unable to parse AWS Account ID from AWSCredentials because GetCredentials() returned null.");
+                }
+                else
+                    agent.Logger.Debug("Unable to parse AWS Account ID from AWSCredentials because AWSCredentials was null.");
+            }
+            else
+                agent.Logger.Debug("Unable to parse AWS Account ID from AWSCredentials because there were no arguments in the method call.");
 
-            // convert the access key to an account id
-            awsAccountId = AwsAccountIdDecoder.GetAccountId(accessKey);
+            // fall back to configuration if we didn't get an account id from the credentials
+            if (string.IsNullOrEmpty(awsAccountId))
+            {
+                agent.Logger.Debug("Using AccountId from configuration.");
+                awsAccountId = agent.Configuration.AwsAccountId;
+            }
         }
         catch (Exception e)
         {
-            agent.Logger.Info($"Unable to parse AWS Account ID from AccessKey. Using AccountId from configuration instead. Exception: {e.Message}");
+            agent.Logger.Debug(e, "Unexpected exception in AmazonServiceClientWrapper.BeforeWrappedMethod(). Using AccountId from configuration.");
             awsAccountId = agent.Configuration.AwsAccountId;
+        }
+
+        // disable the wrapper if we get this far and there's no account id
+        if (string.IsNullOrEmpty(awsAccountId))
+        {
+            agent.Logger.Warn("Unable to parse AWS Account ID from AWSCredentials or configuration. Further AWS Account ID parsing will be disabled.");
+            _disableServiceClientWrapper = true;
+
+            return Delegates.NoOp;
         }
 
         return Delegates.GetDelegateFor(onComplete: () =>


### PR DESCRIPTION
Adds some additional null checks and log messages in `AmazonServiceClientWrapper`. 

If an account ID can't be parsed from credentials and no fallback account ID is available in configuration, the wrapper is disabled on future calls.