### PR TITLE
feat: LLM instrumentation support for `AmazonBedrockRuntimeClient.ConverseAsync()`

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/ConverseAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/ConverseAsyncWrapper.cs
@@ -1,0 +1,253 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Threading.Tasks;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.Helpers;
+using NewRelic.Agent.Extensions.Llm;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Reflection;
+
+namespace NewRelic.Providers.Wrapper.Bedrock;
+
+public class ConverseAsyncWrapper : IWrapper
+{
+    public bool IsTransactionRequired => true; // part of spec, only create events for transactions.
+
+    private static ConcurrentDictionary<Type, Func<object, object>> _getResultFromGenericTask = new();
+    private static ConcurrentDictionary<string, string> _libraryVersions = new();
+    private const string WrapperName = "BedrockConverseAsync";
+    private const string VendorName = "Bedrock";
+
+    public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo)
+    {
+        return new CanWrapResponse(WrapperName.Equals(methodInfo.RequestedWrapperName));
+    }
+
+    public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
+    {
+        // Don't do anything, including sending the version Supportability metric, if we're disabled
+        if (!agent.Configuration.AiMonitoringEnabled)
+        {
+            return Delegates.NoOp;
+        }
+
+        if (instrumentedMethodCall.IsAsync)
+        {
+            transaction.AttachToAsync();
+        }
+
+        dynamic converseRequest = instrumentedMethodCall.MethodCall.MethodArguments[0];
+        string modelId = converseRequest.ModelId.ToLower();
+
+        var operationType = "completion"; // Converse doesn't support embedding
+        var segment = transaction.StartCustomSegment(instrumentedMethodCall.MethodCall, $"Llm/{operationType}/{VendorName}/{instrumentedMethodCall.MethodCall.Method.MethodName}");
+
+        // required per spec
+        var version = GetOrAddLibraryVersion(instrumentedMethodCall.MethodCall.Method.Type.Assembly.ManifestModule.Assembly.FullName);
+        agent.RecordSupportabilityMetric($"DotNet/ML/{VendorName}/{version}");
+
+        return Delegates.GetAsyncDelegateFor<Task>(
+            agent,
+            segment,
+            false,
+            TryProcessConverseResponse,
+            TaskContinuationOptions.ExecuteSynchronously
+        );
+
+        void TryProcessConverseResponse(Task responseTask)
+        {
+            // We need the duration, so we end the segment before creating the events.
+            segment.End();
+
+            if (responseTask.IsFaulted)
+            {
+                HandleError(segment, converseRequest, responseTask, agent, modelId);
+                return;
+            }
+
+            dynamic converseResponse = GetTaskResult(responseTask);
+            if (converseResponse == null || converseResponse.HttpStatusCode >= HttpStatusCode.MultipleChoices)
+            {
+                agent.Logger.Log(Agent.Extensions.Logging.Level.Warn, $"Error processing Converse response for model {modelId}: Response {(converseResponse == null ? "is null" : $"has non-success HttpStatusCode: {converseResponse.HttpStatusCode}")}");
+                return;
+            }
+
+            ProcessConverseResponse(segment, converseRequest, converseResponse, agent, modelId);
+        }
+    }
+
+    private void ProcessConverseResponse(ISegment segment, dynamic converseRequest, dynamic converseResponse, IAgent agent, string requestModelId)
+    {
+        // if request message content doesn't have a non-null Text property, we can't support instrumentation
+        // last message is the current prompt
+        var requestMessage = converseRequest?.Messages?[converseRequest.Messages.Count - 1];
+        if (converseRequest == null || requestMessage == null || requestMessage.Content == null || requestMessage.Content.Count == 0 || requestMessage.Content[0].Text == null)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Info, $"Unable to process Converse response for model {requestModelId}: request was null or message content was not Text");
+            return;
+        }
+
+        if (converseResponse == null)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Warn, $"Error processing Converse response for model {requestModelId}: response was null");
+            return;
+        }
+
+        // if response message content doesn't have a non-null Text property, we can't support instrumentation
+        var responseMessage = converseResponse.Output?.Message;
+        if (responseMessage == null || responseMessage.Content == null || responseMessage.Content.Count == 0 || responseMessage.Content[0].Text == null)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Info, $"Unable to process Converse response for model {requestModelId}: response message content was not Text");
+            return;
+        }
+
+        string requestRole = requestMessage.Role?.Value ?? "user";
+        string promptText = requestMessage.Content?[0]?.Text ?? "";
+
+        string responseRole = responseMessage.Role?.Value ?? "assistant";
+        string responseText = responseMessage.Content?[0]?.Text ?? "";
+        string stopReason = converseResponse.StopReason?.Value;
+
+        string requestId = converseResponse.ResponseMetadata?.RequestId;
+        int? requestMaxTokens = converseRequest.InferenceConfig?.MaxTokens;
+        float? requestTemperature = converseRequest.InferenceConfig?.Temperature;
+
+        int? inputTokens = converseResponse.Usage?.InputTokens;
+        int? outputTokens = converseResponse.Usage?.OutputTokens;
+
+        var completionId = EventHelper.CreateChatCompletionEvent(
+            agent,
+            segment,
+            requestId,
+            requestTemperature,
+            requestMaxTokens,
+            requestModelId,
+            requestModelId,
+            2, // one request, one response
+            stopReason,
+            VendorName,
+            false,
+            null,  // not available in AWS
+            null
+        );
+
+        // Prompt
+        EventHelper.CreateChatMessageEvent(
+                agent,
+                segment,
+                requestId,
+                null,
+                requestModelId,
+                promptText,
+                requestRole,
+                0,
+                completionId,
+                false,
+                VendorName,
+                inputTokens);
+
+        // Response
+        EventHelper.CreateChatMessageEvent(
+            agent,
+            segment,
+            requestId,
+            null,
+            requestModelId,
+            responseText,
+            responseRole,
+            1,
+            completionId,
+            true,
+            VendorName,
+            outputTokens);
+    }
+
+    private void HandleError(ISegment segment, dynamic converseRequest, Task responseTask, IAgent agent, string modelId)
+    {
+        agent.Logger.Log(Agent.Extensions.Logging.Level.Info, $"Error processing Converse response for model {modelId}: {responseTask.Exception!.Message}");
+
+        dynamic bedrockException = responseTask.Exception!.InnerException;
+        if (bedrockException == null)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Warn, $"Error processing Converse response for model {modelId}: Task faulted but there was no inner exception");
+            return;
+        }
+
+        var requestMessage = converseRequest?.Messages?[converseRequest.Messages.Count - 1];
+
+        if (converseRequest == null || requestMessage == null)
+        {
+            agent.Logger.Log(Agent.Extensions.Logging.Level.Warn, $"Error processing Converse response for model {modelId}: request Message was null");
+            return;
+        }
+
+        HttpStatusCode statusCode = bedrockException.StatusCode;
+        string errorCode = bedrockException.ErrorCode;
+        string errorMessage = bedrockException.Message;
+        string requestId = bedrockException.RequestId;
+
+        var errorData = new LlmErrorData
+        {
+            HttpStatusCode = ((int)statusCode).ToString(),
+            ErrorCode = errorCode,
+            ErrorParam = null, // not available in AWS
+            ErrorMessage = errorMessage
+        };
+
+        string requestRole = requestMessage.Role?.Value ?? "user";
+        string promptText = requestMessage.Content?[0]?.Text ?? "";
+        int? requestMaxTokens = converseRequest.InferenceConfig?.MaxTokens;
+        float? requestTemperature = converseRequest.InferenceConfig?.Temperature;
+
+
+        var completionId = EventHelper.CreateChatCompletionEvent(
+            agent,
+            segment,
+            requestId,
+            requestTemperature,
+            requestMaxTokens,
+            converseRequest.ModelId,
+            null,
+            0,
+            null,
+            VendorName,
+            true,
+            null,
+            errorData);
+
+        // Prompt
+        EventHelper.CreateChatMessageEvent(
+                agent,
+                segment,
+                requestId,
+                null,
+                converseRequest.ModelId,
+                promptText,
+                requestRole,
+                0,
+                completionId,
+                false,
+                VendorName);
+    }
+
+
+    private string GetOrAddLibraryVersion(string assemblyFullName)
+    {
+        return _libraryVersions.GetOrAdd(assemblyFullName, VersionHelpers.GetLibraryVersion(assemblyFullName));
+    }
+
+    private static object GetTaskResult(object task)
+    {
+        if (((Task)task).IsFaulted)
+        {
+            return null;
+        }
+
+        var getResponse = _getResultFromGenericTask.GetOrAdd(task.GetType(), t => VisibilityBypasser.Instance.GeneratePropertyAccessor<object>(t, "Result"));
+        return getResponse(task);
+    }
+}

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/Instrumentation.xml
@@ -13,6 +13,14 @@ SPDX-License-Identifier: Apache-2.0
         <exactMethodMatcher methodName="InvokeModelAsync" />
       </match>
     </tracerFactory>
-    
+
+    <tracerFactory name="BedrockConverseAsync">
+      <!--
+      public virtual Task<ConverseResponse> ConverseAsync(ConverseRequest request, System.Threading.CancellationToken cancellationToken = default(CancellationToken))
+      -->
+      <match assemblyName="AWSSDK.BedrockRuntime" className="Amazon.BedrockRuntime.AmazonBedrockRuntimeClient">
+        <exactMethodMatcher methodName="ConverseAsync" />
+       </match>
+    </tracerFactory>
   </instrumentation>
 </extension>

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseTests.cs
@@ -1,0 +1,149 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewRelic.Agent.IntegrationTests.LLM
+{
+    public abstract class BedrockConverseTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    {
+        private readonly TFixture _fixture;
+
+        // Prompts have spaces in them, which will not be parsed correctly
+        private string _prompt = "In one sentence, what is a large-language model?";
+
+        private Dictionary<string, LlmMessageTypes> _expectedAttributes = new()
+        {
+            {"id", LlmMessageTypes.All},
+            {"request_id", LlmMessageTypes.All},
+            {"span_id", LlmMessageTypes.All},
+            {"trace_id", LlmMessageTypes.All},
+            {"request.temperature", LlmMessageTypes.LlmChatCompletionSummary},
+            {"request.max_tokens", LlmMessageTypes.LlmChatCompletionSummary},
+            {"request.model", LlmMessageTypes.LlmChatCompletionSummary | LlmMessageTypes.LlmEmbedding},
+            {"response.model", LlmMessageTypes.All},
+            {"response.number_of_messages", LlmMessageTypes.LlmChatCompletionSummary},
+            {"response.choices.finish_reason", LlmMessageTypes.LlmChatCompletionSummary},
+            {"vendor", LlmMessageTypes.All},
+            {"ingest_source", LlmMessageTypes.All},
+            {"duration", LlmMessageTypes.LlmChatCompletionSummary | LlmMessageTypes.LlmEmbedding},
+            {"content", LlmMessageTypes.LlmChatCompletionMessage},
+            {"role", LlmMessageTypes.LlmChatCompletionMessage},
+            {"sequence", LlmMessageTypes.LlmChatCompletionMessage},
+            {"completion_id", LlmMessageTypes.LlmChatCompletionMessage},
+            {"input", LlmMessageTypes.LlmEmbedding},
+        };
+
+        protected BedrockConverseTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+            _fixture.TestLogger = output;
+            _fixture.AddActions(
+                setupConfiguration: () =>
+                {
+                    new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath)
+                        .ForceTransactionTraces()
+                        .EnableAiMonitoring()
+                        .SetLogLevel("finest");
+                },
+                exerciseApplication: () =>
+                {
+                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2), 2);
+                }
+            );
+
+            _fixture.AddCommand($"BedrockExerciser Converse {LLMHelpers.ConvertToBase64(_prompt)}");
+            _fixture.AddCommand($"BedrockExerciser ConverseWithError {LLMHelpers.ConvertToBase64(_prompt)}");
+
+            _fixture.Initialize();
+        }
+
+        private void ValidateCommonAttributes(IEnumerable<CustomEventData> customEvents)
+        {
+            foreach (var evt in customEvents)
+            {
+                if (!Enum.TryParse<LlmMessageTypes>(evt.Header.Type, out var type))
+                {
+                    Assert.Fail($"{evt.Header.Type} is not a recognized LLM message type");
+                }
+                foreach (var pair in evt.Attributes)
+                {
+                    if (_expectedAttributes.TryGetValue(pair.Key, out var expectedTypes))
+                    {
+                        Assert.True(expectedTypes.HasFlag(type), $"{type} is not expected to have the attribute {pair.Key}");
+                    }
+                }
+
+                foreach (var pair in _expectedAttributes)
+                {
+                    if (pair.Value.HasFlag(type))
+                    {
+                        if (!evt.Attributes.TryGetValue(pair.Key, out _))
+                        {
+                            Assert.Fail($"The attribute '{pair.Key}' is expected in an '{type}' event but it was not found");
+                        }
+                    }
+                }
+            }
+
+        }
+
+        [Fact]
+        public void ConverseTest()
+        {
+            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            {
+                new() { metricName = @"Custom/Llm/completion/Bedrock/ConverseAsync", CallCountAllHarvests = 2 },
+                new() { metricName = @"Supportability/DotNet/ML/.*", IsRegexName = true}
+            };
+
+            var customEventsSuccess = _fixture.AgentLog.GetCustomEvents().Where(ce => !ce.Attributes.Keys.Contains("error")).ToList();
+            var customEventFailure = _fixture.AgentLog.GetCustomEvents().SingleOrDefault(ce => ce.Attributes.Keys.Contains("error"));
+
+            ValidateCommonAttributes(customEventsSuccess);
+            Assert.NotNull(customEventFailure);
+            Assert.Equal(true, customEventFailure.Attributes["error"]);
+
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            Assertions.MetricsExist(expectedMetrics, metrics);
+
+            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.BedrockExerciser/Converse");
+            Assert.NotNull( transactionEvent );
+
+            var transactionEventError = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.BedrockExerciser/ConverseWithError");
+            Assert.NotNull(transactionEventError);
+
+            var applicationErrorEvent = _fixture.AgentLog.GetErrorEvents().SingleOrDefault();
+            Assert.NotNull(applicationErrorEvent);
+            Assert.Contains("completion_id", applicationErrorEvent.UserAttributes.Keys);
+            Assert.Contains("http.statusCode", applicationErrorEvent.UserAttributes.Keys);
+            Assert.Contains("error.code", applicationErrorEvent.UserAttributes.Keys);
+        }
+    }
+
+    [NetCoreTest]
+    public class BedrockConverseTests_Basic_CoreLatest : BedrockConverseTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public BedrockConverseTests_Basic_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+
+    [NetFrameworkTest]
+    public class BedrockConverseTests_Basic_FWLatest : BedrockConverseTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public BedrockConverseTests_Basic_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockInvokeTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockInvokeTests.cs
@@ -12,8 +12,7 @@ using Xunit.Abstractions;
 
 namespace NewRelic.Agent.IntegrationTests.LLM
 {
-    public abstract class BedrockTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-where TFixture : ConsoleDynamicMethodFixture
+    public abstract class BedrockInvokeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
     {
         private readonly TFixture _fixture;
 
@@ -48,7 +47,7 @@ where TFixture : ConsoleDynamicMethodFixture
             {"input", LlmMessageTypes.LlmEmbedding},
         };
 
-        public BedrockTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        public BedrockInvokeTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
         {
             _fixture = fixture;
             _fixture.SetTimeout(TimeSpan.FromMinutes(2));
@@ -128,18 +127,18 @@ where TFixture : ConsoleDynamicMethodFixture
     }
 
     [NetCoreTest]
-    public class BedrockTests_Basic_CoreLatest : BedrockTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    public class BedrockInvokeTests_Basic_CoreLatest : BedrockInvokeTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
     {
-        public BedrockTests_Basic_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        public BedrockInvokeTests_Basic_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }
     }
 
     [NetFrameworkTest]
-    public class BedrockTests_Basic_FWLatest : BedrockTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    public class BedrockInvokeTests_Basic_FWLatest : BedrockInvokeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
-        public BedrockTests_Basic_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        public BedrockInvokeTests_Basic_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
             : base(fixture, output)
         {
         }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Amazon.BedrockRuntime.Model;
@@ -290,6 +287,49 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LLM
                 Accept = "application/json"
             });
         }
+
+#if NET481 ||  NET9_0 // Converse API is only available in AWSSDK.BedrockRuntime v3.7.303 and later, tested by net481 and net9.0 tfms
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static async Task<string> ConverseNovaMicro(string prompt, bool generateError)
+        {
+            string responseText = "";
+            try
+            {
+                var response = await Converse("us.amazon.nova-micro-v1:0" + (generateError ? "bogus" : ""), prompt);
+
+                responseText = response?.Output?.Message?.Content?[0]?.Text ?? "";
+            }
+            catch (AmazonBedrockRuntimeException e)
+            {
+                Console.WriteLine(e);
+            }
+            return responseText;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task<ConverseResponse> Converse(string model, string payload)
+        {
+
+            // Create a request with the model ID, the user message, and an inference configuration.
+            var request = new ConverseRequest
+            {
+                ModelId = model,
+
+                Messages =
+                [
+                    new Message { Role = ConversationRole.User, Content = [new ContentBlock { Text = payload }] }
+                ],
+                InferenceConfig = new InferenceConfiguration
+                {
+                    MaxTokens = 512,
+                    Temperature = 0.5F,
+                    TopP = 0.9F
+                }
+            };
+
+            return await _amazonBedrockRuntimeClient.ConverseAsync(request);
+        }
+#endif
     }
 
     internal static class BedrockRegionExtensions


### PR DESCRIPTION
## Description

Adds LLM instrumentation for the `ConverseAsync()` method in `AmazonBedrockRuntimeClient`. This method became available in `AWSSDK.BedrockRuntime` v3.7.303.

Supports Text conversations only.

Includes integration tests.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
