### PR TITLE
chore: Fix indentation issues in newrelic.config

### DIFF
--- a/src/Agent/Configuration/newrelic.config
+++ b/src/Agent/Configuration/newrelic.config
@@ -33,11 +33,11 @@
 		</ignoreStatusCodes>
 	</errorCollector>
 	<browserMonitoring autoInstrument="true">
-    <requestPathsExcluded>
-      <path regex="WebResource\.axd" />
-      <path regex="ScriptResource\.axd" />
-    </requestPathsExcluded>
-  </browserMonitoring>
+		<requestPathsExcluded>
+			<path regex="WebResource\.axd" />
+			<path regex="ScriptResource\.axd" />
+		</requestPathsExcluded>
+	</browserMonitoring>
 	<threadProfiling>
 		<ignoreMethod>System.Threading.WaitHandle:InternalWaitOne</ignoreMethod>
 		<ignoreMethod>System.Threading.WaitHandle:WaitAny</ignoreMethod>


### PR DESCRIPTION
I noticed some indentation oddities when looking at the default `newrelic.config` recently.  Turns out to be a tabs-vs-spaces thing, which would not be apparent if "Show whitespace" isn't enabled in Visual Studio.