### PR TITLE
chore: Where possible, refactored existing implementation to accept DT headers prior to first transaction segment

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore/WrapPipelineMiddleware.cs
@@ -49,6 +49,8 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
                 transaction.AttachToAsync(); //Important that this is called from an Invoke method that has the async keyword.
                 transaction.DetachFromPrimary(); //Remove from thread-local type storage
 
+                ProcessHeaders(context);
+
                 segment = SetupSegment(transaction, context);
                 segment.AlwaysDeductChildDuration = true;
 
@@ -60,8 +62,6 @@ namespace NewRelic.Providers.Wrapper.AspNetCore
                 {
                     transaction.SetRequestHeaders(context.Request.Headers, Agent.Extensions.Providers.Wrapper.Statics.DefaultCaptureHeaders, GetHeaderValue);
                 }
-
-                ProcessHeaders(context);
 
                 context.Response.OnStarting(SetOutboundTracingDataAsync);
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
@@ -63,6 +63,8 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                 transaction.AttachToAsync(); //Important that this is called from an Invoke method that has the async keyword.
                 transaction.DetachFromPrimary(); //Remove from thread-local type storage
 
+                ProcessHeaders(context);
+
                 segment = SetupSegment(transaction, context);
                 segment.AlwaysDeductChildDuration = true;
 
@@ -74,8 +76,6 @@ namespace NewRelic.Providers.Wrapper.AspNetCore6Plus
                 {
                     transaction.SetRequestHeaders(context.Request.Headers, Agent.Extensions.Providers.Wrapper.Statics.DefaultCaptureHeaders, GetHeaderValue);
                 }
-
-                ProcessHeaders(context);
 
                 context.Response.OnStarting(SetOutboundTracingDataAsync);
             }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NServiceBus/LoadHandlersConnectorWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/NServiceBus/LoadHandlersConnectorWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
@@ -48,10 +48,10 @@ namespace NewRelic.Providers.Wrapper.NServiceBus
                 transaction.DetachFromPrimary(); //Remove from thread-local type storage
             }
 
-            var segment = transaction.StartMessageBrokerSegment(instrumentedMethodCall.MethodCall, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, BrokerVendorName, queueName);
-
             var headers = NServiceBusHelpers.GetHeadersFromIncomingLogicalMessageContext(incomingLogicalMessageContext);
             NServiceBusHelpers.ProcessHeaders(headers, agent);
+
+            var segment = transaction.StartMessageBrokerSegment(instrumentedMethodCall.MethodCall, MessageBrokerDestinationType.Queue, MessageBrokerAction.Consume, BrokerVendorName, queueName);
 
             void OnComplete(Task task)
             {

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Owin/OwinStartupMiddleware.cs
@@ -33,6 +33,8 @@ namespace NewRelic.Providers.Wrapper.Owin
                 transaction.AttachToAsync();
                 transaction.DetachFromPrimary();
 
+                ProcessHeaders(context);
+
                 segment = SetupSegment(transaction, context);
                 segment.AlwaysDeductChildDuration = true;
 
@@ -44,8 +46,6 @@ namespace NewRelic.Providers.Wrapper.Owin
                 {
                     transaction.SetRequestHeaders(context.Request.Headers, Statics.DefaultCaptureHeaders, GetHeaderValue);
                 }
-
-                ProcessHeaders(context);
 
                 context.Response.OnSendingHeaders(SetOutboundTracingDataAsync, null);
             }


### PR DESCRIPTION
Updates a few instrumentation wrappers to move DT header acceptance prior to creation of the first segment, for better consistency with OTel.