### PR TITLE
test: Update Redis integration tests to include `LockTake` and `LockRelease` calls.

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
@@ -62,6 +62,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedi
                 db.SetRemove("myset", "cool");
                 db.SetPop("myset");
 
+                db.LockTake(key, "mylock", TimeSpan.FromSeconds(1));
+                db.LockRelease(key, "mylock");
+
                 db.Publish(new RedisChannel("mychannel", RedisChannel.PatternMode.Literal), "cable"); // 31
             }
 
@@ -113,6 +116,9 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedi
                 await db.SetRandomMemberAsync("myset");
                 await db.SetRemoveAsync("myset", "cool");
                 await db.SetPopAsync("myset");
+
+                await db.LockTakeAsync(key, "mylock", TimeSpan.FromSeconds(1));
+                await db.LockReleaseAsync(key, "mylock");
 
                 await db.PublishAsync(new RedisChannel("mychannel", RedisChannel.PatternMode.Literal), "cable"); // 31
             }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
@@ -50,50 +50,49 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Redis
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 62 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 62 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Redis/all", callCount = 62 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Redis/allOther", callCount = 62 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Redis/{CommonUtils.NormalizeHostname(StackExchangeRedisConfiguration.StackExchangeRedisServer)}/{StackExchangeRedisConfiguration.StackExchangeRedisPort}", callCount = 62},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/GET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/GET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/APPEND", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/GETRANGE", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SETRANGE", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/STRLEN", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/DECR", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/INCR", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HMSET", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HINCRBY", callCount = 4 }, // increment and decrement
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HEXISTS", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HVALS", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/EXISTS", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/RANDOMKEY", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/RENAME", callCount = 2 },
+                new() { metricName = @"Datastore/all", callCount = 66 },
+                new() { metricName = @"Datastore/allOther", callCount = 66 },
+                new() { metricName = @"Datastore/Redis/all", callCount = 66 },
+                new() { metricName = @"Datastore/Redis/allOther", callCount = 66 },
+                new() { metricName = $@"Datastore/instance/Redis/{CommonUtils.NormalizeHostname(StackExchangeRedisConfiguration.StackExchangeRedisServer)}/{StackExchangeRedisConfiguration.StackExchangeRedisPort}", callCount = 66},
+                new() { metricName = @"Datastore/operation/Redis/SET", callCount = 4 },
+                new() { metricName = @"Datastore/operation/Redis/GET", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/APPEND", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/GETRANGE", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SETRANGE", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/STRLEN", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/DECR", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/INCR", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/HMSET", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/HINCRBY", callCount = 4 }, // increment and decrement
+                new() { metricName = @"Datastore/operation/Redis/HEXISTS", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/HVALS", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/EXISTS", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/RANDOMKEY", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/RENAME", callCount = 2 },
                 // Delete can resolve to DEL or UNLINK depending on Redis version
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/(DEL|UNLINK)", IsRegexName = true, callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/PING", callCount = 4 }, //ping and identifyendpoint
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SADD", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SUNION", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SISMEMBER", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SCARD", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SMEMBERS", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SMOVE", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SRANDMEMBER", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SPOP", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/SREM", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Redis/PUBLISH", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/(DEL|UNLINK)", IsRegexName = true, callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/PING", callCount = 4 }, //ping and identifyendpoint
+                new() { metricName = @"Datastore/operation/Redis/SADD", callCount = 4 },
+                new() { metricName = @"Datastore/operation/Redis/SUNION", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SISMEMBER", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SCARD", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SMEMBERS", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SMOVE", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SRANDMEMBER", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SPOP", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/SREM", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/PUBLISH", callCount = 2 },
+                new() { metricName = @"Datastore/operation/Redis/EXEC", callCount = 2}
             };
 
             var unexpectedMetrics = new List<Assertions.ExpectedMetric>
             {
                 // The datastore operation happened inside a console app so there should be no allWeb metrics
-                new Assertions.ExpectedMetric {metricName = @"Datastore/allWeb", callCount = 1},
-                new Assertions.ExpectedMetric {metricName = @"Datastore/Redis/allWeb", callCount = 1}
+                new() {metricName = @"Datastore/allWeb", callCount = 1},
+                new() {metricName = @"Datastore/Redis/allWeb", callCount = 1}
             };
 
             var expectedTransactionEventIntrinsicAttributes = new List<string>


### PR DESCRIPTION
Minor update to unbounded integration tests for StackExchange.Redis, to include `LockTake()` and `LockRelease()`. This was spurred by a support question where we needed to verify that these methods were being properly instrumented.