### PR TITLE
feat: Added transaction renaming requirement for Serverless APM mode

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentManager.cs
@@ -295,7 +295,8 @@ namespace NewRelic.Agent.Core
                     "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED",
                     "NEW_RELIC_AGENT_CONTROL_ENABLED",
                     "NEW_RELIC_AGENT_CONTROL_HEALTH_DELIVERY_LOCATION",
-                    "NEW_RELIC_AGENT_CONTROL_HEALTH_FREQUENCY"
+                    "NEW_RELIC_AGENT_CONTROL_HEALTH_FREQUENCY",
+                    "NEW_RELIC_APM_LAMBDA_MODE"
                 };
 
                 List<string> environmentVariablesSensitive = new List<string> {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2224,6 +2224,12 @@ namespace NewRelic.Agent.Core.Configuration
             _azureFunctionModeEnabled ??
             (_azureFunctionModeEnabled = EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AzureFunctionModeEnabled", true), "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED")).Value;
 
+        // Code to support AWS Lambda APM mode for transaction naming [ By default it is disabled ]
+        private bool? _awsLambdaApmModeEnabled;
+        public bool AwsLambdaApmModeEnabled =>
+            _awsLambdaApmModeEnabled ??
+            (_awsLambdaApmModeEnabled = EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AwsLambdaApmModeEnabled", false), "NEW_RELIC_APM_LAMBDA_MODE")).Value;
+
         public string AzureFunctionResourceId
         {
             get

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -742,6 +742,10 @@ namespace NewRelic.Agent.Core.Configuration
         [JsonProperty("agent_control.health.frequency")]
         public int HealthFrequency => _configuration.HealthFrequency;
 
+        [JsonIgnore]
+        public bool AwsLambdaApmModeEnabled => _configuration.AwsLambdaApmModeEnabled;
+        
+
         #endregion
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -244,5 +244,7 @@ namespace NewRelic.Agent.Configuration
         bool AgentControlEnabled { get; }
         string HealthDeliveryLocation { get; }
         int HealthFrequency { get; }
+
+        bool AwsLambdaApmModeEnabled { get; }
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -244,10 +244,14 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             string requestId = _functionDetails.GetRequestId(instrumentedMethodCall);
             var inputObject = _functionDetails.GetInputObject(instrumentedMethodCall);
 
+            // create a transaction for the function invocation if AwsLambdaApmModeEnabled is enabled then based on spec WebTransaction/Function/APIGATEWAY myFunction
+            // else WebTransaction/Function/myFunction
             transaction = agent.CreateTransaction(
                 isWeb: _functionDetails.EventType.IsWebEvent(),
                 category: "Lambda",
-                transactionDisplayName: _functionDetails.FunctionName,
+                transactionDisplayName: agent.Configuration.AwsLambdaApmModeEnabled
+                                        ? _functionDetails.EventType.ToEventTypeString().ToUpper() + " " + _functionDetails.FunctionName
+                                        : _functionDetails.FunctionName,
                 doNotTrackAsUnitOfWork: true);
 
             if (isAsync)

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -538,5 +538,10 @@ namespace NewRelic.Agent.IntegrationTestHelpers
             CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "appSettings", "add"}, "value", $"{enabled}");
             return this;
         }
+        public NewRelicConfigModifier EnableAwsLambdaAPMMode(bool awsLambdaApmModeEnabled)
+        {
+            CommonUtils.SetConfigAppSetting(_configFilePath, "AwsLambdaApmModeEnabled", awsLambdaApmModeEnabled.ToString(), "urn:newrelic-config");
+            return this;
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
@@ -29,6 +29,10 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
                 var configPath = fixture.DestinationNewRelicConfigFilePath;
                 var configModifier = new NewRelicConfigModifier(configPath);
                 configModifier.ForceTransactionTraces();
+                if (_awsLambdaApmModeEnabled)
+                {
+                    configModifier.EnableAwsLambdaAPMMode(true);
+                }
             };
 
             _fixture.Actions(

--- a/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AwsLambda/AwsLambdaSmokeTest.cs
@@ -13,11 +13,13 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     {
         private readonly LambdaSnsEventTriggerFixtureBase _fixture;
         private readonly string _expectedTransactionName;
+        private readonly bool _awsLambdaApmModeEnabled;
 
-        protected AwsLambdaSmokeTestBase(string expectedTransactionName, T fixture, ITestOutputHelper output)
+        protected AwsLambdaSmokeTestBase(string expectedTransactionName, T fixture, ITestOutputHelper output, bool awsLambdaApmModeEnabled)
             : base(fixture)
         {
             _expectedTransactionName = expectedTransactionName;
+            _awsLambdaApmModeEnabled = awsLambdaApmModeEnabled;
 
             _fixture = fixture;
             _fixture.TestLogger = output;
@@ -74,7 +76,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaSmokeTestCoreOldest : AwsLambdaSmokeTestBase<LambdaSnsEventTriggerFixtureCoreOldest>
     {
         public AwsLambdaSmokeTestCoreOldest(LambdaSnsEventTriggerFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandler", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandler", fixture, output, false)
         {
         }
     }
@@ -82,7 +84,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaAsyncSmokeTestCoreOldest : AwsLambdaSmokeTestBase<AsyncLambdaSnsEventTriggerFixtureCoreOldest>
     {
         public AwsLambdaAsyncSmokeTestCoreOldest(AsyncLambdaSnsEventTriggerFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output,false)
         {
         }
     }
@@ -90,7 +92,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaHandlerOnlySmokeTestCoreOldest : AwsLambdaSmokeTestBase<LambdaHandlerOnlySnsTriggerFixtureCoreOldest>
     {
         public AwsLambdaHandlerOnlySmokeTestCoreOldest(LambdaHandlerOnlySnsTriggerFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandler", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandler", fixture, output, false)
         {
         }
     }
@@ -98,7 +100,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaHandlerOnlyAsyncSmokeTestCoreOldest : AwsLambdaSmokeTestBase<AsyncLambdaHandlerOnlySnsTriggerFixtureCoreOldest>
     {
         public AwsLambdaHandlerOnlyAsyncSmokeTestCoreOldest(AsyncLambdaHandlerOnlySnsTriggerFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output, false)
         {
         }
     }
@@ -106,7 +108,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaSmokeTestCoreLatest : AwsLambdaSmokeTestBase<LambdaSnsEventTriggerFixtureCoreLatest>
     {
         public AwsLambdaSmokeTestCoreLatest(LambdaSnsEventTriggerFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandler", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandler", fixture, output,false)
         {
         }
     }
@@ -114,7 +116,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaAsyncSmokeTestCoreLatest : AwsLambdaSmokeTestBase<AsyncLambdaSnsEventTriggerFixtureCoreLatest>
     {
         public AwsLambdaAsyncSmokeTestCoreLatest(AsyncLambdaSnsEventTriggerFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output, false)
         {
         }
     }
@@ -122,7 +124,7 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaHandlerOnlySmokeTestCoreLatest : AwsLambdaSmokeTestBase<LambdaHandlerOnlySnsTriggerFixtureCoreLatest>
     {
         public AwsLambdaHandlerOnlySmokeTestCoreLatest(LambdaHandlerOnlySnsTriggerFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandler", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandler", fixture, output, false)
         {
         }
     }
@@ -130,7 +132,14 @@ namespace NewRelic.Agent.IntegrationTests.AwsLambda.General
     public class AwsLambdaHandlerOnlyAsyncSmokeTestCoreLatest : AwsLambdaSmokeTestBase<AsyncLambdaHandlerOnlySnsTriggerFixtureCoreLatest>
     {
         public AwsLambdaHandlerOnlyAsyncSmokeTestCoreLatest(AsyncLambdaHandlerOnlySnsTriggerFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output)
+            : base("OtherTransaction/Lambda/SnsHandlerAsync", fixture, output,false)
+        {
+        }
+    }
+    public class AwsLambdaServerlessModeSmokeTestCoreLatest : AwsLambdaSmokeTestBase<LambdaSnsEventTriggerFixtureCoreLatest>
+    {
+        public AwsLambdaServerlessModeSmokeTestCoreLatest(LambdaSnsEventTriggerFixtureCoreLatest fixture, ITestOutputHelper output)
+            : base("OtherTransaction/Lambda/SNS SnsHandler", fixture, output, true) // Enable AWS Lambda APM mode
         {
         }
     }

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -47,7 +47,7 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_LAMBDA_FUNCTION_VERSION", lambdaVersion);
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_EXECUTION_ENV", lambdaExecutionEnvironment);
 
-                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_APM_LAMBDA_MODE", "true");
+                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_APM_LAMBDA_MODE", "false");
 
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -47,6 +47,8 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_LAMBDA_FUNCTION_VERSION", lambdaVersion);
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_EXECUTION_ENV", lambdaExecutionEnvironment);
 
+                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_APM_LAMBDA_MODE", "true");
+
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/AwsLambda/LambdaTestToolFixture.cs
@@ -47,8 +47,6 @@ namespace NewRelic.Agent.IntegrationTests.RemoteServiceFixtures.AwsLambda
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_LAMBDA_FUNCTION_VERSION", lambdaVersion);
                     AddAdditionalEnvironmentVariableIfNotNull("AWS_EXECUTION_ENV", lambdaExecutionEnvironment);
 
-                    AddAdditionalEnvironmentVariableIfNotNull("NEW_RELIC_APM_LAMBDA_MODE", "false");
-
                     // Finest level logs are necessary to read the uncompressed payloads from the agent logs
                     remoteApplication.NewRelicConfig.SetLogLevel("finest");
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -506,5 +506,7 @@ namespace NewRelic.Agent.Core.DataTransport
         public bool AgentControlEnabled => true;
         public string HealthDeliveryLocation => "file:///tmp/health";
         public int HealthFrequency => 5;
+
+        public bool AwsLambdaApmModeEnabled => true;
     }
 }


### PR DESCRIPTION
https://source.datanerd.us/agents/agent-specs/pull/733
Serverless APM Mode is a new agent mode required by the Lambda Fusion project, and which would allow Lambda telemetry to be displayed in the APM UI. Some of the requirements are handled by Serverless Team, as in the case of the Lambda Extension. One requirement, however, will (with some exceptions, such as Python) need to be handled by agents.

For this mode, the Function Name segment of the the transaction name will need to have the event source type added before the function name, separated from the function name by a space character. WebTransaction/Function/myFunction, for example, would be renamed WebTransaction/Function/apiGateway myFunction if triggered by API Gateway.