### PR TITLE
chore: Fix ignore rule for Microsoft.Extensions.Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
           - "*"
     ignore:
       - dependency-name: "Autofac" # v6+ doesn't support .NET Framework; we could upgerade to v5.x but there's no good reason for it
-      - dependency-name: "Microsoft.Extensions.Configuration.*"
+      - dependency-name: "Microsoft.Extensions.Configuration*"
       - dependency-name: "SharpZipLib" # we can't upgrade beyond 1.3.3
 
 


### PR DESCRIPTION
Fix the ignore rule for Microsoft.Extensions.Configuration* to actually match Microsoft.Extensions.Configuration as well as its sub-namespaces.