### PR TITLE
ci: When deploying the agent to YUM, use gzip compression for repo metadata

### DIFF
--- a/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
+++ b/deploy/linux/deploy_scripts/libexec/repoman-rebuild.bash
@@ -109,7 +109,7 @@ rebuild_yum() {
 
     printf \\n
     if [[ -d "$REPO_DIR" ]]; then
-      createrepo_c --update "$REPO_DIR"
+      createrepo_c --update --general-compress-type=gz "$REPO_DIR"
     fi
   done
 }


### PR DESCRIPTION
Somewhere between the release of 10.43.0 and 10.44.0, the version of `createrepo_c` (the command that creates the necessary repo metadata for a YUM repo) was updated in whatever APT repos are being pulled from when we build the Debian container that runs the process of deploying the agent to our APT and YUM repos.  This version change caused the repo metadata to be compressed with ZStandard (.zst) instead of Gzip (.gz).  This isn't a problem for newer YUM-based distros (e.g. Fedora) but older versions of yum, such as on Amazon Linux 2, don't understand the .zst format, causing install failures.

This PR fixes this issue by telling `createrepo_c` to use GZip compression for all of its generated repo metadata.  Tested the fix by deploying 10.44.0 to our test YUM repo with the updated deploy process and then testing installation on Amazon Linux 2 from the test repo.  The install completed without errors (which it did not do before the fix).