### PR TITLE
fix: Remove unnecessary dependency on `System.Runtime.InteropServices.RuntimeInformation` in .NET 4.6.2  builds.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -350,8 +350,11 @@ namespace NewRelic.Agent.Core
                     }
                 }
 
-
+#if NETSTANDARD
                 Log.Debug($".NET Runtime Version: {RuntimeInformation.FrameworkDescription}");
+#else
+                Log.Debug($".NET Runtime Version: {AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName}");
+#endif
             }
 
 #if NETFRAMEWORK

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -70,7 +70,6 @@
     <!-- .NET Framework needs to use the legacy gRPC library -->
     <PackageReference Include="Grpc" Version="2.46.6" />
     <PackageReference Include="Grpc.Core" Version="2.46.6" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
@@ -122,7 +121,6 @@
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Buffers'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Memory'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Runtime.CompilerServices.Unsafe'" />
-      <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Runtime.InteropServices.RuntimeInformation'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.Threading.Tasks.Extensions'" />
       <ILRepackInclude Include="@(PossibleRefsForILRepack)" Condition="'%(FileName)' == 'System.ValueTuple'" />
     </ItemGroup>
@@ -137,7 +135,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">20</ILRepackIncludeCount>
+      <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'net462'">19</ILRepackIncludeCount>
       <ILRepackIncludeCount Condition="'$(TargetFramework)' == 'netstandard2.0'">17</ILRepackIncludeCount>
     </PropertyGroup>
 


### PR DESCRIPTION
Removes an unnecessary dependency on `System.Runtime.InteropServices.RuntimeInformtion` for .NET 4.6.2 builds. This has the helpful side effect of also removing a dependency on `System.Runtime` that was reportedly causing the .NET agent to crash for some users running the agent on a .NET Framework 4.8 application. 

Fixes #3032 