### PR TITLE
fix: Specify a non-infinite timeout when creating `HttpClient` and `SocketsHttpHandler` instances.

### DIFF
--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -1,9 +1,6 @@
 name: Ensure PR title has a valid prefix
 
 on:
-  pull_request:
-    branches:
-      - main
   pull_request_target:
     types:
       - opened
@@ -11,6 +8,11 @@ on:
       - synchronize
       - labeled
       - unlabeled
+    branches:
+      - main
+
+permissions:
+  read-all
 
 jobs:
   check:

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/Client/NRHttpClient.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport.Client.Interfaces;
+using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 
 namespace NewRelic.Agent.Core.DataTransport.Client
@@ -33,6 +34,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             _httpClientWrapper = new HttpClientWrapper(httpClient, (int)_timeout.TotalMilliseconds);
         }
 
+        [NrExcludeFromCodeCoverage]
         private dynamic GetHttpHandler(IWebProxy proxy)
         {
             // check whether the application is running .NET 6 or later

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientFactoryTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientFactoryTests.cs
@@ -27,6 +27,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             Mock.Arrange(() => _mockConfiguration.AgentLicenseKey).Returns("12345");
             Mock.Arrange(() => _mockConfiguration.AgentRunId).Returns("123");
             Mock.Arrange(() => _mockConfiguration.CollectorMaxPayloadSizeInBytes).Returns(int.MaxValue);
+            Mock.Arrange(() => _mockConfiguration.CollectorTimeout).Returns(12345);
 
             _mockProxy = Mock.Create<IWebProxy>();
 


### PR DESCRIPTION
Use the configured collector timeout value instead of a hard-coded `Timespan.Infinite` when creating `HttpClient` and `SocketsHttpHandler` instances. 

Fixes #3083 