### PR TITLE
chore: Update TraceIdRatioBasedSampler naming for consistency with agent spec

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -1297,41 +1297,41 @@ namespace NewRelic.Agent.Core.Config
     
     /// <summary>
     /// Based on the OpenTelemetry TraceIdRatioBased sampler.
-    /// It samples traces with a probability defined by the sampleRatio attribute, which must be a decimal value between 0.0 (no sampling) and 1.0 (sample all).
+    /// It samples traces with a probability defined by the ratio attribute, which must be a decimal value between 0.0 (no sampling) and 1.0 (sample all).
     /// For more information, see the OpenTelemetry specification: https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
     /// </summary>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
     [System.SerializableAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(Namespace="urn:newrelic-config")]
-    public partial class TraceIdRatioSamplerType
+    public partial class TraceIdRatioBasedSamplerType
     {
         
-        private decimal sampleRatioField;
+        private decimal ratioField;
         
         /// <summary>
         /// The percentage of traces to sample, between 0.0 and 1.0.
         /// </summary>
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public decimal sampleRatio
+        public decimal ratio
         {
             get
             {
-                return this.sampleRatioField;
+                return this.ratioField;
             }
             set
             {
-                this.sampleRatioField = value;
+                this.ratioField = value;
             }
         }
         
         #region Clone method
         /// <summary>
-        /// Create a clone of this TraceIdRatioSamplerType object
+        /// Create a clone of this TraceIdRatioBasedSamplerType object
         /// </summary>
-        public virtual TraceIdRatioSamplerType Clone()
+        public virtual TraceIdRatioBasedSamplerType Clone()
         {
-            return ((TraceIdRatioSamplerType)(this.MemberwiseClone()));
+            return ((TraceIdRatioBasedSamplerType)(this.MemberwiseClone()));
         }
         #endregion
     }
@@ -4215,7 +4215,7 @@ namespace NewRelic.Agent.Core.Config
         [System.Xml.Serialization.XmlElementAttribute("alwaysOff", typeof(AlwaysOffSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("alwaysOn", typeof(AlwaysOnSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("default", typeof(AdaptiveSamplerType))]
-        [System.Xml.Serialization.XmlElementAttribute("traceIdRatio", typeof(TraceIdRatioSamplerType))]
+        [System.Xml.Serialization.XmlElementAttribute("traceIdRatioBased", typeof(TraceIdRatioBasedSamplerType))]
         [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemElementName")]
         public object Item
         {
@@ -4272,7 +4272,7 @@ namespace NewRelic.Agent.Core.Config
         @default,
         
         /// <remarks/>
-        traceIdRatio,
+        traceIdRatioBased
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
@@ -4290,7 +4290,7 @@ namespace NewRelic.Agent.Core.Config
         [System.Xml.Serialization.XmlElementAttribute("alwaysOff", typeof(AlwaysOffSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("alwaysOn", typeof(AlwaysOnSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("default", typeof(AdaptiveSamplerType))]
-        [System.Xml.Serialization.XmlElementAttribute("traceIdRatio", typeof(TraceIdRatioSamplerType))]
+        [System.Xml.Serialization.XmlElementAttribute("traceIdRatioBased", typeof(TraceIdRatioBasedSamplerType))]
         [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemElementName")]
         public object Item
         {
@@ -4347,7 +4347,7 @@ namespace NewRelic.Agent.Core.Config
         @default,
         
         /// <remarks/>
-        traceIdRatio,
+        traceIdRatioBased,
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]
@@ -4365,7 +4365,7 @@ namespace NewRelic.Agent.Core.Config
         [System.Xml.Serialization.XmlElementAttribute("alwaysOff", typeof(AlwaysOffSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("alwaysOn", typeof(AlwaysOnSamplerType))]
         [System.Xml.Serialization.XmlElementAttribute("default", typeof(AdaptiveSamplerType))]
-        [System.Xml.Serialization.XmlElementAttribute("traceIdRatio", typeof(TraceIdRatioSamplerType))]
+        [System.Xml.Serialization.XmlElementAttribute("traceIdRatioBased", typeof(TraceIdRatioBasedSamplerType))]
         [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemElementName")]
         public object Item
         {
@@ -4422,7 +4422,7 @@ namespace NewRelic.Agent.Core.Config
         @default,
         
         /// <remarks/>
-        traceIdRatio,
+        traceIdRatioBased,
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -94,15 +94,15 @@
         </xs:annotation>
     </xs:complexType>
 
-    <xs:complexType name="TraceIdRatioSamplerType">
+    <xs:complexType name="TraceIdRatioBasedSamplerType">
         <xs:annotation>
             <xs:documentation>
                 Based on the OpenTelemetry TraceIdRatioBased sampler.
-                It samples traces with a probability defined by the sampleRatio attribute, which must be a decimal value between 0.0 (no sampling) and 1.0 (sample all).
+                It samples a percentage of traces defined by the ratio attribute, which must be a decimal value between 0.0 (no sampling) and 1.0 (sample all).
                 For more information, see the OpenTelemetry specification: https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="sampleRatio" type="xs:decimal" use="required">
+        <xs:attribute name="ratio" type="xs:decimal" use="required">
             <xs:annotation>
                 <xs:documentation>
                     The percentage of traces to sample, between 0.0 and 1.0.
@@ -1311,7 +1311,7 @@
                                                 <xs:choice minOccurs="1" maxOccurs="1">
                                                     <xs:element name="default" type="tns:AdaptiveSamplerType"/>
                                                     <xs:element name="adaptive" type="tns:AdaptiveSamplerType"/>
-                                                    <xs:element name="traceIdRatio" type="tns:TraceIdRatioSamplerType"/>
+                                                    <xs:element name="traceIdRatioBased" type="tns:TraceIdRatioBasedSamplerType"/>
                                                     <xs:element name="alwaysOn" type="tns:AlwaysOnSamplerType"/>
                                                     <xs:element name="alwaysOff" type="tns:AlwaysOffSamplerType"/>
                                                 </xs:choice>
@@ -1327,7 +1327,7 @@
                                                 <xs:choice minOccurs="1" maxOccurs="1">
                                                     <xs:element name="default" type="tns:AdaptiveSamplerType"/>
                                                     <xs:element name="adaptive" type="tns:AdaptiveSamplerType"/>
-                                                    <xs:element name="traceIdRatio" type="tns:TraceIdRatioSamplerType"/>
+                                                    <xs:element name="traceIdRatioBased" type="tns:TraceIdRatioBasedSamplerType"/>
                                                     <xs:element name="alwaysOn" type="tns:AlwaysOnSamplerType"/>
                                                     <xs:element name="alwaysOff" type="tns:AlwaysOffSamplerType"/>
                                                 </xs:choice>
@@ -1343,7 +1343,7 @@
                                                 <xs:choice minOccurs="1" maxOccurs="1">
                                                     <xs:element name="default" type="tns:AdaptiveSamplerType"/>
                                                     <xs:element name="adaptive" type="tns:AdaptiveSamplerType"/>
-                                                    <xs:element name="traceIdRatio" type="tns:TraceIdRatioSamplerType"/>
+                                                    <xs:element name="traceIdRatioBased" type="tns:TraceIdRatioBasedSamplerType"/>
                                                     <xs:element name="alwaysOn" type="tns:AlwaysOnSamplerType"/>
                                                     <xs:element name="alwaysOff" type="tns:AlwaysOffSamplerType"/>
                                                 </xs:choice>

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationEnumHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationEnumHelpers.cs
@@ -57,7 +57,7 @@ namespace NewRelic.Agent.Core.Configuration
                 case SamplerType.AlwaysOff:
                     return new AlwaysOffSamplerType();
                 case SamplerType.TraceIdRatioBased:
-                    return new TraceIdRatioSamplerType();
+                    return new TraceIdRatioBasedSamplerType();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(samplerType), samplerType, null);
             }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -957,7 +957,7 @@ namespace NewRelic.Agent.Core.Configuration
                 AdaptiveSamplerType => SamplerType.Adaptive,
                 AlwaysOnSamplerType => SamplerType.AlwaysOn,
                 AlwaysOffSamplerType => SamplerType.AlwaysOff,
-                TraceIdRatioSamplerType => SamplerType.TraceIdRatioBased,
+                TraceIdRatioBasedSamplerType => SamplerType.TraceIdRatioBased,
                 _ => throw new ArgumentOutOfRangeException(nameof(samplerItem), samplerItem, "Unknown sampler type in configuration.")
             };
 
@@ -981,16 +981,16 @@ namespace NewRelic.Agent.Core.Configuration
             switch (samplerLevel)
             {
                 case SamplerLevel.Root:
-                    if (_localConfiguration.distributedTracing.sampler.root.Item is TraceIdRatioSamplerType rootTraceIdRatioSamplerType)
-                        return (float)rootTraceIdRatioSamplerType.sampleRatio;
+                    if (_localConfiguration.distributedTracing.sampler.root.Item is TraceIdRatioBasedSamplerType rootTraceIdRatioSamplerType)
+                        return (float)rootTraceIdRatioSamplerType.ratio;
                     return null;
                 case SamplerLevel.RemoteParentSampled:
-                    if (_localConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioSamplerType remoteParentSampledTraceIdRatioSamplerType)
-                        return (float)remoteParentSampledTraceIdRatioSamplerType.sampleRatio;
+                    if (_localConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioBasedSamplerType remoteParentSampledTraceIdRatioSamplerType)
+                        return (float)remoteParentSampledTraceIdRatioSamplerType.ratio;
                     return null;
                 case SamplerLevel.RemoteParentNotSampled:
-                    if (_localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioSamplerType remoteParentNotSampledTraceIdRatioSamplerType)
-                        return (float)remoteParentNotSampledTraceIdRatioSamplerType.sampleRatio;
+                    if (_localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioBasedSamplerType remoteParentNotSampledTraceIdRatioSamplerType)
+                        return (float)remoteParentNotSampledTraceIdRatioSamplerType.ratio;
                     return null;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null);

--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/Samplers/SamplerFactory.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/Samplers/SamplerFactory.cs
@@ -35,7 +35,7 @@ namespace NewRelic.Agent.Core.DistributedTracing.Samplers
                 case SamplerType.TraceIdRatioBased:
                     // if the ratio is not set, log a warning and use the default sampler
                     if (traceIdRatioSamplerRatio.HasValue)
-                        return new TraceIdRatioSampler(traceIdRatioSamplerRatio.Value); // always return a new instance since it is stateless
+                        return new TraceIdRatioBasedSampler(traceIdRatioSamplerRatio.Value); // always return a new instance since it is stateless
 
                     Log.Warn($"The configured TraceIdRatioBased sampler is missing a ratio value. Using default sampler.");
                     return _adaptiveSampler.Value;

--- a/src/Agent/NewRelic/Agent/Core/DistributedTracing/Samplers/TraceIdRatioBasedSampler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DistributedTracing/Samplers/TraceIdRatioBasedSampler.cs
@@ -5,17 +5,17 @@ using System;
 
 namespace NewRelic.Agent.Core.DistributedTracing.Samplers;
 
-// based on the OpenTelemetry TraceIdRatioSampler https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Trace/Sampler/TraceIdRatioBasedSampler.cs
-public class TraceIdRatioSampler : ISampler
+// based on the OpenTelemetry TraceIdRatioBasedSampler https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Trace/Sampler/TraceIdRatioBasedSampler.cs
+public class TraceIdRatioBasedSampler : ISampler
 {
     private readonly long _idUpperBound;
     private const int TraceIdLength = 16;
 
     private const float PriorityBoost = 1.0f;
 
-    public TraceIdRatioSampler(float sampleRatio)
+    public TraceIdRatioBasedSampler(float ratio)
     {
-        _idUpperBound = sampleRatio switch
+        _idUpperBound = ratio switch
         {
             // Special case the limits, to avoid any possible issues with lack of precision across
             // double/long boundaries. For probability == 0.0, we use Long.MIN_VALUE as this guarantees
@@ -23,7 +23,7 @@ public class TraceIdRatioSampler : ISampler
             // Math.Abs(Long.MIN_VALUE) == Long.MIN_VALUE.
             0.0f => long.MinValue,
             1.0f => long.MaxValue,
-            _ => (long)(sampleRatio * long.MaxValue)
+            _ => (long)(ratio * long.MaxValue)
         };
     }
 

--- a/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/DistributedTracing/TraceContextCrossAgentTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CrossAgentTests/DistributedTracing/TraceContextCrossAgentTests.cs
@@ -141,9 +141,9 @@ namespace CompositeTests.CrossAgentTests.DistributedTracing
                         // This is not valid in our config so we need to treat it as if the sampler is not set
                         return null;
                     }
-                    return new TraceIdRatioSamplerType
+                    return new TraceIdRatioBasedSamplerType
                     {
-                        sampleRatio = (decimal)testData.Ratio
+                        ratio = (decimal)testData.Ratio
                     };
                 case "adaptive":
                 case "default":

--- a/tests/Agent/UnitTests/CompositeTests/RemoteParentSamplerTypeTests.cs
+++ b/tests/Agent/UnitTests/CompositeTests/RemoteParentSamplerTypeTests.cs
@@ -48,13 +48,13 @@ namespace CompositeTests
             // If testing TraceIdRatioBased, inject the ratio into both sampled/not-sampled sampler configs then push config
             if (samplerType == SamplerType.TraceIdRatioBased && ratio.HasValue)
             {
-                if (_compositeTestAgent.LocalConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioSamplerType rpSampled)
+                if (_compositeTestAgent.LocalConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioBasedSamplerType rpSampled)
                 {
-                    rpSampled.sampleRatio = (decimal)ratio.Value;
+                    rpSampled.ratio = (decimal)ratio.Value;
                 }
-                if (_compositeTestAgent.LocalConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioSamplerType rpNotSampled)
+                if (_compositeTestAgent.LocalConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioBasedSamplerType rpNotSampled)
                 {
-                    rpNotSampled.sampleRatio = (decimal)ratio.Value;
+                    rpNotSampled.ratio = (decimal)ratio.Value;
                 }
                 _compositeTestAgent.PushConfiguration();
             }

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfiguration_SamplerConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfiguration_SamplerConfigurationTests.cs
@@ -122,7 +122,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             // Arrange
             var ratio = 0.42m;
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = ratio };
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = ratio };
 
             // Act
             var value = _config.RootTraceIdRatioSamplerRatio;
@@ -157,7 +157,7 @@ namespace NewRelic.Agent.Core.Configuration
             // Arrange
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT"))
                 .Returns("traceIdRatioBased");
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = 0.7m };
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = 0.7m };
 
             // Recreate config to apply env override
             _config = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig,
@@ -175,7 +175,7 @@ namespace NewRelic.Agent.Core.Configuration
         public void RootTraceIdRatioSamplerRatio_IsNull_WhenEnvOverridesSamplerTypeToNonRatioBased()
         {
             // Arrange
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = 0.15m }; // should be ignored
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = 0.15m }; // should be ignored
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT"))
                 .Returns("alwaysOn");
 
@@ -218,7 +218,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             // Arrange
             var ratio = 0.33m;
-            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioSamplerType { sampleRatio = ratio };
+            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioBasedSamplerType { ratio = ratio };
 
             // Act
             var value = _config.RemoteParentSampledTraceIdRatioSamplerRatio;
@@ -253,7 +253,7 @@ namespace NewRelic.Agent.Core.Configuration
             // Arrange
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED"))
                 .Returns("traceIdRatioBased");
-            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.55m };
+            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.55m };
 
             _config = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig,
                 _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic,
@@ -270,7 +270,7 @@ namespace NewRelic.Agent.Core.Configuration
         public void RemoteParentSampledTraceIdRatioSamplerRatio_IsNull_WhenEnvOverridesSamplerTypeToNonRatioBased()
         {
             // Arrange
-            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.25m }; // should be ignored
+            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.25m }; // should be ignored
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED"))
                 .Returns("alwaysOff");
 
@@ -313,7 +313,7 @@ namespace NewRelic.Agent.Core.Configuration
         {
             // Arrange
             var ratio = 0.61m;
-            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioSamplerType { sampleRatio = ratio };
+            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioBasedSamplerType { ratio = ratio };
 
             // Act
             var value = _config.RemoteParentNotSampledTraceIdRatioSamplerRatio;
@@ -348,7 +348,7 @@ namespace NewRelic.Agent.Core.Configuration
             // Arrange
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED"))
                 .Returns("traceIdRatioBased");
-            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.9m };
+            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.9m };
 
             _config = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig,
                 _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic,
@@ -365,7 +365,7 @@ namespace NewRelic.Agent.Core.Configuration
         public void RemoteParentNotSampledTraceIdRatioSamplerRatio_IsNull_WhenEnvOverridesSamplerTypeToNonRatioBased()
         {
             // Arrange
-            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.11m }; // should be ignored
+            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.11m }; // should be ignored
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED"))
                 .Returns("default");
 
@@ -506,7 +506,7 @@ namespace NewRelic.Agent.Core.Configuration
         public void RootSampler_Ratio_EnvironmentOverride_TakesPrecedence()
         {
             // local config ratio (should be overridden)
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = 0.33m };
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = 0.33m };
 
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT"))
                 .Returns("traceIdRatioBased");
@@ -525,7 +525,7 @@ namespace NewRelic.Agent.Core.Configuration
         [Test]
         public void RootSampler_Ratio_InvalidEnv_FallsBackToLocal()
         {
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = 0.25m };
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = 0.25m };
 
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT"))
                 .Returns("traceIdRatioBased");
@@ -544,7 +544,7 @@ namespace NewRelic.Agent.Core.Configuration
         [Test]
         public void RootSampler_Ratio_EnvSamplerNotRatioBased_ReturnsNull()
         {
-            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioSamplerType { sampleRatio = 0.20m };
+            _localConfig.distributedTracing.sampler.root.Item = new TraceIdRatioBasedSamplerType { ratio = 0.20m };
 
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT"))
                 .Returns("alwaysOn");
@@ -563,7 +563,7 @@ namespace NewRelic.Agent.Core.Configuration
         [Test]
         public void RemoteParentSampled_Ratio_EnvironmentOverride_TakesPrecedence()
         {
-            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.10m };
+            _localConfig.distributedTracing.sampler.remoteParentSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.10m };
 
             Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED"))
                 .Returns("traceIdRatioBased");
@@ -582,7 +582,7 @@ namespace NewRelic.Agent.Core.Configuration
         [Test]
         public void RemoteParentNotSampled_Ratio_LocalOnly()
         {
-            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioSamplerType { sampleRatio = 0.60m };
+            _localConfig.distributedTracing.sampler.remoteParentNotSampled.Item = new TraceIdRatioBasedSamplerType { ratio = 0.60m };
 
             CreateConfig();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/SamplerFactoryTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/SamplerFactoryTests.cs
@@ -60,8 +60,8 @@ namespace NewRelic.Agent.Core.DistributedTracing
             var sampler2 = _samplerFactory.GetSampler(SamplerType.TraceIdRatioBased, 0.25f);
 
             Assert.That(sampler1, Is.Not.SameAs(sampler2), "TraceIdRatioSampler should be stateless and newly instantiated each call.");
-            Assert.That(sampler1, Is.TypeOf<TraceIdRatioSampler>());
-            Assert.That(sampler2, Is.TypeOf<TraceIdRatioSampler>());
+            Assert.That(sampler1, Is.TypeOf<TraceIdRatioBasedSampler>());
+            Assert.That(sampler2, Is.TypeOf<TraceIdRatioBasedSampler>());
         }
 
         [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/TraceIdRatioSamplerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/TraceIdRatioSamplerTests.cs
@@ -17,7 +17,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void Constructor_WithZeroRatio_SetsIdUpperBoundToLongMinValue()
         {
             // Arrange & Act
-            var sampler = new TraceIdRatioSampler(0.0f);
+            var sampler = new TraceIdRatioBasedSampler(0.0f);
 
             // Assert
             // We can verify the behavior through sampling - should never sample with 0.0 ratio
@@ -31,7 +31,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void Constructor_WithOneRatio_SetsIdUpperBoundToLongMaxValue()
         {
             // Arrange & Act
-            var sampler = new TraceIdRatioSampler(1.0f);
+            var sampler = new TraceIdRatioBasedSampler(1.0f);
 
             // Assert
             // We can verify the behavior through sampling - should always sample with 1.0 ratio
@@ -50,7 +50,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void Constructor_WithNormalRatio_CalculatesCorrectIdUpperBound(float ratio)
         {
             // Arrange & Act
-            var sampler = new TraceIdRatioSampler(ratio);
+            var sampler = new TraceIdRatioBasedSampler(ratio);
 
             // Assert
             // Verify behavior through sampling - should sample some but not all trace IDs
@@ -85,7 +85,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithNullTraceId_ThrowsArgumentNullException()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
 
             // Act & Assert
             var exception = Assert.Throws<ArgumentNullException>(() => sampler.ShouldSample(new SamplingParameters(null, 0.5f)));
@@ -97,7 +97,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithEmptyTraceId_ThrowsArgumentNullException()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
 
             // Act & Assert
             var exception = Assert.Throws<ArgumentNullException>(() => sampler.ShouldSample(new SamplingParameters(string.Empty, 0.5f)));
@@ -111,7 +111,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithShortTraceId_ThrowsFormatException(string shortTraceId)
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
 
             // Act & Assert
             var exception = Assert.Throws<FormatException>(() => sampler.ShouldSample(new SamplingParameters(shortTraceId, 0.5f)));
@@ -125,7 +125,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithInvalidHexCharacters_ThrowsFormatException(string invalidTraceId)
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
 
             // Act & Assert
             var exception = Assert.Throws<FormatException>(() => sampler.ShouldSample(new SamplingParameters(invalidTraceId, 0.5f)));
@@ -140,7 +140,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithUppercaseHexCharacters_ProcessesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f); // Always sample to verify it processes
+            var sampler = new TraceIdRatioBasedSampler(1.0f); // Always sample to verify it processes
             var traceId = "ABCDEF1234567890ABCDEF1234567890";
 
             // Act & Assert
@@ -155,7 +155,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithLowercaseHexCharacters_ProcessesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f); // Always sample to verify it processes
+            var sampler = new TraceIdRatioBasedSampler(1.0f); // Always sample to verify it processes
             var traceId = "abcdef1234567890abcdef1234567890";
 
             // Act & Assert
@@ -170,7 +170,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithMixedCaseHexCharacters_ProcessesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f); // Always sample to verify it processes
+            var sampler = new TraceIdRatioBasedSampler(1.0f); // Always sample to verify it processes
             var traceId = "AbCdEf1234567890aBcDeF1234567890";
 
             // Act & Assert
@@ -185,7 +185,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithNumericCharacters_ProcessesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f); // Always sample to verify it processes
+            var sampler = new TraceIdRatioBasedSampler(1.0f); // Always sample to verify it processes
             var traceId = "12345678901234567890123456789012";
 
             // Act & Assert
@@ -207,7 +207,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithZeroRatio_NeverSamples(string traceId)
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.0f);
+            var sampler = new TraceIdRatioBasedSampler(0.0f);
 
             // Act & Assert
             var result = sampler.ShouldSample(new SamplingParameters(traceId, 0.5f));
@@ -221,7 +221,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithOneRatio_AlwaysSamples(string traceId)
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f);
+            var sampler = new TraceIdRatioBasedSampler(1.0f);
 
             // Act & Assert
             var result = sampler.ShouldSample(new SamplingParameters(traceId, 0.5f));
@@ -232,7 +232,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithSameTraceId_ReturnsConsistentResult()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
             var traceId = "1234567890abcdef1234567890abcdef";
 
             // Act
@@ -249,7 +249,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_OnlyUsesFirst16Characters()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
             var baseTraceId = "1234567890abcdef";
             var traceId1 = baseTraceId + "0000000000000000"; // 32 chars
             var traceId2 = baseTraceId + "ffffffffffffffff"; // 32 chars, different suffix
@@ -275,7 +275,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithMinimumTraceId_HandlesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
             var minTraceId = "0000000000000000000000000000000000";
 
             // Act & Assert
@@ -291,7 +291,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithMaximumTraceId_HandlesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(0.5f);
+            var sampler = new TraceIdRatioBasedSampler(0.5f);
             var maxTraceId = "ffffffffffffffff111111111111111111";
 
             // Act & Assert
@@ -307,7 +307,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithExactly16Characters_ProcessesCorrectly()
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(1.0f); // Use 1.0 to ensure sampling
+            var sampler = new TraceIdRatioBasedSampler(1.0f); // Use 1.0 to ensure sampling
             var exactTraceId = "1234567890abcdef"; // Exactly 16 characters
 
             // Act & Assert
@@ -329,7 +329,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         public void ShouldSample_WithDifferentRatios_ShowsExpectedDistribution(float ratio)
         {
             // Arrange
-            var sampler = new TraceIdRatioSampler(ratio);
+            var sampler = new TraceIdRatioBasedSampler(ratio);
             var testTraceIds = new[]
             {
                 "0000000000000000111111111111111111",

--- a/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/TracingStateTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DistributedTracing/TracingStateTests.cs
@@ -400,7 +400,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
                     SamplerType.Adaptive => null,
                     SamplerType.AlwaysOn => AlwaysOnSampler.Instance,
                     SamplerType.AlwaysOff => AlwaysOffSampler.Instance,
-                    SamplerType.TraceIdRatioBased => new TraceIdRatioSampler(r ?? 0.5f),
+                    SamplerType.TraceIdRatioBased => new TraceIdRatioBasedSampler(r ?? 0.5f),
                     _ => throw new ArgumentOutOfRangeException(nameof(behavior), behavior, null)
                 };
             }
@@ -426,7 +426,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
         }
 
         [Test]
-        public void AcceptDistributedTraceHeaders_AppliesTraceIdSampleRatioCorrectly()
+        public void AcceptDistributedTraceHeaders_AppliesTraceIdratioCorrectly()
         {
             // Arrange
             var headers = new Dictionary<string, string>()
@@ -436,7 +436,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
             };
 
             Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentSampled))
-                .Returns(new TraceIdRatioSampler(1.0f));
+                .Returns(new TraceIdRatioBasedSampler(1.0f));
 
 
             var tracingState = TracingState.AcceptDistributedTraceHeaders(
@@ -447,12 +447,12 @@ namespace NewRelic.Agent.Core.DistributedTracing
                 transactionStartTime: DateTime.UtcNow.Add(TimeSpan.FromMilliseconds(1)), _samplerService);
 
             // Assert
-            Assert.That(tracingState.Sampled, Is.True, "Sampled should be true when sampleRatio is 1.0");
-            Assert.That(tracingState.Priority, Is.EqualTo(Priority + 1.0f), "Priority should be boosted when sampleRatio is 1.0");
+            Assert.That(tracingState.Sampled, Is.True, "Sampled should be true when ratio is 1.0");
+            Assert.That(tracingState.Priority, Is.EqualTo(Priority + 1.0f), "Priority should be boosted when ratio is 1.0");
         }
 
         [Test]
-        public void AcceptDistributedTraceHeaders_AppliesTraceIdSampleRatio_SampledFalse()
+        public void AcceptDistributedTraceHeaders_AppliesTraceIdratio_SampledFalse()
         {
             // Arrange
             var headers = new Dictionary<string, string>()
@@ -461,7 +461,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
                 { "tracestate", ValidTracestate },
             };
             Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentSampled))
-                .Returns(new TraceIdRatioSampler(0.0f));
+                .Returns(new TraceIdRatioBasedSampler(0.0f));
 
             var tracingState = TracingState.AcceptDistributedTraceHeaders(
                 carrier: headers,
@@ -471,8 +471,8 @@ namespace NewRelic.Agent.Core.DistributedTracing
                 transactionStartTime: DateTime.UtcNow.Add(TimeSpan.FromMilliseconds(1)), _samplerService);
 
             // Assert
-            Assert.That(tracingState.Sampled, Is.EqualTo(false), "Sampled should be false when sampleRatio is 0");
-            Assert.That(tracingState.Priority, Is.EqualTo(Priority), "Priority should use the tracestate priority value when sampleRatio is 0");
+            Assert.That(tracingState.Sampled, Is.EqualTo(false), "Sampled should be false when ratio is 0");
+            Assert.That(tracingState.Priority, Is.EqualTo(Priority), "Priority should use the tracestate priority value when ratio is 0");
         }
 
         [TestCase("0000000000000001", 0.01f, true, true, TestName = "TraceIdRatioBased_LowValue_AlwaysSamples_Ratio001_ParentSampled")]
@@ -503,7 +503,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
             if (parentSampledFlag)
             {
                 Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentSampled))
-                    .Returns(new TraceIdRatioSampler(ratio));
+                    .Returns(new TraceIdRatioBasedSampler(ratio));
                 Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentNotSampled))
                     .Returns((ISampler)null);
             }
@@ -512,7 +512,7 @@ namespace NewRelic.Agent.Core.DistributedTracing
                 Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentSampled))
                     .Returns((ISampler)null);
                 Mock.Arrange(() => _samplerService.GetSampler(SamplerLevel.RemoteParentNotSampled))
-                    .Returns(new TraceIdRatioSampler(ratio));
+                    .Returns(new TraceIdRatioBasedSampler(ratio));
             }
 
             var tracingState = TracingState.AcceptDistributedTraceHeaders(


### PR DESCRIPTION
Our initial implementation used the wrong name for the `<traceIdRatioSampler>` configuration element (wrong, at least, in terms of being in compliance with the agent spec). 

This PR remediates that inconsistency by renaming `traceIdRatioSampler` to `traceIdRatioBasedSampler` and the `samplerRatio` attribute to `ratio` - all relevant classes, properties, enums, etc. are renamed for consistency.

The environment variables that correspond to the configuration elements for the trace id ratio based sampler already have the correct name, so no update is required.