### PR TITLE
chore: Revert static FileWrapper.Instance usage

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentInstallConfiguration.cs
@@ -163,7 +163,7 @@ namespace NewRelic.Agent.Core
         private static string GetNewRelicHome()
         {
             var newRelicHome = EnvironmentVariableProxy.GetEnvironmentVariableFromList(NewRelicHomeEnvironmentVariables);
-            if (newRelicHome != null && DirectoryWrapper.Instance.Exists(newRelicHome)) return Path.GetFullPath(newRelicHome);
+            if (newRelicHome != null && Directory.Exists(newRelicHome)) return Path.GetFullPath(newRelicHome);
 #if NETFRAMEWORK
 			var key = Registry.LocalMachine.OpenSubKey(@"Software\New Relic\.NET Agent");
 			if (key != null) newRelicHome = (string)key.GetValue("NewRelicHome");
@@ -177,7 +177,7 @@ namespace NewRelic.Agent.Core
             if (newRelicInstallPath != null)
             {
                 newRelicInstallPath = Path.Combine(newRelicInstallPath, RuntimeDirectoryName);
-                if (DirectoryWrapper.Instance.Exists(newRelicInstallPath)) return newRelicInstallPath;
+                if (Directory.Exists(newRelicInstallPath)) return newRelicInstallPath;
             }
 
             newRelicInstallPath = EnvironmentVariableProxy.GetEnvironmentVariableFromList(NewRelicHomeEnvironmentVariables);
@@ -194,11 +194,11 @@ namespace NewRelic.Agent.Core
 
             var agentInfoPath = Path.Combine(NewRelicHome, "agentinfo.json");
 
-            if (FileWrapper.Instance.Exists(agentInfoPath))
+            if (File.Exists(agentInfoPath))
             {
                 try
                 {
-                    return JsonConvert.DeserializeObject<AgentInfo>(FileWrapper.Instance.ReadAllText(agentInfoPath));
+                    return JsonConvert.DeserializeObject<AgentInfo>(File.ReadAllText(agentInfoPath));
                 }
                 catch (Exception e)
                 {

--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -51,7 +51,7 @@ namespace NewRelic.Agent.Core.Config
         private BootstrapConfiguration()
         {
             _agentEnabledWithProvenance = new ValueWithProvenance<bool>(true, "Default value");
-            LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), DirectoryWrapper.Instance.Exists, Path.GetFullPath);
+            LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), Directory.Exists, Path.GetFullPath);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NewRelic.Agent.Core.Config
         /// <param name="localConfiguration">The local configuration object to use.</param>
         /// <param name="configurationFileName">The name and path of the local configuration file.</param>
         public BootstrapConfiguration(configuration localConfiguration, string configurationFileName)
-            : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), DirectoryWrapper.Instance.Exists, Path.GetFullPath)
+            : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), Directory.Exists, Path.GetFullPath)
         { }
 
         /// <summary>

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -64,8 +64,8 @@ namespace NewRelic.Agent.Core.Config
         public static Func<string> GetAppDomainName = InternalGetAppDomainName;
 #endif
 
-        public static Func<string, bool> FileExists = FileWrapper.Instance.Exists;
-        public static Func<string, string> FileReadAllText = FileWrapper.Instance.ReadAllText;
+        public static Func<string, bool> FileExists = File.Exists;
+        public static Func<string, string> FileReadAllText = File.ReadAllText;
 
         public static Func<string, string> PathGetDirectoryName = Path.GetDirectoryName;
         public static Func<string, string> GetEnvironmentVar = System.Environment.GetEnvironmentVariable;
@@ -217,7 +217,7 @@ namespace NewRelic.Agent.Core.Config
                     }
                 }
 
-                var currentDirectory = DirectoryWrapper.Instance.GetCurrentDirectory();
+                var currentDirectory = Directory.GetCurrentDirectory();
                 filename = Path.Combine(currentDirectory, NewRelicConfigFileName);
                 if (FileExists(filename))
                 {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.Core.Configuration
             catch (AppDomainUnloadedException)
             {
                 // Fall back to previous behavior of agents <=8.35.0
-                applicationDirectory = DirectoryWrapper.Instance.GetCurrentDirectory();
+                applicationDirectory = Directory.GetCurrentDirectory();
             }
 
             // add default appsettings.json files to config builder

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ConnectionHandler.cs
@@ -50,8 +50,9 @@ namespace NewRelic.Agent.Core.DataTransport
         private readonly Environment _environment;
         private readonly IAgentHealthReporter _agentHealthReporter;
         private readonly IEnvironment _environmentVariableHelper;
+        private readonly IFileWrapper _fileWrapper;
 
-        public ConnectionHandler(ISerializer serializer, ICollectorWireFactory collectorWireFactory, IProcessStatic processStatic, IDnsStatic dnsStatic, ILabelsService labelsService, Environment environment, ISystemInfo systemInfo, IAgentHealthReporter agentHealthReporter, IEnvironment environmentVariableHelper, ICollectorWire dataRequestWire = null)
+        public ConnectionHandler(ISerializer serializer, ICollectorWireFactory collectorWireFactory, IProcessStatic processStatic, IDnsStatic dnsStatic, ILabelsService labelsService, Environment environment, ISystemInfo systemInfo, IAgentHealthReporter agentHealthReporter, IEnvironment environmentVariableHelper, IFileWrapper fileWrapper, ICollectorWire dataRequestWire = null)
         {
             _serializer = serializer;
             _collectorWireFactory = collectorWireFactory;
@@ -62,6 +63,7 @@ namespace NewRelic.Agent.Core.DataTransport
             _systemInfo = systemInfo;
             _agentHealthReporter = agentHealthReporter;
             _environmentVariableHelper = environmentVariableHelper;
+            _fileWrapper = fileWrapper;
 
             _connectionInfo = new ConnectionInfo(_configuration);
             _dataRequestWire = dataRequestWire ??  new NoOpCollectorWire();
@@ -314,7 +316,7 @@ namespace NewRelic.Agent.Core.DataTransport
                 identifier,
                 _labelsService.Labels,
                 metadata ?? new Dictionary<string, string>(),
-                new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter).GetUtilizationSettings(),
+                new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper).GetUtilizationSettings(),
                 _configuration.CollectorSendEnvironmentInfo ? _environment : null,
                 _configuration.SecurityPoliciesTokenExists ? new SecurityPoliciesSettingsModel(_configuration) : null,
                 new EventHarvestConfigModel(_configuration),

--- a/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Logging/LoggerBootstrapper.cs
@@ -260,9 +260,9 @@ namespace NewRelic.Agent.Core
             {
                 // Create the directory if necessary
                 var directory = Path.GetDirectoryName(fileName);
-                if (!DirectoryWrapper.Instance.Exists(directory))
-                    DirectoryWrapper.Instance.CreateDirectory(directory);
-                using (FileWrapper.Instance.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)) { }
+                if (!Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
+                using (File.Open(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)) { }
             }
             catch (Exception exception)
             {

--- a/src/Agent/NewRelic/Agent/Core/RuntimeEnvironmentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/RuntimeEnvironmentInfo.cs
@@ -127,9 +127,9 @@ namespace NewRelic.Agent.Core
 
             try
             {
-                if (FileWrapper.Instance.Exists("/etc/os-release"))
+                if (File.Exists("/etc/os-release"))
                 {
-                    var lines = FileWrapper.Instance.ReadAllLines("/etc/os-release");
+                    var lines = File.ReadAllLines("/etc/os-release");
                     result = new DistroInfo();
                     foreach (var line in lines)
                     {

--- a/src/Agent/NewRelic/Agent/Core/Utilities/DirectoryWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/DirectoryWrapper.cs
@@ -19,8 +19,6 @@ namespace NewRelic.Agent.Core.Utilities
     [NrExcludeFromCodeCoverage]
     public class DirectoryWrapper : IDirectoryWrapper
     {
-        public static IDirectoryWrapper Instance { get; } = new DirectoryWrapper();
-
         public bool Exists(string path) => Directory.Exists(path);
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption = SearchOption.TopDirectoryOnly) => Directory.GetFiles(path, searchPattern, searchOption);

--- a/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/ExtensionsLoader.cs
@@ -158,12 +158,12 @@ namespace NewRelic.Agent.Core.Utilities
 
         private static List<string> GetAssemblyFilesFromFolder(string folder)
         {
-            if (folder == null || !DirectoryWrapper.Instance.Exists(folder))
+            if (folder == null || !Directory.Exists(folder))
             {
                 return new List<string>();
             }
 
-            var assemblyPaths = DirectoryWrapper.Instance.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly);
+            var assemblyPaths = Directory.GetFiles(folder, "*.dll", SearchOption.TopDirectoryOnly);
 
             return assemblyPaths.ToList();
         }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
@@ -23,8 +23,6 @@ namespace NewRelic.Agent.Core.Utilities
     [NrExcludeFromCodeCoverage]
     public class FileWrapper : IFileWrapper
     {
-        public static IFileWrapper Instance { get; } = new FileWrapper();
-        
         public bool Exists(string path)
         {
             return File.Exists(path);

--- a/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/SystemInfo.cs
@@ -101,7 +101,7 @@ namespace NewRelic.Agent.Core.Utilities
 
 				try
 				{
-					var lines = FileWrapper.Instance.ReadAllLines("/proc/sys/kernel/random/boot_id");
+					var lines = File.ReadAllLines("/proc/sys/kernel/random/boot_id");
 					bootId = lines.Length > 0 ? lines[0] : null;
 				}
 				catch (Exception ex)

--- a/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
@@ -19,15 +19,17 @@ namespace NewRelic.Agent.Core.Utilization
         private readonly IConfiguration _configuration;
 
         private readonly IAgentHealthReporter _agentHealthReporter;
+        private readonly IFileWrapper _fileWrapper;
 
         private const int MaxBootIdLength = 128;
 
-        public UtilizationStore(ISystemInfo systemInfo, IDnsStatic dnsStatic, IConfiguration configuration, IAgentHealthReporter agentHealthReporter)
+        public UtilizationStore(ISystemInfo systemInfo, IDnsStatic dnsStatic, IConfiguration configuration, IAgentHealthReporter agentHealthReporter, IFileWrapper fileWrapper)
         {
             _systemInfo = systemInfo;
             _dnsStatic = dnsStatic;
             _configuration = configuration;
             _agentHealthReporter = agentHealthReporter;
+            _fileWrapper = fileWrapper;
         }
 
         public UtilizationSettingsModel GetUtilizationSettings()
@@ -58,7 +60,7 @@ namespace NewRelic.Agent.Core.Utilization
 
         public IDictionary<string, IVendorModel> GetVendorSettings()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, new SharedInterfaces.Environment(), new VendorHttpApiRequestor(), FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, new SharedInterfaces.Environment(), new VendorHttpApiRequestor(), _fileWrapper);
             return vendorInfo.GetVendors();
         }
 

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -125,7 +125,7 @@ namespace NewRelic.Agent.Core.WireModels
                     return false;
                 }
 
-                if (!FileWrapper.Instance.Exists(location))
+                if (!File.Exists(location))
                 {
                     sha1FileHash = null;
                     sha512FileHash = null;

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Couchbase/Couchbase3Exerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Couchbase/Couchbase3Exerciser.cs
@@ -216,6 +216,7 @@ class Couchbase3Exerciser
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task Scan()
     {
+        Console.WriteLine("Scan : Started");
         var initResponse = await InitializeAsync();
         await using var cluster = initResponse.Cluster;
         await using var bucket = initResponse.Bucket;
@@ -223,12 +224,9 @@ class Couchbase3Exerciser
         // get a user-defined collection reference
         var collection = await GetCollectionAsync(bucket, "tenant_agent_00", "users");
 
-        // scan the collection
-        var results = collection.ScanAsync(new RangeScan());
-        await foreach (var result in results)
-        {
-            // process the result
-        }
+        // scan the collection - we don't care about processing the result
+        var _ = collection.ScanAsync(new RangeScan());
+        Console.WriteLine("Scan : Finished");
     }
 #endif
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/Couchbase3Tests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/Couchbase3Tests.cs
@@ -93,10 +93,10 @@ public abstract class Couchbase3TestsBase<TFixture> : NewRelicIntegrationTest<TF
 
         if (_fixture is not (ConsoleDynamicMethodFixtureFW48 or ConsoleDynamicMethodFixtureFW471))
         {
-            _fixture.AddCommand("Couchbase3Exerciser Scan"); // no params required
-
             _fixture.AddCommand("Couchbase3Exerciser ScopeSearch"); // no params required
             _fixture.AddCommand("Couchbase3Exerciser ClusterSearch"); // no params required
+
+            _fixture.AddCommand("Couchbase3Exerciser Scan"); // no params required
         }
 
         _fixture.AddActions

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/SecurityPolicies/SecurityPoliciesCrossAgentTests.cs
@@ -46,6 +46,7 @@ namespace CompositeTests.CrossAgentTests.SecurityPolicies
             var systemInfo = Mock.Create<ISystemInfo>();
             var processStatic = Mock.Create<IProcessStatic>();
             var configurationService = Mock.Create<IConfigurationService>();
+            var fileWrapper = Mock.Create<IFileWrapper>();
             var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic, configurationService);
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
 
@@ -56,7 +57,7 @@ namespace CompositeTests.CrossAgentTests.SecurityPolicies
             _receivedSecurityPoliciesException = false;
 
             _connectionHandler = new ConnectionHandler(new JsonSerializer(), collectorWireFactory, Mock.Create<IProcessStatic>(), Mock.Create<IDnsStatic>(),
-                Mock.Create<ILabelsService>(), agentEnvironment, systemInfo, _agentHealthReporter, Mock.Create<IEnvironment>());
+                Mock.Create<ILabelsService>(), agentEnvironment, systemInfo, _agentHealthReporter, Mock.Create<IEnvironment>(), fileWrapper);
         }
 
         [TearDown]

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/Utilization/UtilizationCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/Utilization/UtilizationCrossAgentTests.cs
@@ -33,7 +33,7 @@ namespace CompositeTests.CrossAgentTests.Utilization
         {
             _compositeTestAgent = new CompositeTestAgent();
             _agent = _compositeTestAgent.GetAgent();
-            _vendorInfo = new VendorInfo(null, null, new NewRelic.Agent.Core.SharedInterfaces.Environment(), null, FileWrapper.Instance);
+            _vendorInfo = new VendorInfo(null, null, new NewRelic.Agent.Core.SharedInterfaces.Environment(), null, new FileWrapper());
         }
 
         [TearDown]

--- a/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/EventHarvestConfigSupportabilityMetricsTests.cs
@@ -34,6 +34,7 @@ namespace CompositeTests
             var systemInfo = Mock.Create<ISystemInfo>();
             var processStatic = Mock.Create<IProcessStatic>();
             var configurationService = Mock.Create<IConfigurationService>();
+            var fileWrapper = Mock.Create<IFileWrapper>();
             var agentEnvironment = new NewRelic.Agent.Core.Environment(systemInfo, processStatic, configurationService);
 
             Mock.Arrange(() => collectorWireFactory.GetCollectorWire(null, Arg.IsAny<IAgentHealthReporter>())).IgnoreArguments().Returns(_collectorWire);
@@ -43,7 +44,7 @@ namespace CompositeTests
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
 
             _connectionHandler = new ConnectionHandler(new JsonSerializer(), collectorWireFactory, Mock.Create<IProcessStatic>(), Mock.Create<IDnsStatic>(),
-                Mock.Create<ILabelsService>(), agentEnvironment, systemInfo, _agentHealthReporter, Mock.Create<IEnvironment>());
+                Mock.Create<ILabelsService>(), agentEnvironment, systemInfo, _agentHealthReporter, Mock.Create<IEnvironment>(), fileWrapper);
         }
 
         [TearDown]

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectionHandlerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectionHandlerTests.cs
@@ -31,6 +31,7 @@ namespace NewRelic.Agent.Core.DataTransport.Tests
         private IConfiguration _configuration;
         private ConnectionHandler _connectionHandler;
         private ICollectorWire _dataRequestWire;
+        private IFileWrapper _fileWrapper;
 
         [SetUp]
         public void SetUp()
@@ -46,6 +47,7 @@ namespace NewRelic.Agent.Core.DataTransport.Tests
             _environmentVariableHelper = Mock.Create<IEnvironment>();
             _configuration = Mock.Create<IConfiguration>();
             _dataRequestWire = Mock.Create<ICollectorWire>();
+            _fileWrapper = Mock.Create<IFileWrapper>();
 
             Mock.Arrange(() => _configuration.SecurityPoliciesTokenExists).Returns(false);
             Mock.Arrange(() => _configuration.ApplicationNames).Returns(new List<string> { "TestApp" });
@@ -63,6 +65,7 @@ namespace NewRelic.Agent.Core.DataTransport.Tests
                 _systemInfo,
                 _agentHealthReporter,
                 _environmentVariableHelper,
+                _fileWrapper,
                 _dataRequestWire
             );
 

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/ConvertMetricDataToJsonTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/ConvertMetricDataToJsonTests.cs
@@ -29,9 +29,10 @@ namespace NewRelic.Agent.Core.JsonConverters
         [SetUp]
         public void Setup()
         {
+            var fileWrapper = Mock.Create<IFileWrapper>();
             Mock.Arrange(() => _metricNameService.RenameMetric(Arg.IsAny<string>())).Returns<string>(name => name);
             _connectionHandler = new ConnectionHandler(new JsonSerializer(), Mock.Create<ICollectorWireFactory>(), Mock.Create<IProcessStatic>(), Mock.Create<IDnsStatic>(),
-                Mock.Create<ILabelsService>(), Mock.Create<Environment>(), Mock.Create<ISystemInfo>(), Mock.Create<IAgentHealthReporter>(), Mock.Create<IEnvironment>());
+                Mock.Create<ILabelsService>(), Mock.Create<Environment>(), Mock.Create<ISystemInfo>(), Mock.Create<IAgentHealthReporter>(), Mock.Create<IEnvironment>(), fileWrapper);
 
             var validScopedMetric = MetricWireModel.BuildMetric(_metricNameService, "DotNet/name", "WebTransaction/DotNet/name",
                 MetricDataWireModel.BuildTimingData(TimeSpan.FromSeconds(3.0), TimeSpan.FromSeconds(2.0)));

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/UtilizationStoreTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/UtilizationStoreTest.cs
@@ -18,12 +18,14 @@ namespace NewRelic.Agent.Core.Utilization
         private IDnsStatic _dnsStatic;
         private IAgentHealthReporter _agentHealthReporter;
         private IConfiguration _configuration;
+        private IFileWrapper _fileWrapper;
 
         [SetUp]
         public void Setup()
         {
             _systemInfo = Mock.Create<ISystemInfo>();
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
+            _fileWrapper = Mock.Create<IFileWrapper>();
 
             Mock.Arrange(() => _systemInfo.GetTotalLogicalProcessors()).Returns(6);
             Mock.Arrange(() => _systemInfo.GetTotalPhysicalMemoryBytes()).Returns((ulong)16000 * 1024 * 1024);
@@ -39,7 +41,7 @@ namespace NewRelic.Agent.Core.Utilization
         public void when_calling_utilization_logical_cores_are_calculated_accurately()
         {
             _configuration = Mock.Create<IConfiguration>();
-            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter);
+            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper);
             var settings = service.GetUtilizationSettings();
 
             Assert.That(settings.LogicalProcessors, Is.EqualTo(6), string.Format("Expected {0}, but was {1}", 8, settings.LogicalProcessors));
@@ -49,7 +51,7 @@ namespace NewRelic.Agent.Core.Utilization
         public void when_calling_utilization_total_ram_is_calculated_accurately()
         {
             _configuration = Mock.Create<IConfiguration>();
-            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter);
+            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper);
             var settings = service.GetUtilizationSettings();
 
             Assert.That(settings.TotalRamMebibytes, Is.EqualTo(16000), string.Format("Expected {0}, but was {1}", 16000, settings.TotalRamMebibytes));
@@ -60,7 +62,7 @@ namespace NewRelic.Agent.Core.Utilization
         {
             _configuration = Mock.Create<IConfiguration>();
             Mock.Arrange(() => _configuration.UtilizationHostName).Returns("Host-Name");
-            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter);
+            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper);
             var settings = service.GetUtilizationSettings();
 
             Assert.That(settings.Hostname, Is.EqualTo("Host-Name"), string.Format("Expected {0}, but was {1}", "Host-Name", settings.Hostname));
@@ -71,7 +73,7 @@ namespace NewRelic.Agent.Core.Utilization
         {
             _configuration = Mock.Create<IConfiguration>();
             Mock.Arrange(() => _configuration.UtilizationFullHostName).Returns("Host-Name.Domain");
-            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter);
+            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper);
             var settings = service.GetUtilizationSettings();
 
             Assert.That(settings.FullHostName, Is.EqualTo("Host-Name.Domain"), string.Format("Expected {0}, but was {1}", "Host-Name.Domain", settings.FullHostName));
@@ -82,7 +84,7 @@ namespace NewRelic.Agent.Core.Utilization
         {
             _configuration = Mock.Create<IConfiguration>();
 
-            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter);
+            var service = new UtilizationStore(_systemInfo, _dnsStatic, _configuration, _agentHealthReporter, _fileWrapper);
             var settings = service.GetUtilizationSettings();
 
             Assert.That(settings.IpAddress, Has.Count.EqualTo(2));

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilization/VendorInfoTests.cs
@@ -24,6 +24,7 @@ namespace NewRelic.Agent.Core.Utilization
         private IAgentHealthReporter _agentHealthReporter;
         private IEnvironment _environment;
         private VendorHttpApiRequestor _vendorHttpApiRequestor;
+        private IFileWrapper _fileWrapper;
 
         private const string PcfInstanceGuid = @"CF_INSTANCE_GUID";
         private const string PcfInstanceIp = @"CF_INSTANCE_IP";
@@ -39,6 +40,7 @@ namespace NewRelic.Agent.Core.Utilization
             _agentHealthReporter = Mock.Create<IAgentHealthReporter>();
             _environment = Mock.Create<IEnvironment>();
             _vendorHttpApiRequestor = Mock.Create<VendorHttpApiRequestor>();
+            _fileWrapper = Mock.Create<IFileWrapper>();
         }
 
         [Test]
@@ -51,7 +53,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.UtilizationDetectDocker).Returns(true);
             Mock.Arrange(() => _configuration.UtilizationDetectAzureFunction).Returns(true);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
             Assert.That(vendors.Any(), Is.False);
         }
@@ -59,7 +61,7 @@ namespace NewRelic.Agent.Core.Utilization
         [Test]
         public void GetVendors_Returns_Empty_Dictionary_When_Detect_False()
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
             Assert.That(vendors.Any(), Is.False);
         }
@@ -71,7 +73,7 @@ namespace NewRelic.Agent.Core.Utilization
         [TestCase("10.96.0.1", "kubernetes_service_host", "kubernetes", "10.96.0.1")]
         public void GetVendors_NormalizeAndValidateMetadata(string metadataValue, string metadataField, string vendorName, string expectedResponse)
         {
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var result = vendorInfo.NormalizeAndValidateMetadata(metadataValue, metadataField, vendorName);
 
             if (expectedResponse == null)
@@ -93,7 +95,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AwsVendorModel)vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -113,7 +115,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.$micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AwsVendorModel)vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -128,7 +130,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""instanceType"" : ""t1.micro""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = vendorInfo.ParseAwsVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -144,7 +146,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmSize"": ""Standard_DS2""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -166,7 +168,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmId"": ""5c08b38e-4d57-4c23-ac45-aca61037f084""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -183,7 +185,7 @@ namespace NewRelic.Agent.Core.Utilization
 							  ""vmSize"": ""Standard_DS2""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureVendorModel)vendorInfo.ParseAzureVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -199,7 +201,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""zone"": ""projects/492690098729/zones/us-central1-c""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Not.Null);
@@ -221,7 +223,7 @@ namespace NewRelic.Agent.Core.Utilization
 							""name"": ""aef-default-20170501t160547-7gh8?""
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -237,7 +239,7 @@ namespace NewRelic.Agent.Core.Utilization
 							I'm not valid json. Deal with it.
 						}";
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (GcpVendorModel)vendorInfo.ParseGcpVendorInfo(json);
 
             Assert.That(model, Is.Null);
@@ -250,7 +252,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(PcfInstanceIp, "10.10.147.130", EnvironmentVariableTarget.Process);
             SetEnvironmentVariable(PcfMemoryLimit, "1024m", EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (PcfVendorModel)vendorInfo.GetPcfVendorInfo();
 
             Assert.That(model, Is.Not.Null);
@@ -269,7 +271,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(PcfInstanceIp, null, EnvironmentVariableTarget.Process);
             SetEnvironmentVariable(PcfMemoryLimit, null, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (PcfVendorModel)vendorInfo.GetPcfVendorInfo();
 
             Assert.That(model, Is.Null);
@@ -281,7 +283,7 @@ namespace NewRelic.Agent.Core.Utilization
             var serviceHost = "10.96.0.1";
             SetEnvironmentVariable(KubernetesServiceHost, serviceHost, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (KubernetesVendorModel)vendorInfo.GetKubernetesInfo();
 
             Assert.That(model, Is.Not.Null);
@@ -293,7 +295,7 @@ namespace NewRelic.Agent.Core.Utilization
         {
             SetEnvironmentVariable(KubernetesServiceHost, null, EnvironmentVariableTarget.Process);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (KubernetesVendorModel)vendorInfo.GetKubernetesInfo();
 
             Assert.That(model, Is.Null);
@@ -559,7 +561,7 @@ namespace NewRelic.Agent.Core.Utilization
 
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, ecsUri, EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
 
             var ecsModel = vendors["ecs"];
@@ -630,7 +632,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
 
             var model = vendors["ecs"];
@@ -700,7 +702,7 @@ namespace NewRelic.Agent.Core.Utilization
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, ecsUri, EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
             Mock.Arrange(() => _configuration.UtilizationDetectDocker).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
 
             var ecsModel = vendors["ecs"];
@@ -719,7 +721,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
 
             Assert.That(vendors, Is.Empty);
@@ -785,7 +787,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Not.Null);
@@ -832,7 +834,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "1e1698469422439ea356071e581e8545-2769485393";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Not.Null);
@@ -848,7 +850,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -863,7 +865,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -878,7 +880,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV4EnvVar, $"http://169.254.170.2/v4/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -893,7 +895,7 @@ namespace NewRelic.Agent.Core.Utilization
             var dockerId = "ae4c507ab5956a9dee9b908e221d72616373861d7ccc3c9703aa346571aef9ef";
             SetEnvironmentVariable(AwsEcsMetadataV3EnvVar, $"http://169.254.170.2/v3/{dockerId}", EnvironmentVariableTarget.Process);
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -903,7 +905,7 @@ namespace NewRelic.Agent.Core.Utilization
         public void GetVendors_GetEcsVendorInfo_Returns_Null()
         {
             Mock.Arrange(() => _configuration.UtilizationDetectAws).Returns(true);
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
 
             var model = vendorInfo.GetEcsVendorInfo();
             Assert.That(model, Is.Null);
@@ -919,7 +921,7 @@ namespace NewRelic.Agent.Core.Utilization
 
             Mock.Arrange(() => _configuration.UtilizationDetectAzureFunction).Returns(enableAzureFunctionUtilization);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var vendors = vendorInfo.GetVendors();
 
             if (enableAzureFunctionUtilization)
@@ -944,7 +946,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns("North Central US");
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns("AzureResourceId");
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             if (expectNull)
@@ -968,7 +970,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns((string)null);
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns("AzureResourceId");
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             Assert.That(model, Is.Null);
@@ -982,7 +984,7 @@ namespace NewRelic.Agent.Core.Utilization
             Mock.Arrange(() => _configuration.AzureFunctionRegion).Returns("North Central US");
             Mock.Arrange(() => _configuration.AzureFunctionResourceId).Returns((string)null);
 
-            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, FileWrapper.Instance);
+            var vendorInfo = new VendorInfo(_configuration, _agentHealthReporter, _environment, _vendorHttpApiRequestor, _fileWrapper);
             var model = (AzureFunctionVendorModel)vendorInfo.GetAzureFunctionVendorInfo();
 
             Assert.That(model, Is.Null);


### PR DESCRIPTION
* Removes the static `FileWrapper.Instance` and `DirectoryWrapper.Instance` properties that were added in #3058, reverting to using `File.` and `Directory.` instead.
* Refactors unit tests to use a mock IFileWrapper in places where `File` was used previously.

Additional unit tests for changes in #3058 that use `IFileWrapper` will follow in a separate PR