### PR TITLE
ci: Update Nuget packages that Dependabot won't. 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,10 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "Autofac"
+      - dependency-name: "Autofac" # v6+ doesn't support .NET Framework; we could upgerade to v5.x but there's no good reason for it
       - dependency-name: "Microsoft.Extensions.Configuration.*"
+      - dependency-name: "SharpZipLib" # we can't upgrade beyond 1.3.3
+
 
   # Update a specific set of packages for unit and integration tests
   - package-ecosystem: nuget

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -37,18 +37,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.5.0" />
+    <!-- Autofac v6+ doesn't support framework. We could possibly upgrade to v5.x but there's no compelling reason for it. -->
+    <PackageReference Include="Autofac" Version="[4.5.0]" />
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
     <PackageReference Include="Grpc.Tools" Version="2.72.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.0.1" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="ILRepack" Version="2.0.44">
       <PrivateAssets>all</PrivateAssets>
@@ -74,7 +75,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[2.0.0]" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[2.0.0]" />

--- a/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
+++ b/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
@@ -8,7 +8,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRHttpClientTests.cs
@@ -36,7 +36,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             Mock.Arrange(() => _mockConfiguration.PutForDataSend).Returns(false);
 
             _mockConnectionInfo = Mock.Create<IConnectionInfo>();
-            Mock.Arrange(() => _mockConnectionInfo.Host).Returns("testhost.com");
+            Mock.Arrange(() => _mockConnectionInfo.Host).Returns("google.com");
             Mock.Arrange(() => _mockConnectionInfo.HttpProtocol).Returns("https");
             Mock.Arrange(() => _mockConnectionInfo.Port).Returns(123);
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/Client/NRWebRequestClientTests.cs
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.Core.DataTransport.Client
             Mock.Arrange(() => _mockConfiguration.PutForDataSend).Returns(false);
 
             _mockConnectionInfo = Mock.Create<IConnectionInfo>();
-            Mock.Arrange(() => _mockConnectionInfo.Host).Returns("testhost.com");
+            Mock.Arrange(() => _mockConnectionInfo.Host).Returns("google.com");
             Mock.Arrange(() => _mockConnectionInfo.HttpProtocol).Returns("https");
             Mock.Arrange(() => _mockConnectionInfo.Port).Returns(123);
 

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="JustMock" Version="2025.2.520.440" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
@@ -10,11 +10,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.0.1" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
   </ItemGroup>

--- a/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
+++ b/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
-    <PackageReference Include="Verify.NUnit" Version="30.3.0" />
+    <PackageReference Include="Verify.NUnit" Version="30.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -21,7 +21,7 @@
     <PackageReference Include="MoreLinq" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.8.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
* Updates some Nuget packages that Dependabot seems unable to handle. Why does Dependabot skip them? Who knows. 
* Updates a couple of unit tests that reference `testhost.com` to use `google.com` instead, which avoids triggering CloudFlare WARP blocking when running the tests locally.