### PR TITLE
ci: Update gpg import syntax in post-deploy install verification for ubuntu-latest

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Validate
         run: |
           echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
-          wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg
+          wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent
           installed_version=$(dpkg -s newrelic-dotnet-agent | grep -i version)


### PR DESCRIPTION
This PR updates the syntax of the `gpg` command used to import the public APT repo signing key in the post-deploy workflow's Linux install test to be more robust (the previous syntax worked, but would fail if ran a second time, perhaps to import a different public key to the same location - the new syntax does not have this issue).