### PR TITLE
chore: Ignore local claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ build/Linux/keys
 /build/_staging
 
 # Claude AI settings
-.claude/settings.local.json
+.claude


### PR DESCRIPTION
Ignores the `.claude` folder in the root of the repo; that folder is for user-specific local claude code settings.