### PR TITLE
fix: Null reference exception in Asp.NET Core 6+ browser monitoring injection. 

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Agent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Agent.cs
@@ -324,7 +324,7 @@ namespace NewRelic.Agent.Core
 
             if (rumBytes == null)
             {
-                transaction.LogFinest("Skipping RUM Injection: No script was available.");
+                transaction?.LogFinest("Skipping RUM Injection: No script was available.");
                 await baseStream.WriteAsync(buffer, 0, buffer.Length);
             }
             else

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectionMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/BrowserInjectionMiddleware.cs
@@ -21,7 +21,7 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
 
         public Task Invoke(HttpContext context)
         {
-            if (!BrowserInjectingStreamWrapper.Disabled)
+            if (!BrowserInjectingStreamWrapper.Disabled || !_agent.CurrentTransaction.IsValid)
             {
                 // wrap the response body in our stream wrapper which will inject the RUM script if appropriate
                 using var injectedResponse = new BrowserInjectingStreamWrapper(_agent, context.Response.Body, context);


### PR DESCRIPTION
In some cases, neither of the instrumentation wrappers for Asp.NET Core 6+ will be hit (for example, when OpenAPI and Swagger is configured), which means that no transaction will be created and can result in a null reference exception. 

Also updates the pipeline that executes the browser injection wrapper to check for a valid transaction, which will keep the wrapper from running when there is no transaction.

Fixes #3101