### PR TITLE
ci: When deploying the .deb package to APT on a release, sign with multiple GPG keys

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -371,19 +371,25 @@ jobs:
           name: deploy-artifacts
           path: ${{ github.workspace }}/
 
-      - name: Get GPG Key
-        id: write_gpgkey
+      - name: Get GPG Keys
+        id: write_gpgkeys
         run: |
-          filePath="/tmp/gpg.tar.bz2"
-          echo "${{ secrets.GPG_KEY }}" | base64 -d > $filePath
-          echo "filePath=$filePath" >> $GITHUB_OUTPUT
+          # old signing key
+          old_key_file="/tmp/old-secret-key.gpg"
+          echo "${{ secrets.OLD_GPG_KEY }}" | base64 -d > $old_key_file
+          echo "old_key_file=$old_key_file" >> $GITHUB_OUTPUT
+          # new signing key
+          new_key_file="/tmp/new-secret-key.gpg"
+          echo "${{ secrets.NEW_GPG_KEY }}" | base64 -d > $new_key_file
+          echo "new_key_file=$new_key_file" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Move Artifacts and GPG Key to Staging Location
         run: |
           cp LinuxRpm/*.rpm ${{ github.workspace }}/deploy/linux/packages
           cp LinuxDeb/*.deb ${{ github.workspace }}/deploy/linux/packages
-          cp -f ${{ steps.write_gpgkey.outputs.filePath }} ${{ github.workspace }}/deploy/linux/deploy_scripts/gpg.tar.bz2
+          cp -f ${{ steps.write_gpgkeys.outputs.old_key_file }} ${{ github.workspace }}/deploy/linux/deploy_scripts/old-private-key.gpg
+          cp -f ${{ steps.write_gpgkeys.outputs.new_key_file }} ${{ github.workspace }}/deploy/linux/deploy_scripts/new-private-key.gpg
         shell: bash
 
       - name: Prepare docker.env
@@ -414,7 +420,11 @@ jobs:
             echo "AWS_ACCESS_KEY_ID=${{ secrets.TEST_BUCKET_AWS_ACCESS_KEY_ID }}" >> docker.env
             echo "AWS_SECRET_ACCESS_KEY=${{ secrets.TEST_BUCKET_AWS_SECRET_ACCESS_KEY }}" >> docker.env
           fi
-          echo "GPG_KEYS=/data/deploy_scripts/gpg.tar.bz2" >> docker.env
+          echo "OLD_PRIVATE_KEY=/data/deploy_scripts/old-private-key.gpg" >> docker.env
+          echo "NEW_PRIVATE_KEY=/data/deploy_scripts/new-private-key.gpg" >> docker.env
+          echo "NEW_PRIVATE_KEY_PASSPHRASE=${{ secrets.NEW_GPG_KEY_PASSPHRASE }}" >> docker.env
+          echo "OLD_KEY_ID=${{ secrets.OLD_GPG_KEY_ID }}" >> docker.env
+          echo "NEW_KEY_ID=${{ secrets.NEW_GPG_KEY_ID }}" >> docker.env
         shell: bash
 
       - name: Build and Run Container

--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -384,7 +384,7 @@ jobs:
           echo "new_key_file=$new_key_file" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Move Artifacts and GPG Key to Staging Location
+      - name: Move Artifacts and GPG Keys to Staging Location
         run: |
           cp LinuxRpm/*.rpm ${{ github.workspace }}/deploy/linux/packages
           cp LinuxDeb/*.deb ${{ github.workspace }}/deploy/linux/packages

--- a/deploy/linux/.gitignore
+++ b/deploy/linux/.gitignore
@@ -3,3 +3,4 @@ docker.env
 gpg.tar.bz2
 # ASCII-armored GPG key files
 *.asc
+*.gpg

--- a/deploy/linux/.gitignore
+++ b/deploy/linux/.gitignore
@@ -1,2 +1,5 @@
 docker.env
+# old tarball method of adding signing keys to the container
 gpg.tar.bz2
+# ASCII-armored GPG key files
+*.asc

--- a/deploy/linux/README.md
+++ b/deploy/linux/README.md
@@ -6,6 +6,7 @@ The assets in this path are used to deploy the Linux packages (.deb and .rpm) fo
 1. Docker, with the ability to run Linux containers.
 2. AWS S3 access keys with read/write access to the bucket(s) you are updating
 3. A Linux-like command line environment, such as `git-bash` on Windows, or a real Linux system or VM (e.g. WSL2)
+4. The proper GPG signing keys and their IDs.
 
 To deploy the .rpm and .deb packages for a particular release version (e.g. 10.0.0): (note: all commands should be run from the same location as this README)
 
@@ -15,7 +16,8 @@ To deploy the .rpm and .deb packages for a particular release version (e.g. 10.0
 
 2. Add the GPG signing keys to the `deploy_scripts` subfolder:
 
-        cp gpg.tar.bz2 ./deploy_scripts
+        cp private-key-1.gpg ./deploy_scripts
+        cp private-key-2.gpg ./deploy_scripts
 
 3. Create the `docker.env` [environment variable file](https://docs.docker.com/compose/env-file/) with required values (the values shown here are just examples, you will need to supply the correct ones):
 
@@ -23,7 +25,11 @@ To deploy the .rpm and .deb packages for a particular release version (e.g. 10.0
         echo "S3_BUCKET=s3://your-s3-bucket" >>docker.env
         echo "AWS_ACCESS_KEY_ID=AKAKAKAKAKAKAKA" >>docker.env
         echo "AWS_SECRET_ACCESS_KEY=6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ6SQ" >>docker.env
-        echo "GPG_KEYS=/data/deploy_scripts/gpg.tar.bz2" >>docker.env
+        echo "OLD_PRIVATE_KEY=/data/deploy_scripts/private-key-1.gpg" >> docker.env
+        echo "NEW_PRIVATE_KEY=/data/deploy_scripts/private-key-2.gpg" >> docker.env
+        echo "NEW_PRIVATE_KEY_PASSPHRASE=xxxxxxxxxxxxxx" >> docker.env
+        echo "OLD_KEY_ID="0123456789ABCFEF" >> docker.env
+        echo "NEW_KEY_ID="FEDCBA9876543210" >> docker.env
 
 4. Optionally, add additional non-required environment variables to the environment file:
     - `AWS_DEFAULT_REGION` (defaults to `us-west-2`)

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -84,7 +84,7 @@ rebuild_apt() (
 
   echo "Importing signing keys"
   gpg --import "${OLD_PRIVATE_KEY}"
-  gpg --import "${NEW_PRIVATE_KEY}"
+  gpg --import --batch --pinentry-mode loopback --passphrase "${NEW_PRIVATE_KEY_PASSPHRASE}" "${NEW_PRIVATE_KEY}"
 
   echo "rm -f dists/$REPO/Release.gpg"
   rm -f "dists/$REPO/Release.gpg"
@@ -93,8 +93,7 @@ rebuild_apt() (
   rm -f "dists/$REPO/InRelease"
 
   echo "gpg signing" 
-  gpg --armor --digest-algo SHA256 --clear-sign -u "${OLD_KEY_ID}" -u "${NEW_KEY_ID}" -o "dists/$REPO/InRelease" "dists/$REPO/Release"
-  gpg --armor --digest-algo SHA256 --detach-sign -u "${OLD_KEY_ID}" -u "${NEW_KEY_ID}" -o "dists/$REPO/Release.gpg" "dists/$REPO/Release"
+  gpg --armor --digest-algo SHA256 --detach-sign --batch --pinentry-mode loopback --passphrase "${NEW_PRIVATE_KEY_PASSPHRASE}" -u "${OLD_KEY_ID}" -u "${NEW_KEY_ID}" -o "dists/$REPO/Release.gpg" "dists/$REPO/Release"
   chmod 644 dists/"$REPO"/Contents-*.{gz,bz2}
 
   popd >/dev/null

--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -89,9 +89,6 @@ rebuild_apt() (
   echo "rm -f dists/$REPO/Release.gpg"
   rm -f "dists/$REPO/Release.gpg"
 
-  echo "rm -f dists/$REPO/InRelease"
-  rm -f "dists/$REPO/InRelease"
-
   echo "gpg signing" 
   gpg --armor --digest-algo SHA256 --detach-sign --batch --pinentry-mode loopback --passphrase "${NEW_PRIVATE_KEY_PASSPHRASE}" -u "${OLD_KEY_ID}" -u "${NEW_KEY_ID}" -o "dists/$REPO/Release.gpg" "dists/$REPO/Release"
   chmod 644 dists/"$REPO"/Contents-*.{gz,bz2}

--- a/deploy/linux/docker-compose.yml
+++ b/deploy/linux/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
     deploy_packages: 
         build: .


### PR DESCRIPTION
## Description

When deploying the .deb package for the agent to `apt.newrelic.com`, sign the repo with multiple GPG keys.  This will solve issues we have seen with our current signing key being rejected by the latest versions of `apt` in Ubuntu 24.04+.
