### PR TITLE
ci: Add more post-deploy Linux install tests

### DIFF
--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Validate
         run: |
           echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
-          curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor | sudo tee /usr/share/keyrings/newrelic-apt2.gpg >/dev/null
+          curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor | sudo tee /usr/share/keyrings/newrelic-apt.gpg >/dev/null
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent
           installed_version=$(dpkg -s newrelic-dotnet-agent | grep '^Version:' |cut -d' ' -f2)

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Validate
         run: |
           echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
-          wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg
+          curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor | sudo tee /usr/share/keyrings/newrelic-apt2.gpg >/dev/null
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent
           installed_version=$(dpkg -s newrelic-dotnet-agent | grep '^Version:' |cut -d' ' -f2)
@@ -91,6 +91,7 @@ jobs:
       - name: Validate
         run: |
           echo 'deb https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+          # Test using the old key on an older OS to make sure it still works
           wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   validate-apt-repo-ubuntu-latest:
-    name: Validate APT-based repo
+    name: Validate APT repo on latest Ubuntu with new key
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -74,7 +74,7 @@ jobs:
           AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-apt-repo-ubuntu-2204:
-    name: Validate APT-based repo
+    name: Validate APT repo on older Ubuntu with old key
     runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
@@ -149,7 +149,7 @@ jobs:
           AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-apt-repo-debian-latest:
-    name: Validate APT-based repo
+    name: Validate APT repo on latest Debian
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -190,7 +190,7 @@ jobs:
           AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-apt-repo-debian-oldest:
-    name: Validate APT-based repo
+    name: Validate APT repo on older Debian
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/post_deploy_agent.yml
+++ b/.github/workflows/post_deploy_agent.yml
@@ -12,7 +12,7 @@ on:
         default: true
         required: true
       test_mode:
-        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
+        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue, and release tags will not be created.'
         type: boolean
         default: false
         required: true
@@ -27,7 +27,7 @@ on:
         default: true
         required: true
       test_mode:
-        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue.'
+        description: 'Run workflow in test mode.  If set to true, the NugetVersionDeprecator will not create a GitHub issue, and release tags will not be created.'
         type: boolean
         default: false
         required: false
@@ -61,7 +61,7 @@ jobs:
           wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent
-          installed_version=$(dpkg -s newrelic-dotnet-agent | grep -i version)
+          installed_version=$(dpkg -s newrelic-dotnet-agent | grep '^Version:' |cut -d' ' -f2)
           if [ "$AGENT_VERSION" = "$installed_version" ]; then
               echo "Versions match."
               exit 0
@@ -71,7 +71,7 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "Version: ${{ inputs.agent_version }}"
+          AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-apt-repo-ubuntu-2204:
     name: Validate APT-based repo
@@ -94,7 +94,7 @@ jobs:
           wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install newrelic-dotnet-agent
-          installed_version=$(dpkg -s newrelic-dotnet-agent | grep -i version)
+          installed_version=$(dpkg -s newrelic-dotnet-agent | grep '^Version:' |cut -d' ' -f2)
           if [ "$AGENT_VERSION" = "$installed_version" ]; then
               echo "Versions match."
               exit 0
@@ -104,7 +104,7 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "Version: ${{ inputs.agent_version }}"
+          AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-yum-repo:
     name: Validate YUM-based repo
@@ -145,7 +145,89 @@ jobs:
           fi
         shell: bash
         env:
-          AGENT_VERSION: "newrelic-dotnet-agent-${{ inputs.agent_version }}-1.x86_64"
+          AGENT_VERSION: "${{ inputs.agent_version }}"
+
+  validate-apt-repo-debian-latest:
+    name: Validate APT-based repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Wait for APT to update
+        if: ${{ inputs.wait_for_apt_and_yum }} # only wait if requested
+        run: |
+          echo "Sleeping 5 minutes to wait for apt to update itself"
+          sleep 300
+        shell: bash
+
+      - name: Validate
+        run: |
+          cd deploy/validation/validate-debian-latest
+
+          # This will setup the New Relic apt repo and install the agent.
+          docker build -t localtesting/validate-debian-latest:latest .
+          docker run --name validate-debian-latest localtesting/validate-debian-latest:latest
+          installed_version=$(docker logs --tail 1 validate-debian-latest)
+          if [ "$AGENT_VERSION" = "$installed_version" ]; then
+              echo "Versions match."
+              exit 0
+          else
+              echo "ERROR: Version mismatch: Expected $AGENT_VERSION was $installed_version"
+              exit 1
+          fi
+        shell: bash
+        env:
+          AGENT_VERSION: "${{ inputs.agent_version }}"
+
+  validate-apt-repo-debian-oldest:
+    name: Validate APT-based repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Wait for APT to update
+        if: ${{ inputs.wait_for_apt_and_yum }} # only wait if requested
+        run: |
+          echo "Sleeping 5 minutes to wait for apt to update itself"
+          sleep 300
+        shell: bash
+
+      - name: Validate
+        run: |
+          cd deploy/validation/validate-debian-oldest
+
+          # This will setup the New Relic apt repo and install the agent.
+          docker build -t localtesting/validate-debian-oldest:latest .
+          docker run --name validate-debian-oldest localtesting/validate-debian-oldest:latest
+          installed_version=$(docker logs --tail 1 validate-debian-oldest)
+          if [ "$AGENT_VERSION" = "$installed_version" ]; then
+              echo "Versions match."
+              exit 0
+          else
+              echo "ERROR: Version mismatch: Expected $AGENT_VERSION was $installed_version"
+              exit 1
+          fi
+        shell: bash
+        env:
+          AGENT_VERSION: "${{ inputs.agent_version }}"
 
   validate-download-site-s3:
     name: Validate S3-hosted Download Site
@@ -224,6 +306,7 @@ jobs:
           PUBLISH_PATH: ${{ github.workspace }}/publish
 
   release-tags:
+    if: ${{ inputs.test_mode == false }} # only run if not in test mode
     name: Create release tags
     runs-on: ubuntu-latest
     steps:

--- a/deploy/validation/validate-debian-latest/Dockerfile
+++ b/deploy/validation/validate-debian-latest/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:trixie-20250908@sha256:833c135acfe9521d7a0035a296076f98c182c542a2b6b5a0fd7063d355d696be
+
+RUN apt-get update && apt-get install -y curl gnupg \
+    && curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /usr/share/keyrings/newrelic-apt.gpg
+
+COPY --chmod=777 check-version.sh /tmp/
+
+ENTRYPOINT ["/tmp/check-version.sh"]

--- a/deploy/validation/validate-debian-latest/check-version.sh
+++ b/deploy/validation/validate-debian-latest/check-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list
+apt-get update && apt-get install newrelic-dotnet-agent -y
+
+dpkg -s newrelic-dotnet-agent | grep '^Version:' | cut -d' ' -f2

--- a/deploy/validation/validate-debian-oldest/Dockerfile
+++ b/deploy/validation/validate-debian-oldest/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bullseye-20250908@sha256:f58b816c2acc96e3e1dfe6b6c166c3d52b5541571ac4fa72a64a0bb5beaf25a3
+
+RUN apt-get update && apt-get install -y curl gnupg \
+    && curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /usr/share/keyrings/newrelic-apt.gpg
+
+COPY --chmod=777 check-version.sh /tmp/
+
+ENTRYPOINT ["/tmp/check-version.sh"]

--- a/deploy/validation/validate-debian-oldest/check-version.sh
+++ b/deploy/validation/validate-debian-oldest/check-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list
+apt-get update && apt-get install newrelic-dotnet-agent -y
+
+dpkg -s newrelic-dotnet-agent | grep '^Version:' | cut -d' ' -f2

--- a/deploy/validation/validate-yum/check-version.sh
+++ b/deploy/validation/validate-yum/check-version.sh
@@ -13,4 +13,4 @@ REPO
 
 yum install newrelic-dotnet-agent -y
 
-rpm -q newrelic-dotnet-agent
+rpm -q --queryformat '%{VERSION}\n' newrelic-dotnet-agent


### PR DESCRIPTION
This PR updates the post-deploy APT/YUM repo install tests to:

1. Test Debian 13 (latest) and 11 (oldest-ish), using new repo signing key configuration logic that works equally well on both (see #3240 for context)
2. Use the new repo signing key config command for the `ubuntu-latest` case
3. Tweak the commands to get the version of the agent that was installed to output just the version, simplifying the version check logic
4. Made the names of the various validation jobs unique and descriptive