### PR TITLE
[HA Metrics] Update the OpenTelemetry SDK used by the agent

### DIFF
--- a/build/Dotty/packageInfo.json
+++ b/build/Dotty/packageInfo.json
@@ -178,5 +178,11 @@
     },
     {
         "packageName": "system.data.odbc"
+    },
+    {
+        "packageName": "opentelemetry"
+    },
+    {
+        "packageName": "opentelemetry.exporter.opentelemetryprotocol"
     }
 ]

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -59,9 +59,9 @@
     <!-- 1.3.3 is the latest package of SharpZipLib that still has a .NET Framework target. Later versions
     only have a .NET Standard target -->
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
-    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -79,9 +79,9 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
OpenTelemetry packages upgraded from 1.12.0 → 1.14.0 
Microsoft.Extensions.Configuration updated: Version 9.0.8 → 10.0.0 (required for OpenTelemetry 1.14.0 compatibility) 
Dotty monitoring: OpenTelemetry packages now tracked in packageInfo.json

Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

The what, the why and the how of your PR.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
