### PR TITLE
chore: Rework System.ValueTuple updates to use latest version

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="[4.5.0]" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="ILRepack" Version="2.0.40">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>net481;net9.0</TargetFrameworks>
     <RootNamespace>NewRelic.Agent.Core</RootNamespace>
@@ -40,6 +40,7 @@
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
     <Reference Include="System.XML" />
+    <Reference Include="System.ValueTuple" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RootProjectDirectory)\src\Agent\NewRelic.Api.Agent\NewRelic.Api.Agent.csproj" />


### PR DESCRIPTION
Updates to allow latest `System.ValueTuple` package to be used in `Core.csproj` without breaking `Core.UnitTest.csproj`. 

The trick was, apparently, to add a `System.ValueTuple` reference from the GAC for the `net481` build. 🤷 