### PR TITLE
chore: Add entity guid to health check file per agent control spec.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -77,7 +77,9 @@ namespace NewRelic.Agent.Core.AgentHealth
             _customInstrumentationCounter = new InterlockedCounter();
 
             if (_configuration.AgentControlEnabled)
+            {
                 _healthCheck = new() { IsHealthy = true, Status = "Agent starting", LastError = string.Empty };
+            }
         }
 
         public override void Dispose()
@@ -840,7 +842,7 @@ namespace NewRelic.Agent.Core.AgentHealth
                 return;
             }
 
-            var healthCheckYaml = _healthCheck.ToYaml();
+            var healthCheckYaml = _healthCheck.ToYaml(_configuration.EntityGuid);
 
             Log.Finest("Publishing Agent Control health check report: {HealthCheckYaml}", healthCheckYaml);
 

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCheck.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCheck.cs
@@ -49,12 +49,12 @@ namespace NewRelic.Agent.Core.AgentHealth
             }
         }
 
-        public string ToYaml()
+        public string ToYaml(string entityGuid)
         {
             lock (this)
             {
                 return
-                    $"healthy: {IsHealthy}\nstatus: {Status}\nlast_error: {LastError}\nstart_time_unix_nano: {StartTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}\nstatus_time_unix_nano: {StatusTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}";
+                    $"entity_guid: {entityGuid}\nhealthy: {IsHealthy}\nstatus: {Status}\nlast_error: {LastError}\nstart_time_unix_nano: {StartTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}\nstatus_time_unix_nano: {StatusTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}";
             }
         }
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/HealthCheckTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/HealthCheckTests.cs
@@ -72,10 +72,11 @@ namespace NewRelic.Agent.Core.UnitTests.AgentHealth
             var healthStatus = (IsHealthy: true, Code: "200", Status: "OK");
             _healthCheck.TrySetHealth(healthStatus);
 
-            var yaml = _healthCheck.ToYaml();
+            var yaml = _healthCheck.ToYaml("someEntityGuid");
 
             Assert.Multiple(() =>
             {
+                Assert.That(yaml, Does.Contain("entity_guid: someEntityGuid"));
                 Assert.That(yaml, Does.Contain("healthy: True"));
                 Assert.That(yaml, Does.Contain("status: OK"));
                 Assert.That(yaml, Does.Contain("last_error: 200"));
@@ -172,10 +173,11 @@ namespace NewRelic.Agent.Core.UnitTests.AgentHealth
         [Test]
         public void ToYaml_HandlesNullValues()
         {
-            var yaml = _healthCheck.ToYaml();
+            var yaml = _healthCheck.ToYaml(null);
 
             Assert.Multiple(() =>
             {
+                Assert.That(yaml, Does.Match(@"entity_guid:\s\n"));
                 Assert.That(yaml, Does.Match(@"healthy:\sFalse"));
                 Assert.That(yaml, Does.Match(@"status:\s\n"));
                 Assert.That(yaml, Does.Match(@"last_error:\s\n"));


### PR DESCRIPTION
Adds entity guid at the beginning of the health check file as specified by the agent control spec. Includes updated tests.