### PR TITLE
chore: Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "chore(deps):"
     groups:
       github-actions:
         patterns:
@@ -32,13 +34,15 @@ updates:
       - /src/Agent/MsiInstaller
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
     groups: 
       nuget-agent:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "WixToolset*"
-        versions: [ ">=6.0.0" ] # WIX 6.0+ requires payment for commerical projects, avoiding upgrade for now
+      - dependency-name: "WixToolset.*"
+        versions: [ "6.*" ] # WIX 6.0+ requires payment for commerical projects, avoiding upgrade for now
 
   # Update a specific set of packages for unit and integration tests
   - package-ecosystem: nuget
@@ -47,6 +51,8 @@ updates:
       - / # will pick up FullAgent.sln which contains the unit tests
     schedule:
       interval: monthly
+    commit-message:
+      prefix: "chore(deps):"
     groups:
       nuget-tests:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,14 +24,14 @@ updates:
 #        patterns:
 #          - "*"
           
-  # We do not scan anything in the /src/Agent/NewRelic/Agent/Extensions folder, as those projects
-  # intentionally reference old versions of the Nuget packages they instrument.
   - package-ecosystem: nuget
-    directories:
-      - /src/Agent/NewRelic/Agent/Core
-      - /src/Agent/NewRelic.Api.Agent
-      - /build
-      - /src/Agent/MsiInstaller
+    directories: # not recursive - only the specified directory will be scanned for .csproj or .sln files
+      - /src/Agent/NewRelic/Agent/Core # Core.csproj
+      - /src/Agent/NewRelic.Api.Agent # NewRelic.Api.Agent.csproj
+      - /build # BuildTools.sln
+      - /src/Agent/MsiInstaller # MsiInstaller.sln
+      # We do not scan the /src/Agent/NewRelic/Agent/Extensions folder, as those projects
+      # intentionally reference old versions of the Nuget packages they instrument.
     schedule:
       interval: weekly
     commit-message:
@@ -41,7 +41,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "WixToolset.*"
+      - dependency-name: "WixToolset*"
         versions: [ "6.*" ] # WIX 6.0+ requires payment for commerical projects, avoiding upgrade for now
 
   # Update a specific set of packages for unit and integration tests


### PR DESCRIPTION
* For some reason, Dependabot stopped adding conventional commit prefixes to PRs within the last month or so. This update specifies an explicit commit prefix that meets our requirements. 
* The version exclusion configuration for `WixToolset.*` was incorrect; this update fixes it to use the NuGet-specific version pattern. as per the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versions-ignore).