### PR TITLE
fix: Restore min/max occurs properties on `<distributedTracing>` config element.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd
@@ -126,7 +126,7 @@
             </xs:documentation>
         </xs:annotation>
     </xs:complexType>
-    
+
     <xs:element name="configuration">
         <xs:complexType>
             <xs:all>
@@ -1289,7 +1289,7 @@
                     </xs:complexType>
                 </xs:element>
 
-                <xs:element name="distributedTracing">
+                <xs:element name="distributedTracing" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the transition guide before you enable this feature: https://docs.newrelic.com/docs/transition-guide-distributed-tracing
@@ -1413,7 +1413,7 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
-                
+
                 <xs:element name="spanEvents" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Restore min/max occurs properties on `distributedTracing` config element. (#3381) (#3388)
END_COMMIT_OVERRIDE

Fixes #3381
