### PR TITLE
fix: Fix agent connection error when debug logging is enabled.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -93,11 +93,12 @@ namespace NewRelic.Agent.Core.Configuration
                 }
                 else
                 {
+                    var valueToLog = value;
                     if (key.Equals(Constants.AppSettingsLicenseKey))
                     {
-                        value = Strings.ObfuscateLicenseKey(value);
+                        valueToLog = Strings.ObfuscateLicenseKey(value);
                     }
-                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={value}'");
+                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={valueToLog}'");
                 }
             }
 


### PR DESCRIPTION
Thank you for submitting a pull request.  Please review our [contributing guidelines](/CONTRIBUTING.md) and [code of conduct](https://opensource.newrelic.com/code-of-conduct/).

## Description

Fixes a problem that is caused when the agent log is more verbose than `info` and the license key is specified in the application's appsettings.json file. 

I manually verified that the license key is obfuscated on all log lines in the agent log file even at the `finest` (most verbose) log level.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
