### PR TITLE
chore: Update mssql to 2022-latest

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mssql/Dockerfile
@@ -7,14 +7,14 @@ ENV MSSQL_SA_PASSWORD=${SA_PASS}
 ENV SQLCMDPASSWORD=${SA_PASS}
 ENV SA_PASSWORD=${SA_PASS}
 
+USER root
 COPY setup.sh /var/
 COPY entrypoint.sh /var/
 COPY restore.sql /var/
-
 # Copy database backup file to container
 COPY NewRelicDB.bak /var/opt/mssql/backup/NewRelicDB.bak
-
 RUN chmod 777 /var/setup.sh \
    && chmod 777 /var/entrypoint.sh
 
+USER mssql
 ENTRYPOINT ["/var/entrypoint.sh"]

--- a/tests/Agent/IntegrationTests/UnboundedServices/mssql/setup.sh
+++ b/tests/Agent/IntegrationTests/UnboundedServices/mssql/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Starts a loop to check if SQL is ready before running setup script.
-STATUS=$(/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h-1 )
+STATUS=$(/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -No -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h-1 )
 while [ "$STATUS" != 1 ]
 do
 sleep 1s
-STATUS=$(/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h-1 )
+STATUS=$(/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -No -d master -Q "SET NOCOUNT ON; SELECT 1" -W -h-1 )
 done
 
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -i /var/restore.sql
+/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -No -i /var/restore.sql


### PR DESCRIPTION
Updates the unbounded services MSSQL configuration to run MSSQL 2022-latest. Also updates Dockerfile and setup.sh to work with the latest version. 

This matches what is already running on the unbounded services EC2 instance.