### PR TITLE
fix: Look for `ASPNETCORE_IIS_APP_POOL_ID` if `APP_POOL_ID` isn't found.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -376,6 +376,9 @@ namespace NewRelic.Agent.Core.Configuration
             var appPoolId = _environment.GetEnvironmentVariable("APP_POOL_ID");
             if (!string.IsNullOrEmpty(appPoolId)) return appPoolId;
 
+            appPoolId = _environment.GetEnvironmentVariable("ASPNETCORE_IIS_APP_POOL_ID");
+            if (!string.IsNullOrEmpty(appPoolId)) return appPoolId;
+
             var isW3wp = _processStatic.GetCurrentProcess().ProcessName?.Equals("w3wp", StringComparison.InvariantCultureIgnoreCase);
             if (!isW3wp.HasValue || !isW3wp.Value) return appPoolId;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1898,7 +1898,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesPullsMultipleNamesFromIisExpressSitenameEnvironmentVariaible()
+        public void ApplicationNamesPullsMultipleNamesFromIisExpressSitenameEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
@@ -1918,7 +1918,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesPullsSingleNameFromRoleNameEnvironmentVariaible()
+        public void ApplicationNamesPullsSingleNameFromRoleNameEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
 
@@ -1941,7 +1941,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesPullsMultipleNamesFromRoleNameEnvironmentVariaible()
+        public void ApplicationNamesPullsMultipleNamesFromRoleNameEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
 
@@ -1988,7 +1988,29 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesPullsSingleNameFromAppPoolIdEnvironmentVariaible()
+        public void ApplicationNamesPullsNameFromAspNetCoreIISAppPool_IfAppPoolId_IsNotAvailable()
+        {
+            _runTimeConfig.ApplicationNames = new List<string>();
+
+            //Sets to default return null for all calls unless overriden by later arrange.
+            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
+
+            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
+
+            _localConfig.application.name = new List<string>();
+            Mock.Arrange(() => _environment.GetEnvironmentVariable("ASPNETCORE_IIS_APP_POOL_ID")).Returns("MyAppName");
+            Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
+            Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
+
+            NrAssert.Multiple(
+                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
+                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyAppName")),
+                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Pool"))
+            );
+        }
+
+        [Test]
+        public void ApplicationNamesPullsSingleNameFromAppPoolIdEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
 
@@ -2010,7 +2032,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
         }
 
         [Test]
-        public void ApplicationNamesPullsMultipleNamesFromAppPoolIdEnvironmentVariaible()
+        public void ApplicationNamesPullsMultipleNamesFromAppPoolIdEnvironmentVariable()
         {
             _runTimeConfig.ApplicationNames = new List<string>();
 


### PR DESCRIPTION
Added a check for the `ASPNETCORE_IIS_APP_POOL_ID` environment variable if the `APP_POOL_ID` environment variable isn't available.

 Fixes #3035