### PR TITLE
test: Update Elastic test secret configuration

### DIFF
--- a/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
+++ b/tests/Agent/IntegrationTests/Shared/ElasticSearchConfiguration.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace NewRelic.Agent.IntegrationTests.Shared
 {
-    public class ElasticSearchConfiguration
+    public class ElasticSearch8Configuration
     {
         private static string _elasticServer;
         private static string _elasticUserName;
@@ -20,7 +20,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                     try
                     {
                         var testConfiguration =
-                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch8Tests");
                         _elasticServer = testConfiguration["Server"];
                     }
                     catch (Exception ex)
@@ -42,7 +42,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                     try
                     {
                         var testConfiguration =
-                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch8Tests");
                         _elasticUserName = testConfiguration["UserName"];
                     }
                     catch (Exception ex)
@@ -62,7 +62,7 @@ namespace NewRelic.Agent.IntegrationTests.Shared
                     try
                     {
                         var testConfiguration =
-                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearchTests");
+                            IntegrationTestConfiguration.GetIntegrationTestConfiguration("ElasticSearch8Tests");
                         _elasticPassword = testConfiguration["Password"];
                     }
                     catch (Exception ex)

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchElasticClient.cs
@@ -28,21 +28,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         {
             get
             {
-                return new Uri(ElasticSearchConfiguration.ElasticServer);
+                return new Uri(ElasticSearch8Configuration.ElasticServer);
             }
         }
         protected override string Username
         {
             get
             {
-                return ElasticSearchConfiguration.ElasticUserName;
+                return ElasticSearch8Configuration.ElasticUserName;
             }
         }
         protected override string Password
         {
             get
             {
-                return ElasticSearchConfiguration.ElasticPassword;
+                return ElasticSearch8Configuration.ElasticPassword;
             }
         }
 
@@ -192,7 +192,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ElasticsearchClientSettings(Address)
-                    .Authentication(new BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
+                    .Authentication(new BasicAuthentication(ElasticSearch8Configuration.ElasticUserName,
                     "12345")).
                     DefaultIndex(IndexName);
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNestClient.cs
@@ -180,7 +180,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionSettings(Address).
-                BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
+                BasicAuthentication(ElasticSearch8Configuration.ElasticUserName,
                 "1234").
                 DefaultIndex(IndexName);
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Elasticsearch/ElasticsearchNetClient.cs
@@ -215,7 +215,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch
         {
             // This isn't the password, so connection should fail, but we won't get an error until the Ping
             var settings = new ConnectionConfiguration(Address)
-                .BasicAuthentication(ElasticSearchConfiguration.ElasticUserName,
+                .BasicAuthentication(ElasticSearch8Configuration.ElasticUserName,
                     "1234")
                 .RequestTimeout(TimeSpan.FromMinutes(2));
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/OpenSearch/OpenSearchTestClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/OpenSearch/OpenSearchTestClient.cs
@@ -23,21 +23,21 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.OpenSearch
         {
             get
             {
-                return new Uri(ElasticSearchConfiguration.ElasticServer);
+                return new Uri(ElasticSearch8Configuration.ElasticServer);
             }
         }
         protected string Username
         {
             get
             {
-                return ElasticSearchConfiguration.ElasticUserName;
+                return ElasticSearch8Configuration.ElasticUserName;
             }
         }
         protected string Password
         {
             get
             {
-                return ElasticSearchConfiguration.ElasticPassword;
+                return ElasticSearch8Configuration.ElasticPassword;
             }
         }
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -202,7 +202,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
 
         private static string GetHostFromElasticServer(ClientType clientType)
         {
-            var elasticServer = clientType == ClientType.ElasticClients ? ElasticSearchConfiguration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
+            var elasticServer = clientType == ClientType.ElasticClients ? ElasticSearch8Configuration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
   
             if (elasticServer.StartsWith("https://"))
             {

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/OpenSearch/OpenSearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/OpenSearch/OpenSearchTests.cs
@@ -181,7 +181,7 @@ namespace NewRelic.Agent.UnboundedIntegrationTests.OpenSearch
         // Using the Elasticsearch server credentials since it OpenSearch supports it.
         private static string GetHostFromElasticServer()
         {
-            var elasticServer = ElasticSearchConfiguration.ElasticServer;
+            var elasticServer = ElasticSearch8Configuration.ElasticServer;
 
             if (elasticServer.StartsWith("https://"))
             {


### PR DESCRIPTION
Updates elastic test configuration to reference Elastic8. Works in conjunction with a github secrets update I just pushed and is needed in order for the Elastic / OTel bridge PR to run tests against Elastic 9