### PR TITLE
test: Update Container tests for .NET 10

### DIFF
--- a/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
+++ b/tests/Agent/IntegrationTests/ContainerApplications/CustomBaseContainerBuild/README.md
@@ -8,18 +8,20 @@ https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
 https://docs.docker.com/engine/reference/commandline/buildx_build/
 
 * Relevant secrets are available in 1Password
+* Requires [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) and [Docker CLI](https://docs.docker.com/reference/cli/docker/)
 
 ## Azure container registry login via Docker
 From a Powershell command prompt in the same folder as this README file:
 
 0. Set the container registry name and login server in a variable
 ```
+$acrUserName="{container registry username}"
 $acrName="{container registry name}"
-$acrLoginServer="{container registry login server}"
 ```
-1. Log in to the container repository
+1. Log in to the container registry
 ```
-docker login -u $acrName -p {password} $acrLoginServer
+az login
+az acr login --name $acrUserName
 ```
 2. Configure buildx in Docker Desktop
 ```
@@ -29,19 +31,17 @@ docker buildx create --use
 
 ```
 docker buildx  build --build-arg DOTNET_VERSION="8.0" --build-arg DOTNET_QUALITY="GA" -f Dockerfile.AmazonBaseImage --tag $acrName/amazonlinux-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
-# TODO: UPDATE TO GA QUALITY AND REMOVE -preview IMAGE TAG WHEN .NET 10 IS RELEASED
-docker buildx  build --build-arg DOTNET_VERSION="10.0" --build-arg DOTNET_QUALITY="Preview" -f Dockerfile.AmazonBaseImage --tag $acrName/amazonlinux-aspnet:10.0-preview --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="10.0" --build-arg DOTNET_QUALITY="GA" -f Dockerfile.AmazonBaseImage --tag $acrName/amazonlinux-aspnet:10.0 --platform linux/amd64,linux/arm64/v8 --push .
 
 docker buildx  build --build-arg DOTNET_VERSION="8.0" --build-arg DOTNET_QUALITY="GA" -f Dockerfile.FedoraBaseImage --tag $acrName/fedora-aspnet:8.0 --platform linux/amd64,linux/arm64/v8 --push .
-# TODO: UPDATE TO GA QUALITY AND REMOVE -preview IMAGE TAG WHEN .NET 10 IS RELEASED
-docker buildx  build --build-arg DOTNET_VERSION="10.0" --build-arg DOTNET_QUALITY="Preview" -f Dockerfile.FedoraBaseImage --tag $acrName/fedora-aspnet:10.0-preview --platform linux/amd64,linux/arm64/v8 --push .
+docker buildx  build --build-arg DOTNET_VERSION="10.0" --build-arg DOTNET_QUALITY="GA" -f Dockerfile.FedoraBaseImage --tag $acrName/fedora-aspnet:10.0 --platform linux/amd64,linux/arm64/v8 --push .
 ```
 
 4. Disable buildx in Docker Desktop
 `docker buildx rm`
 
 5. Log out of the {container registry name} container repository
-`docker logout $acrName`
+`az logout`
 
 # Enabling Anonymous Pull Access
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Dockerfile
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Dockerfile
@@ -1,48 +1,27 @@
-ARG DISTRO_TAG
+ARG DOTNET_VERSION
 ARG BUILD_ARCH
-# TODO Use stable .NET 10.0 image when available
-FROM --platform=amd64 mcr.microsoft.com/dotnet/aspnet:10.0-preview-trixie-slim AS base
+FROM --platform=amd64 mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS base
 WORKDIR /app
 EXPOSE 80
 
-# TODO: use packages.microsoft.com/config/debian/13 when available
-# Install .NET 8 runtime side-by-side
-RUN apt-get update \
-    && apt-get install -y wget \
-    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \ 
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y aspnetcore-runtime-8.0
-
 # build arch may be different from target arch (i.e., when running locally with QEMU)
-# TODO Use stable .NET 10.0 image when available
-FROM --platform=${BUILD_ARCH} mcr.microsoft.com/dotnet/sdk:10.0-preview-trixie-slim AS build
-
-# TODO: use packages.microsoft.com/config/debian/13 when available
-# Install .NET 8 SDK side-by-side
-RUN apt-get update \
-    && apt-get install -y wget \
-    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \ 
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y dotnet-sdk-8.0
+ARG DOTNET_VERSION
+ARG BUILD_ARCH
+FROM --platform=${BUILD_ARCH} mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
 
 WORKDIR /src
 COPY ["KafkaTestApp/KafkaTestApp.csproj", "KafkaTestApp/"]
 ARG APP_DOTNET_VERSION
-RUN dotnet restore "KafkaTestApp/KafkaTestApp.csproj" -p:TargetFramework=net${APP_DOTNET_VERSION}
+RUN dotnet restore "KafkaTestApp/KafkaTestApp.csproj" -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64
 
 COPY . .
 WORKDIR "/src/KafkaTestApp"
-RUN dotnet build "KafkaTestApp.csproj" -c Release -o /app/build --self-contained --os linux --framework net${APP_DOTNET_VERSION}
+RUN dotnet build "KafkaTestApp.csproj" -c Release -o /app/build --self-contained --framework net${APP_DOTNET_VERSION} -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64 --no-restore
 
 
 FROM build AS publish
 ARG APP_DOTNET_VERSION
-RUN dotnet publish "KafkaTestApp.csproj" -c Release -o /app/publish --self-contained --os linux --framework net${APP_DOTNET_VERSION}
-
+RUN dotnet publish "KafkaTestApp.csproj" -c Release -o /app/publish --self-contained --framework net${APP_DOTNET_VERSION} -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64 --no-restore
 
 FROM base AS final
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Dockerfile
+++ b/tests/Agent/IntegrationTests/ContainerApplications/MemcachedTestApp/Dockerfile
@@ -1,43 +1,27 @@
-ARG DISTRO_TAG
+ARG DOTNET_VERSION
 ARG BUILD_ARCH
-
-# TODO Use stable .NET 10.0 image when available
-FROM --platform=amd64 mcr.microsoft.com/dotnet/aspnet:10.0-preview-trixie-slim AS base
+FROM --platform=amd64 mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS base
 WORKDIR /app
 EXPOSE 80
-# TODO: use packages.microsoft.com/config/debian/13 when available
-RUN apt-get update \
-    && apt-get install -y wget \
-    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y aspnetcore-runtime-8.0
 
 # build arch may be different from target arch (i.e., when running locally with QEMU)
-# TODO Use stable .NET 10.0 image when available
-FROM --platform=${BUILD_ARCH} mcr.microsoft.com/dotnet/sdk:10.0-preview-trixie-slim AS build
-# TODO: use packages.microsoft.com/config/debian/13 when available
-RUN apt-get update \
-    && apt-get install -y wget \
-    && wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && rm packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y dotnet-sdk-8.0
+ARG DOTNET_VERSION
+ARG BUILD_ARCH
+FROM --platform=${BUILD_ARCH} mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+
 WORKDIR /src
 COPY ["MemcachedTestApp/MemcachedTestApp.csproj", "MemcachedTestApp/"]
 ARG APP_DOTNET_VERSION
-RUN dotnet restore "MemcachedTestApp/MemcachedTestApp.csproj" -p:TargetFramework=net${APP_DOTNET_VERSION}
+RUN dotnet restore "MemcachedTestApp/MemcachedTestApp.csproj" -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64
 
 COPY . .
 WORKDIR "/src/MemcachedTestApp"
-RUN dotnet build "MemcachedTestApp.csproj" -c Release -o /app/build --self-contained --os linux --framework net${APP_DOTNET_VERSION}
+RUN dotnet build "MemcachedTestApp.csproj" -c Release -o /app/build --self-contained --framework net${APP_DOTNET_VERSION} -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64 --no-restore
 
 
 FROM build AS publish
 ARG APP_DOTNET_VERSION
-RUN dotnet publish "MemcachedTestApp.csproj" -c Release -o /app/publish --self-contained --os linux --framework net${APP_DOTNET_VERSION}
+RUN dotnet publish "MemcachedTestApp.csproj" -c Release -o /app/publish --self-contained --framework net${APP_DOTNET_VERSION} -p:TargetFramework=net${APP_DOTNET_VERSION} -p:TargetFrameworks=net${APP_DOTNET_VERSION} --runtime linux-x64 --no-restore
 
 
 FROM base AS final

--- a/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.centos
+++ b/tests/Agent/IntegrationTests/ContainerApplications/SmokeTestApp/Dockerfile.centos
@@ -22,15 +22,7 @@ RUN dotnet publish "SmokeTestApp.csproj" -c Release -o /app/publish /p:UseAppHos
 FROM base AS final
 ARG DOTNET_VERSION
 # install asp.netcore
-#TODO: Manually install .NET 10 Preview until official images are available
-RUN curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh \
-  && chmod +x ./dotnet-install.sh \
-  && ./dotnet-install.sh --channel 10.0 --quality preview \
-  && dnf install libicu -y
-ENV PATH="${PATH}:/root/.dotnet:/root/.dotnet/tools"
-
-# TODO Use this line instead of the block above when official .NET 10 images are available
-#RUN dnf install aspnetcore-runtime-${DOTNET_VERSION} -y
+RUN dnf install aspnetcore-runtime-${DOTNET_VERSION} -y
 
 # Enable the agent
 ARG NEW_RELIC_HOST

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-awssdk.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-awssdk.yml
@@ -2,7 +2,7 @@
 #
 # AGENT_PATH      host path to the Agent linux home folder - will map to /usr/local/newrelic-dotnet-agent in the container
 # LOG_PATH        host path for Agent logfile output - will map to /app/logs in the container
-# DISTRO_TAG      distro tag for build, not including the architecture suffix - possible values 8.0-trixie-slim, 8.0-alpine, 8.0-jammy
+# DISTRO_TAG      distro tag for build, not including the architecture suffix
 # TARGET_ARCH     the target architecture for the run -- either amd64 or arm64
 # BUILD_ARCH      the build architecture-- either amd64 or arm64
 # PORT            external port for the smoketest API

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-kafka.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-kafka.yml
@@ -2,7 +2,7 @@
 #
 # AGENT_PATH      host path to the Agent linux home folder - will map to /usr/local/newrelic-dotnet-agent in the container
 # LOG_PATH        host path for Agent logfile output - will map to /app/logs in the container
-# DISTRO_TAG      distro tag for build, not including the architecture suffix - possible values 8.0-trixie-slim, 8.0-alpine, 8.0-jammy
+# DISTRO_TAG      distro tag for build, not including the architecture suffix
 # TARGET_ARCH     the target architecture for the run -- either amd64 or arm64
 # BUILD_ARCH      the build architecture -- either amd64 or arm64
 # PORT            external port for the smoketest API

--- a/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
+++ b/tests/Agent/IntegrationTests/ContainerApplications/docker-compose-memcached.yml
@@ -2,7 +2,7 @@
 #
 # AGENT_PATH      host path to the Agent linux home folder - will map to /usr/local/newrelic-dotnet-agent in the container
 # LOG_PATH        host path for Agent logfile output - will map to /app/logs in the container
-# DISTRO_TAG      distro tag for build, not including the architecture suffix - possible values 8.0-trixie-slim, 8.0-alpine, 8.0-jammy
+# DISTRO_TAG      distro tag for build, not including the architecture suffix
 # TARGET_ARCH     the target architecture for the run -- either amd64 or arm64
 # BUILD_ARCH      the build architecture -- either amd64 or arm64
 # PORT            external port for the smoketest API

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
@@ -10,7 +10,7 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Fixtures;
 
 public abstract class ContainerTestFixtureBase : RemoteApplicationFixture
 {
-    private const string DotnetVersion = "10.0-preview"; // TODO: Update to a stable version when available
+    private const string DotnetVersion = "10.0";
 
     protected override int MaxTries => 1;
 
@@ -31,15 +31,6 @@ public abstract class ContainerTestFixtureBase : RemoteApplicationFixture
     }
 }
 
-public class DebianX64ContainerTestFixture : ContainerTestFixtureBase
-{
-    private const string Dockerfile = "SmokeTestApp/Dockerfile";
-    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
-    private const string DistroTag = "trixie-slim"; // Debian 13
-
-    public DebianX64ContainerTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
-}
-
 public class UbuntuX64ContainerTestFixture : ContainerTestFixtureBase
 {
     private const string Dockerfile = "SmokeTestApp/Dockerfile";
@@ -55,15 +46,6 @@ public class AlpineX64ContainerTestFixture : ContainerTestFixtureBase
     private const string DistroTag = "alpine";
 
     public AlpineX64ContainerTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
-}
-
-public class DebianArm64ContainerTestFixture : ContainerTestFixtureBase
-{
-    private const string Dockerfile = "SmokeTestApp/Dockerfile";
-    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.Arm64;
-    private const string DistroTag = "trixie-slim"; // Debian 13
-
-    public DebianArm64ContainerTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
 }
 
 public class UbuntuArm64ContainerTestFixture : ContainerTestFixtureBase

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
@@ -58,7 +58,7 @@ public class KafkaDotNet8TestFixture : KafkaTestFixtureBase
 {
     private const string Dockerfile = "KafkaTestApp/Dockerfile";
     private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
-    private const string DistroTag = "trixie-slim";
+    private const string DistroTag = "noble";
     private const string DotnetVersion = "8.0";
 
     public KafkaDotNet8TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }
@@ -68,7 +68,7 @@ public class KafkaDotNet10TestFixture : KafkaTestFixtureBase
 {
     private const string Dockerfile = "KafkaTestApp/Dockerfile";
     private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
-    private const string DistroTag = "trixie-slim";
+    private const string DistroTag = "noble";
     private const string DotnetVersion = "10.0";
 
     public KafkaDotNet10TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/MemcachedTestFixtures.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using NewRelic.Agent.ContainerIntegrationTests.Applications;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using Xunit;
 
 namespace NewRelic.Agent.ContainerIntegrationTests.Fixtures;
 
@@ -38,25 +37,21 @@ public abstract class MemcachedTestFixtureBase : RemoteApplicationFixture
 }
 
 
-[Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
 public class MemcachedDotNet8TestFixture : MemcachedTestFixtureBase
 {
     private const string Dockerfile = "MemcachedTestApp/Dockerfile";
     private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
-    private const string DistroTag = "trixie-slim";
+    private const string DistroTag = "noble";
     private const string DotnetVersion = "8.0";
 
     public MemcachedDotNet8TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }
 }
 
-[Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
 public class MemcachedDotNet10TestFixture : MemcachedTestFixtureBase
 {
     private const string Dockerfile = "MemcachedTestApp/Dockerfile";
     private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
-    private const string DistroTag = "trixie-slim";
+    private const string DistroTag = "noble";
     private const string DotnetVersion = "10.0";
 
     public MemcachedDotNet10TestFixture() : base(DistroTag, Architecture, Dockerfile, DotnetVersion) { }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
@@ -76,11 +76,6 @@ public abstract class InfiniteTracingContainerTest<T> : NewRelicIntegrationTest<
 
 // only testing on a subset of linux distros to keep total test runtime under control. Additional distros can be uncommented below if needed.
 
-[Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
-public class DebianX64InfiniteTracingContainerTest(DebianX64ContainerTestFixture fixture, ITestOutputHelper output)
-    : InfiniteTracingContainerTest<DebianX64ContainerTestFixture>(fixture, output);
-
 //[Trait("Architecture", "amd64")]
 //public class UbuntuX64InfiniteTracingContainerTest(UbuntuX64ContainerTestFixture fixture, ITestOutputHelper output)
 //    : InfiniteTracingContainerTest<UbuntuX64ContainerTestFixture>(fixture, output);
@@ -89,11 +84,6 @@ public class DebianX64InfiniteTracingContainerTest(DebianX64ContainerTestFixture
 [Trait("Distro", "Alpine")]
 public class AlpineX64InfiniteTracingContainerTest(AlpineX64ContainerTestFixture fixture, ITestOutputHelper output)
     : InfiniteTracingContainerTest<AlpineX64ContainerTestFixture>(fixture, output);
-
-[Trait("Architecture", "arm64")]
-[Trait("Distro", "Debian")]
-public class DebianArm64InfiniteTracingContainerTest(DebianArm64ContainerTestFixture fixture, ITestOutputHelper output)
-    : InfiniteTracingContainerTest<DebianArm64ContainerTestFixture>(fixture, output);
 
 //[Trait("Architecture", "arm64")]
 //public class UbuntuArm64InfiniteTracingContainerTest(UbuntuArm64ContainerTestFixture fixture, ITestOutputHelper output)

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -135,7 +135,7 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
 }
 
 [Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
+[Trait("Distro", "Ubuntu")]
 public class KafkaDotNet8Test : LinuxKafkaTest<KafkaDotNet8TestFixture>
 {
     public KafkaDotNet8Test(KafkaDotNet8TestFixture fixture, ITestOutputHelper output) : base(fixture, output)
@@ -144,7 +144,7 @@ public class KafkaDotNet8Test : LinuxKafkaTest<KafkaDotNet8TestFixture>
 }
 
 [Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
+[Trait("Distro", "Ubuntu")]
 public class KafkaDotNet10Test : LinuxKafkaTest<KafkaDotNet10TestFixture>
 {
     public KafkaDotNet10Test(KafkaDotNet10TestFixture fixture, ITestOutputHelper output) : base(fixture, output)

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
@@ -47,15 +47,6 @@ public abstract class LinuxContainerTest<T> : NewRelicIntegrationTest<T> where T
 }
 
 [Trait("Architecture", "amd64")]
-[Trait("Distro", "Debian")]
-public class DebianX64ContainerTest : LinuxContainerTest<DebianX64ContainerTestFixture>
-{
-    public DebianX64ContainerTest(DebianX64ContainerTestFixture fixture, ITestOutputHelper output) : base(fixture, output)
-    {
-    }
-}
-
-[Trait("Architecture", "amd64")]
 [Trait("Distro", "Ubuntu")]
 public class UbuntuX64ContainerTest : LinuxContainerTest<UbuntuX64ContainerTestFixture>
 {
@@ -69,15 +60,6 @@ public class UbuntuX64ContainerTest : LinuxContainerTest<UbuntuX64ContainerTestF
 public class AlpineX64ContainerTest : LinuxContainerTest<AlpineX64ContainerTestFixture>
 {
     public AlpineX64ContainerTest(AlpineX64ContainerTestFixture fixture, ITestOutputHelper output) : base(fixture, output)
-    {
-    }
-}
-
-[Trait("Architecture", "arm64")]
-[Trait("Distro", "Debian")]
-public class DebianArm64ContainerTest : LinuxContainerTest<DebianArm64ContainerTestFixture>
-{
-    public DebianArm64ContainerTest(DebianArm64ContainerTestFixture fixture, ITestOutputHelper output) : base(fixture, output)
     {
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/MemcachedTests.cs
@@ -128,7 +128,7 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
     }
 
     [Trait("Architecture", "amd64")]
-   [Trait("Distro", "Debian")]
+   [Trait("Distro", "Ubuntu")]
     public class MemcachedDotNet8Test : LinuxMemcachedTest<MemcachedDotNet8TestFixture>
     {
         public MemcachedDotNet8Test(MemcachedDotNet8TestFixture fixture, ITestOutputHelper output) : base(fixture, output)
@@ -137,7 +137,7 @@ namespace NewRelic.Agent.ContainerIntegrationTests.Tests
     }
 
     [Trait("Architecture", "amd64")]
-   [Trait("Distro", "Debian")]
+   [Trait("Distro", "Ubuntu")]
     public class MemcachedDotNet10Test : LinuxMemcachedTest<MemcachedDotNet10TestFixture>
     {
         public MemcachedDotNet10Test(MemcachedDotNet10TestFixture fixture, ITestOutputHelper output) : base(fixture, output)


### PR DESCRIPTION
* Updates all container integration tests to use the GA version of .NET 10
* Removes Debian from container tests, since Microsoft no longer publishes new .NET images on Debian
*  Converts Kafka and Memcached container tests to run on Ubuntu instead of Debian and simplifies the container build so that .NET 8 and 10 don't both have to be installed on the base image.
* Updates instructions for building new Amazon Linux and Fedora base images with .NET 10 pre-installed