### PR TITLE
feat Enable ASP.NET Core browser auto-injection by default.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -813,6 +813,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             ReportIfAwsAccountIdProvided();
             ReportIfAgentControlHealthEnabled();
             ReportIfAzureFunctionModeIsEnabled();
+            ReportIfAspNetCore6PlusIsEnabled();
         }
 
         public void CollectMetrics()
@@ -990,6 +991,18 @@ namespace NewRelic.Agent.Core.AgentHealth
             if (_configuration.AzureFunctionModeEnabled && _configuration.AzureFunctionModeDetected)
             {
                 ReportSupportabilityCountMetric(MetricNames.SupportabilityAzureFunctionModeEnabled);
+            }
+        }
+
+        private void ReportIfAspNetCore6PlusIsEnabled()
+        {
+            if (_configuration.EnableAspNetCore6PlusBrowserInjection)
+            {
+                ReportSupportabilityCountMetric(MetricNames.SupportabilityAspNetCore6PlusBrowserInjectionEnabled);
+            }
+            else
+            {
+                ReportSupportabilityCountMetric(MetricNames.SupportabilityAspNetCore6PlusBrowserInjectionDisabled);
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2373,7 +2373,7 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 return _enableAspNetCore6PlusBrowserInjection.HasValue
                     ? _enableAspNetCore6PlusBrowserInjection.Value
-                    : (_enableAspNetCore6PlusBrowserInjection = TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", false)).Value;
+                    : (_enableAspNetCore6PlusBrowserInjection = TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", true)).Value;
             }
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNames.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNames.cs
@@ -840,6 +840,8 @@ namespace NewRelic.Agent.Core.Metrics
         public const string SupportabilityGCSamplerV2Enabled = SupportabilityDotnetPs + "GCSamplerV2/Enabled";
         public const string SupportabilityAwsAccountIdProvided = SupportabilityDotnetPs + "AwsAccountId/Config";
         public const string SupportabilityAzureFunctionModeEnabled = SupportabilityDotnetPs + "AzureFunctionMode/Enabled";
+        public const string SupportabilityAspNetCore6PlusBrowserInjectionEnabled = SupportabilityDotnetPs + "AspNetCore6PlusBrowserInjection/Enabled";
+        public const string SupportabilityAspNetCore6PlusBrowserInjectionDisabled = SupportabilityDotnetPs + "AspNetCore6PlusBrowserInjection/Disabled";
 
         #endregion Supportability
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection6Plus.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/BrowserAgentAutoInjection6Plus.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
@@ -85,6 +86,11 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
             // verify that the browser injecting stream wrapper didn't catch an exception and disable itself
             var agentDisabledLogLine = _fixture.AgentLog.TryGetLogLine(AgentLogBase.ErrorLogLinePrefixRegex + "Unexpected exception. Browser injection will be disabled. *?");
             Assert.Null(agentDisabledLogLine);
+
+            var expectedMetric = new Assertions.ExpectedMetric { metricName = $@"Supportability/Dotnet/AspNetCore6PlusBrowserInjection/{(_browserInjectionEnabled ? "Enabled" : "Disabled")}" };
+            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            Assertions.MetricExists(expectedMetric, metrics);
+
         }
     }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterTests.cs
@@ -26,12 +26,14 @@ namespace NewRelic.Agent.Core.AgentHealth
         private List<MetricWireModel> _publishedMetrics;
         private ConfigurationAutoResponder _configurationAutoResponder;
         private bool _enableLogging;
+        private bool _enableAspNetCore6PlusBrowserInjection;
         private List<IDictionary<string, string>> _ignoredInstrumentation;
 
         [SetUp]
         public void SetUp()
         {
             _enableLogging = true;
+            _enableAspNetCore6PlusBrowserInjection = true;
             _ignoredInstrumentation = new List<IDictionary<string, string>>();
             var configuration = GetDefaultConfiguration();
             _configurationAutoResponder = new ConfigurationAutoResponder(configuration);
@@ -61,7 +63,7 @@ namespace NewRelic.Agent.Core.AgentHealth
             Mock.Arrange(() => configuration.GCSamplerV2Enabled).Returns(true);
             Mock.Arrange(() => configuration.AwsAccountId).Returns("123456789012");
             Mock.Arrange(() => configuration.LabelsEnabled).Returns(true);
-
+            Mock.Arrange(() => configuration.EnableAspNetCore6PlusBrowserInjection).Returns(_enableAspNetCore6PlusBrowserInjection);
             Mock.Arrange(() => configuration.AgentControlEnabled).Returns(true);
             Mock.Arrange(() => configuration.HealthDeliveryLocation).Returns("file://foo");
             Mock.Arrange(() => configuration.HealthFrequency).Returns(12);
@@ -543,6 +545,20 @@ namespace NewRelic.Agent.Core.AgentHealth
         {
             _agentHealthReporter.CollectMetrics();
             Assert.That(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Dotnet/AwsAccountId/Config"), Is.True);
+        }
+
+        public void AspNetCore6PlusBrowserInjectionEnabledMetricPresent()
+        {
+            _enableAspNetCore6PlusBrowserInjection = true;
+            _agentHealthReporter.CollectMetrics();
+            Assert.That(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Dotnet/AspNetCore6PlusBrowserInjection/Enabled"), Is.True);
+        }
+
+        public void AspNetCore6PlusBrowserInjectionDisabledMetricPresent()
+        {
+            _enableAspNetCore6PlusBrowserInjection = false;
+            _agentHealthReporter.CollectMetrics();
+            Assert.That(_publishedMetrics.Any(x => x.MetricNameModel.Name == "Supportability/Dotnet/AspNetCore6PlusBrowserInjection/Disabled"), Is.True);
         }
     }
 }


### PR DESCRIPTION
## Description

- Enable ASP.NET Core browser auto-injection by default.
- Add supportability metrics to track when it is enabled or disabled:  `Supportability/Dotnet/AspNetCore6PlusBrowserInjection/{Enabled|Disabled}`
- Update unit and integration tests to check for metrics

I ran our browser integration tests with this being true and it worked.  I also ran an ASP.NET Core MVC app working with a gRPC service and HTTP/2 with no issues.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
