### PR TITLE
chore: Configure dependabot to avoid upgrading WIX to 6+.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,9 @@ updates:
       nuget-agent:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "WixToolset*"
+        versions: [ ">=6.0.0" ] # WIX 6.0+ requires payment for commerical projects, avoiding upgrade for now
 
   # Update a specific set of packages for unit and integration tests
   - package-ecosystem: nuget


### PR DESCRIPTION
Due to licensing issues we want to avoid upgrading any WIX components to version 6+.