### PR TITLE
test: Removes a couple of outdated logline regexes and refactors tests to wait for something more appropriate.

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
@@ -42,7 +42,7 @@ public abstract class InfiniteTracingContainerTest<T> : NewRelicIntegrationTest<
                 _fixture.ExerciseApplication();
 
                 _fixture.Delay(12); // wait long enough to ensure a metric harvest occurs after we exercise the app
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(11));
 
                 // Now wait to see that the 8T spans were sent successfully
                 _fixture.AgentLog.WaitForLogLinesCapturedIntCount(AgentLogBase.SpanStreamingSuccessfullySentLogLineRegex, TimeSpan.FromMinutes(1), ExpectedSentCount);

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -45,7 +45,7 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
                 _bootstrapServer = _fixture.GetBootstrapServer();
 
                 _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(11));
 
                 // shut down the container and wait for the agent log to see it
                 _fixture.ShutdownRemoteApplication();

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
@@ -28,7 +28,7 @@ public abstract class LinuxContainerTest<T> : NewRelicIntegrationTest<T> where T
                 _fixture.ExerciseApplication();
 
                 _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(11));
 
                 // shut down the container and wait for the agent log to see it
                 _fixture.ShutdownRemoteApplication();

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxUnicodeLogFileTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxUnicodeLogFileTest.cs
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
                     _fixture.ExerciseApplication();
 
                     _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(11));
 
                     // shut down the container and wait for the agent log to see it
                     _fixture.ShutdownRemoteApplication();

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
@@ -33,7 +33,7 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
                     _fixture.ExerciseApplication();
 
                     _fixture.Delay(11); // wait long enough to ensure a metric harvest occurs after we exercise the app
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromSeconds(11));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromSeconds(11));
 
                     // shut down the container and wait for the agent log to see it
                     _fixture.ShutdownRemoteApplication();

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -24,8 +24,6 @@ namespace NewRelic.Agent.IntegrationTestHelpers
         public const string ErrorLogLinePrefixRegex = @"^.*?NewRelic\s+ERROR: " + LogLineContextDataRegex;
         public const string FinestLogLinePrefixRegex = @"^.*?NewRelic\s+FINEST: " + LogLineContextDataRegex;
         public const string WarnLogLinePrefixRegex = @"^.*?NewRelic\s+WARN: " + LogLineContextDataRegex;
-        public const string HarvestLogLineRegex = InfoLogLinePrefixRegex + @"Harvest starting";
-        public const string HarvestFinishedLogLineRegex = DebugLogLinePrefixRegex + @"Metric harvest finished.";
         public const string AgentReportingToLogLineRegex = InfoLogLinePrefixRegex + @"Reporting to: (.*)";
         public const string AgentConnectedLogLineRegex = InfoLogLinePrefixRegex + @"Agent fully connected.";
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNet/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNet/AllowAllHeadersDisabledTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNet
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     configModifier.SetAllowAllHeaders(false)
                         .ForceTransactionTraces()
                         .EnableSpanEvents(true);
@@ -39,7 +39,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNet
                     var customRequestHeaders = new Dictionary<string, string> { { "foo", "bar" } };
 
                     _fixture.PostWithTestHeaders(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNet/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNet/AllowAllHeadersEnabledTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNet
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     configModifier.SetAllowAllHeaders(true)
                         .ForceTransactionTraces()
                         .EnableSpanEvents(true);
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNet
                     };
 
                     _fixture.PostWithTestHeaders(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersDisabledTests.cs
@@ -30,7 +30,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     configModifier.SetAllowAllHeaders(false)
                     .EnableDistributedTrace().ForceTransactionTraces();
                 },
@@ -38,7 +38,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                 {
                     var customRequestHeaders = new Dictionary<string, string> { { "foo", "bar" } };
                     _fixture.MakePostRequestWithCustomRequestHeader(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/AspNetCore/AllowAllHeadersEnabledTests.cs
@@ -29,7 +29,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                     var configModifier = new NewRelicConfigModifier(configPath);
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     configModifier.SetAllowAllHeaders(true)
                     .EnableDistributedTrace().ForceTransactionTraces();
                 },
@@ -37,7 +37,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.AspNetCore
                 {
                     var customRequestHeaders = new Dictionary<string, string> { { "foo", "bar" } };
                     _fixture.MakePostRequestWithCustomRequestHeader(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersDisabledTests.cs
@@ -27,12 +27,22 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.EnvironmentVaria
             _fixture.TestLogger = output;
             _fixture.Actions
             (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
+                    configModifier.SetAllowAllHeaders(true)
+                    .EnableDistributedTrace().ForceTransactionTraces();
+                },
                 exerciseApplication: () =>
                 {
                     var customRequestHeaders = new Dictionary<string, string> { { "foo", "bar" } };
 
                     _fixture.PostWithTestHeaders(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersEnabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/EnvironmentVariables/AllowAllHeadersEnabledTests.cs
@@ -26,6 +26,16 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.EnvironmentVaria
             _fixture.TestLogger = output;
             _fixture.Actions
             (
+                setupConfiguration: () =>
+                {
+                    var configPath = fixture.DestinationNewRelicConfigFilePath;
+                    var configModifier = new NewRelicConfigModifier(configPath);
+                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
+                    configModifier.SetAllowAllHeaders(true)
+                        .EnableDistributedTrace().ForceTransactionTraces();
+                },
                 exerciseApplication: () =>
                 {
                     var customRequestHeaders = new Dictionary<string, string>
@@ -37,7 +47,7 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.EnvironmentVaria
                     };
 
                     _fixture.PostWithTestHeaders(customRequestHeaders);
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
         }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersDisabledTests.cs
@@ -35,13 +35,13 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
                     configModifier.AddAttributesInclude("request.parameters.*");
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "debug");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.Post();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersEnabledTestsBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AllowAllHeadersEnabledTestsBase.cs
@@ -35,13 +35,13 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
                     configModifier.AddAttributesInclude("request.parameters.*");
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "debug");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.Post();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersDisabledTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersDisabledTests.cs
@@ -35,13 +35,13 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
                     configModifier.AddAttributesInclude("request.parameters.*");
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "debug");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.PostAsync();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();

--- a/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersEnabledTestsBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RequestHeadersCapture/Owin/AsyncAllowAllHeadersEnabledTestsBase.cs
@@ -35,13 +35,13 @@ namespace NewRelic.Agent.IntegrationTests.RequestHeadersCapture.Owin
                     configModifier.AddAttributesInclude("request.parameters.*");
                     configModifier.ConfigureFasterMetricsHarvestCycle(10);
                     configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
                     CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "log" }, "level", "debug");
                 },
                 exerciseApplication: () =>
                 {
                     _fixture.PostAsync();
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.HarvestFinishedLogLineRegex, TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
                 }
             );
             _fixture.Initialize();


### PR DESCRIPTION
This one came up while troubleshooting container tests - even though the tests pass, the logline they're waiting for will never appear (because it's been refactored) and doesn't really do what the name implied. 

So I removed `HarvestLogLineRegex` and `HarvestFinishedLogLineRegex` and updated references to wait for one of the harvest data loglines instead.