### PR TITLE
fix: OpenAI instrumentation ignores chat completions when `CompleteChatAsync()` or `CompleteChat()` `messages` parameter is not an `Array`

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/OpenAITests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/OpenAITests.cs
@@ -54,6 +54,7 @@ namespace NewRelic.Agent.IntegrationTests.LLM
             _fixture.TestLogger = output;
 
             _fixture.AddCommand($"OpenAIExerciser CompleteChatAsync gpt-4o {LLMHelpers.ConvertToBase64(_prompt)}");
+            _fixture.AddCommand($"OpenAIExerciser CompleteChatEnumerableAsync gpt-4o {LLMHelpers.ConvertToBase64(_prompt)}");
             _fixture.AddCommand($"OpenAIExerciser CompleteChat gpt-4o {LLMHelpers.ConvertToBase64(_prompt)}");
             _fixture.AddCommand($"OpenAIExerciser CompleteChatFailureAsync gpt-4o {LLMHelpers.ConvertToBase64(_prompt)}");
 
@@ -112,8 +113,10 @@ namespace NewRelic.Agent.IntegrationTests.LLM
         {
             var expectedMetrics = new List<Assertions.ExpectedMetric>
             {
-                new() { metricName = @"Custom/Llm/completion/openai/CompleteChatAsync" },
+                new() { metricName = @"Custom/Llm/completion/openai/CompleteChatAsync", CallCountAllHarvests = 3},
                 new() { metricName = @"Custom/Llm/completion/openai/CompleteChatAsync", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChatAsync"},
+                new() { metricName = @"Custom/Llm/completion/openai/CompleteChatAsync", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChatEnumerableAsync"},
+                new() { metricName = @"Custom/Llm/completion/openai/CompleteChatAsync", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChatFailureAsync"},
                 new() { metricName = @"Custom/Llm/completion/openai/CompleteChat" },
                 new() { metricName = @"Custom/Llm/completion/openai/CompleteChat", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChat"},
                 new() { metricName = @"Supportability/DotNet/ML/.*", IsRegexName = true},
@@ -129,12 +132,14 @@ namespace NewRelic.Agent.IntegrationTests.LLM
             var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
             var transactionEventAsync = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChatAsync");
+            var transactionEventAsyncWithEnumerable = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChatEnumerableAsync");
             var transactionEventSync = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.OpenAIExerciser/CompleteChat");
 
             Assert.Multiple(() =>
             {
                 Assertions.MetricsExist(expectedMetrics, metrics);
                 Assert.NotNull(transactionEventAsync);
+                Assert.NotNull(transactionEventAsyncWithEnumerable);
                 Assert.NotNull(transactionEventSync);
                 ValidateCommonAttributes(customEventsSuccess);
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/OpenAIExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/OpenAIExerciser.cs
@@ -50,6 +50,19 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LLM
         [LibraryMethod]
         [Transaction]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task CompleteChatEnumerableAsync(string model, string base64Prompt)
+        {
+            ChatClient client = new(model, apiKey: OpenAIConfiguration.ApiKey);
+            var bytes = Convert.FromBase64String(base64Prompt);
+            var prompt = Encoding.UTF8.GetString(bytes);
+            var promptList = new[] { prompt };
+            ChatCompletion completion = await client.CompleteChatAsync(promptList.Select(p => new UserChatMessage(p)));
+            Console.WriteLine(completion.Content.Last().Text);
+        }
+
+        [LibraryMethod]
+        [Transaction]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public async Task CompleteChatFailureAsync(string model, string base64Prompt)
         {
             ChatClient client = new(model, apiKey: OpenAIConfiguration.ApiKey + "BOGUS"); // will cause an authentication failure


### PR DESCRIPTION
Fixes an issue where instrumentation for `CompleteChat()` and `CompleteChatAsync()` incorrectly assumes the `IEnumerable<ChatMessage> messages` parameter is an `Array` type and ignores the completion if it is anything else. 

This change supports a `messages` parameter of any type that implements `IEnumerable`. 

Includes updated integration tests. 

Resolves #3310 