### PR TITLE
chore: Prefer file-scoped namespace by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -160,6 +160,9 @@ csharp_style_prefer_null_check_over_type_check = true:suggestion
 csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
 
+# Code-block preferences
+csharp_style_namespace_declarations = file_scoped:suggestion
+
 # error if file doesn't have the required header
 dotnet_diagnostic.SA1633.severity = error
 


### PR DESCRIPTION
Modifies `.editorconfig` to prefer file-scoped namespace. 

When new classes are added via the UI, they'll automatically get a file-scoped namespace; for existing code, you'll see a suggestion in the build output if you turn on "messages:
<img width="417" height="141" alt="image" src="https://github.com/user-attachments/assets/76824142-712a-49c6-ac0f-cfe40a40fc6e" />
