### PR TITLE
fix: In-process Azure Function publishes Nuget agent DLLs to the wrong folder

### DIFF
--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -13,10 +13,11 @@ namespace ArtifactBuilder.Artifacts
         private readonly AgentComponents _coreAgentX86Components;
         private string _nuGetPackageName;
 
-        public NugetAgent(string configuration)
+        public NugetAgent(string configuration, string versionOverride = null)
             : base(nameof(NugetAgent))
         {
             Configuration = configuration;
+            VersionOverride = versionOverride;
             ValidateContentAction = ValidateContent;
 
             _frameworkAgentComponents = AgentComponents.GetAgentComponents(AgentType.Framework, Configuration, "x64", RepoRootDirectory, HomeRootDirectory);
@@ -27,6 +28,7 @@ namespace ArtifactBuilder.Artifacts
         }
 
         public string Configuration { get; }
+        public string VersionOverride { get; }
 
         protected override void InternalBuild()
         {
@@ -75,7 +77,7 @@ namespace ArtifactBuilder.Artifacts
                 agentInfo.WriteToDisk(Path.GetDirectoryName(newRelicConfigPath));
             }
 
-            package.SetVersion(_frameworkAgentComponents.Version);
+            package.SetVersion(VersionOverride ?? _frameworkAgentComponents.Version);
 
             _nuGetPackageName = package.Pack();
         }

--- a/build/ArtifactBuilder/Program.cs
+++ b/build/ArtifactBuilder/Program.cs
@@ -83,7 +83,10 @@ namespace ArtifactBuilder
         private static void BuildNugetAgent(string[] args)
         {
             var configuration = args[1];
-            var c = new NugetAgent(configuration);
+            string versionOverride = null;
+            if (args.Length > 2)
+                versionOverride = args[2];
+            var c = new NugetAgent(configuration, versionOverride);
             c.Build();
         }
 

--- a/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
+++ b/build/Packaging/NugetAgent/NewRelic.Agent.nuspec
@@ -20,6 +20,7 @@
   <files>
     <file src="**\newrelic\**\*" target="." />
     <file src="tools\**" target="tools" />
+    <file src="build\**" target="build" />
     <file src="README.md" target="." />
     <file src="..\..\icon.png" target="images\" />
   </files>

--- a/build/Packaging/NugetAgent/build/NewRelic.Agent.targets
+++ b/build/Packaging/NugetAgent/build/NewRelic.Agent.targets
@@ -4,8 +4,8 @@
 -->
 
 <!-- This MSBuild target file is used during publish of an Azure In-Process function 
-     to move the NewRelic agent assemblies back to the root of the publish directory
-     after the _GenerateFunctionsAndCopyContentFiles blindly moves all .DLLs to the bin folder. 
+     to move the NewRelic .NET agent assemblies back to the root of the publish directory
+     after the _GenerateFunctionsAndCopyContentFiles task blindly moves all .DLLs to the bin folder. 
      This target applies to Azure Function In-Process apps only -->
 <Project ToolsVersion="14.0"
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -13,10 +13,13 @@
             AfterTargets="_GenerateFunctionsAndCopyContentFiles"
             Condition="Exists('$(PublishDir)bin\newrelic\')">
         <ItemGroup>
-            <NewRelicAgentAssemblies Include="$(PublishDir)bin\newrelic\**\*.dll;$(PublishDir)bin\newrelic\**\*.pdb"/>
+            <NewRelicAgentAssemblies Include="$(PublishDir)bin\newrelic\**\*"/>
         </ItemGroup>
         <Move SourceFiles="@(NewRelicAgentAssemblies)"
               DestinationFiles="$(PublishDir)newrelic\%(RecursiveDir)%(Filename)%(Extension)"
               OverwriteReadOnlyFiles="true" />
+        <RemoveDir Directories="$(PublishDir)bin\newrelic\" 
+                   Condition="Exists('$(PublishDir)bin\newrelic\')" />
+        <Message Importance="high" Text="Moved NewRelic agent assemblies to $(PublishDir)newrelic\"/>
     </Target>
 </Project>

--- a/build/Packaging/NugetAgent/build/NewRelic.Agent.targets
+++ b/build/Packaging/NugetAgent/build/NewRelic.Agent.targets
@@ -1,0 +1,22 @@
+<!-- 
+ Copyright 2020 New Relic Corporation. All rights reserved.
+ SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- This MSBuild target file is used during publish of an Azure In-Process function 
+     to move the NewRelic agent assemblies back to the root of the publish directory
+     after the _GenerateFunctionsAndCopyContentFiles blindly moves all .DLLs to the bin folder. 
+     This target applies to Azure Function In-Process apps only -->
+<Project ToolsVersion="14.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="MoveNewRelicFiles" 
+            AfterTargets="_GenerateFunctionsAndCopyContentFiles"
+            Condition="Exists('$(PublishDir)bin\newrelic\')">
+        <ItemGroup>
+            <NewRelicAgentAssemblies Include="$(PublishDir)bin\newrelic\**\*.dll;$(PublishDir)bin\newrelic\**\*.pdb"/>
+        </ItemGroup>
+        <Move SourceFiles="@(NewRelicAgentAssemblies)"
+              DestinationFiles="$(PublishDir)newrelic\%(RecursiveDir)%(Filename)%(Extension)"
+              OverwriteReadOnlyFiles="true" />
+    </Target>
+</Project>


### PR DESCRIPTION
## Description

Add a build target for the agent Nuget package that runs during publish and moves .NET agent DLLs back to `\newrelic`. 

This is to compensate for the [`_GenerateFunctionsAndCopyContentFiles` target](https://github.com/Azure/azure-functions-vs-build-sdk/blob/7a3e505c2382ee9c461985baef1603e980740ca6/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/Microsoft.NET.Sdk.Functions.Publish.targets#L134) invoked during in-process Azure Function publish that incorrectly moves every .DLL in the build output folder (and subfolders) to the `\bin` folder. 

Fixes #3067. 