### PR TITLE
ci: Use NuGet "Trusted Publishing" to publish packages

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -277,15 +277,6 @@ jobs:
         id: login
         with:
           user: ${{ secrets.NUGET_TRUSTED_PUBLISH_POLICY_USER }}
-      
-      - name: Validate NuGet API key
-        run: |
-          if ([string]::IsNullOrWhiteSpace("${{ steps.login.outputs.NUGET_API_KEY }}")) {
-            Write-Host "::error::NuGet API key from login step is empty or not set. Failing job."
-            exit 1
-          }
-          Write-Host "NuGet API key acquired (masked)."
-        shell: powershell
         
       - name: Deploy Agent to Nuget
         run: |


### PR DESCRIPTION
Updates the `deploy_agent.yml` workflow to use [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) in lieu of an API key. This change eliminates the need to manage and rotate an API key for Nuget publishing. 

The trusted publishing certificate is tied to a specific NuGet user; the name of that user is in the `NUGET_TRUSTED_PUBLISH_POLICY_USER` secret. 

See this [successful test run](https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/20108415457/job/57698886541#step:3:11) (login but no package deployment).