### PR TITLE
ci: Update post-deploy YUM repo validation to use the same process in user documentation

### DIFF
--- a/deploy/validation/validate-yum/Dockerfile
+++ b/deploy/validation/validate-yum/Dockerfile
@@ -1,8 +1,6 @@
 FROM rockylinux:9.2.20230513@sha256:b07e21a7bbcecbae55b9153317d333d4d50808bf5dc0859db0180b6fbd7afb3d
 
-RUN yum install wget -y \
-    && wget https://download.newrelic.com/548C16BF.gpg -O /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic \
-    && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
+RUN curl -o /etc/yum.repos.d/newrelic-dotnet-agent.repo https://download.newrelic.com/dot_net_agent/yum/newrelic-dotnet-agent.repo
 
 COPY --chmod=777 check-version.sh /tmp/
 

--- a/deploy/validation/validate-yum/check-version.sh
+++ b/deploy/validation/validate-yum/check-version.sh
@@ -2,15 +2,6 @@
 
 set -e
 
-cat << REPO | tee "/etc/yum.repos.d/newrelic-dotnet-agent.repo"
-[newrelic-dotnet-agent-repo]
-name=New Relic .NET Core packages for Enterprise Linux
-baseurl=https://yum.newrelic.com/pub/newrelic/el7/\$basearch
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
-REPO
-
 yum install newrelic-dotnet-agent -y
 
 rpm -q --queryformat '%{VERSION}\n' newrelic-dotnet-agent


### PR DESCRIPTION
Not only is this better from a "test the product the way you expect customers to use it" perspective, it will work with the latest agent versions that use a newer GPG key to sign the RPMs.

