### PR TITLE
test: Update ConsoleLoggingTests to complete faster

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/ConsoleLoggingTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentLogs/ConsoleLoggingTests.cs
@@ -18,6 +18,7 @@ namespace NewRelic.Agent.IntegrationTests.AgentLogs
             _fixture = fixture;
             _fixture.SetTimeout(TimeSpan.FromMinutes(1));
             _fixture.TestLogger = output;
+            _fixture.AgentLogExpected = false;
 
             _fixture.AddCommand($"RootCommands InstrumentedMethodToStartAgent");
             _fixture.AddCommand($"RootCommands DelaySeconds 10");


### PR DESCRIPTION
The ConsoleLoggingTests verify that console logging works correctly. But they each run for upwards of 5 minutes, because they're waiting for an agent log file that will never get generated. This has made the AgentLogs namespace one of the longest running namespaces in our test suite.

A simple one line change resolves that issue, allowing the tests to complete in about 30 seconds each.