### PR TITLE
chore: Change gpg from version 1 to 2.

### DIFF
--- a/deploy/linux/Dockerfile
+++ b/deploy/linux/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     dos2unix \
     bsdmainutils \
     rsync \
-    gnupg1 \
+    gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data


### PR DESCRIPTION
## Description

Change gpg from version 1 to 2 due to some unknown change in the linux deploy images resulting in gpg command not being found.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
