### PR TITLE
feat: Add support for topics to Azure Service Bus.

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureServiceBus/AzureServiceBusSendWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureServiceBus/AzureServiceBusSendWrapper.cs
@@ -20,7 +20,7 @@ public class AzureServiceBusSendWrapper : AzureServiceBusWrapperBase
     public override AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction)
     {
         dynamic serviceBusReceiver = instrumentedMethodCall.MethodCall.InvocationTarget;
-        string queueName = serviceBusReceiver.EntityPath; // some-queue-name
+        string queueOrTopicName = serviceBusReceiver.EntityPath; // some-queue|topic-name
         string fqns = serviceBusReceiver.FullyQualifiedNamespace; // some-service-bus-entity.servicebus.windows.net   
 
         // determine message broker action based on method name
@@ -41,10 +41,10 @@ public class AzureServiceBusSendWrapper : AzureServiceBusWrapperBase
         // start a message broker segment
         var segment = transaction.StartMessageBrokerSegment(
             instrumentedMethodCall.MethodCall,
-            MessageBrokerDestinationType.Queue,
+            MessageBrokerDestinationType.Queue, // ASB doesn't differentiate between queue or topic when sending, so we default to Queue which has more features.
             action,
             BrokerVendorName,
-            queueName,
+            queueOrTopicName,
             serverAddress: fqns);
 
         if (action == MessageBrokerAction.Produce)

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureServiceBus/AzureServiceBusWrapperBase.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AzureServiceBus/AzureServiceBusWrapperBase.cs
@@ -1,6 +1,7 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
@@ -15,4 +16,49 @@ public abstract class AzureServiceBusWrapperBase : IWrapper
     public abstract CanWrapResponse CanWrap(InstrumentedMethodInfo instrumentedMethodInfo);
 
     public abstract AfterWrappedMethodDelegate BeforeWrappedMethod(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction);
+
+    /// <summary>
+    /// Determines the type of message broker destination based on the provided name.
+    /// </summary>
+    /// <param name="queueOrTopicName">The name of the queue or topic to evaluate. Must not be null or empty.</param>
+    /// <returns>A <see cref="MessageBrokerDestinationType"/> value indicating whether the destination is a queue or a topic.</returns>
+    internal static MessageBrokerDestinationType GetMessageBrokerDestinationType(string queueOrTopicName)
+    {
+        // Default to Queue if the name is null or empty
+        if (string.IsNullOrWhiteSpace(queueOrTopicName))
+        {
+            return MessageBrokerDestinationType.Queue;
+        }
+
+        // Topics have a subscription, queues do not
+        var destinationType = queueOrTopicName.Contains("Subscriptions")
+            ? MessageBrokerDestinationType.Topic
+            : MessageBrokerDestinationType.Queue;
+
+        return destinationType;
+    }
+
+    /// <summary>
+    /// Retrieves the name of a queue or topic based on the specified destination type.
+    /// </summary>
+    /// <remarks>This method is useful for extracting the base name of a topic when working with message
+    /// broker destinations  that include subscription paths.</remarks>
+    /// <param name="destinationType">The type of the message broker destination, indicating whether the name represents a queue or a topic.</param>
+    /// <param name="queueOrTopicName">The full name of the queue or topic. For topics, this may include a subscription path.</param>
+    /// <returns>The name of the queue or topic. If the destination type is <see cref="MessageBrokerDestinationType.Topic"/>, 
+    /// the subscription path is removed, returning only the topic name. Otherwise, the original name is returned.</returns>
+    internal static string GetQueueOrTopicName(MessageBrokerDestinationType destinationType, string queueOrTopicName)
+    {
+        if (destinationType == MessageBrokerDestinationType.Topic)
+        {
+            // remove the "/Subscriptions/*" part to get just the topic name
+            var index = queueOrTopicName.IndexOf("/Subscriptions/", StringComparison.Ordinal);
+            if (index > 0)
+            {
+                return queueOrTopicName.Substring(0, index);
+            }
+        }
+
+        return queueOrTopicName;
+    }
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
@@ -11,211 +11,393 @@ using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
 using NewRelic.Api.Agent;
 
-namespace MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus;
-
-[Library]
-internal class AzureServiceBusExerciser
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus
 {
-    [LibraryMethod]
-    public static async Task InitializeQueue(string queueName)
+    [Library]
+    internal class AzureServiceBusExerciser
     {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        // if the queue exists, delete it and re-create it
-        if (await adminClient.QueueExistsAsync(queueName))
+        private const string Subscription = "test";
+
+        #region Queue
+
+        [LibraryMethod]
+        public static async Task InitializeQueue(string queueName)
         {
-            await adminClient.DeleteQueueAsync(queueName);
+            var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
+            // if the queue exists, delete it and re-create it
+            if (await adminClient.QueueExistsAsync(queueName))
+            {
+                await adminClient.DeleteQueueAsync(queueName);
+            }
+
+            await adminClient.CreateQueueAsync(queueName);
         }
-        await adminClient.CreateQueueAsync(queueName);
 
-    }
-
-    [LibraryMethod]
-    public static async Task DeleteQueue(string queueName)
-    {
-        var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
-        if (await adminClient.QueueExistsAsync(queueName))
+        [LibraryMethod]
+        public static async Task DeleteQueue(string queueName)
         {
-            await adminClient.DeleteQueueAsync(queueName);
+            var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
+            if (await adminClient.QueueExistsAsync(queueName))
+            {
+                await adminClient.DeleteQueueAsync(queueName);
+            }
         }
-    }
 
-    [LibraryMethod]
-    [Transaction]
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task ExerciseMultipleReceiveOperationsOnAMessage(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-
-        await SendAMessage(client, queueName, "Hello world!");
-
-        await using var receiver = client.CreateReceiver(queueName, new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
-
-        await receiver.PeekMessageAsync();
-
-        // receive the message in peek lock mode
-        var receivedMessage = await receiver.ReceiveMessageAsync();
-
-        // renew message lock
-        await receiver.RenewMessageLockAsync(receivedMessage);
-
-        // defer the message
-        await receiver.DeferMessageAsync(receivedMessage);
-
-        // receive the deferred message
-        var deferredMessage = await receiver.ReceiveDeferredMessageAsync(receivedMessage.SequenceNumber);
-
-        // complete the message
-        await receiver.CompleteMessageAsync(deferredMessage);
-    }
-
-    [LibraryMethod]
-    [Transaction]
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task ScheduleAndCancelAMessage(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-        await using var sender = client.CreateSender(queueName);
-
-        var message = new ServiceBusMessage("Hello world!");
-        var messageSequenceId = await sender.ScheduleMessageAsync(message, DateTime.UtcNow.AddSeconds(90));
-
-        // cancel the scheduled message
-        await sender.CancelScheduledMessageAsync(messageSequenceId);
-    }
-
-    [LibraryMethod]
-    [Transaction]
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task ReceiveAndDeadLetterAMessage(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-
-        await SendAMessage(client, queueName, "Hello world!");
-
-        await using var receiver = client.CreateReceiver(queueName, new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
-
-        // receive the message in peek lock mode
-        var receivedMessage = await receiver.ReceiveMessageAsync();
-
-        // dead-letter the message
-        await receiver.DeadLetterMessageAsync(receivedMessage);
-    }
-
-    [LibraryMethod]
-    [Transaction]
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task ReceiveAndAbandonAMessage(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-
-        await SendAMessage(client, queueName, "Hello world!");
-
-        await using var receiver = client.CreateReceiver(queueName, new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
-
-        // receive the message in peek lock mode
-        var receivedMessage = await receiver.ReceiveMessageAsync();
-
-        // abandon the message - it'll go back on the queue
-        await receiver.AbandonMessageAsync(receivedMessage);
-
-        // receive the message again and complete it to remove it from the queue
-        var receivedMessage2 = await receiver.ReceiveMessageAsync();
-        await receiver.CompleteMessageAsync(receivedMessage2);
-    }
-
-
-    private static async Task SendAMessage(ServiceBusClient client, string queueName, string messageBody)
-    {
-        await using var sender = client.CreateSender(queueName);
-        var message = new ServiceBusMessage(messageBody);
-        await sender.SendMessageAsync(message);
-    }
-
-    [LibraryMethod]
-    [Transaction]
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task SendAndReceiveAMessage(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-
-        await SendAMessage(client, queueName, "Hello world!");
-
-        await using var receiver = client.CreateReceiver(queueName, new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
-        await receiver.ReceiveMessageAsync();
-    }
-
-    [LibraryMethod]
-    // [Transaction] no transaction on this one; we're testing that the ServiceBusProcessor is creating transactions
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    public static async Task ExerciseServiceBusProcessor(string queueName)
-    {
-        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
-
-        // create the sender
-        await using ServiceBusSender sender = client.CreateSender(queueName);
-
-        // create a set of messages that we can send
-        ServiceBusMessage[] messages = new ServiceBusMessage[]
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task SendAndReceiveAMessageForQueue(string queueName)
         {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+            await SendAMessage(client, queueName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(queueName,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
+            await receiver.ReceiveMessageAsync();
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ExerciseMultipleReceiveOperationsOnAMessageForQueue(string queueName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            await SendAMessage(client, queueName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(queueName,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+            await receiver.PeekMessageAsync();
+
+            // receive the message in peek lock mode
+            var receivedMessage = await receiver.ReceiveMessageAsync();
+
+            // renew message lock
+            await receiver.RenewMessageLockAsync(receivedMessage);
+
+            // defer the message
+            await receiver.DeferMessageAsync(receivedMessage);
+
+            // receive the deferred message
+            var deferredMessage = await receiver.ReceiveDeferredMessageAsync(receivedMessage.SequenceNumber);
+
+            // complete the message
+            await receiver.CompleteMessageAsync(deferredMessage);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ReceiveAndDeadLetterAMessageForQueue(string queueName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            await SendAMessage(client, queueName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(queueName,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+            // receive the message in peek lock mode
+            var receivedMessage = await receiver.ReceiveMessageAsync();
+
+            // dead-letter the message
+            await receiver.DeadLetterMessageAsync(receivedMessage);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ReceiveAndAbandonAMessageForQueue(string queueName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            await SendAMessage(client, queueName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(queueName,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+            // receive the message in peek lock mode
+            var receivedMessage = await receiver.ReceiveMessageAsync();
+
+            // abandon the message - it'll go back on the queue
+            await receiver.AbandonMessageAsync(receivedMessage);
+
+            // receive the message again and complete it to remove it from the queue
+            var receivedMessage2 = await receiver.ReceiveMessageAsync();
+            await receiver.CompleteMessageAsync(receivedMessage2);
+        }
+
+        [LibraryMethod]
+        // [Transaction] no transaction on this one; we're testing that the ServiceBusProcessor is creating transactions
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ExerciseServiceBusProcessorForQueue(string queueName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            // create the sender
+            await using ServiceBusSender sender = client.CreateSender(queueName);
+
+            // create a set of messages that we can send
+            ServiceBusMessage[] messages = new ServiceBusMessage[]
+            {
                 new ServiceBusMessage("First"),
                 new ServiceBusMessage("Second")
-        };
+            };
 
-        // send the message batch
-        await sender.SendMessagesAsync(messages);
+            // send the message batch
+            await sender.SendMessagesAsync(messages);
 
-        // create the options to use for configuring the processor
-        ServiceBusProcessorOptions options = new()
-        {
-            MaxConcurrentCalls = 1 // multi-threading. Yay!
-        };
+            // create the options to use for configuring the processor
+            ServiceBusProcessorOptions options = new()
+            {
+                MaxConcurrentCalls = 1 // multi-threading. Yay!
+            };
 
-        // create a processor that we can use to process the messages
-        await using ServiceBusProcessor processor = client.CreateProcessor(queueName, options);
+            // create a processor that we can use to process the messages
+            await using ServiceBusProcessor processor = client.CreateProcessor(queueName, options);
 
-        var receivedMessages = 0;
+            var receivedMessages = 0;
 
-        // configure the message handler to use
-        processor.ProcessMessageAsync += MessageHandler;
-        processor.ProcessErrorAsync += ErrorHandler; // ErrorHandler is required, but we won't exercise it
+            // configure the message handler to use
+            processor.ProcessMessageAsync += MessageHandler;
+            processor.ProcessErrorAsync += ErrorHandler; // ErrorHandler is required, but we won't exercise it
 
-        async Task MessageHandler(ProcessMessageEventArgs args)
-        {
-            string body = args.Message.Body.ToString();
-            var threadId = Thread.CurrentThread.ManagedThreadId;
-            Console.WriteLine($"ThreadId: {threadId} - body: {body}");
+            async Task MessageHandler(ProcessMessageEventArgs args)
+            {
+                string body = args.Message.Body.ToString();
+                var threadId = Thread.CurrentThread.ManagedThreadId;
+                Console.WriteLine($"ThreadId: {threadId} - body: {body}");
 
-            Interlocked.Increment(ref receivedMessages);
+                Interlocked.Increment(ref receivedMessages);
 
-            await Task.Delay(1000); // simulate processing the message
+                await Task.Delay(1000); // simulate processing the message
+            }
+
+            Task ErrorHandler(ProcessErrorEventArgs args)
+            {
+                // the error source tells me at what point in the processing an error occurred
+                Console.WriteLine(args.ErrorSource);
+                // the fully qualified namespace is available
+                Console.WriteLine(args.FullyQualifiedNamespace);
+                // as well as the entity path
+                Console.WriteLine(args.EntityPath);
+                Console.WriteLine(args.Exception.ToString());
+                return Task.CompletedTask;
+            }
+
+            // start processing
+            await processor.StartProcessingAsync();
+
+            // wait up to 30 seconds or until receivedMessages has a count of 2
+            var timeout = DateTime.UtcNow.AddSeconds(30);
+            while (receivedMessages < 2 && DateTime.UtcNow < timeout)
+            {
+                await Task.Delay(1000);
+            }
+
+            // chill for a bit
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            // stop processing
+            await processor.StopProcessingAsync();
         }
 
-        Task ErrorHandler(ProcessErrorEventArgs args)
+        #endregion Queue
+
+        #region Topic
+
+        [LibraryMethod]
+        public static async Task InitializeTopic(string topicName)
         {
-            // the error source tells me at what point in the processing an error occurred
-            Console.WriteLine(args.ErrorSource);
-            // the fully qualified namespace is available
-            Console.WriteLine(args.FullyQualifiedNamespace);
-            // as well as the entity path
-            Console.WriteLine(args.EntityPath);
-            Console.WriteLine(args.Exception.ToString());
-            return Task.CompletedTask;
+            var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
+            // if the topic exists, delete it and re-create it
+            if (await adminClient.TopicExistsAsync(topicName))
+            {
+                await adminClient.DeleteTopicAsync(topicName);
+            }
+
+            await adminClient.CreateTopicAsync(topicName);
+            await adminClient.CreateSubscriptionAsync(topicName, Subscription);
         }
 
-        // start processing
-        await processor.StartProcessingAsync();
-
-        // wait up to 30 seconds or until receivedMessages has a count of 2
-        var timeout = DateTime.UtcNow.AddSeconds(30);
-        while (receivedMessages < 2 && DateTime.UtcNow < timeout)
+        [LibraryMethod]
+        public static async Task DeleteTopic(string topicName)
         {
-            await Task.Delay(1000);
+            var adminClient = new ServiceBusAdministrationClient(AzureServiceBusConfiguration.ConnectionString);
+            if (await adminClient.TopicExistsAsync(topicName))
+            {
+                await adminClient.DeleteTopicAsync(topicName);
+            }
         }
 
-        // chill for a bit
-        await Task.Delay(TimeSpan.FromSeconds(5));
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task SendAndReceiveAMessageForTopic(string topicName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+            await SendAMessage(client, topicName, "Hello world!");
 
-        // stop processing
-        await processor.StopProcessingAsync();
+            await using var receiver = client.CreateReceiver(topicName, Subscription,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete });
+            await receiver.ReceiveMessageAsync();
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ExerciseMultipleReceiveOperationsOnAMessageForTopic(string topicName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            await SendAMessage(client, topicName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(topicName, Subscription,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+            await receiver.PeekMessageAsync();
+
+            // receive the message in peek lock mode
+            var receivedMessage = await receiver.ReceiveMessageAsync();
+
+            // renew message lock
+            await receiver.RenewMessageLockAsync(receivedMessage);
+
+            // defer the message
+            await receiver.DeferMessageAsync(receivedMessage);
+
+            // receive the deferred message
+            var deferredMessage = await receiver.ReceiveDeferredMessageAsync(receivedMessage.SequenceNumber);
+
+            // complete the message
+            await receiver.CompleteMessageAsync(deferredMessage);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ReceiveAndAbandonAMessageForTopic(string topicName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            await SendAMessage(client, topicName, "Hello world!");
+
+            await using var receiver = client.CreateReceiver(topicName, Subscription,
+                new ServiceBusReceiverOptions() { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+            // receive the message in peek lock mode
+            var receivedMessage = await receiver.ReceiveMessageAsync();
+
+            // abandon the message - it'll go back on the queue
+            await receiver.AbandonMessageAsync(receivedMessage);
+
+            // receive the message again and complete it to remove it from the queue
+            var receivedMessage2 = await receiver.ReceiveMessageAsync();
+            await receiver.CompleteMessageAsync(receivedMessage2);
+        }
+
+        [LibraryMethod]
+        // [Transaction] no transaction on this one; we're testing that the ServiceBusProcessor is creating transactions
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ExerciseServiceBusProcessorForTopic(string topicName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+
+            // create the sender
+            await using ServiceBusSender sender = client.CreateSender(topicName);
+
+            // create a set of messages that we can send
+            ServiceBusMessage[] messages = new ServiceBusMessage[]
+            {
+                new ServiceBusMessage("First"), new ServiceBusMessage("Second")
+            };
+
+            // send the message batch
+            await sender.SendMessagesAsync(messages);
+
+            // create the options to use for configuring the processor
+            ServiceBusProcessorOptions options = new()
+            {
+                MaxConcurrentCalls = 1 // multi-threading. Yay!
+            };
+
+            // create a processor that we can use to process the messages
+            await using ServiceBusProcessor processor = client.CreateProcessor(topicName, Subscription, options);
+
+            var receivedMessages = 0;
+
+            // configure the message handler to use
+            processor.ProcessMessageAsync += MessageHandler;
+            processor.ProcessErrorAsync += ErrorHandler; // ErrorHandler is required, but we won't exercise it
+
+            async Task MessageHandler(ProcessMessageEventArgs args)
+            {
+                string body = args.Message.Body.ToString();
+                var threadId = Thread.CurrentThread.ManagedThreadId;
+                Console.WriteLine($"ThreadId: {threadId} - body: {body}");
+
+                Interlocked.Increment(ref receivedMessages);
+
+                await Task.Delay(1000); // simulate processing the message
+            }
+
+            Task ErrorHandler(ProcessErrorEventArgs args)
+            {
+                // the error source tells me at what point in the processing an error occurred
+                Console.WriteLine(args.ErrorSource);
+                // the fully qualified namespace is available
+                Console.WriteLine(args.FullyQualifiedNamespace);
+                // as well as the entity path
+                Console.WriteLine(args.EntityPath);
+                Console.WriteLine(args.Exception.ToString());
+                return Task.CompletedTask;
+            }
+
+            // start processing
+            await processor.StartProcessingAsync();
+
+            // wait up to 30 seconds or until receivedMessages has a count of 2
+            var timeout = DateTime.UtcNow.AddSeconds(30);
+            while (receivedMessages < 2 && DateTime.UtcNow < timeout)
+            {
+                await Task.Delay(1000);
+            }
+
+            // chill for a bit
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            // stop processing
+            await processor.StopProcessingAsync();
+        }
+
+        #endregion Topic
+
+        #region Queue and Topic
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static async Task ScheduleAndCancelAMessage(string queueOrTopicName)
+        {
+            await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+            await using var sender = client.CreateSender(queueOrTopicName);
+
+            var message = new ServiceBusMessage("Hello world!");
+            var messageSequenceId = await sender.ScheduleMessageAsync(message, DateTime.UtcNow.AddSeconds(90));
+
+            // cancel the scheduled message
+            await sender.CancelScheduledMessageAsync(messageSequenceId);
+        }
+
+        #endregion Queue and Topic
+
+        // The same method sends a message to either a queue or a topic.
+        private static async Task SendAMessage(ServiceBusClient client, string queueOrTopicName, string messageBody)
+        {
+            await using var sender = client.CreateSender(queueOrTopicName);
+            var message = new ServiceBusMessage(messageBody);
+            await sender.SendMessageAsync(message);
+        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
@@ -9,57 +9,69 @@ using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
-
-public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-    where TFixture : ConsoleDynamicMethodFixture
+namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus
 {
-    private readonly TFixture _fixture;
-    private readonly string _queueName;
-
-    protected AzureServiceBusW3CTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+    public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+        where TFixture : ConsoleDynamicMethodFixture
     {
-        _fixture = fixture;
-        _fixture.SetTimeout(TimeSpan.FromMinutes(1));
-        _fixture.TestLogger = output;
+        private readonly TFixture _fixture;
+        private readonly string _queueOrTopicName;
+        private readonly string _destinationType;
 
-        _queueName = $"test-queue-{Guid.NewGuid()}";
+        protected AzureServiceBusW3CTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
+            base(fixture)
+        {
+            _fixture = fixture;
+            _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+            _fixture.TestLogger = output;
 
-        _fixture.AddCommand($"AzureServiceBusExerciser InitializeQueue {_queueName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser SendAndReceiveAMessage {_queueName}");
-        _fixture.AddCommand($"AzureServiceBusExerciser DeleteQueue {_queueName}");
+            _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
+            _destinationType = destinationType;
 
-        _fixture.AddActions
-        (
-            setupConfiguration: () =>
-            {
-                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
-                configModifier.ForceTransactionTraces();
+            _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
+            _fixture.AddCommand($"AzureServiceBusExerciser SendAndReceiveAMessageFor{_destinationType} {_queueOrTopicName}");
+            _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
-                configModifier.SetOrDeleteDistributedTraceEnabled(true);
-                configModifier.SetOrDeleteSpanEventsEnabled(true);
-            }
-        );
+            _fixture.AddActions
+            (
+                setupConfiguration: () =>
+                {
+                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
-        _fixture.Initialize();
-    }
+                    configModifier.ForceTransactionTraces();
 
-    private readonly string _metricScopeBase = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
+                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                    configModifier.SetOrDeleteSpanEventsEnabled(true);
+                }
+            );
+
+            _fixture.Initialize();
+        }
+
+        private readonly string _metricScopeBase =
+            "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
 
         [Fact]
         public void Test()
         {
             // attributes
 
-            var headerValueTx = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendAndReceiveAMessage");
+            var headerValueTx =
+                _fixture.AgentLog.TryGetTransactionEvent(
+                    $"{_metricScopeBase}/SendAndReceiveAMessageFor{_destinationType}");
 
             var spanEvents = _fixture.AgentLog.GetSpanEvents();
 
-            var produceSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/ServiceBus/Queue/Produce/Named/"))
+            // produce is always queue.
+            var produceSpan = spanEvents.Where(@event =>
+                    @event.IntrinsicAttributes["name"].ToString()
+                        .Contains("MessageBroker/ServiceBus/Queue/Produce/Named/"))
                 .FirstOrDefault();
 
-            var consumeSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/ServiceBus/Queue/Consume/Named/"))
+            var consumeSpan = spanEvents.Where(@event =>
+                    @event.IntrinsicAttributes["name"].ToString()
+                        .Contains($"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/"))
                 .FirstOrDefault();
 
             Assert.NotNull(produceSpan);
@@ -67,51 +79,111 @@ public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegratio
 
             Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
             Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], produceSpan.IntrinsicAttributes["traceId"]);
-            Assert.True(AttributeComparer.IsEqualTo(headerValueTx.IntrinsicAttributes["priority"], produceSpan.IntrinsicAttributes["priority"]),
+            Assert.True(
+                AttributeComparer.IsEqualTo(headerValueTx.IntrinsicAttributes["priority"],
+                    produceSpan.IntrinsicAttributes["priority"]),
                 $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {produceSpan.IntrinsicAttributes["priority"]}");
 
             Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
             Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], consumeSpan.IntrinsicAttributes["traceId"]);
-            Assert.True(AttributeComparer.IsEqualTo(headerValueTx.IntrinsicAttributes["priority"], consumeSpan.IntrinsicAttributes["priority"]),
+            Assert.True(
+                AttributeComparer.IsEqualTo(headerValueTx.IntrinsicAttributes["priority"],
+                    consumeSpan.IntrinsicAttributes["priority"]),
                 $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {consumeSpan.IntrinsicAttributes["priority"]}");
 
             // metrics
 
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new Assertions.ExpectedMetric { metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Create/Success", callCount = 1},
+                new Assertions.ExpectedMetric
+                {
+                    metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1
+                },
+                new Assertions.ExpectedMetric
+                {
+                    metricName = $"Supportability/TraceContext/Create/Success", callCount = 1
+                },
             };
 
             var metrics = _fixture.AgentLog.GetMetrics();
             Assertions.MetricsExist(expectedMetrics, metrics);
         }
-}
-
-public class AzureServiceBusW3CTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-{
-    public AzureServiceBusW3CTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-    {
     }
-}
 
-public class AzureServiceBusW3CTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
-{
-    public AzureServiceBusW3CTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-    {
-    }
-}
+    #region Queue Tests
 
-public class AzureServiceBusW3CTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-{
-    public AzureServiceBusW3CTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
+    public class AzureServiceBusW3CQueueTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
     {
+        public AzureServiceBusW3CQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+            ITestOutputHelper output) : base(fixture, "Queue", output)
+        {
+        }
     }
-}
 
-public class AzureServiceBusW3CTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-{
-    public AzureServiceBusW3CTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    public class AzureServiceBusW3CQueueTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
     {
+        public AzureServiceBusW3CQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+            base(fixture, "Queue", output)
+        {
+        }
     }
+
+    public class
+        AzureServiceBusW3CQueueTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    {
+        public AzureServiceBusW3CQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+            ITestOutputHelper output) : base(fixture, "Queue", output)
+        {
+        }
+    }
+
+    public class
+        AzureServiceBusW3CQueueTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public AzureServiceBusW3CQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+            ITestOutputHelper output) : base(fixture, "Queue", output)
+        {
+        }
+    }
+
+    #endregion Queue Tests
+
+    #region Topic Tests
+
+    public class AzureServiceBusW3CTopicTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    {
+        public AzureServiceBusW3CTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+            ITestOutputHelper output) : base(fixture, "Topic", output)
+        {
+        }
+    }
+
+    public class AzureServiceBusW3CTopicTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
+    {
+        public AzureServiceBusW3CTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+            base(fixture, "Topic", output)
+        {
+        }
+    }
+
+    public class
+        AzureServiceBusW3CTopicTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    {
+        public AzureServiceBusW3CTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+            ITestOutputHelper output) : base(fixture, "Topic", output)
+        {
+        }
+    }
+
+    public class
+        AzureServiceBusW3CTopicTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    {
+        public AzureServiceBusW3CTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+            ITestOutputHelper output) : base(fixture, "Topic", output)
+        {
+        }
+    }
+
+    #endregion Topic Tests
+
 }


### PR DESCRIPTION
## Description

We captured the timing for Azure Service Bus topics, but labelled them as "queues" and didn't normalize the topic name to remove the "/Subscription/*" part of the topic name.  This PR updates the instrumentation to properly label topics as topics and removes the suffix. Produce names are going to continue to be labelled as "Queue" since ASB does not differentiate between queues and topics when sending messages.  Topic subscriptions for incoming messages are handled "server side".

Includes expanded tests.  

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
