### PR TITLE
fix: Profiler should not log "with parent process" unless parent process is non-empty

### DIFF
--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -509,7 +509,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
         {
             auto isIis = Strings::EndsWith(processName, _X("W3WP.EXE")) || Strings::EndsWith(parentProcessName, _X("W3WP.EXE"));
 
-            LogInfo(_X("Process ") + processName + _X(" with parent process ") + parentProcessName + (isIis ? _X(" is") : _X(" is not")) + _X(" IIS."));
+            LogInfo(_X("Process ") + processName + (parentProcessName == _X("") ? _X("") : _X(" with parent process ") + parentProcessName) + (isIis ? _X(" is") : _X(" is not")) + _X(" IIS."));
 
             return isIis;
         }


### PR DESCRIPTION
Recently I noticed some confusing profiler log messages when trying to troubleshoot a customer issue:

`[Info ] 2025-03-28 01:33:06 Process C:\HOME\SITE\WWWROOT\MYAPP.EXE with parent process  is not IIS.`

Note the extra space between "parent process" and "is not IIS".  This happens when this line is logged for a .NET Framework process; the profiler code explicitly passes an empty string for the parent process parameter to the function that logs this message.  This is because .NET framework web apps are expected to run inside the w3wp (IIS) process.

However, if you don't know all that, you might think the lack of a parent process in this log message indicates a problem.

This PR modifies that logging call to only log the "with parent process" bit if the parent process path string is non-empty.
