### PR TITLE
fix: Profiler doesn't handle wide-character files correctly

### DIFF
--- a/src/Agent/NewRelic/Profiler/Common/Common.vcxproj
+++ b/src/Agent/NewRelic/Profiler/Common/Common.vcxproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <ClInclude Include="CorStandIn.h" />
     <ClInclude Include="AssemblyVersion.h" />
+    <ClInclude Include="FileUtils.h" />
     <ClInclude Include="Macros.h" />
     <ClInclude Include="OnDestruction.h" />
     <ClInclude Include="Strings.h" />

--- a/src/Agent/NewRelic/Profiler/Common/Common.vcxproj.filters
+++ b/src/Agent/NewRelic/Profiler/Common/Common.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClInclude Include="OnDestruction.h" />
     <ClInclude Include="xplat.h" />
     <ClInclude Include="AssemblyVersion.h" />
+    <ClInclude Include="FileUtils.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)newrelic-icon.png" />

--- a/src/Agent/NewRelic/Profiler/Common/FileUtils.h
+++ b/src/Agent/NewRelic/Profiler/Common/FileUtils.h
@@ -10,16 +10,22 @@
 #include <iostream>
 
 #include "xplat.h"
+#include "../Logging/Logger.h"
 
 namespace NewRelic {
     namespace Profiler
     {
+        /// <summary>
+        /// Reads the contents of a file specified by a wide string path and returns it as a wide string.
+        /// Handles UTF-8 encoding and BOM if present.
+        /// If the file cannot be opened, logs an error and throws an exception.
+        /// </summary>
         static std::wstring ReadFile(const std::wstring& filePath) {
             // Open file with wide character path
             std::wifstream file(filePath, std::ios::binary);
             if (!file.is_open()) {
-                std::wcerr << L"Failed to open file: " << filePath << std::endl;
-                return L"";
+                LogError(L"Unable to open file. File path: ", filePath);
+                throw std::exception();
             }
 
             // Configure locale for UTF-8 and handle BOM
@@ -31,7 +37,5 @@ namespace NewRelic {
 
             return wss.str();
         }
-
-
     }
 };

--- a/src/Agent/NewRelic/Profiler/Common/FileUtils.h
+++ b/src/Agent/NewRelic/Profiler/Common/FileUtils.h
@@ -1,0 +1,37 @@
+/*
+* Copyright 2020 New Relic Corporation. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include <string>
+#include <algorithm>
+#include <codecvt>
+#include <fstream>
+#include <iostream>
+
+#include "xplat.h"
+
+namespace NewRelic {
+    namespace Profiler
+    {
+        static std::wstring ReadFile(const std::wstring& filePath) {
+            // Open file with wide character path
+            std::wifstream file(filePath, std::ios::binary);
+            if (!file.is_open()) {
+                std::wcerr << L"Failed to open file: " << filePath << std::endl;
+                return L"";
+            }
+
+            // Configure locale for UTF-8 and handle BOM
+            file.imbue(std::locale(file.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::consume_header>()));
+
+            // Read file content
+            std::wstringstream wss;
+            wss << file.rdbuf();
+
+            return wss.str();
+        }
+
+
+    }
+};

--- a/src/Agent/NewRelic/Profiler/CommonTest/CommonTest.vcxproj
+++ b/src/Agent/NewRelic/Profiler/CommonTest/CommonTest.vcxproj
@@ -164,6 +164,7 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileUtilsTest.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/src/Agent/NewRelic/Profiler/CommonTest/CommonTest.vcxproj.filters
+++ b/src/Agent/NewRelic/Profiler/CommonTest/CommonTest.vcxproj.filters
@@ -9,6 +9,7 @@
     <ClCompile Include="TestModuleAttributes.cpp" />
     <ClCompile Include="StringsTest.cpp" />
     <ClCompile Include="VersionTest.cpp" />
+    <ClCompile Include="FileUtilsTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)newrelic-icon.png" />

--- a/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
@@ -19,7 +19,7 @@ namespace NewRelic {
             TEST_CLASS(FileUtilsTest)
             {
             public:
-                TEST_METHOD(ReadFile_WithJapaneseCharacters)
+                TEST_METHOD(ReadFile_JapaneseCharactersInContent_NoBOM)
                 {
                     // create a temporary file with Japanese characters
                     std::wstring tempFilePath = L"temp_japanese.txt";
@@ -35,7 +35,7 @@ namespace NewRelic {
                     Assert::AreEqual(japaneseContent, readContent);
                 }
 
-                TEST_METHOD(ReadFile_WithBOM)
+                TEST_METHOD(ReadFile_WithMixedCharactersInContent_WithBOM)
                 {
                     // create a temporary file with BOM
                     std::wstring tempFilePath = L"temp_bom.txt";
@@ -53,7 +53,7 @@ namespace NewRelic {
                     Assert::AreEqual(expected, actual);
                 }
 
-                TEST_METHOD(ReadFile_EnglishCharactersOnly_NoBOM)
+                TEST_METHOD(ReadFile_EnglishCharactersOnlyInContent_NoBOM)
                 {
                     // create a temporary file with English characters only
                     std::wstring tempFilePath = L"temp_english.txt";
@@ -69,7 +69,7 @@ namespace NewRelic {
                     Assert::AreEqual(englishContent, readContent);
                 }
 
-                TEST_METHOD(ReadFile_EnglishCharactersOnly_WithBOM)
+                TEST_METHOD(ReadFile_EnglishCharactersOnlyInContent_WithBOM)
                 {
                     // create a temporary file with English characters only and BOM
                     std::wstring tempFilePath = L"temp_english_bom.txt";
@@ -87,7 +87,7 @@ namespace NewRelic {
                     Assert::AreEqual(expected, actual); 
                 }
 
-                TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_NoBOM)
+                TEST_METHOD(ReadFile_JapaneseCharactersInFileName_JapaneseAndEnglishCharactersInContent_NoBOM)
                 {
                     // create a temporary file with Japanese characters in the name and content
                     std::wstring tempFilePath = L"テストファイル.txt"; // "Test file" in Japanese
@@ -103,7 +103,7 @@ namespace NewRelic {
                     Assert::AreEqual(content, readContent);
                 }
 
-                TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_WithBOM)
+                TEST_METHOD(ReadFile_JapaneseCharactersInFileName_JapaneseAndEnglishCharactersInContent_WithBOM)
                 {
                     // create a temporary file with Japanese characters in the name and content with BOM
                     std::wstring tempFilePath = L"テストファイル_bom.txt"; // "Test file" in Japanese

--- a/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
@@ -1,0 +1,126 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stdafx.h"
+
+#include <codecvt>
+#include <fstream>
+
+#include "CppUnitTest.h"
+#include "../Common/Strings.h"
+#include "../Common/FileUtils.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace NewRelic {
+    namespace Profiler {
+        namespace Common
+        {
+            TEST_CLASS(FileUtilsTest)
+            {
+            public:
+                TEST_METHOD(ReadFile_WithJapaneseCharacters)
+                {
+                    // create a temporary file with Japanese characters
+                    std::wstring tempFilePath = L"c:\\temp\\temp_japanese.txt";
+                    std::wstring japaneseContent = L"こんにちは、世界！"; // "Hello, World!" in Japanese
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::generate_header>()));
+                        outFile << japaneseContent;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring readContent = ReadFile(tempFilePath);
+                    // verify the content matches
+                    Assert::AreEqual(japaneseContent, readContent);
+                }
+
+                TEST_METHOD(ReadFile_WithBOM)
+                {
+                    // create a temporary file with BOM
+                    std::wstring tempFilePath = L"c:\\temp\\temp_bom.txt";
+                    std::wstring contentWithBOM = L"This file starts with a BOM and has some Japanese characters. こんにちは、世界！";
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::generate_header>()));
+                        outFile << contentWithBOM;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring actual = ReadFile(tempFilePath);
+
+                    // verify the content matches (BOM should be handled)
+                    auto expected = contentWithBOM;
+                    Assert::AreEqual(expected, actual);
+                }
+
+                TEST_METHOD(ReadFile_EnglishCharactersOnly_NoBOM)
+                {
+                    // create a temporary file with English characters only
+                    std::wstring tempFilePath = L"c:\\temp\\temp_english.txt";
+                    std::wstring englishContent = L"This is a test file with English characters only.";
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::consume_header>()));
+                        outFile << englishContent;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring readContent = ReadFile(tempFilePath);
+                    // verify the content matches
+                    Assert::AreEqual(englishContent, readContent);
+                }
+
+                TEST_METHOD(ReadFile_EnglishCharactersOnly_WithBOM)
+                {
+                    // create a temporary file with English characters only and BOM
+                    std::wstring tempFilePath = L"c:\\temp\\temp_english_bom.txt";
+                    std::wstring englishContentWithBOM = L"This is a test file with English characters only and BOM.";
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::generate_header>()));
+                        outFile << englishContentWithBOM;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring actual = ReadFile(tempFilePath);
+
+                    // verify the content matches (BOM should be handled)
+                    auto expected = englishContentWithBOM;
+                    Assert::AreEqual(expected, actual); 
+                }
+
+                TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_NoBOM)
+                {
+                    // create a temporary file with Japanese characters in the name and content
+                    std::wstring tempFilePath = L"c:\\temp\\テストファイル.txt"; // "Test file" in Japanese
+                    std::wstring content = L"This file has a Japanese filename and contains both English and Japanese characters. こんにちは、世界！";
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::consume_header>()));
+                        outFile << content;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring readContent = ReadFile(tempFilePath);
+                    // verify the content matches
+                    Assert::AreEqual(content, readContent);
+                }
+
+                TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_WithBOM)
+                {
+                    // create a temporary file with Japanese characters in the name and content with BOM
+                    std::wstring tempFilePath = L"c:\\temp\\テストファイル_bom.txt"; // "Test file" in Japanese
+                    std::wstring contentWithBOM = L"This file has a Japanese filename and contains both English and Japanese characters with BOM. こんにちは、世界！";
+                    {
+                        std::wofstream outFile(tempFilePath, std::ios::binary);
+                        outFile.imbue(std::locale(outFile.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::generate_header>()));
+                        outFile << contentWithBOM;
+                    }
+                    // read the file using ReadFile function
+                    std::wstring actual = ReadFile(tempFilePath);
+                    // verify the content matches (BOM should be handled)
+                    auto expected = contentWithBOM;
+                    Assert::AreEqual(expected, actual);
+                }
+
+            };
+        }
+    }
+}

--- a/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
+++ b/src/Agent/NewRelic/Profiler/CommonTest/FileUtilsTest.cpp
@@ -22,7 +22,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_WithJapaneseCharacters)
                 {
                     // create a temporary file with Japanese characters
-                    std::wstring tempFilePath = L"c:\\temp\\temp_japanese.txt";
+                    std::wstring tempFilePath = L"temp_japanese.txt";
                     std::wstring japaneseContent = L"こんにちは、世界！"; // "Hello, World!" in Japanese
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -38,7 +38,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_WithBOM)
                 {
                     // create a temporary file with BOM
-                    std::wstring tempFilePath = L"c:\\temp\\temp_bom.txt";
+                    std::wstring tempFilePath = L"temp_bom.txt";
                     std::wstring contentWithBOM = L"This file starts with a BOM and has some Japanese characters. こんにちは、世界！";
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -56,7 +56,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_EnglishCharactersOnly_NoBOM)
                 {
                     // create a temporary file with English characters only
-                    std::wstring tempFilePath = L"c:\\temp\\temp_english.txt";
+                    std::wstring tempFilePath = L"temp_english.txt";
                     std::wstring englishContent = L"This is a test file with English characters only.";
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -72,7 +72,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_EnglishCharactersOnly_WithBOM)
                 {
                     // create a temporary file with English characters only and BOM
-                    std::wstring tempFilePath = L"c:\\temp\\temp_english_bom.txt";
+                    std::wstring tempFilePath = L"temp_english_bom.txt";
                     std::wstring englishContentWithBOM = L"This is a test file with English characters only and BOM.";
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -90,7 +90,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_NoBOM)
                 {
                     // create a temporary file with Japanese characters in the name and content
-                    std::wstring tempFilePath = L"c:\\temp\\テストファイル.txt"; // "Test file" in Japanese
+                    std::wstring tempFilePath = L"テストファイル.txt"; // "Test file" in Japanese
                     std::wstring content = L"This file has a Japanese filename and contains both English and Japanese characters. こんにちは、世界！";
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -106,7 +106,7 @@ namespace NewRelic {
                 TEST_METHOD(ReadFile_JapaneseFileName_JapaneseAndEnglishCharacters_WithBOM)
                 {
                     // create a temporary file with Japanese characters in the name and content with BOM
-                    std::wstring tempFilePath = L"c:\\temp\\テストファイル_bom.txt"; // "Test file" in Japanese
+                    std::wstring tempFilePath = L"テストファイル_bom.txt"; // "Test file" in Japanese
                     std::wstring contentWithBOM = L"This file has a Japanese filename and contains both English and Japanese characters with BOM. こんにちは、世界！";
                     {
                         std::wofstream outFile(tempFilePath, std::ios::binary);
@@ -118,6 +118,13 @@ namespace NewRelic {
                     // verify the content matches (BOM should be handled)
                     auto expected = contentWithBOM;
                     Assert::AreEqual(expected, actual);
+                }
+
+                TEST_METHOD(ReadFile_FileDoesNotExist_ThrowsException)
+                {
+                    std::wstring nonExistentFilePath = L"file_does_not_exist.txt";
+                    auto func = [&]() { ReadFile(nonExistentFilePath); };
+                    Assert::ExpectException<std::exception>(func);
                 }
 
             };

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -1104,8 +1104,7 @@ namespace NewRelic { namespace Profiler {
             {
                 try {
                     xstring_t logfilename(nrlog::DefaultFileLogLocation(_systemCalls).GetPathAndFileName());
-                    std::string wlogfilename(std::begin(logfilename), std::end(logfilename));
-                    nrlog::StdLog.get_dest().open(wlogfilename);
+                    nrlog::StdLog.get_dest().open(logfilename);
                     // Imbue with locale and codecvt facet is used to allow the log file to write non-ascii chars to the log
                     nrlog::StdLog.get_dest().imbue(std::locale(std::locale::classic(), new std::codecvt_utf8<wchar_t>));
                     nrlog::StdLog.get_dest().exceptions(std::wostream::failbit | std::wostream::badbit);

--- a/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
+++ b/src/Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h
@@ -13,6 +13,7 @@
 #include "../MethodRewriter/MethodRewriter.h"
 #include "../SignatureParser/Exceptions.h"
 #include "../ThreadProfiler/ThreadProfiler.h"
+#include "../Common/FileUtils.h"
 #include "Function.h"
 #include "FunctionResolver.h"
 #include "Win32Helpers.h"
@@ -1002,25 +1003,6 @@ namespace NewRelic { namespace Profiler {
             LocalFree(commandLineArgv);
             return appPoolId;
 #endif
-        }
-
-        static xstring_t ReadFile(const xstring_t& filePath)
-        {
-            // Open file with wide character path
-            std::wifstream file(filePath, std::ios::binary);
-            if (!file.is_open()) {
-                LogError(L"Unable to open file. File path: ", filePath);
-                throw ProfilerException();
-            }
-
-            // Configure locale for UTF-8 and handle BOM
-            file.imbue(std::locale(file.getloc(), new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::consume_header>()));
-
-            // Read file content
-            std::wstringstream wss;
-            wss << file.rdbuf();
-
-            return wss.str();
         }
 
         static std::unique_ptr<xstring_t> TryGetNewRelicHomeFromRegistry()


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Updates the Profiler to correctly handle reading of files with wide-character paths and file content. Fixes #3158. Fixes #3159.

Includes unit tests for various combinations of paths and file content.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
