### PR TITLE
test: Add an assert to all integration tests for common errors and warnings

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
@@ -15,10 +15,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 {
     public class AgentLogFile : AgentLogBase
     {
-        private readonly string _filePath;
+        public string FilePath { get; }
         private readonly string _fileName;
 
-        public bool Found => File.Exists(_filePath);
+        public bool Found => File.Exists(FilePath);
 
         public AgentLogFile(string logDirectoryPath, ITestOutputHelper testLogger, string fileName = "", TimeSpan? timeoutOrZero = null, bool logFileExpected = true)
             : base(testLogger)
@@ -45,7 +45,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
                     if (mostRecentlyUpdatedFile != null)
                     {
-                        _filePath = mostRecentlyUpdatedFile;
+                        FilePath = mostRecentlyUpdatedFile;
                         return;
                     }
 
@@ -62,7 +62,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
                 yield break;
 
             string line;
-            using (var fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var streamReader = new StreamReader(fileStream))
                 while ((line = streamReader.ReadLine()) != null)
                 {
@@ -72,7 +72,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers
 
         public string GetFullLogAsString()
         {
-            using (var fileStream = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var streamReader = new StreamReader(fileStream))
             {
                 return streamReader.ReadToEnd();
@@ -86,9 +86,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var timeTaken = Stopwatch.StartNew();
             do
             {
-                if (!CommonUtils.IsFileLocked(_filePath))
+                if (!CommonUtils.IsFileLocked(FilePath))
                 {
-                    File.WriteAllText(_filePath, string.Empty);
+                    File.WriteAllText(FilePath, string.Empty);
                     return;
                 }
 
@@ -103,9 +103,9 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             var timeTaken = Stopwatch.StartNew();
             do
             {
-                if (!CommonUtils.IsFileLocked(_filePath))
+                if (!CommonUtils.IsFileLocked(FilePath))
                 {
-                    File.Delete(_filePath);
+                    File.Delete(FilePath);
                     return;
                 }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -612,30 +612,21 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         // Works best when logging is at FINEST.
         private void TestForKnownProblems()
         {
-            try
+            // If agent log is not expected, we don't need to check for known problems.
+            // Using AgentLog when the file doesn't exist results in a 3 minute wait - manually checking is faster.
+            if (!AgentLogExpected || !Directory.Exists(DestinationNewRelicLogFileDirectoryPath) ||
+                !File.Exists(Path.Combine(DestinationNewRelicLogFileDirectoryPath, AgentLogFileName)))
             {
-                // If agent log is not expected, we don't need to check for known problems.
-                // Using AgentLog when the file doesn't exist results in a 3 minute wait - manually checking is faster.
-                if (!AgentLogExpected || !Directory.Exists(DestinationNewRelicLogFileDirectoryPath) ||
-                    !File.Exists(Path.Combine(DestinationNewRelicLogFileDirectoryPath, AgentLogFileName)))
-                {
-                    return;
-                }
+                return;
+            }
 
-                Assert.Multiple(
-                    _problemsToCheck.Select(problem => (Action)(
-                        () => Assert.Null(AgentLog.WaitForLogLine(problem, TimeSpan.FromSeconds(5)))
-                    )).ToArray()
-                );
-            }
-            catch
-            {
-                TestLogger?.WriteLine("Could not find agent log for known problem tests, skipping tests.");
-            }
-            finally
-            {
-                TestLogger?.WriteLine("Finished known problems check.");
-            }
+            Assert.Multiple(
+                _problemsToCheck.Select(problem => (Action)(
+                    () => Assert.Null(AgentLog.WaitForLogLine(problem, TimeSpan.FromSeconds(5)))
+                )).ToArray()
+            );
+
+            TestLogger?.WriteLine("Finished known problems check.");
         }
     }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -226,15 +226,15 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
         }
 
         /// <summary>
-        /// Adds or replaces known problems to check for. This is used to check for things like transaction garbage collected.
+        /// Adds or replaces known problems. This is used to check for things like transaction garbage collected.
         /// Add an empty/null string[] with keepDefaults = false to clear the defaults.
         ///
         /// Includes by default:
         /// - AgentLogBase.TransactionEndedByGCFinalizerLogLineRegEx
         /// </summary>
-        /// <param name="problems">Regex values to check for from AgentLogBase.</param>
         /// <param name="keepDefaults">If true, the default problems will be kept. If false, the default problems will be cleared.</param>
-        public void KnownProblemsToCheck(bool keepDefaults = true, params string[] problems)
+        /// <param name="problems">Regex values to check for from AgentLogBase.</param>
+        public void SetKnownProblems(bool keepDefaults = true, params string[] problems)
         {
             _problemsToCheck = keepDefaults ? _problemsToCheck.Concat(problems).ToList() : new List<string>(problems);
         }

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -622,7 +622,7 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
 
             Assert.Multiple(
                 _problemsToCheck.Select(problem => (Action)(
-                    () => Assert.Null(AgentLog.WaitForLogLine(problem, TimeSpan.FromSeconds(5)))
+                    () => Assert.Null(AgentLog.WaitForLogLines(problem, TimeSpan.FromSeconds(5), 0).FirstOrDefault())
                 )).ToArray()
             );
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -335,6 +335,11 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
                                     Thread.Sleep(1000);
                                     numberOfTries++;
                                 }
+
+                                if (!applicationHadNonZeroExitCode)
+                                {
+                                    TestForKnownProblems();
+                                }
                             });
                             TestLogger?.WriteLine($"Remote application shutdown time: {timer.Total:N4} seconds");
                         }
@@ -584,8 +589,17 @@ namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures
             Assert.True(result.IsSuccessStatusCode);
         }
 
-    }
+        // Tests for things like transaction garbage collected and other errors.
+        // Works best when logging is at FINEST.
+        public virtual void TestForKnownProblems()
+        {
+            Assert.Multiple(
+                () => Assert.Null(AgentLog.TryGetLogLine(AgentLogBase.TransactionEndedByGCFinalizerLogLineRegEx))
+            );
 
+            TestLogger?.WriteLine("Tests for known problems completed.");
+        }
+    }
 
     // borrowed from XUnit.Sdk.ExecutionTimer, as using their implementation caused a runtime error looking for xunit.execution.dotnet.dll
     /// <summary>

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/ConfigBuilderDeadlock.cs
@@ -24,6 +24,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentFeatures
                 {
                     _fixture.AddCommand($"ConfigBuilderDeadlock Run");
                     _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+                    _fixture.AgentLogExpected = false;
                     _fixture.SetAdditionalEnvironmentVariable("NEW_RELIC_DELAY_AGENT_INIT_METHOD_LIST", "ConsoleMultiFunctionApplicationFW.NetFrameworkLibraries.ConfigBuilderDeadlock.DoTransaction");
                 }
             );


### PR DESCRIPTION
## Description

Adds the ability to include asserts in all integration tests (unbounded as well) that will run after the test app has finished writing to the agent log that can check for common problems.  This runs inside the Initialize method and within the retry loop to ensure they are run with every test and retry.  Has some logic to look for the log file prior to checking for matches to speed things up.

Currently, this only checks for transaction garbage collected.

Calling Fixture.KnownProblemsToCheck() will allow for adding new checks to the defaults, replacing them completely, or removing them.

Updates ConfigBuilderDeadlock tests to not require an agent log speeding up the test by ~3 minutes.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
