### PR TITLE
fix: Properly handle unsupported DynamoDB SDK requests (#3403)

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/RequestHandlers/DynamoDbRequestHandler.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/RequestHandlers/DynamoDbRequestHandler.cs
@@ -1,71 +1,103 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.AwsSdk;
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
-namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers
+namespace NewRelic.Providers.Wrapper.AwsSdk.RequestHandlers;
+
+internal static class DynamoDbRequestHandler
 {
-    internal static class DynamoDbRequestHandler
+    private static readonly ConcurrentDictionary<string, string> _operationNameCache = new();
+
+    // per the spec, these are the only DynamoDB request types that we support
+    // -- everything else should get a NoOp, which will allow the HttpClient instrumentation to create an external segment for the call.
+    private static readonly HashSet<string> _supportedRequestTypes = new()
     {
-        private static readonly ConcurrentDictionary<string, string> _operationNameCache = new();
+        "CreateTableRequest",
+        "DeleteItemRequest",
+        "DeleteTableRequest",
+        "GetItemRequest",
+        "PutItemRequest",
+        "QueryRequest",
+        "ScanRequest",
+        "UpdateItemRequest"
+    };
 
-        public static AfterWrappedMethodDelegate HandleDynamoDbRequest(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction, dynamic request, bool isAsync, ArnBuilder builder)
+    public static AfterWrappedMethodDelegate HandleDynamoDbRequest(InstrumentedMethodCall instrumentedMethodCall, IAgent agent, ITransaction transaction, dynamic request, bool isAsync, ArnBuilder builder)
+    {
+        var requestType = ((object)request).GetType().Name;
+        if (!_supportedRequestTypes.Contains(requestType))
         {
-            var requestType = ((object)request).GetType().Name;
+            agent.Logger.Debug("DynamoDbRequestHandler: {requestType} is not a supported request type.", requestType);
+            return Delegates.NoOp;
+        }
 
-            var operation = _operationNameCache.GetOrAdd(requestType, requestType.Replace("Request", string.Empty).ToSnakeCase());
+        var operation = _operationNameCache.GetOrAdd(requestType, requestType.Replace("Request", string.Empty).ToSnakeCase());
 
-            // all request objects implement a TableName property
-            string model = request.TableName;
+        string model = null;
+        try
+        {
+            model = request.TableName;
+        }
+        catch (Exception) // this shouldn't happen, as the TableName property should exist on all supported request types
+        {
+            agent.Logger.Debug("DynamoDbRequestHandler: {requestType} does not have a TableName property. Not building an ARN for this request.", requestType);
+        }
 
-            var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, new ParsedSqlStatement(DatastoreVendor.DynamoDB, model, operation), isLeaf: true);
+        var segment = transaction.StartDatastoreSegment(instrumentedMethodCall.MethodCall, new ParsedSqlStatement(DatastoreVendor.DynamoDB, model, operation), isLeaf: true);
 
+        // build the ARN if we have a model (table name)
+        if (!string.IsNullOrEmpty(model))
+        {
             var arn = builder.Build("dynamodb", $"table/{model}");
             if (!string.IsNullOrEmpty(arn))
                 segment.AddCloudSdkAttribute("cloud.resource_id", arn);
-            segment.AddCloudSdkAttribute("aws.operation", operation);
-            segment.AddCloudSdkAttribute("aws.region", builder.Region);
-
-            return isAsync ?
-                Delegates.GetAsyncDelegateFor<Task>(agent, segment, true, responseTask =>
-                {
-                    try
-                    {
-                        if (responseTask.IsFaulted)
-                            transaction.NoticeError(responseTask.Exception);
-                        else
-                            SetRequestIdIfAvailable(agent, segment, ((dynamic)responseTask).Result);
-                    }
-                    finally
-                    {
-                        segment.End();
-                    }
-
-                }, TaskContinuationOptions.ExecuteSynchronously)
-                :
-                Delegates.GetDelegateFor<object>(
-                    onFailure: segment.End,
-                    onSuccess: response =>
-                    {
-                        SetRequestIdIfAvailable(agent, segment, response);
-                        segment.End();
-                    }
-            );
-
         }
 
-        private static void SetRequestIdIfAvailable(IAgent agent, ISegment segment, dynamic response)
-        {
-            if (response != null && response.ResponseMetadata != null && response.ResponseMetadata.RequestId != null)
+        segment.AddCloudSdkAttribute("aws.operation", operation);
+        segment.AddCloudSdkAttribute("aws.region", builder.Region);
+
+        return isAsync ?
+            Delegates.GetAsyncDelegateFor<Task>(agent, segment, true, responseTask =>
             {
-                string requestId = response.ResponseMetadata.RequestId;
-                segment.AddCloudSdkAttribute("aws.requestId", requestId);
-            }
+                try
+                {
+                    if (responseTask.IsFaulted)
+                        transaction.NoticeError(responseTask.Exception);
+                    else
+                        SetRequestIdIfAvailable(agent, segment, ((dynamic)responseTask).Result);
+                }
+                finally
+                {
+                    segment.End();
+                }
+
+            }, TaskContinuationOptions.ExecuteSynchronously)
+            :
+            Delegates.GetDelegateFor<object>(
+                onFailure: segment.End,
+                onSuccess: response =>
+                {
+                    SetRequestIdIfAvailable(agent, segment, response);
+                    segment.End();
+                }
+            );
+
+    }
+
+    private static void SetRequestIdIfAvailable(IAgent agent, ISegment segment, dynamic response)
+    {
+        if (response != null && response.ResponseMetadata != null && response.ResponseMetadata.RequestId != null)
+        {
+            string requestId = response.ResponseMetadata.RequestId;
+            segment.AddCloudSdkAttribute("aws.requestId", requestId);
         }
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkDynamoDBTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkDynamoDBTest.cs
@@ -84,8 +84,6 @@ public class AwsSdkDynamoDBTest : NewRelicIntegrationTest<AwsSdkContainerDynamoD
         {
             new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/create_table", callCount = 1},
             new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/create_table", callCount = 1, metricScope = createTableScope},
-            new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/describe_table", callCount = 1},
-            new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/describe_table", callCount = 1, metricScope = createTableScope},
             new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/put_item", callCount = 1},
             new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/put_item", callCount = 1, metricScope = putItemScope},
             new() { metricName = $"Datastore/statement/DynamoDB/{_tableName}/get_item", callCount = 1},
@@ -103,7 +101,7 @@ public class AwsSdkDynamoDBTest : NewRelicIntegrationTest<AwsSdkContainerDynamoD
 
         };
 
-        var expectedOperations = new[] { "create_table", "describe_table", "put_item", "get_item", "update_item", "delete_item", "query", "scan", "delete_table" };
+        var expectedOperations = new[] { "create_table", "put_item", "get_item", "update_item", "delete_item", "query", "scan", "delete_table" };
         var expectedOperationsCount = expectedOperations.Length;
 
         string expectedArn = $"arn:aws:dynamodb:(unknown):{_accountId}:table/{_tableName}";


### PR DESCRIPTION
Updates DynamoDB instrumentation so that it properly handles requests that are not supported, without causing the instrumentation to become disabled. Unsupported requests will still have an external (Http) segment but will not have a datastore segment. 

Includes updated integration tests.

Resolves #3403.