### PR TITLE
chore: Update ElasticSearch and RabbitMQ configuration for release with OpenTelemetry Bridge support

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2694,8 +2694,7 @@ namespace NewRelic.Agent.Core.Configuration
         #region Otel Bridge
 
         // The activity sources we listen to by default - these are the sources that we will automatically instrument
-        // TODO: eventually we want to include "Elastic.Transport", "RabbitMQ.Client.Subscriber", "RabbitMQ.Client.Publisher" by default
-        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent"]; 
+        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent,Elastic.Transport,RabbitMQ.Client.Subscriber,RabbitMQ.Client.Publisher"]; 
 
         private List<string> _includedActivitySources;
         public List<string> IncludedActivitySources

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2694,7 +2694,7 @@ namespace NewRelic.Agent.Core.Configuration
         #region Otel Bridge
 
         // The activity sources we listen to by default - these are the sources that we will automatically instrument
-        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent,Elastic.Transport,RabbitMQ.Client.Subscriber,RabbitMQ.Client.Publisher"]; 
+        private static readonly string[] DefaultIncludedActivitySources = ["NewRelic.Agent","Elastic.Transport","RabbitMQ.Client.Subscriber","RabbitMQ.Client.Publisher"]; 
 
         private List<string> _includedActivitySources;
         public List<string> IncludedActivitySources

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Elasticsearch/Instrumentation.xml
@@ -5,56 +5,54 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <extension xmlns="urn:newrelic-extension">
 	<instrumentation>
-    <!-- TODO: Add maxVersion="8.15.10" on all <match> elements when OtelBridge is enabled by default in the agent. -->
-
     <!--7.x NEST/Elasticsearch.Net -->
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elasticsearch.Net" className="Elasticsearch.Net.Transport`1">
+      <match assemblyName="Elasticsearch.Net" className="Elasticsearch.Net.Transport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="Request" parameters="Elasticsearch.Net.HttpMethod,System.String,Elasticsearch.Net.PostData,Elasticsearch.Net.IRequestParameters" />
       </match>
     </tracerFactory>
 
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elasticsearch.Net" className="Elasticsearch.Net.Transport`1">
+      <match assemblyName="Elasticsearch.Net" className="Elasticsearch.Net.Transport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="RequestAsync" parameters="Elasticsearch.Net.HttpMethod,System.String,System.Threading.CancellationToken,Elasticsearch.Net.PostData,Elasticsearch.Net.IRequestParameters" />
       </match>
     </tracerFactory>
 
     <!--8.x Elastic.Clients.Elasticsearch -->
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="Request" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters" />
       </match>
     </tracerFactory>
 
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="RequestAsync" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,System.Threading.CancellationToken" />
       </match>
     </tracerFactory>
 
     <!--8.10.0+-->
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="Request" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;" />
       </match>
     </tracerFactory>
 
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DefaultHttpTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="RequestAsync" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;,System.Threading.CancellationToken" />
       </match>
     </tracerFactory>
 
     <!--8.12.1+-->
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="Request" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;" />
       </match>
     </tracerFactory>
 
     <tracerFactory name="ElasticsearchRequestWrapper">
-      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1">
+      <match assemblyName="Elastic.Transport" className="Elastic.Transport.DistributedTransport`1" maxVersion="8.15.10">
         <exactMethodMatcher methodName="RequestAsync" parameters="Elastic.Transport.HttpMethod,System.String,Elastic.Transport.PostData,Elastic.Transport.RequestParameters,Elastic.Transport.Diagnostics.OpenTelemetryData&amp;,System.Threading.CancellationToken" />
       </match>
     </tracerFactory>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/Instrumentation.xml
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RabbitMq/Instrumentation.xml
@@ -4,19 +4,17 @@ Copyright 2020 New Relic Corporation. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 <extension xmlns="urn:newrelic-extension">
-
-  <!-- TODO: Add maxVersion="6.8.1" on all <match> elements when OtelBridge is enabled by default in the agent. -->
 	<instrumentation>
     <!-- Consume Pull -->
 		<tracerFactory name="BasicGetWrapper">
-			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model">
+			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model" maxVersion="6.8.1">
 				<exactMethodMatcher methodName="_Private_BasicGet" />
 			</match>
 		</tracerFactory>
 
     <!-- Produce -->
 		<tracerFactory name="BasicPublishWrapper">
-			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model">
+			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model" maxVersion="6.8.1">
 				<exactMethodMatcher methodName="_Private_BasicPublish" parameters="System.String,System.String,System.Boolean,RabbitMQ.Client.IBasicProperties,System.Byte[]"/>
 				<exactMethodMatcher methodName="_Private_BasicPublish" parameters="System.String,System.String,System.Boolean,RabbitMQ.Client.IBasicProperties,System.ReadOnlyMemory`1[System.Byte]"/>
 			</match>
@@ -24,20 +22,20 @@ SPDX-License-Identifier: Apache-2.0
 
     <!-- Produce -->
 		<tracerFactory name="BasicPublishWrapperLegacy">
-			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model">
+			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model" maxVersion="6.8.1">
 				<exactMethodMatcher methodName="_Private_BasicPublish" parameters="System.String,System.String,System.Boolean,System.Boolean,RabbitMQ.Client.IBasicProperties,System.Byte[]"/>
 			</match>
 		</tracerFactory>
 
     <!-- Consume  Push / Event / Subscribe -->
 		<tracerFactory name="HandleBasicDeliverWrapper">
-      <match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Events.EventingBasicConsumer">
+      <match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Events.EventingBasicConsumer" maxVersion="6.8.1">
         <exactMethodMatcher methodName="HandleBasicDeliver" />
       </match>
 		</tracerFactory>
 		
 		<tracerFactory name="QueuePurgeWrapper">
-			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model">
+			<match assemblyName="RabbitMQ.Client" className="RabbitMQ.Client.Framing.Impl.Model" maxVersion="6.8.1">
 				<exactMethodMatcher methodName="_Private_QueuePurge" />
 			</match>
 		</tracerFactory>

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4674,7 +4674,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             _localConfig.appSettings.Add(new configurationAdd { key = "OpenTelemetry.ActivitySource.Include", value = "  , Foo , , Bar,Baz,, " });
             var defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic, _agentHealthReporter);
             var includedActivitySources = defaultConfig.IncludedActivitySources;
-            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Foo", "Bar", "Baz"]));
+            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Elastic.Transport", "RabbitMQ.Client.Subscriber", "RabbitMQ.Client.Publisher", "Foo", "Bar", "Baz"]));
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4666,7 +4666,6 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
             var includedActivitySources = defaultConfig.IncludedActivitySources;
 
             Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Elastic.Transport", "RabbitMQ.Client.Subscriber", "RabbitMQ.Client.Publisher", "Foo", "Bar", "Baz"]));
-            //TODO: Use this line with Elastic.Transport is included by default  Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Elastic.Transport", "Foo", "Bar", "Baz"]));
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4665,7 +4665,7 @@ namespace NewRelic.Agent.Core.Configuration.UnitTest
 
             var includedActivitySources = defaultConfig.IncludedActivitySources;
 
-            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Foo", "Bar", "Baz"]));
+            Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Elastic.Transport", "RabbitMQ.Client.Subscriber", "RabbitMQ.Client.Publisher", "Foo", "Bar", "Baz"]));
             //TODO: Use this line with Elastic.Transport is included by default  Assert.That(includedActivitySources, Is.EquivalentTo(["NewRelic.Agent", "Elastic.Transport", "Foo", "Bar", "Baz"]));
         }
 


### PR DESCRIPTION
Minor updates to enable ElasticSearch and RabbitMQ instrumentation via OpenTelemetry Bridge. Adds the activity sources for Elastic and Rabbit to the default set of sources we listen to. 

Does NOT automatically enable OpenTelemetry Bridge. 

OpenTelemetry Bridge can be enabled in two ways: 
* Set an environment variable:
    `NEW_RELIC_OPEN_TELEMETRY_BRIDGE_ENABLED=true`
* Edit the `<appSettings>` section in `newrelic.config`:
```
	<appSettings>
		<add key="OpenTelemetry.Enabled" value="true" />
	</appSettings>
```    