### PR TITLE
chore: Fix vulnerabilities in build tool project dependencies

### DIFF
--- a/build/Dotty/Dotty.csproj
+++ b/build/Dotty/Dotty.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Nuget.Protocol" Version="6.14.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
   </ItemGroup>
 
   <ItemGroup>

--- a/build/NugetValidator/NugetValidator.csproj
+++ b/build/NugetValidator/NugetValidator.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
+++ b/build/NugetVersionDeprecator/NugetVersionDeprecator.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NuGet.Protocol" Version="6.14.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.10" /> <!-- For Nuget.Protocol transient depedency vulnerability -->
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="112.1.0" />


### PR DESCRIPTION
Fixes https://github.com/newrelic/newrelic-dotnet-agent/security/dependabot/96 by updating to the latest `Microsoft.Build` package version in `Dotty.csproj`.

Also fixes some warnings-as-errors about a vulnerability in a transient dependency of `Nuget.Protocol` by referencing a specific, patched version of that dependency (`System.Formats.Asn1`)