### PR TITLE
ci: Update container tests to use new Azure container registry

### DIFF
--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -35,7 +35,6 @@ jobs:
     env:
       test_results_path: tests\TestResults
       integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      CONTAINER_TEST_ACR_NAME: ${{ secrets.CONTAINER_TEST_ACR_NAME }}
       NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
       # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
       enhanced_logging: false

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -98,7 +98,6 @@ jobs:
     env:
       test_results_path: tests\TestResults
       integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
-      CONTAINER_TEST_ACR_NAME: ${{ secrets.CONTAINER_TEST_ACR_NAME }}
       NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
       # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
       enhanced_logging: false

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       test_results_path: tests\TestResults
       integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      CONTAINER_TEST_ACR_NAME: ${{ secrets.CONTAINER_TEST_ACR_NAME }}
       NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
       # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
       enhanced_logging: false
@@ -98,6 +99,7 @@ jobs:
     env:
       test_results_path: tests\TestResults
       integration_tests_shared_project: ${{ github.workspace }}/tests/Agent/IntegrationTests/Shared
+      CONTAINER_TEST_ACR_NAME: ${{ secrets.CONTAINER_TEST_ACR_NAME }}
       NR_DOTNET_TEST_SAVE_WORKING_DIRECTORY: 1
       # Make this variable true to enable extra data-gathering and logging to help troubleshoot test failures, at the cost of additional time and resources
       enhanced_logging: false

--- a/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/AzureFunctionApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/AzureFunctionApplication.csproj
@@ -31,6 +31,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/ServiceBusTriggerFunction.cs
+++ b/tests/Agent/IntegrationTests/Applications/AzureFunctionApplication/ServiceBusTriggerFunction.cs
@@ -7,13 +7,14 @@ using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+using NewRelic.Agent.IntegrationTests.Shared;
 
 namespace AzureFunctionApplication;
 
 public class ServiceBusTriggerFunction
 {
     [Function("ServiceBusTriggerFunction")]
-    public void Run([ServiceBusTrigger("func-test-queue")] ServiceBusReceivedMessage message, ILogger log)
+    public void Run([ServiceBusTrigger(AzureServiceBusConfiguration.FuncTestQueueName)] ServiceBusReceivedMessage message, ILogger log)
     {
         var jsonMessage = JsonSerializer.Serialize(message, new JsonSerializerOptions() { WriteIndented = true });
 
@@ -24,7 +25,7 @@ public class ServiceBusTriggerFunction
     /// Takes input from an HTTP trigger and sends a Service Bus message, which should then trigger ServiceBusTriggerFunction automagically
     /// </summary>
     [Function("HttpTrigger_SendServiceBusMessage")]
-    [ServiceBusOutput("func-test-queue")]
+    [ServiceBusOutput(AzureServiceBusConfiguration.FuncTestQueueName)]
     public async Task<ServiceBusMessage> ServiceBusOutput([HttpTrigger(AuthorizationLevel.Admin, "post", Route = null)] HttpRequestMessage requestMessage, ILogger log)
     {
         var input = await requestMessage!.Content!.ReadAsStringAsync();

--- a/tests/Agent/IntegrationTests/Applications/AzureFunctionInProcApplication/AzureFunctionInProcApplication.csproj
+++ b/tests/Agent/IntegrationTests/Applications/AzureFunctionInProcApplication/AzureFunctionInProcApplication.csproj
@@ -10,6 +10,9 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Agent/IntegrationTests/Applications/AzureFunctionInProcApplication/ServiceBusTriggerFunction.cs
+++ b/tests/Agent/IntegrationTests/Applications/AzureFunctionInProcApplication/ServiceBusTriggerFunction.cs
@@ -7,6 +7,7 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using NewRelic.Agent.IntegrationTests.Shared;
 using Newtonsoft.Json;
 
 namespace AzureFunctionInProcApplication
@@ -14,7 +15,7 @@ namespace AzureFunctionInProcApplication
     public class ServiceBusTriggerFunction
     {
         [FunctionName("ServiceBusTriggerFunction")]
-        public void Run([ServiceBusTrigger("func-test-queue")] ServiceBusReceivedMessage message, ILogger log)
+        public void Run([ServiceBusTrigger(AzureServiceBusConfiguration.FuncTestQueueName)] ServiceBusReceivedMessage message, ILogger log)
         {
             var jsonMessage = JsonConvert.SerializeObject(message, Formatting.Indented);
 
@@ -25,7 +26,7 @@ namespace AzureFunctionInProcApplication
         /// Takes input from an HTTP trigger and sends a Service Bus message, which should then trigger ServiceBusTriggerFunction automagically
         /// </summary>
         [FunctionName("HttpTrigger_SendServiceBusMessage")]
-        [return: ServiceBus("func-test-queue")]
+        [return: ServiceBus(AzureServiceBusConfiguration.FuncTestQueueName)]
         public async Task<ServiceBusMessage> ServiceBusOutput([HttpTrigger(AuthorizationLevel.Admin, "post", Route = null)] HttpRequestMessage requestMessage, ILogger log)
         {
             var input = await requestMessage!.Content!.ReadAsStringAsync();

--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -7,40 +7,29 @@ Instructions for building a set of custom base images, used by the Container Int
 https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
 https://docs.docker.com/engine/reference/commandline/buildx_build/
 
+* The container registry name is kept in a Github secret and is also accessible via 1Password.
+* The `dotnet-agent-acr-token` password is accessible in 1Password
 
 ## Azure container registry login via Docker
 From a Powershell command prompt in the same folder as this README file:
-1. Log in to the DotNetReg container repository
-`docker login -u dotnet-agent-token -p {insert password here} dotnetreg.azurecr.io`
+0. Set the container registry name in a variable
+`$acrName="{container registry name}"`
+1. Log in to the container repository
+`docker login -u dotnet-agent-acr-token -p {password} $acrName`
 2. Configure buildx in Docker Desktop
 `docker buildx create --use`
-3. Build the base images. The images will be pushed to the DotNetReg container registry with tags per .NET version
+3. Build the base images. The images will be pushed to the container registry with tags per .NET version
 
 ```
-docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
-docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.AmazonBaseImage --tag dotnetreg.azurecr.io/amazonlinux-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.AmazonBaseImage --tag $acrName/amazonlinux-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.AmazonBaseImage --tag $acrName/amazonlinux-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
 
-docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseImage --tag dotnetreg.azurecr.io/fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
-docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.FedoraBaseImage --tag dotnetreg.azurecr.io/fedora-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="8.0" -f Dockerfile.FedoraBaseImage --tag $acrName/fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.FedoraBaseImage --tag $acrName/fedora-aspnet:9.0 --platform linux/amd64,linux/arm64/v8 --push .
 ```
 
 4. Disable buildx in Docker Desktop
 `docker buildx rm`
 
-5. Log out of the DotNetReg container repository
-`docker logout dotnetreg.azurecr.io`
-
-### Azure Container Registry Changes:
-The DotNetReg container registry was originally created on the Basic SKU. The only way to enable anonymous pull from the container registry is to upgrade to the Standard SKU. For reference, this is the process that was followed:
-
-#### Prerequisites:
-* [Azure CLI (32 bit)](https://aka.ms/installazurecliwindows)
-
-#### Azure login
-1. Open a Powershell command prompt
-2. Run `az login <your_azure_login_email` and follow the authentication instructions
-3. Run the following:
-```
-  az acr update --name dotnetreg --sku Standard  # sku was Basic
-  az acr update --name dotnetreg --anonymous-pull-enabled
-```
+5. Log out of the {container registry name} container repository
+`docker logout $acrName`

--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -33,3 +33,7 @@ docker buildx  build --build-arg DOTNET_VERSION="9.0" -f Dockerfile.FedoraBaseIm
 
 5. Log out of the {container registry name} container repository
 `docker logout $acrName`
+
+# Enabling Anonymous Pull Access
+
+By default, anonymous pull access is disabled but is required for the container integration tests workflow. See [Configure anonymous pull access](https://learn.microsoft.com/en-us/azure/container-registry/anonymous-pull-access) for details. 

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.amazon
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.amazon
@@ -1,9 +1,10 @@
 ARG DOTNET_VERSION
 ARG TARGET_ARCH
 ARG BUILD_ARCH
+ARG CONTAINER_TEST_ACR_NAME
 # Uses a custom-built Amazon Linux image with ASP.NET Core pre-installed, served from a private
 # container repository under the .NET Team Sandbox Azure subscription
-FROM --platform=${TARGET_ARCH} dotnetreg.azurecr.io/amazonlinux-aspnet:${DOTNET_VERSION} AS base
+FROM --platform=${TARGET_ARCH} ${CONTAINER_TEST_ACR_NAME}/amazonlinux-aspnet:${DOTNET_VERSION} AS base
 WORKDIR /app
 EXPOSE 80
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.fedora
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.fedora
@@ -1,8 +1,9 @@
 ARG DOTNET_VERSION
 ARG BUILD_ARCH
+ARG CONTAINER_TEST_ACR_NAME
 # Uses a custom-built Fedora image with ASP.NET Core pre-installed, served from a private
 # container repository under the .NET Team Sandbox Azure subscription
-FROM dotnetreg.azurecr.io/fedora-aspnet:${DOTNET_VERSION} AS base
+FROM ${CONTAINER_TEST_ACR_NAME}/fedora-aspnet:${DOTNET_VERSION} AS base
 WORKDIR /app
 EXPOSE 80
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose.yml
@@ -10,6 +10,7 @@
 # PLATFORM        The platform that the service runs on -- linux/amd64 or linux/arm64/v8
 # DOTNET_VERSION  The dotnet version number to use (8.0, etc)
 # TEST_DOCKERFILE The path and dockerfile to use for the service.
+# CONTAINER_TEST_ACR_NAME The name of the Azure Container Registry to use for tests that use a custom container image.
 # 
 # and the usual suspects:
 # NEW_RELIC_LICENSE_KEY
@@ -37,6 +38,7 @@ services:
                 NEW_RELIC_HOST: ${NEW_RELIC_HOST}
                 DOTNET_VERSION: ${DOTNET_VERSION}
                 APP_DOTNET_VERSION: ${APP_DOTNET_VERSION}
+                CONTAINER_TEST_ACR_NAME: ${CONTAINER_TEST_ACR_NAME}
         ports:
           - "${PORT}:80"
         volumes:

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
@@ -140,6 +140,8 @@ public class ContainerApplication : RemoteApplication
         startInfo.EnvironmentVariables.Add("DISTRO_TAG", _distroTag);
         startInfo.EnvironmentVariables.Add("TARGET_ARCH", _targetArch);
 
+        startInfo.EnvironmentVariables.Add("CONTAINER_TEST_ACR_NAME", testConfiguration.DefaultSetting.ContainerTestAcrName);
+
         // Workflow will set BUILD_ARCH if it's a CI build
         // otherwise, assume it's a local build and set it to amd64
         if (!startInfo.EnvironmentVariables.ContainsKey("BUILD_ARCH"))

--- a/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AzureFunction/AzureFunctionServiceBusTriggerTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace NewRelic.Agent.IntegrationTests.AzureFunction;
 
+// NOTE: If these tests fail, verify that the queue named in AzureServiceBusConfiguration.FuncTestQueueName has been created.
+
 public abstract class AzureFunctionServiceBusTriggerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
     where TFixture : AzureFunctionApplicationFixture
 {

--- a/tests/Agent/IntegrationTests/Shared/AzureServiceBusConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/AzureServiceBusConfiguration.cs
@@ -7,6 +7,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
 {
     public class AzureServiceBusConfiguration
     {
+        public const string FuncTestQueueName = "azure_func_test_queue";
         private static string _connectionString;
 
     public static string ConnectionString

--- a/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/IntegrationTestConfiguration.cs
@@ -114,6 +114,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         public string TraceObserverUrl { get; set; }
         public IDictionary<string, string> CustomSettings { get; set; }
         public string TraceObserverPort { get; set; } = "443";
+        public string ContainerTestAcrName { get; set; }
     }
 
 }


### PR DESCRIPTION
Updates the container integration tests to reference the new Azure container repository. Also slightly modifies the Azure Function service bus trigger tests to use a constant for the queue name.