### PR TITLE
ci: Update Dotty workflow to install .NET 9.0

### DIFF
--- a/.github/workflows/dotty.yml
+++ b/.github/workflows/dotty.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           egress-policy: audit # Leave it audit mode
 
+      - name: Install .NET 9
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: '9.0.x'
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/build/Dotty/Dotty.csproj
+++ b/build/Dotty/Dotty.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Dotty/Dotty.csproj
+++ b/build/Dotty/Dotty.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I forgot that you have to install .NET 9.0 on `ubuntu-latest` runners when I updated Dotty a week or two ago. 