### PR TITLE
feat: Enable Azure Function instrumentation by default

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2216,7 +2216,7 @@ namespace NewRelic.Agent.Core.Configuration
         private bool? _azureFunctionModeEnabled;
         public bool AzureFunctionModeEnabled =>
             _azureFunctionModeEnabled ??
-            (_azureFunctionModeEnabled = EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AzureFunctionModeEnabled", false), "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED")).Value;
+            (_azureFunctionModeEnabled = EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AzureFunctionModeEnabled", true), "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED")).Value;
 
         public string AzureFunctionResourceId
         {

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -138,7 +138,8 @@ namespace NewRelic.Agent.Core.Utilization
 
         public IVendorModel GetAzureFunctionVendorInfo()
         {
-            if (!_configuration.AzureFunctionModeDetected)
+            // per the spec, only report Azure Function metadata if the agent is running in an Azure Function mode and instrumentation is enabled
+            if (!(_configuration.AzureFunctionModeEnabled &&_configuration.AzureFunctionModeDetected))
                 return null;
 
             var appName = _configuration.AzureFunctionResourceId;

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -138,7 +138,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         public IVendorModel GetAzureFunctionVendorInfo()
         {
-            if (!(_configuration.AzureFunctionModeDetected && _configuration.AzureFunctionModeEnabled))
+            if (!_configuration.AzureFunctionModeDetected)
                 return null;
 
             var appName = _configuration.AzureFunctionResourceId;

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
         public async Task Invoke(HttpContext context)
         {
             // if we're in Azure function mode, we don't want to do execute this wrapper
-            if (_agent.Configuration.AzureFunctionModeEnabled)
+            if (_agent.Configuration.AzureFunctionModeDetected && _agent.Configuration.AzureFunctionModeEnabled)
             {
                 if (!_loggedDisabledMessage)
                 {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/FunctionsHttpProxyingMiddlewareWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/FunctionsHttpProxyingMiddlewareWrapper.cs
@@ -25,7 +25,7 @@ public class FunctionsHttpProxyingMiddlewareWrapper : IWrapper
     /// </summary>
     public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
     {
-        if (agent.Configuration.AzureFunctionModeEnabled)
+        if (agent.Configuration.AzureFunctionModeDetected && agent.Configuration.AzureFunctionModeEnabled)
         {
             dynamic httpContext;
             switch (instrumentedMethodCall.MethodCall.Method.MethodName)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/InvokeFunctionAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/InvokeFunctionAsyncWrapper.cs
@@ -32,7 +32,7 @@ public class InvokeFunctionAsyncWrapper : IWrapper
     public AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent,
         ITransaction transaction)
     {
-        if (!agent.Configuration.AzureFunctionModeEnabled) // bail early if azure function mode isn't enabled
+        if (!(agent.Configuration.AzureFunctionModeDetected && agent.Configuration.AzureFunctionModeEnabled) ) // bail early if azure function mode isn't enabled
         {
             if (!_loggedDisabledMessage)
             {

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.36.0.5"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.37.0.7"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -636,7 +636,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
             auto azureFunctionModeEnabled = _systemCalls->TryGetEnvironmentVariable(_X("NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED"));
 
             if (azureFunctionModeEnabled == nullptr || azureFunctionModeEnabled->length() == 0) {
-                return false;
+                return true; // enabled by default if environment variable isn't specified
             }
 
             return Strings::AreEqualCaseInsensitive(*azureFunctionModeEnabled, _X("true")) || Strings::AreEqualCaseInsensitive(*azureFunctionModeEnabled, _X("1"));

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/AzureFuncTool.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/AzureFuncTool.cs
@@ -111,7 +111,8 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
             startInfo.EnvironmentVariables.Add("NEW_RELIC_PROFILER_LOG_DIRECTORY", profilerLogDirectoryPath);
 
-            startInfo.Environment.Add("NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED", _enableAzureFunctionMode.ToString());
+            if (!_enableAzureFunctionMode) // enabled by default, only set the environment variable if it's disabled
+                startInfo.Environment.Add("NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED", _enableAzureFunctionMode.ToString());
 
             // environment variables needed by azure function instrumentation
             startInfo.Environment.Add("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -3062,6 +3062,12 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             return _defaultConfig.UtilizationDetectAzureFunction;
         }
+
+        [Test]
+        public void AzureFunctionModeEnabledByDefault()
+        {
+            Assert.That(_defaultConfig.AzureFunctionModeEnabled, Is.True, "AzureFunctionMode should be enabled by default");
+        }
         #endregion
 
         #region Log Metrics and Events


### PR DESCRIPTION
Azure Function instrumentation is now enabled by default. 

To disable Azure Function instrumentation, set the `NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED=0` environment variable.