### PR TITLE
fix: Fix Profiler build errors with latest VS

### DIFF
--- a/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h
@@ -32,9 +32,9 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
 
     private:
         InstrumentationSettingsPtr _instrumentationSettings;
-        uint16_t _tracerLocalIndex;
-        uint16_t _resultLocalIndex;
-        uint16_t _userExceptionLocalIndex;
+        uint16_t _tracerLocalIndex = 0;
+        uint16_t _resultLocalIndex = 0;
+        uint16_t _userExceptionLocalIndex = 0;
 
         void BuildDefaultInstructions(Configuration::InstrumentationPointPtr instrumentationPoint)
         {

--- a/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
+++ b/src/Agent/NewRelic/Profiler/MethodRewriter/Instrumentors.h
@@ -116,7 +116,7 @@ namespace NewRelic { namespace Profiler { namespace MethodRewriter
     // An instrumentor for the methods we inject into mscorlib
     struct HelperInstrumentor : public IInstrumentor
     {
-        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr instrumentationSettings) override
+        bool Instrument(IFunctionPtr function, InstrumentationSettingsPtr) override
         {
             if (!Strings::EndsWith(function->GetModuleName(), _X("mscorlib.dll")))
                 return false;

--- a/src/Agent/NewRelic/Profiler/Profiler/Function.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/Function.h
@@ -246,7 +246,7 @@ namespace NewRelic { namespace Profiler
             const FunctionID functionId,
             CComPtr<IMetaDataImport2> metaDataImport,
             CComPtr<IMetaDataAssemblyImport> metaDataAssemblyImport,
-            std::shared_ptr<MethodRewriter::MethodRewriter> methodRewriter,
+            std::shared_ptr<MethodRewriter::MethodRewriter>,
             AppDomainID appDomainId,
             ULONG signatureSize,
             const uint8_t* signature,

--- a/src/Agent/NewRelic/Profiler/Profiler/FunctionPreprocessor.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FunctionPreprocessor.h
@@ -99,15 +99,15 @@ namespace NewRelic {
                     return xstring_t((_valid ? _X("[") : _X("*["))) + to_hex_string(_offset) + _X("] : ") + _opcode->name;
                 }
 
-                virtual void ResolveTargets(ByteVectorPtr methodBody, std::shared_ptr<std::map<unsigned, std::shared_ptr<Instruction>>> instructions)
+                virtual void ResolveTargets(ByteVectorPtr, std::shared_ptr<std::map<unsigned, std::shared_ptr<Instruction>>>)
                 {
                 }
 
-                virtual void WriteBranches(ByteVectorPtr instructions, std::shared_ptr<std::map<unsigned, std::shared_ptr<Instruction>>> instructionMap)
+                virtual void WriteBranches(ByteVectorPtr, std::shared_ptr<std::map<unsigned, std::shared_ptr<Instruction>>>)
                 {
                 }
 
-                virtual void OnInstructionChange(std::shared_ptr<Instruction> oldInstruction, std::shared_ptr<Instruction> newInstruction)
+                virtual void OnInstructionChange(std::shared_ptr<Instruction>, std::shared_ptr<Instruction>)
                 {
                 }
 
@@ -171,7 +171,7 @@ namespace NewRelic {
                     _targets = std::make_shared<std::list<InstructionPtr>>();
                 }
 
-                virtual void WriteBranches(ByteVectorPtr instructions, OffsetToInstructionMapPtr instructionMap) override
+                virtual void WriteBranches(ByteVectorPtr instructions, OffsetToInstructionMapPtr) override
                 {
                     if (_valid)
                     {
@@ -254,7 +254,7 @@ namespace NewRelic {
                     }
                 }
 
-                virtual void WriteBranches(ByteVectorPtr instructions, OffsetToInstructionMapPtr instructionMap) override
+                virtual void WriteBranches(ByteVectorPtr instructions, OffsetToInstructionMapPtr) override
                 {
                     if (_valid)
                     {
@@ -498,7 +498,7 @@ namespace NewRelic {
                     return true;
                 }
 
-                static bool PassesCheck(ByteVectorPtr functionBytes, OffsetToInstructionMapPtr firstPassInstructions)
+                static bool PassesCheck(ByteVectorPtr functionBytes, OffsetToInstructionMapPtr)
                 {
                     const unsigned headerSize = sizeof(COR_ILMETHOD_FAT);
                     COR_ILMETHOD_FAT* header = (COR_ILMETHOD_FAT*)functionBytes->data();

--- a/src/Agent/NewRelic/Profiler/Profiler/FunctionPreprocessor.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/FunctionPreprocessor.h
@@ -524,15 +524,20 @@ namespace NewRelic {
                     return true;
                 }
 
+#ifdef DEBUG
                 static void PrintInstructions(OffsetToInstructionMapPtr instructions)
                 {
-#ifdef DEBUG
                     for (auto iter : *instructions.get())
                     {
                         LogInfo(iter.second->ToString());
                     }
-#endif
                 }
+#else
+                static void PrintInstructions(OffsetToInstructionMapPtr)
+                {
+
+                }
+#endif
 
                 bool WriteSEH(ByteVectorPtr newByteCode, OffsetToInstructionMapPtr instructions) {
                     if (_headerInfo->HasSEH()) {

--- a/src/Agent/NewRelic/Profiler/RapidXML/rapidxml.hpp
+++ b/src/Agent/NewRelic/Profiler/RapidXML/rapidxml.hpp
@@ -658,6 +658,8 @@ namespace rapidxml
             : m_name(0)
             , m_value(0)
             , m_parent(0)
+            , m_name_size(0)
+            , m_value_size(0)
         {
         }
 
@@ -808,6 +810,8 @@ namespace rapidxml
         //! Constructs an empty attribute with the specified type. 
         //! Consider using memory_pool of appropriate xml_document if allocating attributes manually.
         xml_attribute()
+            : m_next_attribute(nullptr)
+            , m_prev_attribute(nullptr)
         {
         }
 
@@ -902,6 +906,9 @@ namespace rapidxml
             : m_type(type)
             , m_first_node(0)
             , m_first_attribute(0)
+            , m_last_node(nullptr)
+            , m_next_sibling(nullptr)
+            , m_prev_sibling(nullptr)
         {
         }
 

--- a/src/Agent/NewRelic/Profiler/SignatureParser/Types.h
+++ b/src/Agent/NewRelic/Profiler/SignatureParser/Types.h
@@ -510,7 +510,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
 
         MvarType(uint32_t number) : Type(Kind::MVAR), _number(number) {}
 
-        virtual xstring_t ToString(ITokenResolverPtr tokenResolver) const override
+        virtual xstring_t ToString(ITokenResolverPtr) const override
         {
             return _X("!!") + to_xstring(_number);
         }
@@ -531,7 +531,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
 
         VarType(uint32_t number) : Type(Kind::VAR), _number(number) {}
         
-        virtual xstring_t ToString(ITokenResolverPtr tokenResolver) const override
+        virtual xstring_t ToString(ITokenResolverPtr) const override
         {
             return _X("!") + to_xstring(_number);
         }
@@ -573,7 +573,7 @@ namespace NewRelic { namespace Profiler { namespace SignatureParser
     {
         VoidPointerType() : Type(Kind::VOIDPOINTER) {}
 
-        virtual xstring_t ToString(ITokenResolverPtr tokenResolver) const override
+        virtual xstring_t ToString(ITokenResolverPtr) const override
         {
             return _X("void*");
         }


### PR DESCRIPTION
The latest Visual Studio update seems to have changed the compiler, and we were getting some warnings we weren't before. And since we have Warnings-as-Errors enabled, builds were failing. I think these are all safe changes but please look closely. :)