### PR TITLE
chore: Remove sha checksum option from createrepo_c command.

### DIFF
--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -109,7 +109,7 @@ rebuild_yum() {
 
     printf \\n
     if [[ -d "$REPO_DIR" ]]; then
-      createrepo_c --update --checksum sha "$REPO_DIR"
+      createrepo_c --update "$REPO_DIR"
     fi
   done
 }


### PR DESCRIPTION
## Description

Remove sha checksum option from createrepo_c command.  It defaults to sha256 now.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
