### PR TITLE
ci: Update name of PR title check job

### DIFF
--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   check:
+    name: Ensure PR title has a valid prefix
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Required status check rules look at the job name, not the workflow name. This sets a name for the job run by the PR title checking workflow so we can make it a required status.