### PR TITLE
ci: Update Dotty to use `Microsoft.Build` package for csproj parsing

### DIFF
--- a/build/Dotty/CsprojHandler.cs
+++ b/build/Dotty/CsprojHandler.cs
@@ -49,7 +49,9 @@ namespace Dotty
 
                             // look for a condition attribute and parse the tfm if found
                             var condition = packageReference.Condition;
-                            var tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
+                            string tfm = null;
+                            if (condition?.StartsWith("'$(TargetFramework)'") ?? false)
+                                tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
 
                             if (version.AsVersion() < versionData.NewVersion.AsVersion() &&
                                 !string.IsNullOrEmpty(versionData.IgnoreTfMs) &&

--- a/build/Dotty/CsprojHandler.cs
+++ b/build/Dotty/CsprojHandler.cs
@@ -5,63 +5,79 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
+using Microsoft.Build.Construction;
+using NuGet.Packaging;
 using Serilog;
 
 namespace Dotty
 {
     public class CsprojHandler
     {
-        public static async Task<List<string>> UpdatePackageReferences(string csprojPath, List<NugetVersionData> versionDatas)
+        public static List<string> UpdatePackageReferences(string csprojPath, List<ProjectPackageInfo> packages, List<NugetVersionData> versionDatas)
         {
             Log.Information("Processing {CSProj}...", csprojPath);
             var updateLog = new List<string>();
-            var csprojLines = await File.ReadAllLinesAsync(csprojPath);
 
-            var packages = Parse(csprojPath, csprojLines);
             if (packages.Count == 0)
             {
                 Log.Warning("No packages found in csproj file " + csprojPath);
                 return updateLog;
             }
-
             var updatedCsProj = false;
-            foreach (var versionData in versionDatas)
+
+            var projectRootElement = ProjectRootElement.Open(csprojPath);
+            if (projectRootElement != null)
             {
-                var matchingPackages = packages.Where(p => p.Include == versionData.PackageName).ToList();
-                if (matchingPackages.Count == 0)
+                foreach (var itemGroup in projectRootElement.ItemGroups)
                 {
-                    //Log.Warning($"No matching packages found in csproj file for {versionData.PackageName}");
-                    continue;
+                    var packageReferences = itemGroup.Items.Where(i => i.ItemType == "PackageReference").ToList();
+
+                    foreach (var versionData in versionDatas)
+                    {
+                        // check whether packageReferences contains the package
+                        var matchingPackages =
+                            packageReferences.Where(p => p.Include == versionData.PackageName).ToList();
+                        if (matchingPackages.Count == 0)
+                        {
+                            //Log.Warning($"No matching packages found in csproj file for {versionData.PackageName}");
+                            continue;
+                        }
+
+                        foreach (var packageReference in matchingPackages)
+                        {
+                            var version = packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")?.Value;
+
+                            // look for a condition attribute and parse the tfm if found
+                            var condition = packageReference.Condition;
+                            var tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
+
+                            if (version.AsVersion() < versionData.NewVersion.AsVersion() &&
+                                !string.IsNullOrEmpty(versionData.IgnoreTfMs) &&
+                                versionData.IgnoreTfMs.Split(",").Contains(tfm))
+                            {
+                                Log.Warning($"Not updating {packageReference.Include} for {tfm}, this TFM is ignored.  Manual verification recommended.");
+                                continue;
+                            }
+
+                            if (version.AsVersion() < versionData.NewVersion.AsVersion())
+                            {
+                                Log.Information($"{Path.GetFileName(csprojPath)}: Updating {packageReference.Include}{(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} from {version} to {versionData.NewVersion}");
+
+                                packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")!.Value = versionData.NewVersion;
+
+                                updatedCsProj = true;
+
+                                updateLog.Add($"- Package [{versionData.PackageName}]({versionData.Url}){(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} was updated from {version} to {versionData.NewVersion}.");
+                            }
+                        }
+                    }
                 }
 
-                foreach (var package in matchingPackages)
+                if (updatedCsProj)
                 {
-                    if (package.VersionAsVersion < versionData.NewVersionAsVersion && !string.IsNullOrEmpty(versionData.IgnoreTfMs) && versionData.IgnoreTfMs.Split(",").Contains(package.TargetFramework))
-                    {
-                        Log.Warning($"Not updating {package.Include} for {package.TargetFramework}, this TFM is ignored.  Manual verification recommended.");
-                        continue;
-                    }
-
-                    if (package.VersionAsVersion < versionData.NewVersionAsVersion)
-                    {
-                        Log.Information($"Updating {package.Include} from {package.Version} to {versionData.NewVersion}");
-                        var pattern = @"\d+(\.\d+){2,3}";
-                        var result = Regex.Replace(csprojLines[package.LineNumber], pattern, versionData.NewVersion);
-                        csprojLines[package.LineNumber] = result;
-                        updatedCsProj = true;
-
-                        updateLog.Add($"- Package [{versionData.PackageName}]({versionData.Url}) " +
-                            $"for {package.TargetFramework} " +
-                            $"was updated from {versionData.OldVersion} to {versionData.NewVersion} " +
-                            $"on {versionData.PublishDate.ToShortDateString()}.");
-                    }
+                    projectRootElement.Save();
+                    updateLog.Add("");
                 }
-            }
-
-            if (updatedCsProj)
-            {
-                await File.WriteAllLinesAsync(csprojPath, csprojLines);
-                updateLog.Add("");
             }
 
             return updateLog;

--- a/build/Dotty/Dotty.csproj
+++ b/build/Dotty/Dotty.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="17.13.9" />
     <PackageReference Include="NewRelic.Agent.Api" Version="10.39.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />

--- a/build/Dotty/Program.cs
+++ b/build/Dotty/Program.cs
@@ -148,9 +148,11 @@ namespace Dotty
                     {
                         var packageName = packageReference.Include;
                         var version = packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")?.Value;
-                        // look for a condition attribute and parse the tfm if found
                         var condition = packageReference.Condition;
-                        var tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
+                        string tfm = null;
+                        if (condition?.StartsWith("'$(TargetFramework)'") ?? false)
+                            tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
+
                         if (version != null)
                         {
                             Log.Information($"Found package {packageName} with version {version}{(!string.IsNullOrEmpty(tfm) ? $" targeting {tfm}" : "")}");

--- a/build/Dotty/Program.cs
+++ b/build/Dotty/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.Build;
 using NewRelic.Api.Agent;
 using Octokit;
 using Serilog;
@@ -15,6 +16,8 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using Repository = NuGet.Protocol.Core.Types.Repository;
 using System.IO;
+using Microsoft.Build.Construction;
+using NuGet.Versioning;
 
 namespace Dotty
 {
@@ -44,6 +47,17 @@ namespace Dotty
             var searchTime = _lastRunTimestamp == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow.Date.AddDays(-_daysToSearch) : _lastRunTimestamp;
 
             Log.Information($"Searching for package updates since {searchTime.ToUniversalTime():s}Z.");
+
+            var projectInfoJson = await File.ReadAllTextAsync(ProjectsJsonFilename);
+            var projectInfos = JsonSerializer.Deserialize<ProjectInfo[]>(projectInfoJson);
+            Dictionary<ProjectInfo, List<ProjectPackageInfo>> projectPackages = new();
+            foreach (var projectInfo in projectInfos)
+            {
+                var projectFile = Path.Combine(_searchRootPath, projectInfo.ProjectFile);
+                var currentPackageVersions = ParsePackageVersions(projectFile);
+                if (currentPackageVersions != null)
+                    projectPackages.Add(projectInfo, currentPackageVersions);
+            }
 
             // initialize nuget repo
             var ps = new PackageSource("https://api.nuget.org/v3/index.json");
@@ -80,8 +94,6 @@ namespace Dotty
             }
 
             var updateLog = new List<string>();
-            var projectInfoJson = await File.ReadAllTextAsync(ProjectsJsonFilename);
-            var projectInfos = JsonSerializer.Deserialize<ProjectInfo[]>(projectInfoJson);
             foreach (var projectInfo in projectInfos)
             {
                 var projectFile = Path.Combine(_searchRootPath, projectInfo.ProjectFile);
@@ -106,6 +118,42 @@ namespace Dotty
             // Currently don'y want to create issues, but may in the future
             // If/When we do, this shuold be moved above the PR creation so we can link issues to the PR
             //await CreateGithubIssuesForNewVersions();
+        }
+
+        private static List<ProjectPackageInfo> ParsePackageVersions(string projectFilePath)
+        {
+            Log.Information($"Parsing project file {projectFilePath}");
+            var projectRootElement = ProjectRootElement.Open(projectFilePath);
+            if (projectRootElement != null)
+            {
+                List<ProjectPackageInfo> packageVersions = new();
+
+                foreach (var itemGroup in projectRootElement.ItemGroups)
+                {
+                    var packageReferences = itemGroup.Items.Where(i => i.ItemType == "PackageReference").ToList();
+                    foreach (var packageReference in packageReferences)
+                    {
+                        var packageName = packageReference.Include;
+                        var version = packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")?.Value;
+                        // look for a condition attribute and parse the tfm if found
+                        var condition = packageReference.Condition;
+                        var tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
+                        if (version != null)
+                        {
+                            Log.Information(
+                                $"Found package {packageName} with version {version}{(!string.IsNullOrEmpty(tfm) ? $" targeting {tfm}" : "")}");
+                            packageVersions.Add(new ProjectPackageInfo
+                            {
+                                PackageName = packageName, PackageVersion = version, Tfm = tfm
+                            });
+                        }
+                    }
+                }
+
+                return packageVersions;
+            }
+
+            return null;
         }
 
         [Transaction]

--- a/build/Dotty/ProjectPackageInfo.cs
+++ b/build/Dotty/ProjectPackageInfo.cs
@@ -1,9 +1,19 @@
+using System;
+
 namespace Dotty
 {
-    internal class ProjectPackageInfo
+    public class ProjectPackageInfo
     {
         public string PackageName { get; set; }
         public string PackageVersion { get; set; }
         public string Tfm { get; set; }
+    }
+
+    public static class VersionHelpers
+    {
+        public static Version AsVersion(this string version)
+        {
+            return new Version(version);
+        }
     }
 }

--- a/build/Dotty/ProjectPackageInfo.cs
+++ b/build/Dotty/ProjectPackageInfo.cs
@@ -1,0 +1,9 @@
+namespace Dotty
+{
+    internal class ProjectPackageInfo
+    {
+        public string PackageName { get; set; }
+        public string PackageVersion { get; set; }
+        public string Tfm { get; set; }
+    }
+}


### PR DESCRIPTION
A quick update to Dotty that uses the [`Microsoft.Build`](https://www.nuget.org/packages/Microsoft.Build) package to parse csproj files and manage updates to package versions.  We now report the version in the project file as the "old" version and the latest Nuget package version as the "updated to" version.

This work lays the foundation for later work to extract the current set of package versions used in our project files for purposes of building the compatibility documentation.