### PR TITLE
test: strip newlines from environment variables in hostedwebcore tests

### DIFF
--- a/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
+++ b/tests/Agent/IntegrationTests/HostedWebCore/Program.cs
@@ -30,7 +30,9 @@ namespace HostedWebCore
             var environmentVariables = new StringBuilder();
             foreach (DictionaryEntry de in Environment.GetEnvironmentVariables())
             {
-                environmentVariables.Append($"  {de.Key} = {de.Value}; ");
+                // strip newlines in the environment variable value - otherwise our log parsing may fail
+                var valueStr = de.Value?.ToString().Replace("\r", string.Empty).Replace("\n", string.Empty);
+                environmentVariables.Append($"  {de.Key} = {valueStr}; ");
             }
             Log("Environment Variables: " + environmentVariables.ToString());
 


### PR DESCRIPTION
This is a workaround for some environment variables introduced by newer versions of Visual Studio that include multi-line environment vars. These environment vars are written to the hostedwebcore logs, and these multi-line environment variables break our hostedwebcore log validator. By removing the newlines we can still get an idea of what the environment variable value is, and not need to increase the complexity in our hostedwebcore log validator.