### PR TITLE
chore: Update PR title checker regex to recognize more valid prefixes

### DIFF
--- a/.github/workflows/pr-title-checker-config.json
+++ b/.github/workflows/pr-title-checker-config.json
@@ -3,7 +3,7 @@
       "name": ""
     },
     "CHECKS": {
-      "regexp": "^(fix|feat|security|notice|chore|ci|docs|test|summary)(\\([^)]+\\))?: "
+      "regexp": "^(fix|feat|security|notice|chore|ci|docs|test|summary)(\([^)]+\))?: "
     },
     "MESSAGES": {
       "success": "Pull request title is properly formatted.",


### PR DESCRIPTION
Converted to using regex instead of a static list of prefixes, primarily to allow things like `chore(hybrid-agent): blah blah blah` to be acceptable; Release Please already knows how to handle commit messages in that format.