### PR TITLE
chore: Add READMEs to NuGet packages

### DIFF
--- a/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
+++ b/build/ArtifactBuilder/Artifacts/AzureSiteExtension.cs
@@ -85,6 +85,9 @@ namespace ArtifactBuilder.Artifacts
             // images folder - New Relic icon
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, "images"), "icon.png");
 
+            // README
+            ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "README.md");
+
             // content folder - installation items
             var contentFolder = Path.Combine(installedFilesRoot, "content");
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, contentFolder, "applicationHost.xdt");
@@ -103,6 +106,7 @@ namespace ArtifactBuilder.Artifacts
         {
             var unpackedComponents = ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "content"));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "images")));
+            unpackedComponents.Add(Path.Combine(installedFilesRoot, "README.md"));
 
             return unpackedComponents;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -142,6 +142,8 @@ namespace ArtifactBuilder.Artifacts
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, toolsFolder, "install.ps1");
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, toolsFolder, "NewRelicHelper.psm1");
 
+            // README
+            ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "README.md");
             // content folder - framework agent (x64 and x86)
             AddAllFrameworkAgentComponents(expectedComponents, Path.Combine(installedFilesRoot, "content", "newrelic"));
 
@@ -194,6 +196,7 @@ namespace ArtifactBuilder.Artifacts
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "contentFiles")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "images")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "tools")));
+            unpackedComponents.Add(Path.Combine(installedFilesRoot, "README.md"));
 
             return unpackedComponents;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgentApi.cs
@@ -83,6 +83,7 @@ namespace ArtifactBuilder.Artifacts
             // root folder
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents,installedFilesRoot, "LICENSE.txt");
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "THIRD_PARTY_NOTICES.txt");
+            ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "README.md");
 
             return expectedComponents;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureCloudServices.cs
@@ -94,6 +94,9 @@ namespace ArtifactBuilder.Artifacts
             // images folder - New Relic icon
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, "images"), "icon.png");
 
+            // README
+            ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "README.md");
+
             // tools folder - Install scripts
             var toolsFolder = Path.Combine(installedFilesRoot, "tools");
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, toolsFolder, "install.ps1");
@@ -117,6 +120,7 @@ namespace ArtifactBuilder.Artifacts
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "lib")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "images")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "tools")));
+            unpackedComponents.Add(Path.Combine(installedFilesRoot, "README.md"));
 
             return unpackedComponents;
         }

--- a/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAzureWebSites.cs
@@ -116,6 +116,9 @@ namespace ArtifactBuilder.Artifacts
             // images folder - New Relic icon
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, "images"), "icon.png");
 
+            // README
+            ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "README.md");
+
             // tools folder - Install scripts
             var toolsFolder = Path.Combine(installedFilesRoot, "tools");
             ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, toolsFolder, "install.ps1");
@@ -152,6 +155,7 @@ namespace ArtifactBuilder.Artifacts
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "lib")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "images")));
             unpackedComponents.UnionWith(ValidationHelpers.GetUnpackedComponents(Path.Combine(installedFilesRoot, "tools")));
+            unpackedComponents.Add(Path.Combine(installedFilesRoot, "README.md"));
 
             return unpackedComponents;
         }

--- a/build/NewRelic.NuGetHelper/Utils.cs
+++ b/build/NewRelic.NuGetHelper/Utils.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NuGet;
 
 namespace NewRelic.NuGetHelper

--- a/build/Packaging/AzureSiteExtension/NewRelic.Azure.WebSites.Extension.nuspec
+++ b/build/Packaging/AzureSiteExtension/NewRelic.Azure.WebSites.Extension.nuspec
@@ -9,6 +9,7 @@
     <projectUrl>https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>This extension adds the New Relic .NET Agent to your Azure WebSite.</description>
+    <readme>README.md</readme>
     <iconUrl>https://newrelic.com/static-assets/images/icons/avatar-newrelic.png</iconUrl>
     <icon>images\icon.png</icon>
     <copyright>New Relic, Inc., 2022</copyright>
@@ -20,5 +21,6 @@
   <files>
     <file src="content\**\*.*" target="content" />
     <file src="..\..\icon.png" target="images\" />
+    <file src="README.md" target="." />
   </files>
 </package>

--- a/build/Packaging/AzureSiteExtension/README.md
+++ b/build/Packaging/AzureSiteExtension/README.md
@@ -1,0 +1,5 @@
+## New Relic .NET Agent Azure Websites Extension
+
+This extension adds the New Relic .NET Agent to your Azure WebSite.
+
+See our [public documentation](https://docs.newrelic.com/install/dotnet/?deployment=azure&azure=azuresiteextension) for details on how to use this extension to add the New Relic .NET Agent to your Azure web application.

--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -11,16 +11,7 @@
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <readme>README.md</readme>
-    <description>Make sure you go to New Relic first to sign up and get your license key at https://newrelic.com. Performance monitoring will never be the same after you do!  
-            The package is available through your NuGet package manager and on the web at https://nuget.org/packages/NewRelic.Agent
-
-            Run: Install-Package NewRelic.Agent
-
-            Note: If you want to instrument more than one project in your solution, simply change the "Default project" in the package manager console and install the package.
-
-            Visit https://one.newrelic.com after your package deploy is complete to see your performance metrics.
-    </description>
-    <summary>Includes the latest New Relic .NET Agent artifacts for deployment to your application's build output directory.</summary>
+    <description>Includes the latest New Relic .NET Agent artifacts for deployment to your application's build output directory.</description>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
     <contentFiles>
       <files include="**/newrelic/**/*.*" buildAction="None" copyToOutput="true" flatten="false" />

--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -10,6 +10,7 @@
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <readme>README.md</readme>
     <description>Make sure you go to New Relic first to sign up and get your license key at https://newrelic.com. Performance monitoring will never be the same after you do!  
             The package is available through your NuGet package manager and on the web at https://nuget.org/packages/NewRelic.Agent
 
@@ -28,6 +29,7 @@
   <files>
     <file src="**\newrelic\**\*" target="." />
     <file src="tools\**" target="tools" />
+    <file src="README.md" target="." />
     <file src="..\..\icon.png" target="images\" />
   </files>
 </package>

--- a/build/Packaging/NugetAgent/README.md
+++ b/build/Packaging/NugetAgent/README.md
@@ -1,5 +1,7 @@
-# New Relic Agent NuGet Package
+## New Relic .NET Agent NuGet Package
 
-## EatoinShrdlu
+Includes the latest New Relic .NET Agent artifacts for deployment to your application's build output directory.
 
-### QWERTY
+See our [public documentation](https://docs.newrelic.com/install/dotnet/?deployment=nuget) for details on how to add this package to your application and enable the agent.
+
+See our [examples repository](https://github.com/newrelic/newrelic-dotnet-examples/blob/main/docker-agent-nuget/README.md) for some Docker-based examples of how to use this package.

--- a/build/Packaging/NugetAgent/README.md
+++ b/build/Packaging/NugetAgent/README.md
@@ -1,0 +1,5 @@
+# New Relic Agent NuGet Package
+
+## EatoinShrdlu
+
+### QWERTY

--- a/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
+++ b/build/Packaging/NugetAgentApi/NewRelic.Agent.Api.nuspec
@@ -10,8 +10,8 @@
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The New Relic .NET Agent API supports custom error and metric reporting, and custom transaction parameters. If the agent is not installed or is disabled, method invocations of this API will have no effect. You can find more information about the NewRelic.Agent.Api at https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.</description>
-    <summary>The New Relic .NET Agent API supports custom error and metric reporting, and custom transaction parameters. This is the ANY CPU build of the API.</summary>
+    <description>The New Relic .NET Agent API supports custom error and metric reporting, custom transaction parameters, custom instrumentation of methods with attributes, and more. If the agent is not installed or is disabled, method invocations of this API will have no effect. You can find more information about the API at https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.</description>
+    <readme>README.md</readme>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
     <language>en-US</language>
     <tags>New Relic</tags>
@@ -22,5 +22,6 @@
     <file src="LICENSE.txt" target="." />
     <file src="THIRD_PARTY_NOTICES.txt" target="." />
     <file src="..\..\icon.png" target="images\" />
+    <file src="README.md" target="." />
   </files>
 </package>

--- a/build/Packaging/NugetAgentApi/README.md
+++ b/build/Packaging/NugetAgentApi/README.md
@@ -1,0 +1,3 @@
+## New Relic .NET Agent API Package
+
+The New Relic .NET Agent API supports custom error and metric reporting, custom transaction parameters, custom instrumentation of methods with attributes, and more. If the agent is not installed or is disabled, method invocations of this API will have no effect. You can find more information about the API at https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.

--- a/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
+++ b/build/Packaging/NugetAzureCloudServices/NewRelicWindowsAzure.nuspec
@@ -10,19 +10,8 @@
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Make sure you go to New Relic first to sign up and get your key at https://newrelic.com. Performance monitoring will never be the same after you do!  
-            The package is available through your NuGet package manager and on the web at https://nuget.org/packages/NewRelicWindowsAzure  
-
-            Set up:  
-            1. install-package NewRelicWindowsAzure  
-            2. The Package installer will prompt you for your NewRelic.AppName and your New Relic license key  
-
-            Note: If you want to instrument more than one project in your solution, simply change the "Default project" in the package manager console and install the package 
-
-            Visit https://one.newrelic.com after your package deploy is complete to see your performance metrics.  
-
-            For more information on what this package is doing go to: https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services/</description>
-    <summary>Includes the latest New Relic x64 installer, so that you can easily include New Relic in your Azure deployment.</summary>
+    <readme>README.md</readme>
+    <description>This package adds the New Relic .NET Agent to Azure Cloud Services ("classic"): https://learn.microsoft.com/en-us/previous-versions/azure/cloud-services/cloud-services-choose-me</description>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
   </metadata>
   <files>
@@ -30,5 +19,6 @@
     <file src="lib\**" target="lib" />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
+    <file src="README.md" target="." />
   </files>
 </package>

--- a/build/Packaging/NugetAzureCloudServices/README.md
+++ b/build/Packaging/NugetAzureCloudServices/README.md
@@ -1,0 +1,5 @@
+## New Relic .NET Agent for Azure Cloud Services
+
+This package adds the New Relic .NET Agent to [Azure Cloud Services ("classic")](https://learn.microsoft.com/en-us/previous-versions/azure/cloud-services/cloud-services-choose-me)
+
+See our [public documentation](https://docs.newrelic.com/install/dotnet/?deployment=azurecloudservices) for details on how to install and use this package.

--- a/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x64/NewRelic.Azure.WebSites.x64.nuspec
@@ -10,8 +10,9 @@
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>
-    <summary>This package will add all of the resources needed to profile your Windows Azure Web Site running as a reserved 64-bit instance. For more information on this package visit: https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</summary>
+    <readme>README.md</readme>
+    <description>This package will add all of the resources needed to profile your Windows Azure Web Site running as a reserved 64-bit instance. For more information on this package visit: https://docs.newrelic.com/install/dotnet/?deployment=azure&amp;azure=azurenugetframework</description>
+    <summary></summary>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
     <contentFiles>
       <files include="**/newrelic/**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
@@ -22,5 +23,6 @@
     <file src="lib\**" target="lib" />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
+    <file src="README.md" target="." />
   </files>
 </package>

--- a/build/Packaging/NugetAzureWebSites-x64/README.md
+++ b/build/Packaging/NugetAzureWebSites-x64/README.md
@@ -1,0 +1,3 @@
+# New Relic .NET Agent for Azure Websites (64-bit instance)
+
+This package will add all of the resources needed to profile your Windows Azure Web Site running as a reserved 64-bit instance. For more information on this package visit: https://docs.newrelic.com/install/dotnet/?deployment=azure&azure=azurenugetframework

--- a/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
+++ b/build/Packaging/NugetAzureWebSites-x86/NewRelic.Azure.WebSites.nuspec
@@ -10,8 +10,8 @@
     <repository type="git" url="https://github.com/newrelic/newrelic-dotnet-agent" />
     <icon>images\icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Go to New Relic to sign up and get your license key at https://newrelic.com or you can get a license key through the Windows Azure management portal via Add-On store.</description>
-    <summary>This package will add all of the resources needed to profile your Windows Azure Web Site. For more information on this package visit: https://docs.newrelic.com/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps</summary>
+    <readme>README.md</readme>
+    <description>This package will add all of the resources needed to profile your Windows Azure Web Site. For more information on this package visit: https://docs.newrelic.com/install/dotnet/?deployment=azure&amp;azure=azurenugetframework</description>
     <releaseNotes>For detailed information see: https://docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/</releaseNotes>
     <contentFiles>
       <files include="**/newrelic/**/*.*" buildAction="None" copyToOutput="true" flatten="false" />
@@ -22,5 +22,6 @@
     <file src="lib\**" target="lib" />
     <file src="tools\**" target="tools" />
     <file src="..\..\icon.png" target="images\" />
+    <file src="README.md" target="." />
   </files>
 </package>

--- a/build/Packaging/NugetAzureWebSites-x86/README.md
+++ b/build/Packaging/NugetAzureWebSites-x86/README.md
@@ -1,0 +1,3 @@
+# New Relic .NET Agent for Azure Websites (32-bit instance)
+
+This package will add all of the resources needed to profile your Windows Azure Web Site running as a reserved 32-bit instance. For more information on this package visit: https://docs.newrelic.com/install/dotnet/?deployment=azure&azure=azurenugetframework


### PR DESCRIPTION
## Description

Add README files to the NuGet packages we produce.

I also removed the `<summary>....</summary>` element from .nuspec files where it was present, as this field is deprecated in favor of the required `description` field. 

The content of the new REAME files is generally sourced from a combination of the existing description and summary fields, although in some cases I added additional links to our examples and/or documentation.  I also fixed outdated links to our documentation.
