### PR TITLE
test: Adds sha to Couchbase dockerfile to address security issue

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/couchbase/Dockerfile
@@ -1,5 +1,5 @@
 # sandbox image with travel-sample bucket pre-installed
-FROM couchbase/server-sandbox:7.6.5  
+FROM couchbase/server-sandbox:7.6.5@sha256:daaac2c1291f0ac383fe0daba6c1e8c5b845d3e166e3e252c85bce63c555beb7
 
 COPY configure-server.sh /opt/couchbase
 


### PR DESCRIPTION
Adds a sha to the Couchbase `Dockerfile` to address https://github.com/newrelic/newrelic-dotnet-agent/security/code-scanning/407