### PR TITLE
feat:Add support for PackageReference with NewRelic.Azure.WebSites packages.

### DIFF
--- a/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="3.3.0">
     <id>NewRelic.Azure.WebSites.x64</id>
     <version>REPLACE_WITH_VERSION</version>
     <title>New Relic for Windows Azure Web Sites (x64)</title>
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
-    <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</projectUrl>
+    <projectUrl>https://docs.newrelic.com/install/dotnet/?deployment=azure&amp;azure=azurenugetframework</projectUrl>
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>
     <summary>This package will add all of the resources needed to profile your Windows Azure Web Site running as a reserved 64-bit instance. For more information on this package visit: https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</summary>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
+    <contentFiles>
+      <files include="**/newrelic/**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
   </metadata>
   <files>
-    <file src="content\**" target="content" />
+    <file src="**\newrelic\**\*" target="." />
     <file src="lib\**" target="lib" />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />

--- a/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="3.3.0">
     <id>NewRelic.Azure.WebSites</id>
     <version>REPLACE_WITH_VERSION</version>
     <title>New Relic for Windows Azure Web Sites (x86)</title>
     <authors>New Relic</authors>
     <license type="expression">Apache-2.0</license>
-    <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</projectUrl>
+    <projectUrl>https://docs.newrelic.com/install/dotnet/?deployment=azure&amp;azure=azurenugetframework</projectUrl>
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>
     <summary>This package will add all of the resources needed to profile your Windows Azure Web Site. For more information on this package visit: https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</summary>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
+    <contentFiles>
+      <files include="**/newrelic/**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
   </metadata>
   <files>
-    <file src="content\**" target="content" />
+    <file src="**\newrelic\**\*" target="." />
     <file src="lib\**" target="lib" />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />


### PR DESCRIPTION
## Description

Instead of updating the docs, this will update the packages to work with PackageRef in modern csproj files.  It doesn't change how the package operates with .NET Framework style csproj files.  I updated the minClientVersion setting the the nuspecs to match the NewRelic.Agent package. I didn't run into any issues with this, 2.8.6 is the oldest and only 2.x version.  it came out in 2015.  The next version is 3.3.0 which is what we set as the minimum.

Tested the package with both types of apps and the files appear in the output correctly both times.
Test same nuget.exe command used in AzureSiteExtension and it outputs both sets of files.

Regarding the AzureSiteExtension, it only uses the websites package version is greater than 8.17.438, it just uses the NewRelic.Agent package.  Even if it did use the Websites package, it would not affect the AzureSiteExtension since it only copies over a specific set of folders and deletes the rest.  The extra space used by the new files would only be around for a few minutes during install.

fixes #3000

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
