### PR TITLE
Activity Source configuration

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3098,6 +3098,53 @@ namespace NewRelic.Agent.Core.Configuration
         }
         #endregion
 
+        #region Otel Bridge
+
+        // TODO: configure the initial list of activity sources to include
+        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent", "TestApp activity source"];
+
+        private List<string> _includedActivitySources;
+        public List<string> IncludedActivitySources
+        {
+            get
+            {
+                if (_includedActivitySources == null)
+                {
+
+                    var includedActivitySources = DefaultIncludedActivitySources.ToList();
+                    var appSetting = TryGetAppSettingAsString("OpenTelemetry.ActivitySource.Include");
+                    if (!string.IsNullOrEmpty(appSetting))
+                    {
+                        includedActivitySources.AddRange(appSetting.Split(','));
+                    }
+
+                    _includedActivitySources = includedActivitySources;
+                }
+                return _includedActivitySources;
+            }
+        }
+
+        private List<string> _excludedActivitySources;
+        public List<string> ExcludedActivitySources
+        {
+            get
+            {
+                if (_excludedActivitySources == null)
+                {
+                    _excludedActivitySources = new List<string>();
+                    var appSetting = TryGetAppSettingAsString("OpenTelemetry.ActivitySource.Exclude");
+                    if (!string.IsNullOrEmpty(appSetting))
+                    {
+                        _excludedActivitySources = new List<string>(appSetting.Split(','));
+                    }
+                }
+
+                return _excludedActivitySources;
+            }
+        }
+
+        #endregion
+
         public static bool GetLoggingEnabledValue(IEnvironment environment, configurationLog localLogConfiguration)
         {
             return EnvironmentOverrides(environment, localLogConfiguration.enabled, "NEW_RELIC_LOG_ENABLED");

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3136,7 +3136,7 @@ namespace NewRelic.Agent.Core.Configuration
                     var appSetting = TryGetAppSettingAsString("OpenTelemetry.ActivitySource.Exclude");
                     if (!string.IsNullOrEmpty(appSetting))
                     {
-                        _excludedActivitySources = new List<string>(appSetting.Split(','));
+                        _excludedActivitySources.AddRange(appSetting.Split(','));
                     }
                 }
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3100,8 +3100,7 @@ namespace NewRelic.Agent.Core.Configuration
 
         #region Otel Bridge
 
-        // TODO: configure the initial list of activity sources to include
-        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent", "TestApp activity source"];
+        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent"];
 
         private List<string> _includedActivitySources;
         public List<string> IncludedActivitySources

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -3109,8 +3109,8 @@ namespace NewRelic.Agent.Core.Configuration
             {
                 if (_includedActivitySources == null)
                 {
-
                     var includedActivitySources = DefaultIncludedActivitySources.ToList();
+
                     var appSetting = TryGetAppSettingAsString("OpenTelemetry.ActivitySource.Include");
                     if (!string.IsNullOrEmpty(appSetting))
                     {
@@ -3119,6 +3119,7 @@ namespace NewRelic.Agent.Core.Configuration
 
                     _includedActivitySources = includedActivitySources;
                 }
+
                 return _includedActivitySources;
             }
         }
@@ -3131,6 +3132,7 @@ namespace NewRelic.Agent.Core.Configuration
                 if (_excludedActivitySources == null)
                 {
                     _excludedActivitySources = new List<string>();
+
                     var appSetting = TryGetAppSettingAsString("OpenTelemetry.ActivitySource.Exclude");
                     if (!string.IsNullOrEmpty(appSetting))
                     {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -737,6 +737,12 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("agent_control.health.frequency")]
         public int HealthFrequency => _configuration.HealthFrequency;
 
+        [JsonProperty("otel_bridge.included_activity_sources")]
+        public List<string> IncludedActivitySources => _configuration.IncludedActivitySources;
+
+        [JsonProperty("otel_bridge.excluded_activity_sources")]
+        public List<string> ExcludedActivitySources => _configuration.ExcludedActivitySources;
+
         #endregion
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
@@ -83,7 +83,7 @@ namespace NewRelic.Agent.Core.OpenTelemetryBridge
 
             _activityListener = Activator.CreateInstance(activityListenerType);
 
-            ConfigureShouldListenToCallback(this, _activityListener, activityListenerType, activitySourceType);
+            ConfigureShouldListenToCallback(_activityListener, activityListenerType, activitySourceType);
 
             // Need to subscribe to ActivityStarted and ActivityStopped callbacks. These methods will be used to trigger the starting and stopping
             // of segments and potentially transactions using the agent's API.

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
@@ -202,7 +202,7 @@ namespace NewRelic.Agent.Core.OpenTelemetryBridge
 
         // Generates code similar to the following.
         // activityListener.ShouldListenTo = (activitySource) => instance.ShouldListenToActivitySource(activitySource);
-        private static void ConfigureShouldListenToCallback(ActivityBridge instance, object activityListener, Type activityListenerType, Type activitySourceType)
+        private void ConfigureShouldListenToCallback(object activityListener, Type activityListenerType, Type activitySourceType)
         {
             var shouldListenToProperty = activityListenerType.GetProperty("ShouldListenTo");
 
@@ -211,7 +211,7 @@ namespace NewRelic.Agent.Core.OpenTelemetryBridge
             var shouldListenToActivitySourceMethod =
                 typeof(ActivityBridge).GetMethod(nameof(ShouldListenToActivitySource),
                     BindingFlags.NonPublic | BindingFlags.Instance);
-            var activityBridgeInstanceExpression = Expression.Constant(instance);
+            var activityBridgeInstanceExpression = Expression.Constant(this);
 
             var shouldListenToCall = Expression.Call(activityBridgeInstanceExpression, shouldListenToActivitySourceMethod, activitySourceParameter);
 

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
@@ -208,7 +208,9 @@ namespace NewRelic.Agent.Core.OpenTelemetryBridge
 
             var activitySourceParameter = Expression.Parameter(activitySourceType, "activitySource");
 
-            var shouldListenToActivitySourceMethod = typeof(ActivityBridge).GetMethod(nameof(ShouldListenToActivitySource), BindingFlags.NonPublic | BindingFlags.Static);
+            var shouldListenToActivitySourceMethod =
+                typeof(ActivityBridge).GetMethod(nameof(ShouldListenToActivitySource),
+                    BindingFlags.NonPublic | BindingFlags.Instance);
 
             var shouldListenToCall = Expression.Call(null, shouldListenToActivitySourceMethod, activitySourceParameter);
 

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/ActivityBridge.cs
@@ -217,22 +217,17 @@ namespace NewRelic.Agent.Core.OpenTelemetryBridge
             shouldListenToProperty.SetValue(activityListener, shouldListenToLambda.Compile());
         }
 
-        // This hard coded list contains the activity sources used for the hybrid agent cross agent tests
-        // and the activity source used to create activities from New Relic segments.
-        private static readonly List<string> _includedActivitySourceNames = new List<string>
-        {
-            "NewRelic.Agent",
-            "TestApp activity source"
-        };
-        private static bool ShouldListenToActivitySource(object activitySource)
+        private bool ShouldListenToActivitySource(object activitySource)
         {
             dynamic dynamicActivitySource = activitySource;
-
-            // TODO: Make the activity source names that should be listened to configurable.
-            // It probably needs to be a combination of exclude and include lists.
-
             string activitySourceName = (string)dynamicActivitySource.Name;
-            return !string.IsNullOrEmpty(activitySourceName) && _includedActivitySourceNames.Contains(activitySourceName);
+
+            var includedActivitySources = _agent.Configuration.IncludedActivitySources;
+            var excludedActivitySources = _agent.Configuration.ExcludedActivitySources;
+
+            return !string.IsNullOrEmpty(activitySourceName)
+                   && includedActivitySources.Contains(activitySourceName)
+                   && !excludedActivitySources.Contains(activitySourceName);
         }
 
         // Activity will not actually be created by an activity source unless an activity listener is listening to it and the

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -240,5 +240,8 @@ namespace NewRelic.Agent.Configuration
         bool AgentControlEnabled { get; }
         string HealthDeliveryLocation { get; }
         int HealthFrequency { get; }
+
+        List<string> IncludedActivitySources { get; }
+        List<string> ExcludedActivitySources { get; }
     }
 }

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/HybridAgent/HybridAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/HybridAgent/HybridAgentTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using NewRelic.Agent.Api;
+using NewRelic.Agent.Core.Config;
 using NewRelic.Agent.Core.Errors;
 using NewRelic.Agent.Core.OpenTelemetryBridge;
 using NewRelic.Agent.Core.Segments;
@@ -32,6 +33,10 @@ namespace CompositeTests.CrossAgentTests.HybridAgent
             _compositeTestAgent = new CompositeTestAgent();
             // Used for the DT tests to identify the correct tracestate header component
             _compositeTestAgent.ServerConfiguration.TrustedAccountKey = "1";
+
+            // configure the activity source we want to listen to
+            _compositeTestAgent.LocalConfiguration.appSettings.Add(new configurationAdd() { key = "OpenTelemetry.ActivitySource.Include", value = "TestApp activity source" });
+            _compositeTestAgent.PushConfiguration();
 
             _agent = _compositeTestAgent.GetAgent();
             _newRelicAgentOperations = new NewRelicAgentOperations(_agent);

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4612,7 +4612,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             var includedActivitySources = defaultConfig.IncludedActivitySources;
 
-            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "TestApp activity source", "Foo", "Bar", "Baz"]));
+            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Foo", "Bar", "Baz"]));
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4604,6 +4604,28 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
         }
 
+        [Test]
+        public void IncludedActivitySources_IncludesDefaultPlusConfigured()
+        {
+            _localConfig.appSettings.Add(new configurationAdd { key = "OpenTelemetry.ActivitySource.Include", value = "Foo,Bar,Baz" });
+            var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic, _agentHealthReporter);
+
+            var includedActivitySources = defaultConfig.IncludedActivitySources;
+
+            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "TestApp activity source", "Foo", "Bar", "Baz"]));
+        }
+
+        [Test]
+        public void ExcludedActivitySources_IncludesConfigured()
+        {
+            _localConfig.appSettings.Add(new configurationAdd { key = "OpenTelemetry.ActivitySource.Exclude", value = "Foo,Bar,Baz" });
+            var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic, _agentHealthReporter);
+
+            var excludedActivitySources= defaultConfig.ExcludedActivitySources;
+
+            Assert.That(excludedActivitySources, Is.EquivalentTo(["Foo", "Bar", "Baz"]));
+        }
+
 
         private DefaultConfiguration GenerateConfigFromXml(string xml)
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -347,7 +347,9 @@ namespace NewRelic.Agent.Core.Configuration
                     "gc_sampler_v2.enabled": true,
                     "agent_control.enabled" : true,
                     "agent_control.health.delivery_location": "file:///tmp/health",
-                    "agent_control.health.frequency": 5
+                    "agent_control.health.frequency": 5,
+                    "otel_bridge.included_activity_sources": ["SomeIncludedActivitySourceName","AnotherIncludedActivitySourceName"],
+                    "otel_bridge.excluded_activity_sources": ["SomeExcludedActivitySourceName","AnotherExcludedActivitySourceName"]
                 }
                 """;
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
@@ -418,7 +418,9 @@ namespace NewRelic.Agent.Core.DataTransport
                             "gc_sampler_v2.enabled": true,
                             "agent_control.enabled" : true,
                             "agent_control.health.delivery_location": "file:///tmp/health",
-                            "agent_control.health.frequency": 5
+                            "agent_control.health.frequency": 5,
+                            "otel_bridge.included_activity_sources": ["SomeIncludedActivitySourceName","AnotherIncludedActivitySourceName"],
+                            "otel_bridge.excluded_activity_sources": ["SomeExcludedActivitySourceName","AnotherExcludedActivitySourceName"]
                         },
                         "metadata": {
                             "hello": "there"

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -503,5 +503,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public bool AgentControlEnabled => true;
         public string HealthDeliveryLocation => "file:///tmp/health";
         public int HealthFrequency => 5;
+        public List<string> IncludedActivitySources => ["SomeIncludedActivitySourceName"];
+        public List<string> ExcludedActivitySources => ["SomeExcludedActivitySourceName"];
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -503,7 +503,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public bool AgentControlEnabled => true;
         public string HealthDeliveryLocation => "file:///tmp/health";
         public int HealthFrequency => 5;
-        public List<string> IncludedActivitySources => ["SomeIncludedActivitySourceName"];
-        public List<string> ExcludedActivitySources => ["SomeExcludedActivitySourceName"];
+        public List<string> IncludedActivitySources => ["SomeIncludedActivitySourceName","AnotherIncludedActivitySourceName"];
+        public List<string> ExcludedActivitySources => ["SomeExcludedActivitySourceName","AnotherExcludedActivitySourceName"];
     }
 }


### PR DESCRIPTION
Add `appSettings` configuration support for the list of Activity Sources that should included and excluded. Adds a (placeholder) list of default included activity sources.