### PR TITLE
Feature work: Kinesis POC cleanup

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/AwsSdk/KinesisHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/AwsSdk/KinesisHelper.cs
@@ -1,0 +1,103 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NewRelic.Agent.Extensions.AwsSdk
+{
+    public static class KinesisHelper
+    {
+
+        private static readonly ConcurrentDictionary<string, string> _streamNameCache = new();
+        private static readonly ConcurrentDictionary<Type, List<string>> _propertyInfoCache = new();
+
+        public static string GetStreamNameFromRequest(dynamic request)
+        {
+            try
+            {
+                var streamName = GetPropertyFromDynamic(request, "StreamName");
+                if (streamName != null)
+                {
+                    return streamName;
+                }
+                // if StreamName is null/unavailable, StreamARN may exist
+                var streamARN = GetStreamArnFromRequest(request);
+                if (streamARN != null)
+                {
+                    return GetStreamNameFromArn(streamARN);
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+
+        public static string GetDeliveryStreamNameFromRequest(dynamic request)
+        {
+            try
+            {
+                var streamName = GetPropertyFromDynamic(request, "DeliveryStreamName");
+                if (streamName != null)
+                {
+                    return streamName;
+                }
+                // if StreamName is null/unavailable, StreamARN may exist
+                var streamARN = GetDeliveryStreamArnFromRequest(request);
+                if (streamARN != null)
+                {
+                    return GetStreamNameFromArn(streamARN);
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+        public static string GetStreamArnFromRequest(dynamic request)
+        {
+            return GetPropertyFromDynamic(request, "StreamArn");
+        }
+
+        public static string GetDeliveryStreamArnFromRequest(dynamic request)
+        {
+            return GetPropertyFromDynamic(request, "DeliveryStreamArn");
+        }
+
+        private static string GetPropertyFromDynamic(dynamic request, string propertyName)
+        {
+            Type type = request.GetType();
+            List<string> properties = _propertyInfoCache.ContainsKey(type) ? _propertyInfoCache[type] : _propertyInfoCache[type] = type.GetProperties().Select(p => p.Name).ToList();
+            return properties.Contains(propertyName) ? type.GetProperty(propertyName).GetValue(request) : null;
+        }
+
+        public static string GetStreamNameFromArn(string streamARN)
+        {
+            // arn:aws:kinesis:us-west-2:111111111111:deliverystream/NameOfStream
+            if (_streamNameCache.ContainsKey(streamARN))
+            {
+                return _streamNameCache[streamARN];
+            }
+            else
+            {
+                var arnParts = streamARN.Split(':');
+                if (arnParts.Length > 1)
+                {
+                    var lastPart = arnParts[arnParts.Length - 1];
+                    if (lastPart.Contains('/'))
+                    {
+                        var streamName = lastPart.Split('/')[1];
+                        return _streamNameCache[streamARN] = streamName;
+                    }
+                }
+                return null;
+            }
+        }
+
+    }
+}

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/KinesisHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/KinesisHelperTests.cs
@@ -1,16 +1,10 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using NewRelic.Agent.Api;
+using Aws.Kinesis.Models;
 using NewRelic.Agent.Extensions.AwsSdk;
-using NewRelic.Agent.Extensions.Providers.Wrapper;
 using NewRelic.Testing.Assertions;
 using NUnit.Framework;
-using Telerik.JustMock;
 
 namespace Agent.Extensions.Tests.Helpers
 {
@@ -31,5 +25,89 @@ namespace Agent.Extensions.Tests.Helpers
             // Assert
             Assert.That(streamName.IsEqualTo(expectedStreamName));
         }
+
+        [Test]
+        [TestCase("KinesisStreamName", "arn:aws:kinesis:us-west-2:111111111111:stream/KinesisStreamName", "KinesisStreamName")]
+        [TestCase("KinesisStreamName", null, "KinesisStreamName")]
+        [TestCase(null, "arn:aws:kinesis:us-west-2:111111111111:stream/KinesisStreamName", "KinesisStreamName")]
+        [TestCase(null, null, null)]
+        public void GetStreamNameFromRequest(string streamName, string streamArn, string expectedStreamName)
+        {
+            dynamic request = new MockKinesisDataStreamRequest();
+            request.StreamName = streamName;
+            request.StreamArn = streamArn;
+
+            // Act
+            var streamNameFromHelper = KinesisHelper.GetStreamNameFromRequest(request) as string;
+
+            // Assert
+            Assert.That(streamNameFromHelper.IsEqualTo(expectedStreamName));
+        }
+
+        [Test]
+        [TestCase("FirehoseStreamName", "arn:aws:kinesis:us-west-2:111111111111:deliverystream/FirehoseStreamName", "FirehoseStreamName")]
+        [TestCase("FirehoseStreamName", null, "FirehoseStreamName")]
+        [TestCase(null, "arn:aws:kinesis:us-west-2:111111111111:stream/FirehoseStreamName", "FirehoseStreamName")]
+        [TestCase(null, null, null)]
+        public void GetDeliveryStreamNameFromRequest(string streamName, string streamArn, string expectedStreamName)
+        {
+            dynamic request = new MockKinesisFirehoseRequest();
+            request.DeliveryStreamName = streamName;
+            request.DeliveryStreamArn = streamArn;
+
+            // Act
+            var streamNameFromHelper = KinesisHelper.GetDeliveryStreamNameFromRequest(request) as string;
+
+            // Assert
+            Assert.That(streamNameFromHelper.IsEqualTo(expectedStreamName));
+        }
+
+        [Test]
+        public void GetStreamNameFromRequest_UnknownRequestType_ReturnsNull()
+        {
+            dynamic request = new MockUnknownRequest();
+            request.NotTheDroidsYoureLookingFor = "Daleks";
+
+            // Act
+            var streamNameFromHelper = KinesisHelper.GetStreamNameFromRequest(request) as string;
+
+            // Assert
+            Assert.That(streamNameFromHelper.IsEqualTo(null));
+        }
+
+        [Test]
+        public void GetDeliveryStreamNameFromRequest_UnknownRequestType_ReturnsNull()
+        {
+            dynamic request = new MockUnknownRequest();
+            request.NotTheDroidsYoureLookingFor = "Lore";
+
+            // Act
+            var streamNameFromHelper = KinesisHelper.GetDeliveryStreamNameFromRequest(request) as string;
+
+            // Assert
+            Assert.That(streamNameFromHelper.IsEqualTo(null));
+        }
+
     }
 }
+
+namespace Aws.Kinesis.Models
+{
+    public class MockKinesisDataStreamRequest
+    {
+        public string StreamName { get; set; }
+        public string StreamArn { get; set; }
+    }
+
+    public class MockKinesisFirehoseRequest
+    {
+        public string DeliveryStreamName { get; set; }
+        public string DeliveryStreamArn { get; set; }
+    }
+
+    public class MockUnknownRequest
+    {
+        public string NotTheDroidsYoureLookingFor { get; set; }
+    }
+}
+

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/KinesisHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/KinesisHelperTests.cs
@@ -1,0 +1,35 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Extensions.AwsSdk;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
+using NewRelic.Testing.Assertions;
+using NUnit.Framework;
+using Telerik.JustMock;
+
+namespace Agent.Extensions.Tests.Helpers
+{
+    [TestFixture]
+    public class KinesisHelperTests
+    {
+
+        [Test]
+        [TestCase("arn:aws:kinesis:us-west-2:111111111111:deliverystream/FirehoseStreamName", "FirehoseStreamName")]
+        [TestCase("arn:aws:kinesis:us-west-2:111111111111:stream/KinesisStreamName", "KinesisStreamName")]
+        [TestCase("notAnArn", null)]
+        [TestCase("arn:with:no:slash:in:last:part", null)]
+        public void GetStreamNameFromArn(string arn, string expectedStreamName)
+        {
+            // Act
+            var streamName = KinesisHelper.GetStreamNameFromArn(arn);
+
+            // Assert
+            Assert.That(streamName.IsEqualTo(expectedStreamName));
+        }
+    }
+}


### PR DESCRIPTION
Clean up the POC branch.  Refactored some of the helper methods into a separate helpers class and added unit tests.  Also attempted to add caching of values for performance, and (based on reading online) avoid using try/catch as a control flow mechanism for request types without properties we're looking for, and use reflection instead.