### PR TITLE
chore: Refactor app pool id lookup in profiler and agent

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -373,14 +373,13 @@ namespace NewRelic.Agent.Core.Configuration
 
         private string GetAppPoolId()
         {
-            var appPoolId = _environment.GetEnvironmentVariable("APP_POOL_ID");
-            if (!string.IsNullOrEmpty(appPoolId)) return appPoolId;
-
-            appPoolId = _environment.GetEnvironmentVariable("ASPNETCORE_IIS_APP_POOL_ID");
-            if (!string.IsNullOrEmpty(appPoolId)) return appPoolId;
+            var appPoolId = _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID");
+            if (!string.IsNullOrEmpty(appPoolId))
+                return appPoolId;
 
             var isW3wp = _processStatic.GetCurrentProcess().ProcessName?.Equals("w3wp", StringComparison.InvariantCultureIgnoreCase);
-            if (!isW3wp.HasValue || !isW3wp.Value) return appPoolId;
+            if (!isW3wp.HasValue || !isW3wp.Value)
+                return null;
 
             var commandLineArgs = _environment.GetCommandLineArgs();
             const string appPoolCommandLineArg = "-ap";

--- a/src/Agent/NewRelic/Agent/Core/SharedInterfaces/Environment.cs
+++ b/src/Agent/NewRelic/Agent/Core/SharedInterfaces/Environment.cs
@@ -24,7 +24,7 @@ namespace NewRelic.Agent.Core.SharedInterfaces
         public string GetEnvironmentVariableFromList(params string[] variables)
         {
             var envValue = (variables ?? Enumerable.Empty<string>())
-                .Select(System.Environment.GetEnvironmentVariable)
+                .Select(GetEnvironmentVariable)
                 .FirstOrDefault(value => value != null);
 
             return envValue == string.Empty ? null : envValue;

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.38.0.36"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.38.0.14"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/ISystemCalls.h
@@ -86,7 +86,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter {
 
         virtual std::unique_ptr<xstring_t> GetAppPoolId()
         {
-            return TryGetEnvironmentVariable(_X("APP_POOL_ID"));
+            return GetEnvironmentVariableWithFallback(_X("APP_POOL_ID"), _X("ASPNETCORE_IIS_APP_POOL_ID"));
         }
 
         virtual bool GetLoggingEnabled(bool fallback)

--- a/src/Agent/NewRelic/Profiler/MethodRewriterTest/SystemCallsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/MethodRewriterTest/SystemCallsTest.cpp
@@ -243,9 +243,28 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter { namespace T
             Assert::AreEqual(L"info", logLevel->c_str());
         }
 
-        TEST_METHOD(GetAppPoolId_ReturnsExpectedValue)
+        TEST_METHOD(GetAppPoolId_ReturnsExpectedValue_WhenAppPoolIdIsDefined)
         {
             _systemCalls.environmentVariables[_X("APP_POOL_ID")] = _X("MyAppPool");
+
+            auto appPoolId = _systemCalls.GetAppPoolId();
+            Assert::IsNotNull(appPoolId.get());
+            Assert::AreEqual(L"MyAppPool", appPoolId->c_str());
+        }
+
+        TEST_METHOD(GetAppPoolId_ReturnsExpectedValue_WhenAspNetCore_IIS_App_Pool_Id_IsDefined)
+        {
+            _systemCalls.environmentVariables[_X("ASPNETCORE_IIS_APP_POOL_ID")] = _X("MyAppPool");
+
+            auto appPoolId = _systemCalls.GetAppPoolId();
+            Assert::IsNotNull(appPoolId.get());
+            Assert::AreEqual(L"MyAppPool", appPoolId->c_str());
+        }
+
+        TEST_METHOD(GetAppPoolId_ReturnsAppPoolId_WhenBothAreDefined)
+        {
+            _systemCalls.environmentVariables[_X("APP_POOL_ID")] = _X("MyAppPool");
+            _systemCalls.environmentVariables[_X("ASPNETCORE_IIS_APP_POOL_ID")] = _X("NotMyAppPool");
 
             auto appPoolId = _systemCalls.GetAppPoolId();
             Assert::IsNotNull(appPoolId.get());

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1827,7 +1827,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns((string)null);
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns((string)null);
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1847,7 +1847,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("OtherAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1866,7 +1866,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("OtherAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1886,7 +1886,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("MyAppName");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1905,7 +1905,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME")).Returns("MyAppName1,MyAppName2");
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("OtherAppName");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1929,7 +1929,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("MyAppName");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1952,7 +1952,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             Mock.Arrange(() => _environment.GetEnvironmentVariable("RoleName")).Returns("MyAppName1,MyAppName2");
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1975,7 +1975,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string> { "MyAppName1", "MyAppName2" };
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("OtherAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("OtherAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -1984,28 +1984,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
                 () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyAppName1")),
                 () => Assert.That(_defaultConfig.ApplicationNames.ElementAtOrDefault(1), Is.EqualTo("MyAppName2")),
                 () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("NewRelic Config"))
-            );
-        }
-
-        [Test]
-        public void ApplicationNamesPullsNameFromAspNetCoreIISAppPool_IfAppPoolId_IsNotAvailable()
-        {
-            _runTimeConfig.ApplicationNames = new List<string>();
-
-            //Sets to default return null for all calls unless overriden by later arrange.
-            Mock.Arrange(() => _environment.GetEnvironmentVariable(Arg.IsAny<string>())).Returns<string>(null);
-
-            Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
-
-            _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("ASPNETCORE_IIS_APP_POOL_ID")).Returns("MyAppName");
-            Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
-            Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
-
-            NrAssert.Multiple(
-                () => Assert.That(_defaultConfig.ApplicationNames.Count(), Is.EqualTo(1)),
-                () => Assert.That(_defaultConfig.ApplicationNames.FirstOrDefault(), Is.EqualTo("MyAppName")),
-                () => Assert.That(_defaultConfig.ApplicationNamesSource, Is.EqualTo("Application Pool"))
             );
         }
 
@@ -2020,7 +1998,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns((string)null);
 
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("MyAppName");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("MyAppName");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 
@@ -2042,7 +2020,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             Mock.Arrange(() => _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName)).Returns<string>(null);
 
             _localConfig.application.name = new List<string>();
-            Mock.Arrange(() => _environment.GetEnvironmentVariable("APP_POOL_ID")).Returns("MyAppName1,MyAppName2");
+            Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID")).Returns("MyAppName1,MyAppName2");
             Mock.Arrange(() => _httpRuntimeStatic.AppDomainAppVirtualPath).Returns("NotNull");
             Mock.Arrange(() => _processStatic.GetCurrentProcess().ProcessName).Returns("OtherAppName");
 


### PR DESCRIPTION
Updates the profiler logic to check for `ASPNETCORE_IIS_APP_POOL_ID` as a fallback when `APP_POOL_ID` isn't available.

Also includes a minor refactor in the agent related to the app pool id lookup work from yesterday.

Unit tests are updated as appropriate.