### PR TITLE
fix: Remove diagnostics tracing output from agent API calls

### DIFF
--- a/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
@@ -8,6 +8,7 @@
     <IntermediateOutputPath>$(RootProjectDirectory)\src\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</IntermediateOutputPath>
     <OutputPath>$(RootProjectDirectory)\src\_build\$(Platform)-$(Configuration)\$(AssemblyName)\</OutputPath>
     <Nullable>enable</Nullable>
+    <DisableDiagnosticTracing>true</DisableDiagnosticTracing>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Fixes #3018.  The agent API assembly has stub methods that contain System.Diagnostics.Tracing.WriteLine calls, mainly so that those methods have a body and use the parameters.  When the agent is actually attached to a process that uses the API, these methods get rewired by the profiler to be the actual API implementations inside the agent.  When running a program that makes agent API calls without the agent attached, the trace calls are made, harmlessly, or so we thought.  Turns out that for a while now, the TRACE constant has been set by msbuild by default, and must be actively disabled to avoid having these calls result in tracing output in certain circumstances (e.g. running your program in Visual Studio).

The fix is just to set `<DisableDiagnosticTracing>true</DisableDiagnosticTracing>` in the API project file.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
