### PR TITLE
chore: Refactor usages of `File.` and `Directory.` to use wrappers

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -163,7 +163,7 @@ namespace NewRelic.Agent.Core
         private static string GetNewRelicHome()
         {
             var newRelicHome = EnvironmentVariableProxy.GetEnvironmentVariableFromList(NewRelicHomeEnvironmentVariables);
-            if (newRelicHome != null && Directory.Exists(newRelicHome)) return Path.GetFullPath(newRelicHome);
+            if (newRelicHome != null && DirectoryWrapper.Instance.Exists(newRelicHome)) return Path.GetFullPath(newRelicHome);
 #if NETFRAMEWORK
 			var key = Registry.LocalMachine.OpenSubKey(@"Software\New Relic\.NET Agent");
 			if (key != null) newRelicHome = (string)key.GetValue("NewRelicHome");
@@ -177,7 +177,7 @@ namespace NewRelic.Agent.Core
             if (newRelicInstallPath != null)
             {
                 newRelicInstallPath = Path.Combine(newRelicInstallPath, RuntimeDirectoryName);
-                if (Directory.Exists(newRelicInstallPath)) return newRelicInstallPath;
+                if (DirectoryWrapper.Instance.Exists(newRelicInstallPath)) return newRelicInstallPath;
             }
 
             newRelicInstallPath = EnvironmentVariableProxy.GetEnvironmentVariableFromList(NewRelicHomeEnvironmentVariables);
@@ -194,11 +194,11 @@ namespace NewRelic.Agent.Core
 
             var agentInfoPath = Path.Combine(NewRelicHome, "agentinfo.json");
 
-            if (File.Exists(agentInfoPath))
+            if (FileWrapper.Instance.Exists(agentInfoPath))
             {
                 try
                 {
-                    return JsonConvert.DeserializeObject<AgentInfo>(File.ReadAllText(agentInfoPath));
+                    return JsonConvert.DeserializeObject<AgentInfo>(FileWrapper.Instance.ReadAllText(agentInfoPath));
                 }
                 catch (Exception e)
                 {

--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.Core.Config
         private BootstrapConfiguration()
         {
             _agentEnabledWithProvenance = new ValueWithProvenance<bool>(true, "Default value");
-            LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), Directory.Exists, Path.GetFullPath);
+            LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), DirectoryWrapper.Instance.Exists, Path.GetFullPath);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.Core.Config
         /// <param name="localConfiguration">The local configuration object to use.</param>
         /// <param name="configurationFileName">The name and path of the local configuration file.</param>
         public BootstrapConfiguration(configuration localConfiguration, string configurationFileName)
-            : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), Directory.Exists, Path.GetFullPath)
+            : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), DirectoryWrapper.Instance.Exists, Path.GetFullPath)
         { }
 
         /// <summary>

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -64,7 +64,9 @@ namespace NewRelic.Agent.Core.Config
         public static Func<string> GetAppDomainName = InternalGetAppDomainName;
 #endif
 
-        public static Func<string, bool> FileExists = File.Exists;
+        public static Func<string, bool> FileExists = FileWrapper.Instance.Exists;
+        public static Func<string, string> FileReadAllText = FileWrapper.Instance.ReadAllText;
+
         public static Func<string, string> PathGetDirectoryName = Path.GetDirectoryName;
         public static Func<string, string> GetEnvironmentVar = System.Environment.GetEnvironmentVariable;
 
@@ -164,7 +166,7 @@ namespace NewRelic.Agent.Core.Config
             try
             {
                 var fileName = AppSettingsConfigResolveWhenUsed.GetAppSetting(Constants.AppSettingsConfigFile);
-                if (!File.Exists(fileName))
+                if (!FileExists(fileName))
                 {
                     return null;
                 }
@@ -208,16 +210,16 @@ namespace NewRelic.Agent.Core.Config
                 {
                     var directory = Path.GetDirectoryName(entryAssembly.Location);
                     filename = Path.Combine(directory, NewRelicConfigFileName);
-                    if (File.Exists(filename))
+                    if (FileExists(filename))
                     {
                         Log.Info("Configuration file found in app/web root directory: {0}", filename);
                         return filename;
                     }
                 }
 
-                var currentDirectory = Directory.GetCurrentDirectory();
+                var currentDirectory = DirectoryWrapper.Instance.GetCurrentDirectory();
                 filename = Path.Combine(currentDirectory, NewRelicConfigFileName);
-                if (File.Exists(filename))
+                if (FileExists(filename))
                 {
                     Log.Info("Configuration file found in app/web root directory: {0}", filename);
                     return filename;
@@ -482,7 +484,7 @@ namespace NewRelic.Agent.Core.Config
             {
                 var home = AgentInstallConfiguration.NewRelicHome;
                 var xsdFile = Path.Combine(home, "newrelic.xsd");
-                configSchemaContents = File.ReadAllText(xsdFile);
+                configSchemaContents = FileReadAllText(xsdFile);
             }
             catch (Exception ex)
             {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.Configuration
             catch (AppDomainUnloadedException)
             {
                 // Fall back to previous behavior of agents <=8.35.0
-                applicationDirectory = Directory.GetCurrentDirectory();
+                applicationDirectory = DirectoryWrapper.Instance.GetCurrentDirectory();
             }
 
             // add default appsettings.json files to config builder

--- a/src/Agent/NewRelic/Agent/Core/Instrumentation/InstrumentationWatcher.cs
+++ b/src/Agent/NewRelic/Agent/Core/Instrumentation/InstrumentationWatcher.cs
@@ -18,15 +18,17 @@ namespace NewRelic.Agent.Core.Instrumentation
         private readonly IInstrumentationService _instrumentationService;
         private readonly IWrapperService _wrapperService;
         private readonly IConfigurationService _configurationService;
+        private readonly IDirectoryWrapper _directoryWrapper;
 
         private List<FileSystemWatcher> _fileWatchers;
         private SignalableAction _action;
 
-        public InstrumentationWatcher(IWrapperService wrapperService, IInstrumentationService instrumentationService, IConfigurationService configurationService)
+        public InstrumentationWatcher(IWrapperService wrapperService, IInstrumentationService instrumentationService, IConfigurationService configurationService, IDirectoryWrapper directoryWrapper)
         {
             _wrapperService = wrapperService;
             _instrumentationService = instrumentationService;
             _configurationService = configurationService;
+            _directoryWrapper = directoryWrapper;
         }
 
         public void Start()
@@ -52,7 +54,7 @@ namespace NewRelic.Agent.Core.Instrumentation
 
         private void SetupFileWatcherForDirectory(string path)
         {
-            if (!Directory.Exists(path)) return;
+            if (!_directoryWrapper.Exists(path)) return;
             var watcher = new FileSystemWatcher(path, "*.xml");
             watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName;
             watcher.Changed += OnChanged;

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -9,7 +9,7 @@ using Serilog;
 using Serilog.Core;
 using Logger = NewRelic.Agent.Core.Logging.Logger;
 using NewRelic.Agent.Core.Logging;
-
+using NewRelic.Agent.Core.Utilities;
 using Serilog.Events;
 #if NETSTANDARD2_0
 using System.Runtime.InteropServices;
@@ -260,9 +260,9 @@ namespace NewRelic.Agent.Core
             {
                 // Create the directory if necessary
                 var directory = Path.GetDirectoryName(fileName);
-                if (!Directory.Exists(directory))
-                    Directory.CreateDirectory(directory);
-                using (File.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)) { }
+                if (!DirectoryWrapper.Instance.Exists(directory))
+                    DirectoryWrapper.Instance.CreateDirectory(directory);
+                using (FileWrapper.Instance.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)) { }
             }
             catch (Exception exception)
             {

--- a/src/Agent/NewRelic/Agent/Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/RuntimeEnvironmentInfo.cs
@@ -127,9 +127,9 @@ namespace NewRelic.Agent.Core
 
             try
             {
-                if (File.Exists("/etc/os-release"))
+                if (FileWrapper.Instance.Exists("/etc/os-release"))
                 {
-                    var lines = File.ReadAllLines("/etc/os-release");
+                    var lines = FileWrapper.Instance.ReadAllLines("/etc/os-release");
                     result = new DistroInfo();
                     foreach (var line in lines)
                     {

--- a/src/Agent/NewRelic/Agent/Core/Utilities/DirectoryWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/DirectoryWrapper.cs
@@ -11,20 +11,21 @@ namespace NewRelic.Agent.Core.Utilities
     public interface IDirectoryWrapper
     {
         bool Exists(string path);
-        string[] GetFiles(string readOnlyPath, string yml);
+        string[] GetFiles(string readOnlyPath, string pattern, SearchOption searchOption = SearchOption.TopDirectoryOnly);
+        string GetCurrentDirectory();
+        DirectoryInfo CreateDirectory(string path);
     }
 
     [NrExcludeFromCodeCoverage]
     public class DirectoryWrapper : IDirectoryWrapper
     {
-        public bool Exists(string path)
-        {
-            return Directory.Exists(path);
-        }
+        public static IDirectoryWrapper Instance { get; } = new DirectoryWrapper();
 
-        public string[] GetFiles(string path, string searchPattern)
-        {
-            return Directory.GetFiles(path, searchPattern);
-        }
+        public bool Exists(string path) => Directory.Exists(path);
+
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly) => Directory.GetFiles(path, searchPattern, searchOption);
+
+        public string GetCurrentDirectory() => Directory.GetCurrentDirectory();
+        public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
@@ -158,12 +158,12 @@ namespace NewRelic.Agent.Core.Utilities
 
         private static List<string> GetAssemblyFilesFromFolder(string folder)
         {
-            if (folder == null || !Directory.Exists(folder))
+            if (folder == null || !DirectoryWrapper.Instance.Exists(folder))
             {
                 return new List<string>();
             }
 
-            var assemblyPaths = Directory.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly);
+            var assemblyPaths = DirectoryWrapper.Instance.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly);
 
             return assemblyPaths.ToList();
         }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 
 namespace NewRelic.Agent.Core.Utilities
@@ -13,11 +14,17 @@ namespace NewRelic.Agent.Core.Utilities
         bool Exists(string path);
         FileStream OpenWrite(string path);
         bool TryCreateFile(string path, bool deleteOnSuccess = true);
+        string ReadAllText(string path);
+        string[] ReadAllLines(string path);
+        DateTime GetLastWriteTimeUtc(string path);
+        FileStream Open(string path, FileMode mode, FileAccess access, FileShare share);
     }
 
     [NrExcludeFromCodeCoverage]
     public class FileWrapper : IFileWrapper
     {
+        public static IFileWrapper Instance { get; } = new FileWrapper();
+        
         public bool Exists(string path)
         {
             return File.Exists(path);
@@ -40,6 +47,26 @@ namespace NewRelic.Agent.Core.Utilities
             {
                 return false;
             }
+        }
+
+        public string ReadAllText(string path)
+        {
+            return File.ReadAllText(path);
+        }
+
+        public string[] ReadAllLines(string path)
+        {
+            return File.ReadAllLines(path);
+        }
+
+        public DateTime GetLastWriteTimeUtc(string path)
+        {
+            return File.GetLastWriteTimeUtc(path);
+        }
+
+        public FileStream Open(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            return File.Open(path, mode, access, share);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
@@ -15,15 +15,17 @@ namespace NewRelic.Agent.Core.Utilities
     public class SystemInfo : ISystemInfo
     {
         private IDnsStatic _dnsStatic;
+        private readonly IFileWrapper _fileWrapper;
 
         private const int ExpectedBootIdLength = 36;
 
         private const int AsciiMaxValue = 127;
 
 
-        public SystemInfo(IDnsStatic dnsStatic)
+        public SystemInfo(IDnsStatic dnsStatic, IFileWrapper fileWrapper)
         {
             _dnsStatic = dnsStatic;
+            _fileWrapper = fileWrapper;
         }
 
         public ulong? GetTotalPhysicalMemoryBytes()
@@ -36,7 +38,7 @@ namespace NewRelic.Agent.Core.Utilities
             {
                 try
                 {
-                    var memInfo = File.ReadAllText("/proc/meminfo");
+                    var memInfo = _fileWrapper.ReadAllText("/proc/meminfo");
                     var memTotalRegex = new Regex(@"MemTotal\:\s*(\d+)\ kB");
                     var match = memTotalRegex.Match(memInfo);
                     if (match.Success)
@@ -99,7 +101,7 @@ namespace NewRelic.Agent.Core.Utilities
 
 				try
 				{
-					var lines = File.ReadAllLines("/proc/sys/kernel/random/boot_id");
+					var lines = FileWrapper.Instance.ReadAllLines("/proc/sys/kernel/random/boot_id");
 					bootId = lines.Length > 0 ? lines[0] : null;
 				}
 				catch (Exception ex)

--- a/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
@@ -58,7 +58,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         public IDictionary<string, IVendorModel> GetVendorSettings()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, new SharedInterfaces.Environment(), new VendorHttpApiRequestor());
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, new SharedInterfaces.Environment(), new VendorHttpApiRequestor(), FileWrapper.Instance);
             return vendorInfo.GetVendors();
         }
 

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -53,16 +53,18 @@ namespace NewRelic.Agent.Core.Utilization
         private readonly IAgentHealthReporter _agentHealthReporter;
         private readonly IEnvironment _environment;
         private readonly VendorHttpApiRequestor _vendorHttpApiRequestor;
+        private readonly IFileWrapper _fileWrapper;
 
         private const string GetMethod = "GET";
         private const string PutMethod = "PUT";
 
-        public VendorInfo(IConfiguration configuration, IAgentHealthReporter agentHealthReporter, IEnvironment environment, VendorHttpApiRequestor vendorHttpApiRequestor)
+        public VendorInfo(IConfiguration configuration, IAgentHealthReporter agentHealthReporter, IEnvironment environment, VendorHttpApiRequestor vendorHttpApiRequestor, IFileWrapper fileWrapper)
         {
             _configuration = configuration;
             _agentHealthReporter = agentHealthReporter;
             _environment = environment;
             _vendorHttpApiRequestor = vendorHttpApiRequestor;
+            _fileWrapper = fileWrapper;
         }
 
         public IDictionary<string, IVendorModel> GetVendors()
@@ -117,7 +119,7 @@ namespace NewRelic.Agent.Core.Utilization
             // If we get AWS ECS info, we don't need to check Docker.
             if (_configuration.UtilizationDetectDocker && !vendors.ContainsKey(EcsName))
             {
-                var dockerVendorInfo = GetDockerVendorInfo(new FileReaderWrapper(), IsLinux());
+                var dockerVendorInfo = GetDockerVendorInfo(_fileWrapper, IsLinux());
                 if (dockerVendorInfo != null)
                 {
                     vendors.Add(dockerVendorInfo.VendorName, dockerVendorInfo);
@@ -309,7 +311,7 @@ namespace NewRelic.Agent.Core.Utilization
             }
         }
 
-        public IVendorModel GetDockerVendorInfo(IFileReaderWrapper fileReaderWrapper, bool isLinux)
+        public IVendorModel GetDockerVendorInfo(IFileWrapper fileReaderWrapper, bool isLinux)
         {
             IVendorModel vendorModel = null;
             if (isLinux)
@@ -505,20 +507,6 @@ namespace NewRelic.Agent.Core.Utilization
 #else
             return false; // No Linux on .NET Framework
 #endif
-        }
-    }
-
-    // needed for unit testing only
-    public interface IFileReaderWrapper
-    {
-        string ReadAllText(string fileName);
-    }
-
-    public class FileReaderWrapper : IFileReaderWrapper
-    {
-        public string ReadAllText(string fileName)
-        {
-            return File.ReadAllText(fileName);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
 using NewRelic.Agent.Core.JsonConverters;
+using NewRelic.Agent.Core.Utilities;
 using Newtonsoft.Json;
 
 namespace NewRelic.Agent.Core.WireModels
@@ -124,7 +125,7 @@ namespace NewRelic.Agent.Core.WireModels
                     return false;
                 }
 
-                if (!File.Exists(location))
+                if (!FileWrapper.Instance.Exists(location))
                 {
                     sha1FileHash = null;
                     sha512FileHash = null;

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/Utilization/UtilizationCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/Utilization/UtilizationCrossAgentTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using NewRelic.Agent.Core.Utilities;
 
 namespace CompositeTests.CrossAgentTests.Utilization
 {
@@ -32,7 +33,7 @@ namespace CompositeTests.CrossAgentTests.Utilization
         {
             _compositeTestAgent = new CompositeTestAgent();
             _agent = _compositeTestAgent.GetAgent();
-            _vendorInfo = new VendorInfo(null, null, new NewRelic.Agent.Core.SharedInterfaces.Environment(), null);
+            _vendorInfo = new VendorInfo(null, null, new NewRelic.Agent.Core.SharedInterfaces.Environment(), null, FileWrapper.Instance);
         }
 
         [TearDown]

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Utilities;
 using NUnit.Framework;
 using Telerik.JustMock;
 using Telerik.JustMock.Helpers;
@@ -50,7 +51,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.UtilizationDetectDocker).Returns(true);
             Mock.Arrange(() => _configuration.UtilizationDetectAzureFunction).Returns(true);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
             Assert.That(vendors.Any(), Is.False);
         }
@@ -58,7 +59,7 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_Returns_Empty_Dictionary_When_Detect_False()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
             Assert.That(vendors.Any(), Is.False);
         }
@@ -70,7 +71,7 @@ namespace NewRelic.Agent.Core.Utilization
         [TestCase("10.96.0.1", "kubernetes_service_host", "kubernetes", "10.96.0.1")]
         public void GetVendors_NormalizeAndValidateMetadata(string metadataValue, string metadataField, string vendorName, string expectedResponse)
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var result = vendorInfo.NormalizeAndValidateMetadata(metadataValue, metadataField, vendorName);
 
             if (expectedResponse == null)
@@ -92,7 +93,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AwsVendorModel)vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -112,7 +113,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.$micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AwsVendorModel)vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -127,7 +128,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -143,7 +144,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmSize"": ""Standard_DS2""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -165,7 +166,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmId"": ""5c08b38e-4d57-4c23-ac45-aca61037f084""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -182,7 +183,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmSize"": ""Standard_DS2""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -198,7 +199,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""zone"": ""projects/492690098729/zones/us-central1-c""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -220,7 +221,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""name"": ""aef-default-20170501t160547-7gh8?""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -236,7 +237,7 @@ namespace NewRelic.Agent.Core.Utilization
 							I'm not valid json. Deal with it.
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -249,7 +250,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(PcfInstanceIp, "10.10.147.130", EnvironmentVariableTarget.Process);
             SetEnvironmentVariable(PcfMemoryLimit, "1024m", EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (PcfVendorModel)vendorInfo.GetPcfVendorInfo();
 
             Assert.That(model, Is.Not.Null);
@@ -268,7 +269,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(PcfInstanceIp, null, EnvironmentVariableTarget.Process);
             SetEnvironmentVariable(PcfMemoryLimit, null, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (PcfVendorModel)vendorInfo.GetPcfVendorInfo();
 
             Assert.That(model, Is.Null);
@@ -280,7 +281,7 @@ namespace NewRelic.Agent.Core.Utilization
             var serviceHost = "10.96.0.1";
             SetEnvironmentVariable(KubernetesServiceHost, serviceHost, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (KubernetesVendorModel)vendorInfo.GetKubernetesInfo();
 
             Assert.That(model, Is.Not.Null);
@@ -292,7 +293,7 @@ namespace NewRelic.Agent.Core.Utilization
         {
             SetEnvironmentVariable(KubernetesServiceHost, null, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (KubernetesVendorModel)vendorInfo.GetKubernetesInfo();
 
             Assert.That(model, Is.Null);
@@ -302,9 +303,9 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_GetDockerVendorInfo_ParsesV2()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
-            var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/mountinfo")).Returns(@"
+            var mockFileWrapper = Mock.Create<IFileWrapper>();
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, mockFileWrapper);
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/mountinfo")).Returns(@"
 1425 1301 0:290 / / rw,relatime master:314 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/SEESBOIUB4X3HZXQDX5TSEQ7BN:/var/lib/docker/overlay2/l/MOPJN3KMFAIZGI5ENZ4O34OONV:/var/lib/docker/overlay2/l/HDHJSGZM5PTRBYHW5EAYHS7XRU:/var/lib/docker/overlay2/l/DPNQ4BZTYI2XJTICBFBZQ3LYGY:/var/lib/docker/overlay2/l/WHFN2B5YEUTYPT77F26T57WB5I:/var/lib/docker/overlay2/l/P7VISFMMKEWRYA7L34PW2O2J54:/var/lib/docker/overlay2/l/ZWNBERDCDMC6LTZHJ4L64AC5LD:/var/lib/docker/overlay2/l/UGWQJ4NGWITVZZNEXAK7ZHDQDD:/var/lib/docker/overlay2/l/IZ5XCLZYFBF7BC4XULL7IJWT3Q:/var/lib/docker/overlay2/l/EGK3Y3BMJAVWDQZLM4DFYAZQNJ:/var/lib/docker/overlay2/l/LNHVYS3UDT2S2TTN2TF3JVSHFH,upperdir=/var/lib/docker/overlay2/14399ff93af039f15ee6a9633110eaf5ac552802c589e7c5595e32adfb635d39/diff,workdir=/var/lib/docker/overlay2/14399ff93af039f15ee6a9633110eaf5ac552802c589e7c5595e32adfb635d39/work
 1426 1425 0:293 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
 1427 1425 0:294 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
@@ -342,7 +343,7 @@ namespace NewRelic.Agent.Core.Utilization
 1342 1429 0:300 / /sys/firmware ro,relatime - tmpfs tmpfs ro
 ");
 
-            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileReaderWrapper, true);
+            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileWrapper, true);
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Id, Is.EqualTo("adf04870aa0a9f01fb712e283765ee5d7c7b1c1c0ad8ebfdea20a8bb3ae382fb"));
         }
@@ -350,10 +351,10 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_GetDockerVendorInfo_ParsesV1_IfV2LookupFailsToParseFile()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
-            var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/mountinfo")).Returns("foo bar baz");
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
+            var mockFileWrapper = Mock.Create<IFileWrapper>();
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, mockFileWrapper);
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/mountinfo")).Returns("foo bar baz");
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
 15:name=systemd:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 14:misc:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 13:rdma:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
@@ -371,7 +372,7 @@ namespace NewRelic.Agent.Core.Utilization
 1:cpuset:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 0::/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043");
 
-            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileReaderWrapper, true);
+            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileWrapper, true);
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Id, Is.EqualTo("b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043"));
         }
@@ -381,9 +382,9 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_GetDockerVendorInfo_ParsesV1_ForCustomerIssue()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
-            var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/mountinfo")).Returns(@"
+            var mockFileWrapper = Mock.Create<IFileWrapper>();
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, mockFileWrapper);
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/mountinfo")).Returns(@"
 14940 3711 0:1357 / / rw,relatime master:1603 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40241/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40240/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40239/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40238/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40237/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40236/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40235/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4615/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4614/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4613/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4612/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4611/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40242/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/40242/work
 14941 14940 0:1373 / / proc rw, nosuid, nodev, noexec, relatime - proc proc rw
 14942 14940 0:1882 / / dev rw, nosuid - tmpfs tmpfs rw, size = 65536k, mode = 755
@@ -422,7 +423,7 @@ namespace NewRelic.Agent.Core.Utilization
 4032 14941 0:1882 / null / proc / sched_debug rw, nosuid - tmpfs tmpfs rw, size = 65536k, mode = 755
 4033 14966 0:1955 / / sys / firmware ro, relatime - tmpfs tmpfs ro");
 
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
 11:hugetlb:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-b10c13eeeea82c495c9e2fbb07ab448024715fdd55218e22cce6cd815c84bd58.scope
 10:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-b10c13eeeea82c495c9e2fbb07ab448024715fdd55218e22cce6cd815c84bd58.scope
 9:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-b10c13eeeea82c495c9e2fbb07ab448024715fdd55218e22cce6cd815c84bd58.scope
@@ -436,7 +437,7 @@ namespace NewRelic.Agent.Core.Utilization
 1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04f9c4b4_5e71_4a0a_aa3a_f62f089e3f73.slice/cri-containerd-b10c13eeeea82c495c9e2fbb07ab448024715fdd55218e22cce6cd815c84bd58.scope
 ");
 
-            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileReaderWrapper, true);
+            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileWrapper, true);
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Id, Is.EqualTo("b10c13eeeea82c495c9e2fbb07ab448024715fdd55218e22cce6cd815c84bd58"));
         }
@@ -444,10 +445,10 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_GetDockerVendorInfo_ParsesV1_IfMountinfoDoesNotExist()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
-            var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/mountinfo")).Throws<FileNotFoundException>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
+            var mockFileWrapper = Mock.Create<IFileWrapper>();
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, mockFileWrapper);
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/mountinfo")).Throws<FileNotFoundException>();
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/cgroup")).Returns(@"
 15:name=systemd:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 14:misc:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 13:rdma:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
@@ -465,7 +466,7 @@ namespace NewRelic.Agent.Core.Utilization
 1:cpuset:/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043
 0::/docker/b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043");
 
-            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileReaderWrapper, true);
+            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileWrapper, true);
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Id, Is.EqualTo("b9d734e13dc5f508571d975edade94a05dfc637e73a83e11077a39bc11681043"));
         }
@@ -474,12 +475,12 @@ namespace NewRelic.Agent.Core.Utilization
         [TestCase(false)]
         public void GetVendors_GetDockerVendorInfo_ReturnsNull_IfUnableToParseV1OrV2(bool isLinux)
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
-            var mockFileReaderWrapper = Mock.Create<IFileReaderWrapper>();
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/mountinfo")).Returns("blah blah blah");
-            Mock.Arrange(() => mockFileReaderWrapper.ReadAllText("/proc/self/cgroup")).Returns("foo bar baz");
+            var mockFileWrapper = Mock.Create<IFileWrapper>();
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, mockFileWrapper);
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/mountinfo")).Returns("blah blah blah");
+            Mock.Arrange(() => mockFileWrapper.ReadAllText("/proc/self/cgroup")).Returns("foo bar baz");
 
-            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileReaderWrapper, isLinux);
+            var model = (DockerVendorModel)vendorInfo.GetDockerVendorInfo(mockFileWrapper, isLinux);
             Assert.That(model, Is.Null);
         }
 #endif
@@ -558,7 +559,7 @@ namespace NewRelic.Agent.Core.Utilization
 
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, ecsUri, EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
 
             var ecsModel = vendors["ecs"];
@@ -629,7 +630,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
 
             var model = vendors["ecs"];
@@ -699,7 +700,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, ecsUri, EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
             Mock.Arrange(() => _configuration.UtilizationDetectDocker).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
 
             var ecsModel = vendors["ecs"];
@@ -718,7 +719,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
 
             Assert.That(vendors, Is.Empty);
@@ -784,7 +785,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Not.Null);
@@ -831,7 +832,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Not.Null);
@@ -847,7 +848,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -862,7 +863,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -877,7 +878,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -892,7 +893,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -902,7 +903,7 @@ namespace NewRelic.Agent.Core.Utilization
         public void GetVendors_GetEcsVendorInfo_Returns_Null()
         {
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -918,7 +919,7 @@ namespace NewRelic.Agent.Core.Utilization
 
             Mock.Arrange(() => _configuration.UtilizationDetectAzureFunction).Returns(enableAzureFunctionUtilization);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var vendors = vendorInfo.GetVendors();
 
             if (enableAzureFunctionUtilization)
@@ -943,7 +944,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns("North Central US");
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns("AzureResourceId");
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             if (expectNull)
@@ -967,7 +968,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns((string)null);
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns("AzureResourceId");
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             Assert.That(model, Is.Null);
@@ -981,7 +982,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns("North Central US");
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns((string)null);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             Assert.That(model, Is.Null);


### PR DESCRIPTION
* Refactors usage of `File.` and `Directory.` to use `IFileWrapper` and `IDirectoryWrapper` instead.
* Adds methods to `IFileWrapper` and `IDirectoryWrapper` as needed with default pass-through implementation.
* Adds a static `Instance` property to `FileWrapper` and `DirectoryWrapper` for use in static methods
* Removes `IFileReaderWrapper` and moves implementation to `IFileWrapper` and `FileWrapper`
* Does not alter any unit tests (aside from required argument refactoring); this change simply reduces friction for future unit tests that may need to mock file and directory operations.
* Did not attempt to refactor usages of `Path.` as that usage is ubiquitous throughout the codebase and we haven't previously had a need to mock that functionality for tests.