### PR TITLE
Chore : updated the category name of the lambda transaction

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsLambda/HandlerMethodWrapper.cs
@@ -248,7 +248,7 @@ namespace NewRelic.Providers.Wrapper.AwsLambda
             // else WebTransaction/Function/myFunction
             transaction = agent.CreateTransaction(
                 isWeb: _functionDetails.EventType.IsWebEvent(),
-                category: "Lambda",
+                category: "Function",
                 transactionDisplayName: agent.Configuration.AwsLambdaApmModeEnabled
                                         ? _functionDetails.EventType.ToEventTypeString().ToUpper() + " " + _functionDetails.FunctionName
                                         : _functionDetails.FunctionName,


### PR DESCRIPTION
Based on the discussion with PM team, for AWS lambda transactions, Category should be "Function" instead if "Lambda" in the transaction  naming.