### PR TITLE
ci: Release Please updates

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -36,6 +36,8 @@ env:
 jobs:
   check-modified-files:
     name: Check if source files were modified, skip remaining jobs if not
+    # skip if the PR source branch starts with "release-please"
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please')
     uses: ./.github/workflows/check_modified_files.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           token: ${{ secrets.DOTNET_AGENT_GH_TOKEN }}
           config-file: release-please/release-please-config.json


### PR DESCRIPTION
* Modifies the the `release-please` action to use the new official source, based on a [deprecation notice](https://github.com/google-github-actions/release-please-action/tree/e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee/?tab=readme-ov-file#deprecated-release-please-action---please-use-httpsgithubcomgoogleapisrelease-please-action) from the previous source and uses the latest version of the action.
* Modifies `all_solutions.yml` so that the workflow doesn't run on `release-please` PR branches