### PR TITLE
chore: Remove unnecessary NuGet package references

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <!--<PackageReference Include="System.ValueTuple" Version="4.6.1" />-->
     <PackageReference Include="ILRepack" Version="2.0.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net481;net10.0</TargetFrameworks>
     <RootNamespace>CompositeTests</RootNamespace>
@@ -24,9 +24,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.7"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.7"/>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>  


### PR DESCRIPTION
Resolves build warning-as-error messages when building under VS2022 with .NET 10 RC1