### PR TITLE
test: Added a wait for metrics harvest log line

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentMetrics/DotNetPerfMetricsTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
@@ -168,7 +169,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
             Fixture.AddCommand($"PerformanceMetrics Test {THREADPOOL_WORKER_MAX} {THREADPOOL_COMPLETION_MAX}");
 
-            Fixture.Actions
+            Fixture.AddActions
             (
                 setupConfiguration: () =>
                 {
@@ -178,6 +179,10 @@ namespace NewRelic.Agent.IntegrationTests.AgentMetrics
 
                     if (_gcSamplerV2Enabled)
                         Fixture.RemoteApplication.NewRelicConfig.EnableGCSamplerV2(true);
+                },
+                exerciseApplication: () =>
+                {
+                    Fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
 


### PR DESCRIPTION
Trying to address test flakiness in DotNetPerfMetricsTests by adding a wait for metrics harvest log line