### PR TITLE
chore: Remove update restriction on OpenAI and update Azure.AI.OpenAI to latest version

### DIFF
--- a/build/Dotty/packageInfo.json
+++ b/build/Dotty/packageInfo.json
@@ -137,11 +137,7 @@
         "ignoreReason": "net481 doesn't support v9.x"
     },
     {
-        "packageName": "openai",
-        "ignorePatch": true,
-        "ignoreMinor": true,
-        "ignoreMajor": true,
-        "ignoreReason": "Breaks Azure.AI.OpenAI since 2.6.0. See https://github.com/Azure/azure-sdk-for-net/issues/53986"
+        "packageName": "openai"
     },
     {
         "packageName": "opensearch.client"

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MFALatestPackages/MFALatestPackages.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="AWSSDK.Lambda" Version="4.0.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.1" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.1" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.1" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.7.0-beta.2" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.7.0-beta.2" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="CouchbaseNetClient" Version="3.6.6" Condition="'$(TargetFramework)' == 'net481'" />
@@ -62,8 +62,8 @@
     <PackageReference Include="NServiceBus" Version="8.2.4" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="NServiceBus" Version="9.2.7" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!--OpenAI -->
-    <PackageReference Include="OpenAI" Version="2.5.0" Condition="'$(TargetFramework)' == 'net481'" />
-    <PackageReference Include="OpenAI" Version="2.5.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="OpenAI" Version="2.7.0" Condition="'$(TargetFramework)' == 'net481'" />
+    <PackageReference Include="OpenAI" Version="2.7.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- OpenSearch -->
     <PackageReference Include="OpenSearch.Client" Version="1.8.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="OpenSearch.Client" Version="1.8.0" Condition="'$(TargetFramework)' == 'net10.0'" />


### PR DESCRIPTION
Azure.AI.OpenAI version 2.7.0-beta.2 fixes the issue which was preventing our tests from passing with OpenAI >2.5.0.  