### PR TITLE
fix: Exclude Azure Function webhost (Linux) process from instrumentation.

### DIFF
--- a/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/Configuration.h
@@ -183,6 +183,12 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
 
         bool ShouldInstrument(xstring_t const& processPath, xstring_t const& parentProcessPath, xstring_t const& appPoolId, xstring_t const& commandLine, bool isCoreClr)
         {
+            LogTrace(_X("Process Path: ") + processPath);
+            LogTrace(_X("Parent Process Path: ") + parentProcessPath);
+            LogTrace(_X("App Pool Id: ") + appPoolId);
+            LogTrace(_X("Command Line: ") + commandLine);
+            LogTrace(_X("Is Core CLR: ") + xstring_t(isCoreClr ? _X("true") : _X("false")));
+
             if (IsAzureFunction()) // valid for both .NET Framework and .NET Core
             {
                 if (IsAzureFunctionModeEnabled()) // if not explicitly enabled, fall back to "legacy" behavior
@@ -684,7 +690,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration {
                 return 0;
             }
 
-            bool isAzureFunctionsHostLinux = NewRelic::Profiler::Strings::ContainsCaseInsensitive(processPath, _X("/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost"));
+            bool isAzureFunctionsHostLinux = NewRelic::Profiler::Strings::ContainsCaseInsensitive(commandLine, _X("/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost"));
             if (isAzureFunctionsHostLinux)
             {
                 LogInfo(L"Appears to be Azure Functions WebHost (Linux) based on commandLine. Not instrumenting this process.");

--- a/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
+++ b/src/Agent/NewRelic/Profiler/ConfigurationTest/ConfigurationTest.cpp
@@ -140,7 +140,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration { namespace Te
 
             Configuration configuration(configurationXml, _missingConfig, L"", systemCalls);
 
-            Assert::IsFalse(configuration.ShouldInstrument(L"/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost", L"", L"", L"blah blah blah FooBarBaz blah blah blah", true));
+            Assert::IsFalse(configuration.ShouldInstrument(L"blah blah blah FooBarBaz blah blah blah", L"", L"", L"/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost", true));
         }
 
         TEST_METHOD(should_not_instrument_isolated_azure_function_app_pool_id_in_commandline)


### PR DESCRIPTION
## Description

The initial fix did not work since the webhost value is seen in the commandline not the process path/name.  This adjusts the check to use the already present command line.

Profiler log showing the check being missed:

```
Command line: /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost 
Azure function detected. Determining whether to instrument /azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost 
Couldn't determine whether this Azure Function process should be instrumented based on commandLine. Falling back to checking application pool
Process . with parent process . is not IIS.
```

Adds additional information about the various values used for ShouldInstrument at Finest/Trace logging.

Original fix: https://github.com/newrelic/newrelic-dotnet-agent/pull/3194

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
