### PR TITLE
ci: Add workflow and configuration file to check PR titles for correct format.

### DIFF
--- a/.github/workflows/pr-title-checker-config.json
+++ b/.github/workflows/pr-title-checker-config.json
@@ -1,0 +1,13 @@
+{
+    "LABEL": {
+      "name": ""
+    },
+    "CHECKS": {
+      "prefixes": ["fix: ", "feat: ", "security: ", "notice: ", "chore: ", "chore(deps): ", "chore(main): ", "ci: ", "docs: ", "test: "]
+    },
+    "MESSAGES": {
+      "success": "Pull request title is properly formatted.",
+      "failure": "Pull request title must begin with a valid prefix (e.g. 'feat: ')",
+      "notice": ""
+    }
+  }

--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -1,0 +1,29 @@
+name: Ensure PR title has a valid prefix
+
+on:
+  pull_request:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - name: Check PR title    
+        uses: thehanimo/pr-title-checker@v1.4.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/workflows/pr-title-checker-config.json #(optional. defaults to .github/pr-title-checker-config.json)

--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -22,8 +22,8 @@ jobs:
           disable-sudo: true
           egress-policy: audit
       - name: Check PR title    
-        uses: thehanimo/pr-title-checker@v1.4.3
+        uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false
-          configuration_path: .github/workflows/pr-title-checker-config.json #(optional. defaults to .github/pr-title-checker-config.json)
+          configuration_path: .github/workflows/pr-title-checker-config.json


### PR DESCRIPTION
Take two.  Use an available action to check PR titles for the correct prefix.  Should only apply to PRs into `main`.
