### PR TITLE
test: Fix server name parsing logic for Oracle and Redis configuration

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/OracleConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/OracleConfiguration.cs
@@ -16,7 +16,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         private static string _oraclePort;
         private static bool _parsedHostPort = false;
 
-        // example: "Data Source=1.2.3.4:4444/XE;User Id=SYSTEM;Password=oraclePassword;"
+        // example: "Data Source=some.server.name:4444/FREEPDB1;User Id=SYSTEM;Password=oraclePassword;"
         public static string OracleConnectionString
         {
             get

--- a/tests/Agent/IntegrationTests/Shared/OracleConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/OracleConfiguration.cs
@@ -4,15 +4,17 @@
 
 using System;
 using System.Data.Common;
+using System.Text.RegularExpressions;
 
 namespace NewRelic.Agent.IntegrationTests.Shared
 {
-    public class OracleConfiguration
+    public static class OracleConfiguration
     {
         private static string _oracleConnectionString;
         private static string _oracleDataSource;
         private static string _oracleServer;
         private static string _oraclePort;
+        private static bool _parsedHostPort = false;
 
         // example: "Data Source=1.2.3.4:4444/XE;User Id=SYSTEM;Password=oraclePassword;"
         public static string OracleConnectionString
@@ -61,19 +63,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         {
             get
             {
-                if (_oracleServer == null)
-                {
-                    try
-                    {
-                        var uri = new UriBuilder(OracleDataSource);
-                        _oracleServer = uri.Host;
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception("OracleServer configuration is invalid.", ex);
-                    }
-                }
-
+                EnsureHostPortParsed();
                 return _oracleServer;
             }
         }
@@ -82,20 +72,43 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         {
             get
             {
-                if (_oraclePort == null)
-                {
-                    try
-                    {
-                        var uri = new UriBuilder(OracleDataSource);
-                        _oraclePort = uri.Port.ToString();
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception("OraclePort configuration is invalid.", ex);
-                    }
-                }
-
+                EnsureHostPortParsed();
                 return _oraclePort;
+            }
+        }
+
+        // Ensures host and port are parsed and cached only once
+        private static void EnsureHostPortParsed()
+        {
+            if (!_parsedHostPort)
+            {
+                try
+                {
+                    ParseHostAndPort(OracleDataSource, out _oracleServer, out _oraclePort);
+                    _parsedHostPort = true;
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception("OracleServer or OraclePort configuration is invalid.", ex);
+                }
+            }
+        }
+
+        // Parses host and port from a data source string like host:port/service
+        private static void ParseHostAndPort(string dataSource, out string host, out string port)
+        {
+            // Regex matches host (hostname or IPv4), port, and ignores service name
+            var match = Regex.Match(dataSource, @"^(?<host>[^:/\[]+(?:\.[^:/\[]+)*)[:](?<port>\d+)");
+            if (match.Success)
+            {
+                host = match.Groups["host"].Value;
+                port = match.Groups["port"].Value;
+            }
+            else
+            {
+                host = string.Empty;
+                port = string.Empty;
+                throw new FormatException($"Could not parse host and port from data source: {dataSource}");
             }
         }
     }

--- a/tests/Agent/IntegrationTests/Shared/StackExchangeRedisConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/StackExchangeRedisConfiguration.cs
@@ -15,7 +15,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
         private static string _stackExchangeRedisPassword;
         private static bool _parsedHostPort = false;
 
-        // example: "1.2.3.4:4444"
+        // example: "some.server.name:4444"
         public static string StackExchangeRedisConnectionString
         {
             get


### PR DESCRIPTION
This PR brings in some changes from my k8s PR that adjust how the Oracle and Redis tests parse the configured server name from configuration. The changes are necessary for tests to succeed when pointed at the Azure k8s based unbounded services. 

The previous version of the affected files worked only because the services were referenced by IP address instead of hostname. 