### PR TITLE
ci: Update unbounded services config to include Elastic 7, 8 and 9 services.

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/build_and_push_acr.sh
+++ b/tests/Agent/IntegrationTests/UnboundedServices/build_and_push_acr.sh
@@ -15,7 +15,7 @@ LOGIN_SERVER=$(az acr show --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP"
 az acr login --name "$ACR_NAME"
 
 # Default list of all services
-all_services=(rabbitmq mongodb32 mongodb60 redis couchbase postgres mssql mysql elastic elastic7 oracle)
+all_services=(rabbitmq mongodb32 mongodb60 redis couchbase postgres mssql mysql elastic9 elastic8 elastic7 oracle)
 
 # If specific services are provided as arguments, use those instead
 if [ $# -gt 0 ]; then

--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -113,8 +113,24 @@ services:
             - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-MysqlPassword}
         container_name: MySqlServer
 
-    elastic:
-        build: ./elastic
+    elastic9:
+        build: ./elastic9
+        ports:
+            - 9202:9200
+        environment:
+            - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ElasticPassword}
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        deploy:
+            resources:
+                limits:
+                    memory: 2GB
+        container_name: Elastic9Server
+
+    elastic8:
+        build: ./elastic8
         ports:
             - 9200:9200
         environment:
@@ -127,7 +143,7 @@ services:
             resources:
                 limits:
                     memory: 2GB
-        container_name: ElasticServer
+        container_name: Elastic8Server
 
     elastic7:
         build: ./elastic7
@@ -145,27 +161,27 @@ services:
                     memory: 2GB
         container_name: Elastic7Server
 
-    # have to manually set the password for kibana_user - use curl to hit the correct endpoint
-    kibana_pw_setup:
-        image: curlimages/curl
-        depends_on:
-            - elastic
-        deploy:
-            restart_policy:
-                condition: on-failure
-        entrypoint: [ "sh", "-c", "sleep 10 && curl --user \"elastic:${ELASTIC_PASSWORD:-ElasticPassword}\" -X POST \"elastic:9200/_security/user/kibana_system/_password?pretty\" -H 'Content-Type: application/json' -d'{  \"password\" : \"${KIBANA_PASSWORD:-KibanaPassword}\"}'" ]
-        container_name: KibanaPWSetup
+    # # have to manually set the password for kibana_user - use curl to hit the correct endpoint
+    # kibana_pw_setup:
+    #     image: curlimages/curl
+    #     depends_on:
+    #         - elastic
+    #     deploy:
+    #         restart_policy:
+    #             condition: on-failure
+    #     entrypoint: [ "sh", "-c", "sleep 10 && curl --user \"elastic:${ELASTIC_PASSWORD:-ElasticPassword}\" -X POST \"elastic:9200/_security/user/kibana_system/_password?pretty\" -H 'Content-Type: application/json' -d'{  \"password\" : \"${KIBANA_PASSWORD:-KibanaPassword}\"}'" ]
+    #     container_name: KibanaPWSetup
 
-    kibana:
-        depends_on:
-            kibana_pw_setup:
-                 condition: service_completed_successfully
-        image: kibana:8.6.2
-        ports:
-            - 5601:5601
-        environment:
-            - SERVERNAME=kibana
-            - ELASTICSEARCH_HOSTS=http://elastic:9200
-            - ELASTICSEARCH_USERNAME=kibana_system
-            - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-KibanaPassword}
-        container_name: Kibana
+    # kibana:
+    #     depends_on:
+    #         kibana_pw_setup:
+    #              condition: service_completed_successfully
+    #     image: kibana:8.6.2
+    #     ports:
+    #         - 5601:5601
+    #     environment:
+    #         - SERVERNAME=kibana
+    #         - ELASTICSEARCH_HOSTS=http://elastic:9200
+    #         - ELASTICSEARCH_USERNAME=kibana_system
+    #         - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD:-KibanaPassword}
+    #     container_name: Kibana

--- a/tests/Agent/IntegrationTests/UnboundedServices/elastic8/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/elastic8/Dockerfile
@@ -1,4 +1,3 @@
-# Standard License Header
 FROM elasticsearch:8.6.2
 ENV discovery.type=single-node
 ENV xpack.security.enabled=true

--- a/tests/Agent/IntegrationTests/UnboundedServices/elastic9/Dockerfile
+++ b/tests/Agent/IntegrationTests/UnboundedServices/elastic9/Dockerfile
@@ -1,0 +1,4 @@
+FROM elasticsearch:9.0.4
+ENV discovery.type=single-node
+ENV xpack.security.enabled=true
+ENV xpack.security.http.ssl.enabled=false

--- a/tests/Agent/IntegrationTests/UnboundedServices/k8s/elastic8.yaml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/k8s/elastic8.yaml
@@ -1,0 +1,57 @@
+# Standard License Header
+# Kubernetes Deployment and Service for ElasticSearch 8.x
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elastic8
+  namespace: unbounded-services
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elastic8
+  template:
+    metadata:
+      labels:
+        app: elastic8
+    spec:
+      containers:
+      - name: elastic8
+        image: dotnetunboundedservicesregistry.azurecr.io/elastic8
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9200
+        env:
+        - name: discovery.type
+          value: "single-node"
+        - name: ELASTIC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: unboundedservices-secrets
+              key: ELASTIC_PASSWORD
+        - name: xpack.security.enabled
+          value: "true"
+        - name: xpack.security.http.ssl.enabled
+          value: "false"
+        resources:
+          limits:
+            memory: 2Gi
+        securityContext:
+          privileged: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elastic8
+  namespace: unbounded-services
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: ${RESOURCE_GROUP}
+    service.beta.kubernetes.io/azure-pip-name: ${PUBLIC_IP_NAME}
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${PUBLIC_IP}
+  ports:
+    - port: 9200
+      targetPort: 9200
+  selector:
+    app: elastic8

--- a/tests/Agent/IntegrationTests/UnboundedServices/k8s/elastic9.yaml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/k8s/elastic9.yaml
@@ -3,21 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: elastic
+  name: elastic9
   namespace: unbounded-services
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: elastic
+      app: elastic9
   template:
     metadata:
       labels:
-        app: elastic
+        app: elastic9
     spec:
       containers:
-      - name: elastic
-        image: dotnetunboundedservicesregistry.azurecr.io/elastic
+      - name: elastic9
+        image: dotnetunboundedservicesregistry.azurecr.io/elastic9
         imagePullPolicy: Always
         ports:
         - containerPort: 9200
@@ -42,7 +42,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: elastic
+  name: elastic9
   namespace: unbounded-services
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-resource-group: ${RESOURCE_GROUP}
@@ -51,7 +51,7 @@ spec:
   type: LoadBalancer
   loadBalancerIP: ${PUBLIC_IP}
   ports:
-    - port: 9200
+    - port: 9202
       targetPort: 9200
   selector:
-    app: elastic
+    app: elastic9


### PR DESCRIPTION
Updates the unbounded services config (K8s and docker-compose) to deploy Elastic search v7, 8 and 9 servers, in preparation for our eventual support of testing on Elastic v9. 

For now, the v9 service will start and run but will not be used anywhere. Test secrets are not affected by this change (though they will get updated eventually so the Elastic / OTel bridge PR can run tests successfully).

Kibana was commented out of the docker-compose configuration, as we never really used it for anything anyway (it's a GUI tool for inspecting Elastic, which we haven't needed). We didn't (and won't) deploy Kibana on K8s. 