### PR TITLE
chore: Update supportability metric names for Azure Function so they're consistent

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionInProcessExecuteWithWatchersAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionInProcessExecuteWithWatchersAsyncWrapper.cs
@@ -61,7 +61,7 @@ public class AzureFunctionInProcessExecuteWithWatchersAsyncWrapper : IWrapper
 
         agent.Logger.Finest("Instrumenting in-process Azure Function: {FunctionName} / invocation ID {invocationId} / Trigger {Trigger}.", inProcessFunctionDetails.FunctionName, invocationId, inProcessFunctionDetails.Trigger);
 
-        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Worker/InProcess");
+        agent.RecordSupportabilityMetric("Dotnet/AzureFunction/Worker/InProcess");
         agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Trigger/{inProcessFunctionDetails.TriggerTypeName ?? "unknown"}");
 
         transaction = agent.CreateTransaction(

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionInProcessExecuteWithWatchersAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionInProcessExecuteWithWatchersAsyncWrapper.cs
@@ -61,8 +61,8 @@ public class AzureFunctionInProcessExecuteWithWatchersAsyncWrapper : IWrapper
 
         agent.Logger.Finest("Instrumenting in-process Azure Function: {FunctionName} / invocation ID {invocationId} / Trigger {Trigger}.", inProcessFunctionDetails.FunctionName, invocationId, inProcessFunctionDetails.Trigger);
 
-        agent.RecordSupportabilityMetric($"DotNet/AzureFunction/Worker/InProcess");
-        agent.RecordSupportabilityMetric($"DotNet/AzureFunction/Trigger/{inProcessFunctionDetails.TriggerTypeName ?? "unknown"}");
+        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Worker/InProcess");
+        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Trigger/{inProcessFunctionDetails.TriggerTypeName ?? "unknown"}");
 
         transaction = agent.CreateTransaction(
             isWeb: inProcessFunctionDetails.IsWebTrigger,

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionIsolatedInvokeFunctionAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionIsolatedInvokeFunctionAsyncWrapper.cs
@@ -58,8 +58,8 @@ public class AzureFunctionIsolatedInvokeAsyncWrapper : IWrapper
             throw new Exception("FunctionDetails are missing some require information.");
         }
 
-        agent.RecordSupportabilityMetric($"DotNet/AzureFunction/Worker/Isolated");
-        agent.RecordSupportabilityMetric($"DotNet/AzureFunction/Trigger/{functionDetails.TriggerTypeName ?? "unknown"}");
+        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Worker/Isolated");
+        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Trigger/{functionDetails.TriggerTypeName ?? "unknown"}");
 
         transaction = agent.CreateTransaction(
             isWeb: functionDetails.IsWebTrigger,

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionIsolatedInvokeFunctionAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureFunction/AzureFunctionIsolatedInvokeFunctionAsyncWrapper.cs
@@ -58,7 +58,7 @@ public class AzureFunctionIsolatedInvokeAsyncWrapper : IWrapper
             throw new Exception("FunctionDetails are missing some require information.");
         }
 
-        agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Worker/Isolated");
+        agent.RecordSupportabilityMetric("Dotnet/AzureFunction/Worker/Isolated");
         agent.RecordSupportabilityMetric($"Dotnet/AzureFunction/Trigger/{functionDetails.TriggerTypeName ?? "unknown"}");
 
         transaction = agent.CreateTransaction(

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionHttpTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionHttpTriggerTests.cs
@@ -130,8 +130,8 @@ public abstract class AzureFunctionHttpTriggerTestsBase<TFixture> : NewRelicInte
             var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
             {
                 new() { metricName = "Supportability/Dotnet/AzureFunctionMode/enabled" },
-                new() { metricName = "Supportability/DotNet/AzureFunction/Worker/Isolated"},
-                new() { metricName = "Supportability/DotNet/AzureFunction/Trigger/Http"}
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Worker/Isolated"},
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Trigger/Http"}
             };
             Assertions.MetricsExist(supportabilityMetrics, metrics);
 
@@ -252,8 +252,8 @@ public abstract class AzureFunctionHttpTriggerTestsBase<TFixture> : NewRelicInte
             var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
             {
                 new() { metricName = "Supportability/Dotnet/AzureFunctionMode/enabled" },
-                new() { metricName = "Supportability/DotNet/AzureFunction/Worker/Isolated"},
-                new() { metricName = "Supportability/DotNet/AzureFunction/Trigger/Http"}
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Worker/Isolated"},
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Trigger/Http"}
             };
             Assertions.MetricsExist(supportabilityMetrics, metrics);
 
@@ -381,8 +381,8 @@ public abstract class AzureFunctionHttpTriggerTestsBase<TFixture> : NewRelicInte
             var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
             {
                 new() { metricName = "Supportability/Dotnet/AzureFunctionMode/enabled" },
-                new() { metricName = "Supportability/DotNet/AzureFunction/Worker/InProcess" },
-                new() { metricName = "Supportability/DotNet/AzureFunction/Trigger/Http" }
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Worker/InProcess" },
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Trigger/Http" }
             };
             Assertions.MetricsExist(supportabilityMetrics, metrics);
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionQueueTriggerTests.cs
@@ -71,7 +71,6 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
             new() {metricName = transactionName, callCount = 1},
         };
 
-
         var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
 
         var metrics = _fixture.AgentLog.GetMetrics().ToList();
@@ -81,6 +80,15 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
         if (_fixture.AzureFunctionModeEnabled)
         {
             Assertions.MetricsExist(expectedMetrics, metrics);
+
+            var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
+            {
+                new() { metricName = "Supportability/Dotnet/AzureFunctionMode/enabled" },
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Worker/Isolated" },
+                new() { metricName = "Supportability/Dotnet/AzureFunction/Trigger/Queue" }
+            };
+
+            Assertions.MetricsExist(supportabilityMetrics, metrics);
 
             Assert.NotNull(transactionSample);
             Assert.NotNull(transaction);
@@ -99,6 +107,11 @@ public abstract class AzureFunctionQueueTriggerTestsBase<TFixture> : NewRelicInt
         else
         {
             Assertions.MetricsDoNotExist(expectedMetrics, metrics);
+            var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
+            {
+                new() { metricName = "Supportability/Dotnet/AzureFunctionMode/disabled" }
+            };
+            Assertions.MetricsExist(supportabilityMetrics, metrics);
             Assert.Null(transactionSample);
 
             Assert.Null(transaction);

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
@@ -92,6 +92,14 @@ public abstract class AzureFunctionServiceBusTriggerTestsBase<TFixture> : NewRel
             new() { metricName = receiveMessageTransactionName},
         };
 
+        var supportabilityMetrics = new List<Assertions.ExpectedMetric>()
+        {
+            new() { metricName = "Supportability/Dotnet/AzureFunctionMode/enabled" },
+            new() { metricName = "Supportability/Dotnet/AzureFunction/Worker/InProcess" },
+            new() { metricName = "Supportability/Dotnet/AzureFunction/Trigger/ServiceBus" }
+        };
+        Assertions.MetricsExist(supportabilityMetrics, metrics);
+
         Assert.NotEmpty(transactionEvents);
         Assert.NotEmpty(metrics);
 


### PR DESCRIPTION
Updates naming of supportability metrics for Azure Functions so they all consistently start with `Supportability\Dotnet` - previously, we had a mixture of `Dotnet` and `DotNet`