### PR TITLE
chore: Refactor code to use file-scoped namespaces phase 1 (A-C)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthEvent.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthEvent.cs
@@ -1,17 +1,16 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public enum AgentHealthEvent
 {
-    public enum AgentHealthEvent
-    {
-        TransactionGarbageCollected,
-        WrapperShutdown,
-        Transaction,
-        Log,
-        Custom,
-        Error,
-        Span,
-        InfiniteTracingSpan
-    }
+    TransactionGarbageCollected,
+    WrapperShutdown,
+    Transaction,
+    Log,
+    Custom,
+    Error,
+    Span,
+    InfiniteTracingSpan
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -20,1120 +20,1119 @@ using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public class AgentHealthReporter : ConfigurationBasedService, IAgentHealthReporter
 {
-    public class AgentHealthReporter : ConfigurationBasedService, IAgentHealthReporter
+    private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(2);
+
+    private readonly IMetricBuilder _metricBuilder;
+    private readonly IScheduler _scheduler;
+    private readonly IFileWrapper _fileWrapper;
+    private readonly IDirectoryWrapper _directoryWrapper;
+    private readonly IList<string> _recurringLogData = new ConcurrentList<string>();
+    private readonly IDictionary<AgentHealthEvent, InterlockedCounter> _agentHealthEventCounters = new Dictionary<AgentHealthEvent, InterlockedCounter>();
+    private readonly ConcurrentDictionary<string, InterlockedCounter> _logLinesCountByLevel = new ConcurrentDictionary<string, InterlockedCounter>();
+    private readonly ConcurrentDictionary<string, InterlockedCounter> _logDeniedCountByLevel = new ConcurrentDictionary<string, InterlockedCounter>();
+
+    private PublishMetricDelegate _publishMetricDelegate;
+    private InterlockedCounter _payloadCreateSuccessCounter;
+    private InterlockedCounter _payloadAcceptSuccessCounter;
+
+    private InterlockedCounter _traceContextCreateSuccessCounter;
+    private InterlockedCounter _traceContextAcceptSuccessCounter;
+    private InterlockedCounter _distributedTraceHeadersAcceptedLateCounter = new InterlockedCounter();
+
+    private readonly InterlockedCounter _customInstrumentationCounter;
+    private readonly HashSet<string> _customInstrumentationIds = new();
+    private bool _customInstrumentationMaxLogged;
+
+    private HealthCheck _healthCheck;
+    private bool _healthChecksInitialized;
+    private bool _healthChecksFailed;
+    private string _healthCheckPath;
+
+    /// <remarks>
+    /// This class is resolved very early during startup. Be careful about adding dependencies.
+    /// </remarks>
+    public AgentHealthReporter(IMetricBuilder metricBuilder, IScheduler scheduler, IFileWrapper fileWrapper, IDirectoryWrapper directoryWrapper)
     {
-        private static readonly TimeSpan _timeBetweenExecutions = TimeSpan.FromMinutes(2);
+        _metricBuilder = metricBuilder;
+        _scheduler = scheduler;
+        _fileWrapper = fileWrapper;
+        _directoryWrapper = directoryWrapper;
 
-        private readonly IMetricBuilder _metricBuilder;
-        private readonly IScheduler _scheduler;
-        private readonly IFileWrapper _fileWrapper;
-        private readonly IDirectoryWrapper _directoryWrapper;
-        private readonly IList<string> _recurringLogData = new ConcurrentList<string>();
-        private readonly IDictionary<AgentHealthEvent, InterlockedCounter> _agentHealthEventCounters = new Dictionary<AgentHealthEvent, InterlockedCounter>();
-        private readonly ConcurrentDictionary<string, InterlockedCounter> _logLinesCountByLevel = new ConcurrentDictionary<string, InterlockedCounter>();
-        private readonly ConcurrentDictionary<string, InterlockedCounter> _logDeniedCountByLevel = new ConcurrentDictionary<string, InterlockedCounter>();
+        _subscriptions.Add<AgentConnectedEvent>(e => OnAgentConnected());
 
-        private PublishMetricDelegate _publishMetricDelegate;
-        private InterlockedCounter _payloadCreateSuccessCounter;
-        private InterlockedCounter _payloadAcceptSuccessCounter;
-
-        private InterlockedCounter _traceContextCreateSuccessCounter;
-        private InterlockedCounter _traceContextAcceptSuccessCounter;
-        private InterlockedCounter _distributedTraceHeadersAcceptedLateCounter = new InterlockedCounter();
-
-        private readonly InterlockedCounter _customInstrumentationCounter;
-        private readonly HashSet<string> _customInstrumentationIds = new();
-        private bool _customInstrumentationMaxLogged;
-
-        private HealthCheck _healthCheck;
-        private bool _healthChecksInitialized;
-        private bool _healthChecksFailed;
-        private string _healthCheckPath;
-
-        /// <remarks>
-        /// This class is resolved very early during startup. Be careful about adding dependencies.
-        /// </remarks>
-        public AgentHealthReporter(IMetricBuilder metricBuilder, IScheduler scheduler, IFileWrapper fileWrapper, IDirectoryWrapper directoryWrapper)
+        var agentHealthEvents = Enum.GetValues(typeof(AgentHealthEvent)) as AgentHealthEvent[];
+        foreach (var agentHealthEvent in agentHealthEvents)
         {
-            _metricBuilder = metricBuilder;
-            _scheduler = scheduler;
-            _fileWrapper = fileWrapper;
-            _directoryWrapper = directoryWrapper;
-
-            _subscriptions.Add<AgentConnectedEvent>(e => OnAgentConnected());
-
-            var agentHealthEvents = Enum.GetValues(typeof(AgentHealthEvent)) as AgentHealthEvent[];
-            foreach (var agentHealthEvent in agentHealthEvents)
-            {
-                _agentHealthEventCounters[agentHealthEvent] = new InterlockedCounter();
-            }
-
-            _payloadCreateSuccessCounter = new InterlockedCounter();
-            _payloadAcceptSuccessCounter = new InterlockedCounter();
-            _traceContextAcceptSuccessCounter = new InterlockedCounter();
-            _traceContextCreateSuccessCounter = new InterlockedCounter();
-            _customInstrumentationCounter = new InterlockedCounter();
-
-            if (_configuration.AgentControlEnabled)
-            {
-                _healthCheck = new() { IsHealthy = true, Status = "Agent starting", LastError = string.Empty };
-            }
+            _agentHealthEventCounters[agentHealthEvent] = new InterlockedCounter();
         }
 
-        public override void Dispose()
+        _payloadCreateSuccessCounter = new InterlockedCounter();
+        _payloadAcceptSuccessCounter = new InterlockedCounter();
+        _traceContextAcceptSuccessCounter = new InterlockedCounter();
+        _traceContextCreateSuccessCounter = new InterlockedCounter();
+        _customInstrumentationCounter = new InterlockedCounter();
+
+        if (_configuration.AgentControlEnabled)
         {
-            _scheduler.StopExecuting(LogPeriodicReport);
-            base.Dispose();
+            _healthCheck = new() { IsHealthy = true, Status = "Agent starting", LastError = string.Empty };
         }
+    }
 
-        public void OnAgentConnected()
+    public override void Dispose()
+    {
+        _scheduler.StopExecuting(LogPeriodicReport);
+        base.Dispose();
+    }
+
+    public void OnAgentConnected()
+    {
+        Log.Debug("AgentHealthReporter: Agent is connected. Initializing health checks.");
+
+        // start the heartbeat timer
+        _scheduler.ExecuteEvery(LogPeriodicReport, _timeBetweenExecutions);
+
+        if (!_configuration.AgentControlEnabled)
+            Log.Debug("Agent Control is disabled. Health checks will not be reported.");
+        else
         {
-            Log.Debug("AgentHealthReporter: Agent is connected. Initializing health checks.");
+            Log.Debug("Agent Control health checks will be published every {HealthCheckInterval} seconds", _configuration.HealthFrequency);
 
-            // start the heartbeat timer
-            _scheduler.ExecuteEvery(LogPeriodicReport, _timeBetweenExecutions);
+            // schedule the health check and issue the first one immediately
+            _scheduler.ExecuteEvery(PublishAgentControlHealthCheck, TimeSpan.FromSeconds(_configuration.HealthFrequency), TimeSpan.Zero);
+        }
+    }
 
-            if (!_configuration.AgentControlEnabled)
-                Log.Debug("Agent Control is disabled. Health checks will not be reported.");
-            else
+    private void LogPeriodicReport()
+    {
+        foreach (var logMessage in _recurringLogData)
+        {
+            Log.Debug(logMessage);
+        }
+        List<string> events = new List<string>();
+        foreach (var counter in _agentHealthEventCounters)
+        {
+            if (counter.Value != null && counter.Value.Value > 0)
             {
-                Log.Debug("Agent Control health checks will be published every {HealthCheckInterval} seconds", _configuration.HealthFrequency);
-
-                // schedule the health check and issue the first one immediately
-                _scheduler.ExecuteEvery(PublishAgentControlHealthCheck, TimeSpan.FromSeconds(_configuration.HealthFrequency), TimeSpan.Zero);
+                var agentHealthEvent = counter.Key;
+                var timesOccured = counter.Value.Exchange(0);
+                events.Add(string.Format("{0} {1} {2}", timesOccured, agentHealthEvent, (timesOccured == 1) ? "event" : "events"));
             }
         }
+        var message = events.Count > 0 ? string.Join(", ", events) : "No events";
+        Log.Info($"AgentHealthReporter: In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
+    }
 
-        private void LogPeriodicReport()
-        {
-            foreach (var logMessage in _recurringLogData)
-            {
-                Log.Debug(logMessage);
-            }
-            List<string> events = new List<string>();
-            foreach (var counter in _agentHealthEventCounters)
-            {
-                if (counter.Value != null && counter.Value.Value > 0)
-                {
-                    var agentHealthEvent = counter.Key;
-                    var timesOccured = counter.Value.Exchange(0);
-                    events.Add(string.Format("{0} {1} {2}", timesOccured, agentHealthEvent, (timesOccured == 1) ? "event" : "events"));
-                }
-            }
-            var message = events.Count > 0 ? string.Join(", ", events) : "No events";
-            Log.Info($"AgentHealthReporter: In the last {_timeBetweenExecutions.TotalMinutes} minutes: {message}");
-        }
+    public void ReportSupportabilityCountMetric(string metricName, long count = 1)
+    {
+        var metric = _metricBuilder.TryBuildSupportabilityCountMetric(metricName, count);
+        TrySend(metric);
+    }
 
-        public void ReportSupportabilityCountMetric(string metricName, long count = 1)
-        {
-            var metric = _metricBuilder.TryBuildSupportabilityCountMetric(metricName, count);
-            TrySend(metric);
-        }
+    public void ReportSupportabilityDataUsageMetric(string metricName, long callCount, float bytesSent, float bytesReceived)
+    {
+        var metric = _metricBuilder.TryBuildSupportabilityDataUsageMetric(metricName, callCount, bytesSent, bytesReceived);
+        TrySend(metric);
+    }
 
-        public void ReportSupportabilityDataUsageMetric(string metricName, long callCount, float bytesSent, float bytesReceived)
-        {
-            var metric = _metricBuilder.TryBuildSupportabilityDataUsageMetric(metricName, callCount, bytesSent, bytesReceived);
-            TrySend(metric);
-        }
-
-        private void ReportSupportabilitySummaryMetric(string metricName, float totalSize, int countSamples, float minValue, float maxValue)
-        {
-            var metric = _metricBuilder.TryBuildSupportabilitySummaryMetric(metricName, totalSize, countSamples, minValue, maxValue);
-            TrySend(metric);
-        }
+    private void ReportSupportabilitySummaryMetric(string metricName, float totalSize, int countSamples, float minValue, float maxValue)
+    {
+        var metric = _metricBuilder.TryBuildSupportabilitySummaryMetric(metricName, totalSize, countSamples, minValue, maxValue);
+        TrySend(metric);
+    }
 
 
-        private void ReportSupportabilityGaugeMetric(string metricName, float value)
-        {
-            var metric = _metricBuilder.TryBuildSupportabilityGaugeMetric(metricName, value);
-            TrySend(metric);
-        }
+    private void ReportSupportabilityGaugeMetric(string metricName, float value)
+    {
+        var metric = _metricBuilder.TryBuildSupportabilityGaugeMetric(metricName, value);
+        TrySend(metric);
+    }
 
-        public void ReportCountMetric(string metricName, long count)
-        {
-            var metric = _metricBuilder.TryBuildCountMetric(metricName, count);
-            TrySend(metric);
-        }
-        public void ReportByteMetric(string metricName, long totalBytes, long? exclusiveBytes = null)
-        {
-            var metric = _metricBuilder.TryBuildByteMetric(metricName, totalBytes, exclusiveBytes);
-            TrySend(metric);
-        }
+    public void ReportCountMetric(string metricName, long count)
+    {
+        var metric = _metricBuilder.TryBuildCountMetric(metricName, count);
+        TrySend(metric);
+    }
+    public void ReportByteMetric(string metricName, long totalBytes, long? exclusiveBytes = null)
+    {
+        var metric = _metricBuilder.TryBuildByteMetric(metricName, totalBytes, exclusiveBytes);
+        TrySend(metric);
+    }
 
 
 
-        public void ReportDotnetVersion()
-        {
+    public void ReportDotnetVersion()
+    {
 #if NETFRAMEWORK
             var metric = _metricBuilder.TryBuildDotnetFrameworkVersionMetric(AgentInstallConfiguration.DotnetFrameworkVersion);
 #else
-            var metric = _metricBuilder.TryBuildDotnetCoreVersionMetric(AgentInstallConfiguration.DotnetCoreVersion);
+        var metric = _metricBuilder.TryBuildDotnetCoreVersionMetric(AgentInstallConfiguration.DotnetCoreVersion);
 #endif
-            TrySend(metric);
+        TrySend(metric);
+    }
+
+    public void ReportAgentVersion(string agentVersion)
+    {
+        TrySend(_metricBuilder.TryBuildAgentVersionMetric(agentVersion));
+    }
+
+    public void ReportLibraryVersion(string assemblyName, string assemblyVersion)
+    {
+        TrySend(_metricBuilder.TryBuildLibraryVersionMetric(assemblyName, assemblyVersion));
+    }
+
+    public void ReportCustomInstrumentation(string assemblyName, string className, string method)
+    {
+        // record only unique custom instrumentation metrics
+        var uniqueIdentifier = $"{assemblyName}.{className}.{method}";
+        if (!_customInstrumentationIds.Add(uniqueIdentifier))
+        {
+            return;
         }
 
-        public void ReportAgentVersion(string agentVersion)
-        {
-            TrySend(_metricBuilder.TryBuildAgentVersionMetric(agentVersion));
-        }
+        // always report the custom instrumentation count metric
+        _customInstrumentationCounter.Increment();
 
-        public void ReportLibraryVersion(string assemblyName, string assemblyVersion)
+        // if the custom instrumentation count exceeds the maximum allowed, log a warning and stop reporting further custom instrumentation metrics
+        if (_customInstrumentationCounter.Value > _configuration.MaxCustomInstrumentationSupportabilityMetrics)
         {
-            TrySend(_metricBuilder.TryBuildLibraryVersionMetric(assemblyName, assemblyVersion));
-        }
-
-        public void ReportCustomInstrumentation(string assemblyName, string className, string method)
-        {
-            // record only unique custom instrumentation metrics
-            var uniqueIdentifier = $"{assemblyName}.{className}.{method}";
-            if (!_customInstrumentationIds.Add(uniqueIdentifier))
+            if (!_customInstrumentationMaxLogged)
             {
-                return;
+                Log.Debug($"Custom instrumentation count {_customInstrumentationCounter.Value} has exceeded the maximum of {_configuration.MaxCustomInstrumentationSupportabilityMetrics}. No further custom instrumentation metrics will be reported.");
+                _customInstrumentationMaxLogged = true;
             }
-
-            // always report the custom instrumentation count metric
-            _customInstrumentationCounter.Increment();
-
-            // if the custom instrumentation count exceeds the maximum allowed, log a warning and stop reporting further custom instrumentation metrics
-            if (_customInstrumentationCounter.Value > _configuration.MaxCustomInstrumentationSupportabilityMetrics)
-            {
-                if (!_customInstrumentationMaxLogged)
-                {
-                    Log.Debug($"Custom instrumentation count {_customInstrumentationCounter.Value} has exceeded the maximum of {_configuration.MaxCustomInstrumentationSupportabilityMetrics}. No further custom instrumentation metrics will be reported.");
-                    _customInstrumentationMaxLogged = true;
-                }
-                return;
-            }
-
-            TrySend(_metricBuilder.TryBuildCustomInstrumentationMetric(assemblyName, className, method));
+            return;
         }
 
-        #region TransactionEvents
+        TrySend(_metricBuilder.TryBuildCustomInstrumentationMetric(assemblyName, className, method));
+    }
 
-        public void ReportTransactionEventReservoirResized(int newSize)
-        {
-            TrySend(_metricBuilder.TryBuildTransactionEventReservoirResizedMetric());
-            Log.Warn("Resizing transaction event reservoir to " + newSize + " events.");
-        }
+    #region TransactionEvents
 
-        public void ReportTransactionEventCollected()
-        {
-            TrySend(_metricBuilder.TryBuildTransactionEventsCollectedMetric());
+    public void ReportTransactionEventReservoirResized(int newSize)
+    {
+        TrySend(_metricBuilder.TryBuildTransactionEventReservoirResizedMetric());
+        Log.Warn("Resizing transaction event reservoir to " + newSize + " events.");
+    }
 
-            // Note: this metric is REQUIRED by APM (see https://source.datanerd.us/agents/agent-specs/pull/84)
-            TrySend(_metricBuilder.TryBuildTransactionEventsSeenMetric());
-        }
+    public void ReportTransactionEventCollected()
+    {
+        TrySend(_metricBuilder.TryBuildTransactionEventsCollectedMetric());
 
-        public void ReportTransactionEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildTransactionEventsRecollectedMetric(count));
+        // Note: this metric is REQUIRED by APM (see https://source.datanerd.us/agents/agent-specs/pull/84)
+        TrySend(_metricBuilder.TryBuildTransactionEventsSeenMetric());
+    }
 
-        public void ReportTransactionEventsSent(int count)
-        {
-            TrySend(_metricBuilder.TryBuildTransactionEventsSentMetric(count));
-            _agentHealthEventCounters[AgentHealthEvent.Transaction]?.Add(count);
-        }
+    public void ReportTransactionEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildTransactionEventsRecollectedMetric(count));
 
-        #endregion TransactionEvents
+    public void ReportTransactionEventsSent(int count)
+    {
+        TrySend(_metricBuilder.TryBuildTransactionEventsSentMetric(count));
+        _agentHealthEventCounters[AgentHealthEvent.Transaction]?.Add(count);
+    }
 
-        #region CustomEvents
+    #endregion TransactionEvents
 
-        public void ReportCustomEventReservoirResized(int newSize)
-        {
-            TrySend(_metricBuilder.TryBuildCustomEventReservoirResizedMetric());
-            Log.Warn("Resizing custom event reservoir to " + newSize + " events.");
-        }
+    #region CustomEvents
 
-        public void ReportCustomEventCollected()
-        {
-            TrySend(_metricBuilder.TryBuildCustomEventsCollectedMetric());
+    public void ReportCustomEventReservoirResized(int newSize)
+    {
+        TrySend(_metricBuilder.TryBuildCustomEventReservoirResizedMetric());
+        Log.Warn("Resizing custom event reservoir to " + newSize + " events.");
+    }
 
-            // Note: Though not required by APM like the transaction event supportability metrics, this metric should still be created to maintain consistency
-            TrySend(_metricBuilder.TryBuildCustomEventsSeenMetric());
-        }
-
-        public void ReportCustomEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildCustomEventsRecollectedMetric(count));
+    public void ReportCustomEventCollected()
+    {
+        TrySend(_metricBuilder.TryBuildCustomEventsCollectedMetric());
 
         // Note: Though not required by APM like the transaction event supportability metrics, this metric should still be created to maintain consistency
-        public void ReportCustomEventsSent(int count)
-        {
-            TrySend(_metricBuilder.TryBuildCustomEventsSentMetric(count));
-            _agentHealthEventCounters[AgentHealthEvent.Custom]?.Add(count);
+        TrySend(_metricBuilder.TryBuildCustomEventsSeenMetric());
+    }
 
+    public void ReportCustomEventsRecollected(int count) => TrySend(_metricBuilder.TryBuildCustomEventsRecollectedMetric(count));
+
+    // Note: Though not required by APM like the transaction event supportability metrics, this metric should still be created to maintain consistency
+    public void ReportCustomEventsSent(int count)
+    {
+        TrySend(_metricBuilder.TryBuildCustomEventsSentMetric(count));
+        _agentHealthEventCounters[AgentHealthEvent.Custom]?.Add(count);
+
+    }
+
+    #endregion CustomEvents
+
+    #region ErrorTraces
+
+    public void ReportErrorTraceCollected() => TrySend(_metricBuilder.TryBuildErrorTracesCollectedMetric());
+
+    public void ReportErrorTracesRecollected(int count) => TrySend(_metricBuilder.TryBuildErrorTracesRecollectedMetric(count));
+
+    public void ReportErrorTracesSent(int count) => TrySend(_metricBuilder.TryBuildErrorTracesSentMetric(count));
+
+    #endregion ErrorTraces
+
+    #region ErrorEvents
+
+    public void ReportErrorEventSeen() => TrySend(_metricBuilder.TryBuildErrorEventsSeenMetric());
+
+    public void ReportErrorEventsSent(int count)
+    {
+        TrySend(_metricBuilder.TryBuildErrorEventsSentMetric(count));
+        _agentHealthEventCounters[AgentHealthEvent.Error]?.Add(count);
+    }
+
+    #endregion ErrorEvents
+
+    #region SqlTraces
+
+    public void ReportSqlTracesRecollected(int count) => TrySend(_metricBuilder.TryBuildSqlTracesRecollectedMetric(count));
+
+    public void ReportSqlTracesSent(int count) => TrySend(_metricBuilder.TryBuildSqlTracesSentMetric(count));
+
+    #endregion ErrorTraces
+
+    public void ReportAgentInfo()
+    {
+        TrySend(_metricBuilder.TryBuildInstallTypeMetric(AgentInstallConfiguration.AgentInfo?.ToString() ?? "Unknown"));
+    }
+
+    public void ReportTransactionGarbageCollected(string transactionGuid, TransactionMetricName transactionMetricName, string lastStartedSegmentName, string lastFinishedSegmentName)
+    {
+        var transactionName = transactionMetricName.PrefixedName;
+        Log.Debug($"Transaction was garbage collected without ever ending.\nTransaction Guid: {transactionGuid}\nTransaction Name: {transactionName}\nLast Started Segment: {lastStartedSegmentName}\nLast Finished Segment: {lastFinishedSegmentName}");
+        _agentHealthEventCounters[AgentHealthEvent.TransactionGarbageCollected]?.Increment();
+    }
+
+    public void ReportWrapperShutdown(IWrapper wrapper, Method method)
+    {
+        var wrapperName = wrapper.GetType().FullName;
+        var metrics = new[]
+        {
+            _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, "all"),
+            _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, $"{wrapperName}/all"),
+            _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, wrapperName, method.Type.Name, method.MethodName)
+        };
+
+        foreach (var metric in metrics)
+        {
+            TrySend(metric);
         }
 
-        #endregion CustomEvents
+        Log.Error($"Wrapper {wrapperName} is being disabled for {method.MethodName} due to too many consecutive exceptions. All other methods using this wrapper will continue to be instrumented. This will reduce the functionality of the agent until the agent is restarted.");
+        _recurringLogData.Add($"Wrapper {wrapperName} was disabled for {method.MethodName} at {DateTime.Now} due to too many consecutive exceptions. All other methods using this wrapper will continue to be instrumented. This will reduce the functionality of the agent until the agent is restarted.");
+    }
 
-        #region ErrorTraces
-
-        public void ReportErrorTraceCollected() => TrySend(_metricBuilder.TryBuildErrorTracesCollectedMetric());
-
-        public void ReportErrorTracesRecollected(int count) => TrySend(_metricBuilder.TryBuildErrorTracesRecollectedMetric(count));
-
-        public void ReportErrorTracesSent(int count) => TrySend(_metricBuilder.TryBuildErrorTracesSentMetric(count));
-
-        #endregion ErrorTraces
-
-        #region ErrorEvents
-
-        public void ReportErrorEventSeen() => TrySend(_metricBuilder.TryBuildErrorEventsSeenMetric());
-
-        public void ReportErrorEventsSent(int count)
-        {
-            TrySend(_metricBuilder.TryBuildErrorEventsSentMetric(count));
-            _agentHealthEventCounters[AgentHealthEvent.Error]?.Add(count);
-        }
-
-        #endregion ErrorEvents
-
-        #region SqlTraces
-
-        public void ReportSqlTracesRecollected(int count) => TrySend(_metricBuilder.TryBuildSqlTracesRecollectedMetric(count));
-
-        public void ReportSqlTracesSent(int count) => TrySend(_metricBuilder.TryBuildSqlTracesSentMetric(count));
-
-        #endregion ErrorTraces
-
-        public void ReportAgentInfo()
-        {
-            TrySend(_metricBuilder.TryBuildInstallTypeMetric(AgentInstallConfiguration.AgentInfo?.ToString() ?? "Unknown"));
-        }
-
-        public void ReportTransactionGarbageCollected(string transactionGuid, TransactionMetricName transactionMetricName, string lastStartedSegmentName, string lastFinishedSegmentName)
-        {
-            var transactionName = transactionMetricName.PrefixedName;
-            Log.Debug($"Transaction was garbage collected without ever ending.\nTransaction Guid: {transactionGuid}\nTransaction Name: {transactionName}\nLast Started Segment: {lastStartedSegmentName}\nLast Finished Segment: {lastFinishedSegmentName}");
-            _agentHealthEventCounters[AgentHealthEvent.TransactionGarbageCollected]?.Increment();
-        }
-
-        public void ReportWrapperShutdown(IWrapper wrapper, Method method)
-        {
-            var wrapperName = wrapper.GetType().FullName;
-            var metrics = new[]
-            {
-                _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, "all"),
-                _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, $"{wrapperName}/all"),
-                _metricBuilder.TryBuildAgentHealthEventMetric(AgentHealthEvent.WrapperShutdown, wrapperName, method.Type.Name, method.MethodName)
-            };
-
-            foreach (var metric in metrics)
-            {
-                TrySend(metric);
-            }
-
-            Log.Error($"Wrapper {wrapperName} is being disabled for {method.MethodName} due to too many consecutive exceptions. All other methods using this wrapper will continue to be instrumented. This will reduce the functionality of the agent until the agent is restarted.");
-            _recurringLogData.Add($"Wrapper {wrapperName} was disabled for {method.MethodName} at {DateTime.Now} due to too many consecutive exceptions. All other methods using this wrapper will continue to be instrumented. This will reduce the functionality of the agent until the agent is restarted.");
-        }
-
-        public void ReportIfHostIsLinuxOs()
-        {
+    public void ReportIfHostIsLinuxOs()
+    {
 #if NETSTANDARD2_0
 
-            bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
-            var metric = _metricBuilder.TryBuildLinuxOsMetric(isLinux);
-            TrySend(metric);
+        bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+        var metric = _metricBuilder.TryBuildLinuxOsMetric(isLinux);
+        TrySend(metric);
 #endif
+    }
+
+    public void ReportBootIdError() => TrySend(_metricBuilder.TryBuildBootIdError());
+
+    public void ReportKubernetesUtilizationError() => TrySend(_metricBuilder.TryBuildKubernetesUsabilityError());
+
+    public void ReportAwsUtilizationError() => TrySend(_metricBuilder.TryBuildAwsUsabilityError());
+
+    public void ReportAzureUtilizationError() => TrySend(_metricBuilder.TryBuildAzureUsabilityError());
+
+    public void ReportPcfUtilizationError() => TrySend(_metricBuilder.TryBuildPcfUsabilityError());
+
+    public void ReportGcpUtilizationError() => TrySend(_metricBuilder.TryBuildGcpUsabilityError());
+
+    #region DistributedTrace
+
+    /// <summary>Incremented when AcceptDistributedTracePayload was called successfully</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadSuccess()
+    {
+        _payloadAcceptSuccessCounter.Increment();
+    }
+
+    /// <summary>Created when AcceptDistributedTracePayload had a generic exception</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadException() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadException);
+
+    /// <summary>Created when AcceptDistributedTracePayload had a parsing exception</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadParseException() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadParseException);
+
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because CreatePayload had already been called</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredCreateBeforeAccept() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredCreateBeforeAccept);
+
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because AcceptPayload had already been called</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMultiple() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredMultiple);
+
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload's major version was greater than the agent's</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMajorVersion() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredMajorVersion);
+
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was null</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredNull() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredNull);
+
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was untrusted</summary>
+    public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredUntrustedAccount() =>
+        TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredUntrustedAccount());
+
+    /// <summary>Incremented when CreateDistributedTracePayload was called successfully</summary>
+    public void ReportSupportabilityDistributedTraceCreatePayloadSuccess()
+    {
+        _payloadCreateSuccessCounter.Increment();
+    }
+
+    /// <summary>Created when CreateDistributedTracePayload had a generic exception</summary>
+    public void ReportSupportabilityDistributedTraceCreatePayloadException() =>
+        TrySend(_metricBuilder.TryBuildCreatePayloadException);
+
+    public void ReportSupportabilityDistributedTraceHeadersAcceptedLate()
+    {
+        _distributedTraceHeadersAcceptedLateCounter.Increment();
+    }
+
+    /// <summary>
+    /// Validates the current agent configuration to ensure it is properly set up for operation.
+    /// </summary>
+    /// <remarks>This method checks several conditions to determine if the agent is correctly
+    /// configured: <list type="bullet"> <item>If the agent is disabled via configuration, the method logs an error
+    /// and returns <see langword="false"/>.</item> <item>If the agent is not in serverless mode and the license key
+    /// is not set, the method logs an error and returns <see langword="false"/>.</item> <item>If no application
+    /// name is configured, the method logs an error and returns <see langword="false"/>.</item> </list> If any of
+    /// these conditions are not met, the agent will fail to start.</remarks>
+    /// <returns><see langword="true"/> if the agent configuration is valid and the agent can start;  otherwise, <see
+    /// langword="false"/>.</returns>
+    public bool ValidateAgentConfiguration()
+    {
+        if (!_configuration.AgentEnabled)
+        {
+            var message = $"The New Relic agent is disabled via configuration. Update {_configuration.AgentEnabledAt} to re-enable it.";
+            FailStartup(message, HealthCodes.AgentDisabledByConfiguration);
+            return false;
         }
 
-        public void ReportBootIdError() => TrySend(_metricBuilder.TryBuildBootIdError());
-
-        public void ReportKubernetesUtilizationError() => TrySend(_metricBuilder.TryBuildKubernetesUsabilityError());
-
-        public void ReportAwsUtilizationError() => TrySend(_metricBuilder.TryBuildAwsUsabilityError());
-
-        public void ReportAzureUtilizationError() => TrySend(_metricBuilder.TryBuildAzureUsabilityError());
-
-        public void ReportPcfUtilizationError() => TrySend(_metricBuilder.TryBuildPcfUsabilityError());
-
-        public void ReportGcpUtilizationError() => TrySend(_metricBuilder.TryBuildGcpUsabilityError());
-
-        #region DistributedTrace
-
-        /// <summary>Incremented when AcceptDistributedTracePayload was called successfully</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadSuccess()
+        if (!_configuration.ServerlessModeEnabled) // license key is not required to be set in serverless mode
         {
-            _payloadAcceptSuccessCounter.Increment();
-        }
-
-        /// <summary>Created when AcceptDistributedTracePayload had a generic exception</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadException() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadException);
-
-        /// <summary>Created when AcceptDistributedTracePayload had a parsing exception</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadParseException() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadParseException);
-
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because CreatePayload had already been called</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredCreateBeforeAccept() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredCreateBeforeAccept);
-
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because AcceptPayload had already been called</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMultiple() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredMultiple);
-
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload's major version was greater than the agent's</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMajorVersion() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredMajorVersion);
-
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was null</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredNull() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredNull);
-
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was untrusted</summary>
-        public void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredUntrustedAccount() =>
-            TrySend(_metricBuilder.TryBuildAcceptPayloadIgnoredUntrustedAccount());
-
-        /// <summary>Incremented when CreateDistributedTracePayload was called successfully</summary>
-        public void ReportSupportabilityDistributedTraceCreatePayloadSuccess()
-        {
-            _payloadCreateSuccessCounter.Increment();
-        }
-
-        /// <summary>Created when CreateDistributedTracePayload had a generic exception</summary>
-        public void ReportSupportabilityDistributedTraceCreatePayloadException() =>
-            TrySend(_metricBuilder.TryBuildCreatePayloadException);
-
-        public void ReportSupportabilityDistributedTraceHeadersAcceptedLate()
-        {
-            _distributedTraceHeadersAcceptedLateCounter.Increment();
-        }
-
-        /// <summary>
-        /// Validates the current agent configuration to ensure it is properly set up for operation.
-        /// </summary>
-        /// <remarks>This method checks several conditions to determine if the agent is correctly
-        /// configured: <list type="bullet"> <item>If the agent is disabled via configuration, the method logs an error
-        /// and returns <see langword="false"/>.</item> <item>If the agent is not in serverless mode and the license key
-        /// is not set, the method logs an error and returns <see langword="false"/>.</item> <item>If no application
-        /// name is configured, the method logs an error and returns <see langword="false"/>.</item> </list> If any of
-        /// these conditions are not met, the agent will fail to start.</remarks>
-        /// <returns><see langword="true"/> if the agent configuration is valid and the agent can start;  otherwise, <see
-        /// langword="false"/>.</returns>
-        public bool ValidateAgentConfiguration()
-        {
-            if (!_configuration.AgentEnabled)
+            if ("REPLACE_WITH_LICENSE_KEY".Equals(_configuration.AgentLicenseKey))
             {
-                var message = $"The New Relic agent is disabled via configuration. Update {_configuration.AgentEnabledAt} to re-enable it.";
-                FailStartup(message, HealthCodes.AgentDisabledByConfiguration);
+                FailStartup("Please set your license key.", HealthCodes.LicenseKeyMissing);
                 return false;
             }
+        }
 
-            if (!_configuration.ServerlessModeEnabled) // license key is not required to be set in serverless mode
+        // check for application names
+        if (!_configuration.TryGetApplicationNames(out _))
+        {
+            FailStartup("An application name is required.", HealthCodes.ApplicationNameMissing);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void FailStartup(string message, (bool IsHealthy, string Code, string Status) healthCode = default)
+    {
+        // have to log here because Shutdown() will terminate logging
+        Log.Error(message);
+
+        if (_configuration.AgentControlEnabled && healthCode != default)
+        {
+            SetAgentControlStatus(healthCode);
+        }
+    }
+
+    /// <summary>Limits Collect calls to once per harvest per metric.</summary>
+    public void CollectDistributedTraceMetrics()
+    {
+        if (TryGetCount(_payloadCreateSuccessCounter, out var createCount))
+        {
+            TrySend(_metricBuilder.TryBuildCreatePayloadSuccess(createCount));
+        }
+
+        if (TryGetCount(_payloadAcceptSuccessCounter, out var acceptCount))
+        {
+            TrySend(_metricBuilder.TryBuildAcceptPayloadSuccess(acceptCount));
+        }
+
+        if (TryGetCount(_distributedTraceHeadersAcceptedLateCounter, out var acceptedLateCount))
+        {
+            TrySend(_metricBuilder.TryBuildDistributedTraceHeadersAcceptedLate(acceptedLateCount));
+        }
+    }
+
+    #endregion DistributedTrace
+
+    #region TraceContext
+
+    /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
+    public void ReportSupportabilityTraceContextAcceptSuccess()
+    {
+        _traceContextAcceptSuccessCounter.Increment();
+    }
+
+    /// <summary>Incremented when the agent successfully creates outbound trace context payloads</summary>
+    public void ReportSupportabilityTraceContextCreateSuccess()
+    {
+        _traceContextCreateSuccessCounter.Increment();
+    }
+
+    /// <summary>Created when a generic exception occurred unrelated to parsing while accepting either payload.</summary>
+    public void ReportSupportabilityTraceContextAcceptException() =>
+        TrySend(_metricBuilder.TryBuildTraceContextAcceptException);
+
+    /// <summary>Created when the inbound traceparent header could not be parsed.</summary>
+    public void ReportSupportabilityTraceContextTraceParentParseException() =>
+        TrySend(_metricBuilder.TryBuildTraceContextTraceParentParseException);
+
+    /// <summary>Created when the inbound tracestate header could not be parsed.</summary>
+    public void ReportSupportabilityTraceContextTraceStateParseException() =>
+        TrySend(_metricBuilder.TryBuildTraceContextTraceStateParseException);
+
+    /// <summary>Created when a generic exception occurred while creating the outbound payloads.</summary>
+    public void ReportSupportabilityTraceContextCreateException() =>
+        TrySend(_metricBuilder.TryBuildTraceContextCreateException);
+
+    /// <summary>Created when the inbound tracestate header exists, and was accepted, but the New Relic entry was invalid.</summary>
+    public void ReportSupportabilityTraceContextTraceStateInvalidNrEntry() =>
+        TrySend(_metricBuilder.TryBuildTraceContextTraceStateInvalidNrEntry);
+
+    /// <summary>Created when the traceparent header exists, and was accepted, but the tracestate header did not contain a trusted New Relic entry.</summary>
+    public void ReportSupportabilityTraceContextTraceStateNoNrEntry() =>
+        TrySend(_metricBuilder.TryBuildTraceContextTraceStateNoNrEntry);
+
+    /// <summary>Limits Collect calls to once per harvest per metric.</summary>
+    public void CollectTraceContextSuccessMetrics()
+    {
+        if (TryGetCount(_traceContextCreateSuccessCounter, out var createCount))
+        {
+            TrySend(_metricBuilder.TryBuildTraceContextCreateSuccess(createCount));
+        }
+
+        if (TryGetCount(_traceContextAcceptSuccessCounter, out var acceptCount))
+        {
+            TrySend(_metricBuilder.TryBuildTraceContextAcceptSuccess(acceptCount));
+        }
+    }
+
+    #endregion TraceContext
+
+    #region Span 
+
+    public void ReportSpanEventCollected(int count) => TrySend(_metricBuilder.TryBuildSpanEventsSeenMetric(count));
+
+    public void ReportSpanEventsSent(int count)
+    {
+        TrySend(_metricBuilder.TryBuildSpanEventsSentMetric(count));
+        _agentHealthEventCounters[AgentHealthEvent.Span]?.Add(count);
+    }
+
+    #endregion Span 
+
+    #region InfiniteTracing
+
+    private InterlockedLongCounter _infiniteTracingSpanResponseError = new InterlockedLongCounter();
+    public void ReportInfiniteTracingSpanResponseError()
+    {
+        _infiniteTracingSpanResponseError.Increment();
+    }
+
+    public void ReportInfiniteTracingSpanQueueSize(int queueSize)
+    {
+        ReportSupportabilityGaugeMetric(MetricNames.SupportabilityInfiniteTracingSpanQueueSize, queueSize);
+    }
+
+
+    private InterlockedLongCounter _infiniteTracingSpanEventsDropped = new InterlockedLongCounter();
+    public void ReportInfiniteTracingSpanEventsDropped(long countSpans)
+    {
+        _infiniteTracingSpanEventsDropped.Add(countSpans);
+    }
+
+
+    private InterlockedLongCounter _infiniteTracingSpanEventsSeen = new InterlockedLongCounter();
+    public void ReportInfiniteTracingSpanEventsSeen(long countSpans)
+    {
+        _infiniteTracingSpanEventsSeen.Add(countSpans);
+    }
+
+    private InterlockedLongCounter _infiniteTracingSpanEventsSent = new InterlockedLongCounter();
+    private InterlockedCounter _infiniteTracingSpanBatchCount = new InterlockedCounter();
+    private long _infiniteTracingSpanBatchSizeMin = long.MaxValue;
+    private long _infiniteTracingSpanBatchSizeMax = long.MinValue;
+
+    private readonly object _syncRootMetrics = new object();
+
+    public void ReportInfiniteTracingSpanEventsSent(long countSpans)
+    {
+        _infiniteTracingSpanEventsSent.Add(countSpans);
+        _infiniteTracingSpanBatchCount.Increment();
+
+        lock (_syncRootMetrics)
+        {
+            _infiniteTracingSpanBatchSizeMin = Math.Min(_infiniteTracingSpanBatchSizeMin, countSpans);
+            _infiniteTracingSpanBatchSizeMax = Math.Max(_infiniteTracingSpanBatchSizeMax, countSpans);
+        }
+        _agentHealthEventCounters[AgentHealthEvent.InfiniteTracingSpan]?.Add((int)countSpans);
+
+    }
+
+    private InterlockedLongCounter _infiniteTracingSpanEventsReceived = new InterlockedLongCounter();
+    public void ReportInfiniteTracingSpanEventsReceived(ulong countSpans)
+    {
+        _infiniteTracingSpanEventsReceived.Add(countSpans);
+    }
+
+    private ConcurrentDictionary<string, InterlockedLongCounter> _infiniteTracingSpanGrpcErrorCounters = new ConcurrentDictionary<string, InterlockedLongCounter>();
+    public void ReportInfiniteTracingSpanGrpcError(string error)
+    {
+        var counter = _infiniteTracingSpanGrpcErrorCounters.GetOrAdd(error, CreateNewGrpcErrorInterlockedCounter);
+        counter.Increment();
+    }
+
+    private InterlockedCounter _infiniteTracingSpanGrpcTimeout = new InterlockedCounter();
+    public void ReportInfiniteTracingSpanGrpcTimeout()
+    {
+        _infiniteTracingSpanGrpcTimeout.Increment();
+    }
+
+    private static InterlockedLongCounter CreateNewGrpcErrorInterlockedCounter(string _)
+    {
+        return new InterlockedLongCounter();
+    }
+
+    private void CollectInfiniteTracingMetrics()
+    {
+        if (TryGetCount(_infiniteTracingSpanResponseError, out var errorCount))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanResponseError, errorCount);
+        }
+
+        if (TryGetCount(_infiniteTracingSpanEventsDropped, out var spansDropped))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanDropped, spansDropped);
+        }
+
+        if (TryGetCount(_infiniteTracingSpanEventsSeen, out var spanEventsSeen))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanSeen, spanEventsSeen);
+        }
+
+        if (TryGetCount(_infiniteTracingSpanEventsSent, out var spanEventsSent) && TryGetCount(_infiniteTracingSpanBatchCount, out var spanBatchCount))
+        {
+
+            var minBatchSize = Interlocked.Exchange(ref _infiniteTracingSpanBatchSizeMin, long.MaxValue);
+            var maxBatchSize = Interlocked.Exchange(ref _infiniteTracingSpanBatchSizeMax, long.MinValue);
+
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanSent, spanEventsSent);
+
+            if (minBatchSize < long.MaxValue && maxBatchSize > long.MinValue)
             {
-                if ("REPLACE_WITH_LICENSE_KEY".Equals(_configuration.AgentLicenseKey))
-                {
-                    FailStartup("Please set your license key.", HealthCodes.LicenseKeyMissing);
-                    return false;
-                }
+                ReportSupportabilitySummaryMetric(MetricNames.SupportabilityInfiniteTracingSpanSentBatchSize, spanEventsSent, spanBatchCount, minBatchSize, maxBatchSize);
             }
+        }
 
-            // check for application names
-            if (!_configuration.TryGetApplicationNames(out _))
+        if (TryGetCount(_infiniteTracingSpanEventsReceived, out var spanEventsReceived))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanReceived, spanEventsReceived);
+        }
+
+        if (TryGetCount(_infiniteTracingSpanGrpcTimeout, out var timeouts))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanGrpcTimeout, timeouts);
+        }
+
+        foreach (var errorCounterPair in _infiniteTracingSpanGrpcErrorCounters)
+        {
+            if (TryGetCount(errorCounterPair.Value, out var grpcErrorCount))
             {
-                FailStartup("An application name is required.", HealthCodes.ApplicationNameMissing);
-                return false;
+                var metricName = MetricNames.SupportabilityInfiniteTracingSpanGrpcError(errorCounterPair.Key);
+                ReportSupportabilityCountMetric(metricName, grpcErrorCount);
             }
+        }
+    }
 
+    private void ReportInfiniteTracingOneTimeMetrics()
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingCompression(_configuration.InfiniteTracingCompression));
+    }
+
+    #endregion
+
+    public void ReportAgentTimingMetric(string suffix, TimeSpan time)
+    {
+        var metric = _metricBuilder.TryBuildAgentTimingMetric(suffix, time);
+        TrySend(metric);
+    }
+
+    #region HttpError
+
+    public void ReportSupportabilityCollectorErrorException(string endpointMethod, TimeSpan responseDuration, HttpStatusCode? statusCode)
+    {
+        if (statusCode.HasValue)
+        {
+            TrySend(_metricBuilder.TryBuildSupportabilityErrorHttpStatusCodeFromCollector(statusCode.Value));
+        }
+
+        TrySend(_metricBuilder.TryBuildSupportabilityEndpointMethodErrorDuration(endpointMethod, responseDuration));
+    }
+
+    #endregion
+
+    #region Log Events and Metrics
+
+    // Used to report a logging framework is being instrumented for log forwarding, it does not take into account if forwarding was enabled or not.
+    private ConcurrentDictionary<string, bool> _loggingFrameworksReported = new ConcurrentDictionary<string, bool>();
+    public void ReportLogForwardingFramework(string logFramework)
+    {
+        _loggingFrameworksReported.TryAdd(logFramework, false);
+    }
+
+    // Used to report that both log forwarding is enabled and that a logging framework is being instrumented for logforwarding.
+    private ConcurrentDictionary<string, bool> _loggingForwardingEnabledWithFrameworksReported = new ConcurrentDictionary<string, bool>();
+    public void ReportLogForwardingEnabledWithFramework(string logFramework)
+    {
+        _loggingForwardingEnabledWithFrameworksReported.TryAdd(logFramework, false);
+    }
+
+    public void ReportLoggingEventsEmpty(int count = 1)
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingEventEmpty);
+    }
+
+    public void CollectLoggingMetrics()
+    {
+        var totalCount = 0;
+        foreach (var logLinesCounter in _logLinesCountByLevel)
+        {
+            if (TryGetCount(logLinesCounter.Value, out var linesCount))
+            {
+                totalCount += linesCount;
+                TrySend(_metricBuilder.TryBuildLoggingMetricsLinesCountBySeverityMetric(logLinesCounter.Key, linesCount));
+            }
+        }
+
+        if (totalCount > 0)
+        {
+            TrySend(_metricBuilder.TryBuildLoggingMetricsLinesCountMetric(totalCount));
+        }
+
+        foreach (var kvp in _loggingFrameworksReported)
+        {
+            if (kvp.Value == false)
+            {
+                ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogFrameworkName(kvp.Key));
+                _loggingFrameworksReported[kvp.Key] = true;
+            }
+        }
+
+        foreach (var kvp in _loggingForwardingEnabledWithFrameworksReported)
+        {
+            if (kvp.Value == false)
+            {
+                ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogForwardingEnabledWithFrameworkName(kvp.Key));
+                _loggingForwardingEnabledWithFrameworksReported[kvp.Key] = true;
+            }
+        }
+
+        var totalDeniedCount = 0;
+        foreach (var logLinesDeniedCounter in _logDeniedCountByLevel)
+        {
+            if (TryGetCount(logLinesDeniedCounter.Value, out var linesCount))
+            {
+                totalDeniedCount += linesCount;
+                TrySend(_metricBuilder.TryBuildLoggingMetricsDeniedCountBySeverityMetric(logLinesDeniedCounter.Key, linesCount));
+            }
+        }
+
+        if (totalDeniedCount > 0)
+        {
+            TrySend(_metricBuilder.TryBuildLoggingMetricsDeniedCountMetric(totalDeniedCount));
+        }
+
+    }
+
+    public void IncrementLogLinesCount(string level)
+    {
+        _logLinesCountByLevel.TryAdd(level, new InterlockedCounter());
+        _logLinesCountByLevel[level].Increment();
+    }
+
+    public void IncrementLogDeniedCount(string level)
+    {
+        _logDeniedCountByLevel.TryAdd(level, new InterlockedCounter());
+        _logDeniedCountByLevel[level].Increment();
+    }
+
+    public void ReportLoggingEventCollected() => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsCollectedMetric());
+
+    public void ReportLoggingEventsSent(int count)
+    {
+        TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsSentMetric(count));
+        _agentHealthEventCounters[AgentHealthEvent.Log]?.Add(count);
+    }
+
+    public void ReportLoggingEventsDropped(int droppedCount) => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(droppedCount));
+
+    public void ReportIfAppDomainCachingDisabled()
+    {
+        if (_configuration.AppDomainCachingDisabled)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityAppDomainCachingDisabled);
+        }
+    }
+
+    public void ReportLogForwardingConfiguredValues()
+    {
+        ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogMetricsConfiguredName(_configuration.LogMetricsCollectorEnabled));
+        ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogForwardingConfiguredName(_configuration.LogEventCollectorEnabled));
+        ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogDecoratingConfiguredName(_configuration.LogDecoratorEnabled));
+        ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogLabelsConfiguredName(_configuration.LabelsEnabled));
+    }
+
+    #endregion
+
+    #region Agent Control
+
+    private void ReportIfAgentControlHealthEnabled()
+    {
+        if (_configuration.AgentControlEnabled)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityAgentControlHealthEnabled);
+        }
+    }
+
+    public void SetAgentControlStatus((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams)
+    {
+        // Do nothing if agent control is not enabled
+        if (!_configuration.AgentControlEnabled)
+            return;
+
+        if (healthStatus.Equals(HealthCodes.AgentShutdownHealthy))
+        {
+            if (_healthCheck.IsHealthy)
+            {
+                _healthCheck.TrySetHealth(healthStatus);
+            }
+        }
+        else
+        {
+            _healthCheck.TrySetHealth(healthStatus, statusParams);
+        }
+    }
+
+    public void PublishAgentControlHealthCheck()
+    {
+        if (!_healthChecksInitialized) // initialize on first invocation
+        {
+            InitializeHealthChecks();
+            _healthChecksInitialized = true;
+        }
+
+        // stop the scheduled task if agent control isn't enabled or health checks fail for any reason
+        if (!_configuration.AgentControlEnabled || _healthChecksFailed)
+        {
+            _scheduler.StopExecuting(PublishAgentControlHealthCheck);
+            return;
+        }
+
+        var healthCheckYaml = _healthCheck.ToYaml(_configuration.EntityGuid);
+
+        Log.Finest("Publishing Agent Control health check report: {HealthCheckYaml}", healthCheckYaml);
+
+        try
+        {
+            using var fs = _fileWrapper.OpenWrite(Path.Combine(_healthCheckPath, _healthCheck.FileName));
+            var payloadBytes = Encoding.UTF8.GetBytes(healthCheckYaml);
+            fs.Write(payloadBytes, 0, payloadBytes.Length);
+            fs.Flush();
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "Failed to write Agent Control health check report. Health checks will be disabled.");
+            _healthChecksFailed = true;
+        }
+    }
+
+    private void InitializeHealthChecks()
+    {
+        if (!_configuration.AgentControlEnabled)
+        {
+            Log.Debug("Agent Control is disabled. Health checks will not be reported.");
+            return;
+        }
+
+        Log.Debug("Initializing Agent Control health checks");
+
+        // make sure the delivery location is a file URI
+        var fileUri = new Uri(_configuration.HealthDeliveryLocation);
+        if (fileUri.Scheme != Uri.UriSchemeFile)
+        {
+            Log.Warn("Agent Control is enabled but the provided agent_control.health.delivery_location is not a file URL. Health checks will be disabled.");
+            _healthChecksFailed = true;
+            return;
+        }
+
+        _healthCheckPath = fileUri.LocalPath;
+
+        // verify the directory exists
+        if (!_directoryWrapper.Exists(_healthCheckPath))
+        {
+            Log.Warn("Agent Control is enabled but the path specified in agent_control.health.delivery_location does not exist. Health checks will be disabled.");
+            _healthChecksFailed = true;
+        }
+
+        // verify we can write a file to the directory
+        var testFile = Path.Combine(_healthCheckPath, Path.GetRandomFileName());
+        if (!_fileWrapper.TryCreateFile(testFile))
+        {
+            Log.Warn("Agent Control is enabled but the agent is unable to create files in the directory specified in agent_control.health.delivery_location. Health checks will be disabled.");
+            _healthChecksFailed = true;
+        }
+    }
+    #endregion
+
+    public void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint)
+    {
+        TrySend(_metricBuilder.TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimit(endpoint));
+    }
+
+    // Only one metric harvest happens at a time, so locking around this bool is not important
+    private bool _oneTimeMetricsCollected;
+    private void CollectOneTimeMetrics()
+    {
+        if (_oneTimeMetricsCollected) return;
+        _oneTimeMetricsCollected = true;
+
+        ReportLogForwardingConfiguredValues();
+        ReportIfAppDomainCachingDisabled();
+        ReportInfiniteTracingOneTimeMetrics();
+        ReportIfLoggingDisabled();
+        ReportIfInstrumentationIsDisabled();
+        ReportIfGCSamplerV2IsEnabled();
+        ReportIfAwsAccountIdProvided();
+        ReportIfAgentControlHealthEnabled();
+        ReportIfAspNetCore6PlusIsEnabled();
+        ReportIfAzureFunctionModeIsDetected();
+        ReportIfOpenTelemetryIsEnabled();
+        ReportIfOpenTelemetryTracingIsEnabled();
+        ReportIfOpenTelemetryMetricsEnabled();
+    }
+
+    public void CollectMetrics()
+    {
+        CollectDistributedTraceMetrics();
+        CollectTraceContextSuccessMetrics();
+        CollectInfiniteTracingMetrics();
+        CollectLoggingMetrics();
+        CollectSupportabilityDataUsageMetrics();
+
+        ReportAgentVersion(AgentInstallConfiguration.AgentVersion);
+        ReportIfHostIsLinuxOs();
+        ReportDotnetVersion();
+        ReportAgentInfo();
+
+        CollectOneTimeMetrics();
+
+        ReportCustomInstrumentationCountMetrics();
+    }
+
+    private void ReportCustomInstrumentationCountMetrics()
+    {
+        TrySend(_metricBuilder.TryBuildCountMetric(MetricNames.SupportabilityCustomInstrumentationCount, _customInstrumentationCounter.Value));
+    }
+
+    public void RegisterPublishMetricHandler(PublishMetricDelegate publishMetricDelegate)
+    {
+        if (_publishMetricDelegate != null)
+        {
+            Log.Warn("Existing PublishMetricDelegate registration being overwritten.");
+        }
+
+        _publishMetricDelegate = publishMetricDelegate;
+    }
+
+    private void TrySend(MetricWireModel metric)
+    {
+        if (metric == null)
+        {
+            return;
+        }
+
+        if (_publishMetricDelegate == null)
+        {
+            Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricNameModel.Name);
+            return;
+        }
+
+        try
+        {
+            _publishMetricDelegate(metric);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "TrySend() failed");
+        }
+    }
+    private bool TryGetCount(InterlockedCounter counter, out int metricCount)
+    {
+        metricCount = 0;
+        if (counter.Value > 0)
+        {
+            metricCount = counter.Exchange(0);
             return true;
         }
 
-        private void FailStartup(string message, (bool IsHealthy, string Code, string Status) healthCode = default)
-        {
-            // have to log here because Shutdown() will terminate logging
-            Log.Error(message);
+        return false;
+    }
 
-            if (_configuration.AgentControlEnabled && healthCode != default)
+    private bool TryGetCount(InterlockedLongCounter counter, out long metricCount)
+    {
+        metricCount = 0;
+        if (counter.Value > 0)
+        {
+            metricCount = counter.Exchange(0);
+            return true;
+        }
+
+        return false;
+    }
+
+    private ConcurrentBag<DestinationInteractionSample> _externalApiDataUsageSamples = new ConcurrentBag<DestinationInteractionSample>();
+
+
+    public void ReportSupportabilityDataUsage(string api, string apiArea, long dataSent, long dataReceived)
+    {
+        _externalApiDataUsageSamples.Add(new DestinationInteractionSample(api, apiArea, dataSent, dataReceived));
+    }
+
+    private void CollectSupportabilityDataUsageMetrics()
+    {
+        var currentHarvest = Interlocked.Exchange(ref _externalApiDataUsageSamples, new ConcurrentBag<DestinationInteractionSample>());
+
+        foreach (var destination in currentHarvest.GroupBy(x => x.Api))
+        {
+            // Setup top level metrics to aggregate
+            var destinationName = string.IsNullOrWhiteSpace(destination.Key) ? "UnspecifiedDestination" : destination.Key;
+            var destinationCallCount = 0L;
+            var destinationBytesSent = 0L;
+            var destinationBytesReceived = 0L;
+
+            // inspect and report sub-metrics
+            foreach (var destinationArea in destination.GroupBy(x => x.ApiArea))
             {
-                SetAgentControlStatus(healthCode);
-            }
-        }
+                var destinationAreaName = string.IsNullOrWhiteSpace(destinationArea.Key) ? "UnspecifiedDestinationArea" : destinationArea.Key;
+                var destinationAreaCallCount = 0L;
+                var destinationAreaBytesSent = 0L;
+                var destinationAreaBytesReceived = 0L;
 
-        /// <summary>Limits Collect calls to once per harvest per metric.</summary>
-        public void CollectDistributedTraceMetrics()
-        {
-            if (TryGetCount(_payloadCreateSuccessCounter, out var createCount))
-            {
-                TrySend(_metricBuilder.TryBuildCreatePayloadSuccess(createCount));
-            }
-
-            if (TryGetCount(_payloadAcceptSuccessCounter, out var acceptCount))
-            {
-                TrySend(_metricBuilder.TryBuildAcceptPayloadSuccess(acceptCount));
-            }
-
-            if (TryGetCount(_distributedTraceHeadersAcceptedLateCounter, out var acceptedLateCount))
-            {
-                TrySend(_metricBuilder.TryBuildDistributedTraceHeadersAcceptedLate(acceptedLateCount));
-            }
-        }
-
-        #endregion DistributedTrace
-
-        #region TraceContext
-
-        /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
-        public void ReportSupportabilityTraceContextAcceptSuccess()
-        {
-            _traceContextAcceptSuccessCounter.Increment();
-        }
-
-        /// <summary>Incremented when the agent successfully creates outbound trace context payloads</summary>
-        public void ReportSupportabilityTraceContextCreateSuccess()
-        {
-            _traceContextCreateSuccessCounter.Increment();
-        }
-
-        /// <summary>Created when a generic exception occurred unrelated to parsing while accepting either payload.</summary>
-        public void ReportSupportabilityTraceContextAcceptException() =>
-            TrySend(_metricBuilder.TryBuildTraceContextAcceptException);
-
-        /// <summary>Created when the inbound traceparent header could not be parsed.</summary>
-        public void ReportSupportabilityTraceContextTraceParentParseException() =>
-            TrySend(_metricBuilder.TryBuildTraceContextTraceParentParseException);
-
-        /// <summary>Created when the inbound tracestate header could not be parsed.</summary>
-        public void ReportSupportabilityTraceContextTraceStateParseException() =>
-            TrySend(_metricBuilder.TryBuildTraceContextTraceStateParseException);
-
-        /// <summary>Created when a generic exception occurred while creating the outbound payloads.</summary>
-        public void ReportSupportabilityTraceContextCreateException() =>
-            TrySend(_metricBuilder.TryBuildTraceContextCreateException);
-
-        /// <summary>Created when the inbound tracestate header exists, and was accepted, but the New Relic entry was invalid.</summary>
-        public void ReportSupportabilityTraceContextTraceStateInvalidNrEntry() =>
-            TrySend(_metricBuilder.TryBuildTraceContextTraceStateInvalidNrEntry);
-
-        /// <summary>Created when the traceparent header exists, and was accepted, but the tracestate header did not contain a trusted New Relic entry.</summary>
-        public void ReportSupportabilityTraceContextTraceStateNoNrEntry() =>
-            TrySend(_metricBuilder.TryBuildTraceContextTraceStateNoNrEntry);
-
-        /// <summary>Limits Collect calls to once per harvest per metric.</summary>
-        public void CollectTraceContextSuccessMetrics()
-        {
-            if (TryGetCount(_traceContextCreateSuccessCounter, out var createCount))
-            {
-                TrySend(_metricBuilder.TryBuildTraceContextCreateSuccess(createCount));
-            }
-
-            if (TryGetCount(_traceContextAcceptSuccessCounter, out var acceptCount))
-            {
-                TrySend(_metricBuilder.TryBuildTraceContextAcceptSuccess(acceptCount));
-            }
-        }
-
-        #endregion TraceContext
-
-        #region Span 
-
-        public void ReportSpanEventCollected(int count) => TrySend(_metricBuilder.TryBuildSpanEventsSeenMetric(count));
-
-        public void ReportSpanEventsSent(int count)
-        {
-            TrySend(_metricBuilder.TryBuildSpanEventsSentMetric(count));
-            _agentHealthEventCounters[AgentHealthEvent.Span]?.Add(count);
-        }
-
-        #endregion Span 
-
-        #region InfiniteTracing
-
-        private InterlockedLongCounter _infiniteTracingSpanResponseError = new InterlockedLongCounter();
-        public void ReportInfiniteTracingSpanResponseError()
-        {
-            _infiniteTracingSpanResponseError.Increment();
-        }
-
-        public void ReportInfiniteTracingSpanQueueSize(int queueSize)
-        {
-            ReportSupportabilityGaugeMetric(MetricNames.SupportabilityInfiniteTracingSpanQueueSize, queueSize);
-        }
-
-
-        private InterlockedLongCounter _infiniteTracingSpanEventsDropped = new InterlockedLongCounter();
-        public void ReportInfiniteTracingSpanEventsDropped(long countSpans)
-        {
-            _infiniteTracingSpanEventsDropped.Add(countSpans);
-        }
-
-
-        private InterlockedLongCounter _infiniteTracingSpanEventsSeen = new InterlockedLongCounter();
-        public void ReportInfiniteTracingSpanEventsSeen(long countSpans)
-        {
-            _infiniteTracingSpanEventsSeen.Add(countSpans);
-        }
-
-        private InterlockedLongCounter _infiniteTracingSpanEventsSent = new InterlockedLongCounter();
-        private InterlockedCounter _infiniteTracingSpanBatchCount = new InterlockedCounter();
-        private long _infiniteTracingSpanBatchSizeMin = long.MaxValue;
-        private long _infiniteTracingSpanBatchSizeMax = long.MinValue;
-
-        private readonly object _syncRootMetrics = new object();
-
-        public void ReportInfiniteTracingSpanEventsSent(long countSpans)
-        {
-            _infiniteTracingSpanEventsSent.Add(countSpans);
-            _infiniteTracingSpanBatchCount.Increment();
-
-            lock (_syncRootMetrics)
-            {
-                _infiniteTracingSpanBatchSizeMin = Math.Min(_infiniteTracingSpanBatchSizeMin, countSpans);
-                _infiniteTracingSpanBatchSizeMax = Math.Max(_infiniteTracingSpanBatchSizeMax, countSpans);
-            }
-            _agentHealthEventCounters[AgentHealthEvent.InfiniteTracingSpan]?.Add((int)countSpans);
-
-        }
-
-        private InterlockedLongCounter _infiniteTracingSpanEventsReceived = new InterlockedLongCounter();
-        public void ReportInfiniteTracingSpanEventsReceived(ulong countSpans)
-        {
-            _infiniteTracingSpanEventsReceived.Add(countSpans);
-        }
-
-        private ConcurrentDictionary<string, InterlockedLongCounter> _infiniteTracingSpanGrpcErrorCounters = new ConcurrentDictionary<string, InterlockedLongCounter>();
-        public void ReportInfiniteTracingSpanGrpcError(string error)
-        {
-            var counter = _infiniteTracingSpanGrpcErrorCounters.GetOrAdd(error, CreateNewGrpcErrorInterlockedCounter);
-            counter.Increment();
-        }
-
-        private InterlockedCounter _infiniteTracingSpanGrpcTimeout = new InterlockedCounter();
-        public void ReportInfiniteTracingSpanGrpcTimeout()
-        {
-            _infiniteTracingSpanGrpcTimeout.Increment();
-        }
-
-        private static InterlockedLongCounter CreateNewGrpcErrorInterlockedCounter(string _)
-        {
-            return new InterlockedLongCounter();
-        }
-
-        private void CollectInfiniteTracingMetrics()
-        {
-            if (TryGetCount(_infiniteTracingSpanResponseError, out var errorCount))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanResponseError, errorCount);
-            }
-
-            if (TryGetCount(_infiniteTracingSpanEventsDropped, out var spansDropped))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanDropped, spansDropped);
-            }
-
-            if (TryGetCount(_infiniteTracingSpanEventsSeen, out var spanEventsSeen))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanSeen, spanEventsSeen);
-            }
-
-            if (TryGetCount(_infiniteTracingSpanEventsSent, out var spanEventsSent) && TryGetCount(_infiniteTracingSpanBatchCount, out var spanBatchCount))
-            {
-
-                var minBatchSize = Interlocked.Exchange(ref _infiniteTracingSpanBatchSizeMin, long.MaxValue);
-                var maxBatchSize = Interlocked.Exchange(ref _infiniteTracingSpanBatchSizeMax, long.MinValue);
-
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanSent, spanEventsSent);
-
-                if (minBatchSize < long.MaxValue && maxBatchSize > long.MinValue)
+                // accumulate values for this destination sub-area 
+                foreach (var dataSample in destinationArea)
                 {
-                    ReportSupportabilitySummaryMetric(MetricNames.SupportabilityInfiniteTracingSpanSentBatchSize, spanEventsSent, spanBatchCount, minBatchSize, maxBatchSize);
+                    destinationAreaCallCount++;
+                    destinationAreaBytesSent += dataSample.BytesSent;
+                    destinationAreaBytesReceived += dataSample.BytesReceived;
                 }
-            }
 
-            if (TryGetCount(_infiniteTracingSpanEventsReceived, out var spanEventsReceived))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanReceived, spanEventsReceived);
-            }
-
-            if (TryGetCount(_infiniteTracingSpanGrpcTimeout, out var timeouts))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingSpanGrpcTimeout, timeouts);
-            }
-
-            foreach (var errorCounterPair in _infiniteTracingSpanGrpcErrorCounters)
-            {
-                if (TryGetCount(errorCounterPair.Value, out var grpcErrorCount))
-                {
-                    var metricName = MetricNames.SupportabilityInfiniteTracingSpanGrpcError(errorCounterPair.Key);
-                    ReportSupportabilityCountMetric(metricName, grpcErrorCount);
-                }
-            }
-        }
-
-        private void ReportInfiniteTracingOneTimeMetrics()
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityInfiniteTracingCompression(_configuration.InfiniteTracingCompression));
-        }
-
-        #endregion
-
-        public void ReportAgentTimingMetric(string suffix, TimeSpan time)
-        {
-            var metric = _metricBuilder.TryBuildAgentTimingMetric(suffix, time);
-            TrySend(metric);
-        }
-
-        #region HttpError
-
-        public void ReportSupportabilityCollectorErrorException(string endpointMethod, TimeSpan responseDuration, HttpStatusCode? statusCode)
-        {
-            if (statusCode.HasValue)
-            {
-                TrySend(_metricBuilder.TryBuildSupportabilityErrorHttpStatusCodeFromCollector(statusCode.Value));
-            }
-
-            TrySend(_metricBuilder.TryBuildSupportabilityEndpointMethodErrorDuration(endpointMethod, responseDuration));
-        }
-
-        #endregion
-
-        #region Log Events and Metrics
-
-        // Used to report a logging framework is being instrumented for log forwarding, it does not take into account if forwarding was enabled or not.
-        private ConcurrentDictionary<string, bool> _loggingFrameworksReported = new ConcurrentDictionary<string, bool>();
-        public void ReportLogForwardingFramework(string logFramework)
-        {
-            _loggingFrameworksReported.TryAdd(logFramework, false);
-        }
-
-        // Used to report that both log forwarding is enabled and that a logging framework is being instrumented for logforwarding.
-        private ConcurrentDictionary<string, bool> _loggingForwardingEnabledWithFrameworksReported = new ConcurrentDictionary<string, bool>();
-        public void ReportLogForwardingEnabledWithFramework(string logFramework)
-        {
-            _loggingForwardingEnabledWithFrameworksReported.TryAdd(logFramework, false);
-        }
-
-        public void ReportLoggingEventsEmpty(int count = 1)
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingEventEmpty);
-        }
-
-        public void CollectLoggingMetrics()
-        {
-            var totalCount = 0;
-            foreach (var logLinesCounter in _logLinesCountByLevel)
-            {
-                if (TryGetCount(logLinesCounter.Value, out var linesCount))
-                {
-                    totalCount += linesCount;
-                    TrySend(_metricBuilder.TryBuildLoggingMetricsLinesCountBySeverityMetric(logLinesCounter.Key, linesCount));
-                }
-            }
-
-            if (totalCount > 0)
-            {
-                TrySend(_metricBuilder.TryBuildLoggingMetricsLinesCountMetric(totalCount));
-            }
-
-            foreach (var kvp in _loggingFrameworksReported)
-            {
-                if (kvp.Value == false)
-                {
-                    ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogFrameworkName(kvp.Key));
-                    _loggingFrameworksReported[kvp.Key] = true;
-                }
-            }
-
-            foreach (var kvp in _loggingForwardingEnabledWithFrameworksReported)
-            {
-                if (kvp.Value == false)
-                {
-                    ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogForwardingEnabledWithFrameworkName(kvp.Key));
-                    _loggingForwardingEnabledWithFrameworksReported[kvp.Key] = true;
-                }
-            }
-
-            var totalDeniedCount = 0;
-            foreach (var logLinesDeniedCounter in _logDeniedCountByLevel)
-            {
-                if (TryGetCount(logLinesDeniedCounter.Value, out var linesCount))
-                {
-                    totalDeniedCount += linesCount;
-                    TrySend(_metricBuilder.TryBuildLoggingMetricsDeniedCountBySeverityMetric(logLinesDeniedCounter.Key, linesCount));
-                }
-            }
-
-            if (totalDeniedCount > 0)
-            {
-                TrySend(_metricBuilder.TryBuildLoggingMetricsDeniedCountMetric(totalDeniedCount));
-            }
-
-        }
-
-        public void IncrementLogLinesCount(string level)
-        {
-            _logLinesCountByLevel.TryAdd(level, new InterlockedCounter());
-            _logLinesCountByLevel[level].Increment();
-        }
-
-        public void IncrementLogDeniedCount(string level)
-        {
-            _logDeniedCountByLevel.TryAdd(level, new InterlockedCounter());
-            _logDeniedCountByLevel[level].Increment();
-        }
-
-        public void ReportLoggingEventCollected() => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsCollectedMetric());
-
-        public void ReportLoggingEventsSent(int count)
-        {
-            TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsSentMetric(count));
-            _agentHealthEventCounters[AgentHealthEvent.Log]?.Add(count);
-        }
-
-        public void ReportLoggingEventsDropped(int droppedCount) => TrySend(_metricBuilder.TryBuildSupportabilityLoggingEventsDroppedMetric(droppedCount));
-
-        public void ReportIfAppDomainCachingDisabled()
-        {
-            if (_configuration.AppDomainCachingDisabled)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityAppDomainCachingDisabled);
-            }
-        }
-
-        public void ReportLogForwardingConfiguredValues()
-        {
-            ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogMetricsConfiguredName(_configuration.LogMetricsCollectorEnabled));
-            ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogForwardingConfiguredName(_configuration.LogEventCollectorEnabled));
-            ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogDecoratingConfiguredName(_configuration.LogDecoratorEnabled));
-            ReportSupportabilityCountMetric(MetricNames.GetSupportabilityLogLabelsConfiguredName(_configuration.LabelsEnabled));
-        }
-
-        #endregion
-
-        #region Agent Control
-
-        private void ReportIfAgentControlHealthEnabled()
-        {
-            if (_configuration.AgentControlEnabled)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityAgentControlHealthEnabled);
-            }
-        }
-
-        public void SetAgentControlStatus((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams)
-        {
-            // Do nothing if agent control is not enabled
-            if (!_configuration.AgentControlEnabled)
-                return;
-
-            if (healthStatus.Equals(HealthCodes.AgentShutdownHealthy))
-            {
-                if (_healthCheck.IsHealthy)
-                {
-                    _healthCheck.TrySetHealth(healthStatus);
-                }
-            }
-            else
-            {
-                _healthCheck.TrySetHealth(healthStatus, statusParams);
-            }
-        }
-
-        public void PublishAgentControlHealthCheck()
-        {
-            if (!_healthChecksInitialized) // initialize on first invocation
-            {
-                InitializeHealthChecks();
-                _healthChecksInitialized = true;
-            }
-
-            // stop the scheduled task if agent control isn't enabled or health checks fail for any reason
-            if (!_configuration.AgentControlEnabled || _healthChecksFailed)
-            {
-                _scheduler.StopExecuting(PublishAgentControlHealthCheck);
-                return;
-            }
-
-            var healthCheckYaml = _healthCheck.ToYaml(_configuration.EntityGuid);
-
-            Log.Finest("Publishing Agent Control health check report: {HealthCheckYaml}", healthCheckYaml);
-
-            try
-            {
-                using var fs = _fileWrapper.OpenWrite(Path.Combine(_healthCheckPath, _healthCheck.FileName));
-                var payloadBytes = Encoding.UTF8.GetBytes(healthCheckYaml);
-                fs.Write(payloadBytes, 0, payloadBytes.Length);
-                fs.Flush();
-            }
-            catch (Exception ex)
-            {
-                Log.Warn(ex, "Failed to write Agent Control health check report. Health checks will be disabled.");
-                _healthChecksFailed = true;
-            }
-        }
-
-        private void InitializeHealthChecks()
-        {
-            if (!_configuration.AgentControlEnabled)
-            {
-                Log.Debug("Agent Control is disabled. Health checks will not be reported.");
-                return;
-            }
-
-            Log.Debug("Initializing Agent Control health checks");
-
-            // make sure the delivery location is a file URI
-            var fileUri = new Uri(_configuration.HealthDeliveryLocation);
-            if (fileUri.Scheme != Uri.UriSchemeFile)
-            {
-                Log.Warn("Agent Control is enabled but the provided agent_control.health.delivery_location is not a file URL. Health checks will be disabled.");
-                _healthChecksFailed = true;
-                return;
-            }
-
-            _healthCheckPath = fileUri.LocalPath;
-
-            // verify the directory exists
-            if (!_directoryWrapper.Exists(_healthCheckPath))
-            {
-                Log.Warn("Agent Control is enabled but the path specified in agent_control.health.delivery_location does not exist. Health checks will be disabled.");
-                _healthChecksFailed = true;
-            }
-
-            // verify we can write a file to the directory
-            var testFile = Path.Combine(_healthCheckPath, Path.GetRandomFileName());
-            if (!_fileWrapper.TryCreateFile(testFile))
-            {
-                Log.Warn("Agent Control is enabled but the agent is unable to create files in the directory specified in agent_control.health.delivery_location. Health checks will be disabled.");
-                _healthChecksFailed = true;
-            }
-        }
-        #endregion
-
-        public void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint)
-        {
-            TrySend(_metricBuilder.TryBuildSupportabilityPayloadsDroppedDueToMaxPayloadLimit(endpoint));
-        }
-
-        // Only one metric harvest happens at a time, so locking around this bool is not important
-        private bool _oneTimeMetricsCollected;
-        private void CollectOneTimeMetrics()
-        {
-            if (_oneTimeMetricsCollected) return;
-            _oneTimeMetricsCollected = true;
-
-            ReportLogForwardingConfiguredValues();
-            ReportIfAppDomainCachingDisabled();
-            ReportInfiniteTracingOneTimeMetrics();
-            ReportIfLoggingDisabled();
-            ReportIfInstrumentationIsDisabled();
-            ReportIfGCSamplerV2IsEnabled();
-            ReportIfAwsAccountIdProvided();
-            ReportIfAgentControlHealthEnabled();
-            ReportIfAspNetCore6PlusIsEnabled();
-            ReportIfAzureFunctionModeIsDetected();
-            ReportIfOpenTelemetryIsEnabled();
-            ReportIfOpenTelemetryTracingIsEnabled();
-            ReportIfOpenTelemetryMetricsEnabled();
-        }
-
-        public void CollectMetrics()
-        {
-            CollectDistributedTraceMetrics();
-            CollectTraceContextSuccessMetrics();
-            CollectInfiniteTracingMetrics();
-            CollectLoggingMetrics();
-            CollectSupportabilityDataUsageMetrics();
-
-            ReportAgentVersion(AgentInstallConfiguration.AgentVersion);
-            ReportIfHostIsLinuxOs();
-            ReportDotnetVersion();
-            ReportAgentInfo();
-
-            CollectOneTimeMetrics();
-
-            ReportCustomInstrumentationCountMetrics();
-        }
-
-        private void ReportCustomInstrumentationCountMetrics()
-        {
-            TrySend(_metricBuilder.TryBuildCountMetric(MetricNames.SupportabilityCustomInstrumentationCount, _customInstrumentationCounter.Value));
-        }
-
-        public void RegisterPublishMetricHandler(PublishMetricDelegate publishMetricDelegate)
-        {
-            if (_publishMetricDelegate != null)
-            {
-                Log.Warn("Existing PublishMetricDelegate registration being overwritten.");
-            }
-
-            _publishMetricDelegate = publishMetricDelegate;
-        }
-
-        private void TrySend(MetricWireModel metric)
-        {
-            if (metric == null)
-            {
-                return;
-            }
-
-            if (_publishMetricDelegate == null)
-            {
-                Log.Warn("No PublishMetricDelegate to flush metric '{0}' through.", metric.MetricNameModel.Name);
-                return;
-            }
-
-            try
-            {
-                _publishMetricDelegate(metric);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "TrySend() failed");
-            }
-        }
-        private bool TryGetCount(InterlockedCounter counter, out int metricCount)
-        {
-            metricCount = 0;
-            if (counter.Value > 0)
-            {
-                metricCount = counter.Exchange(0);
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TryGetCount(InterlockedLongCounter counter, out long metricCount)
-        {
-            metricCount = 0;
-            if (counter.Value > 0)
-            {
-                metricCount = counter.Exchange(0);
-                return true;
-            }
-
-            return false;
-        }
-
-        private ConcurrentBag<DestinationInteractionSample> _externalApiDataUsageSamples = new ConcurrentBag<DestinationInteractionSample>();
-
-
-        public void ReportSupportabilityDataUsage(string api, string apiArea, long dataSent, long dataReceived)
-        {
-            _externalApiDataUsageSamples.Add(new DestinationInteractionSample(api, apiArea, dataSent, dataReceived));
-        }
-
-        private void CollectSupportabilityDataUsageMetrics()
-        {
-            var currentHarvest = Interlocked.Exchange(ref _externalApiDataUsageSamples, new ConcurrentBag<DestinationInteractionSample>());
-
-            foreach (var destination in currentHarvest.GroupBy(x => x.Api))
-            {
-                // Setup top level metrics to aggregate
-                var destinationName = string.IsNullOrWhiteSpace(destination.Key) ? "UnspecifiedDestination" : destination.Key;
-                var destinationCallCount = 0L;
-                var destinationBytesSent = 0L;
-                var destinationBytesReceived = 0L;
-
-                // inspect and report sub-metrics
-                foreach (var destinationArea in destination.GroupBy(x => x.ApiArea))
-                {
-                    var destinationAreaName = string.IsNullOrWhiteSpace(destinationArea.Key) ? "UnspecifiedDestinationArea" : destinationArea.Key;
-                    var destinationAreaCallCount = 0L;
-                    var destinationAreaBytesSent = 0L;
-                    var destinationAreaBytesReceived = 0L;
-
-                    // accumulate values for this destination sub-area 
-                    foreach (var dataSample in destinationArea)
-                    {
-                        destinationAreaCallCount++;
-                        destinationAreaBytesSent += dataSample.BytesSent;
-                        destinationAreaBytesReceived += dataSample.BytesReceived;
-                    }
-
-                    // increment top level metrics
-                    destinationCallCount += destinationAreaCallCount;
-                    destinationBytesSent += destinationAreaBytesSent;
-                    destinationBytesReceived += destinationAreaBytesReceived;
-
-                    ReportSupportabilityDataUsageMetric(
-                        MetricNames.GetPerDestinationAreaDataUsageMetricName(destinationName, destinationAreaName),
-                        destinationAreaCallCount,
-                        destinationAreaBytesSent,
-                        destinationAreaBytesReceived);
-                }
+                // increment top level metrics
+                destinationCallCount += destinationAreaCallCount;
+                destinationBytesSent += destinationAreaBytesSent;
+                destinationBytesReceived += destinationAreaBytesReceived;
 
                 ReportSupportabilityDataUsageMetric(
-                    MetricNames.GetPerDestinationDataUsageMetricName(destinationName),
-                    destinationCallCount,
-                    destinationBytesSent,
-                    destinationBytesReceived);
+                    MetricNames.GetPerDestinationAreaDataUsageMetricName(destinationName, destinationAreaName),
+                    destinationAreaCallCount,
+                    destinationAreaBytesSent,
+                    destinationAreaBytesReceived);
             }
-        }
 
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // Some one time metrics are reporting configured values, so we want to re-report them if the configuration changed
-            _oneTimeMetricsCollected = false;
+            ReportSupportabilityDataUsageMetric(
+                MetricNames.GetPerDestinationDataUsageMetricName(destinationName),
+                destinationCallCount,
+                destinationBytesSent,
+                destinationBytesReceived);
         }
-
-        private void ReportIfLoggingDisabled()
-        {
-            if (!_configuration.LoggingEnabled)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingDisabled);
-            }
-            if (Log.FileLoggingHasFailed)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingFatalError);
-            }
-        }
-
-        private void ReportIfInstrumentationIsDisabled()
-        {
-            var ignoredCount = _configuration.IgnoredInstrumentation.Count();
-            if (ignoredCount > 0)
-            {
-                ReportSupportabilityGaugeMetric(MetricNames.SupportabilityIgnoredInstrumentation, ignoredCount);
-            }
-        }
-
-        private void ReportIfGCSamplerV2IsEnabled()
-        {
-            if (_configuration.GCSamplerV2Enabled)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityGCSamplerV2Enabled);
-            }
-        }
-
-        private void ReportIfAwsAccountIdProvided()
-        {
-            if (!string.IsNullOrEmpty(_configuration.AwsAccountId))
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityAwsAccountIdProvided);
-            }
-        }
-
-        private void ReportIfAzureFunctionModeIsDetected()
-        {
-            if (_configuration.AzureFunctionModeDetected)
-            {
-                ReportSupportabilityCountMetric(MetricNames.SupportabilityAzureFunctionMode(_configuration.AzureFunctionModeEnabled));
-            }
-        }
-
-        private void ReportIfAspNetCore6PlusIsEnabled()
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityAspNetCore6PlusBrowserInjection(_configuration.EnableAspNetCore6PlusBrowserInjection));
-        }
-
-        private void ReportIfOpenTelemetryTracingIsEnabled()
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetryTracing(_configuration.OpenTelemetryTracingEnabled));
-        }
-
-        private void ReportIfOpenTelemetryIsEnabled()
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetry(_configuration.OpenTelemetryEnabled));
-        }
-
-        private void ReportIfOpenTelemetryMetricsEnabled()
-        {
-            ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetryMetrics(_configuration.OpenTelemetryMetricsEnabled));
-        }
-
-        /// <summary>
-        /// FOR UNIT TESTING ONLY
-        /// </summary>
-        public bool HealthCheckFailed => _healthChecksFailed;
     }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // Some one time metrics are reporting configured values, so we want to re-report them if the configuration changed
+        _oneTimeMetricsCollected = false;
+    }
+
+    private void ReportIfLoggingDisabled()
+    {
+        if (!_configuration.LoggingEnabled)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingDisabled);
+        }
+        if (Log.FileLoggingHasFailed)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityLoggingFatalError);
+        }
+    }
+
+    private void ReportIfInstrumentationIsDisabled()
+    {
+        var ignoredCount = _configuration.IgnoredInstrumentation.Count();
+        if (ignoredCount > 0)
+        {
+            ReportSupportabilityGaugeMetric(MetricNames.SupportabilityIgnoredInstrumentation, ignoredCount);
+        }
+    }
+
+    private void ReportIfGCSamplerV2IsEnabled()
+    {
+        if (_configuration.GCSamplerV2Enabled)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityGCSamplerV2Enabled);
+        }
+    }
+
+    private void ReportIfAwsAccountIdProvided()
+    {
+        if (!string.IsNullOrEmpty(_configuration.AwsAccountId))
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityAwsAccountIdProvided);
+        }
+    }
+
+    private void ReportIfAzureFunctionModeIsDetected()
+    {
+        if (_configuration.AzureFunctionModeDetected)
+        {
+            ReportSupportabilityCountMetric(MetricNames.SupportabilityAzureFunctionMode(_configuration.AzureFunctionModeEnabled));
+        }
+    }
+
+    private void ReportIfAspNetCore6PlusIsEnabled()
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityAspNetCore6PlusBrowserInjection(_configuration.EnableAspNetCore6PlusBrowserInjection));
+    }
+
+    private void ReportIfOpenTelemetryTracingIsEnabled()
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetryTracing(_configuration.OpenTelemetryTracingEnabled));
+    }
+
+    private void ReportIfOpenTelemetryIsEnabled()
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetry(_configuration.OpenTelemetryEnabled));
+    }
+
+    private void ReportIfOpenTelemetryMetricsEnabled()
+    {
+        ReportSupportabilityCountMetric(MetricNames.SupportabilityOpenTelemetryMetrics(_configuration.OpenTelemetryMetricsEnabled));
+    }
+
+    /// <summary>
+    /// FOR UNIT TESTING ONLY
+    /// </summary>
+    public bool HealthCheckFailed => _healthChecksFailed;
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentInfo.cs
@@ -3,19 +3,18 @@
 
 using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public class AgentInfo
 {
-    public class AgentInfo
+    [JsonProperty(PropertyName = "install_type", NullValueHandling = NullValueHandling.Ignore)]
+    public string InstallType { get; set; }
+
+    [JsonProperty(PropertyName = "azure_site_extension", NullValueHandling = NullValueHandling.Ignore)]
+    public bool AzureSiteExtension { get; set; }
+
+    public override string ToString()
     {
-        [JsonProperty(PropertyName = "install_type", NullValueHandling = NullValueHandling.Ignore)]
-        public string InstallType { get; set; }
-
-        [JsonProperty(PropertyName = "azure_site_extension", NullValueHandling = NullValueHandling.Ignore)]
-        public bool AzureSiteExtension { get; set; }
-
-        public override string ToString()
-        {
-            return $"{InstallType ?? "Unknown"}{(AzureSiteExtension ? "SiteExtension" : "")}";
-        }
+        return $"{InstallType ?? "Unknown"}{(AzureSiteExtension ? "SiteExtension" : "")}";
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/DestinationInteractionSample.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/DestinationInteractionSample.cs
@@ -1,21 +1,20 @@
-﻿// Copyright 2020 New Relic, Inc. All rights reserved.
+// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.AgentHealth
-{
-    public class DestinationInteractionSample
-    {
-        public readonly string Api;
-        public readonly string ApiArea;
-        public readonly long BytesSent;
-        public readonly long BytesReceived;
+namespace NewRelic.Agent.Core.AgentHealth;
 
-        public DestinationInteractionSample(string api, string apiArea, long dataSent, long dataReceived)
-        {
-            Api = api;
-            ApiArea = apiArea;
-            BytesSent = dataSent;
-            BytesReceived = dataReceived;
-        }
+public class DestinationInteractionSample
+{
+    public readonly string Api;
+    public readonly string ApiArea;
+    public readonly long BytesSent;
+    public readonly long BytesReceived;
+
+    public DestinationInteractionSample(string api, string apiArea, long dataSent, long dataReceived)
+    {
+        Api = api;
+        ApiArea = apiArea;
+        BytesSent = dataSent;
+        BytesReceived = dataReceived;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCheck.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCheck.cs
@@ -4,58 +4,57 @@
 using System;
 using NewRelic.Agent.Core.Utilities;
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public class HealthCheck
 {
-    public class HealthCheck
+    private const int NanoSecondsPerMillisecond = 1000000;
+
+    public bool IsHealthy { get; internal set; }
+    public string Status { get; internal set; }
+    public string LastError { get; internal set; }
+    public DateTime StartTime { get; } = DateTime.UtcNow;
+    public DateTime StatusTime { get; internal set; }
+    public string FileName { get; } = "health-" + System.Guid.NewGuid().ToString("N") + ".yml";
+
+    /// <summary>
+    /// Set the health status of the agent, but only update changed values.
+    /// </summary>
+    /// <param name="healthy"></param>
+    /// <param name="healthStatus"></param>
+    /// <param name="statusParams"></param>
+    public void TrySetHealth((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams)
     {
-        private const int NanoSecondsPerMillisecond = 1000000;
-
-        public bool IsHealthy { get; internal set; }
-        public string Status { get; internal set; }
-        public string LastError { get; internal set; }
-        public DateTime StartTime { get; } = DateTime.UtcNow;
-        public DateTime StatusTime { get; internal set; }
-        public string FileName { get; } = "health-" + System.Guid.NewGuid().ToString("N") + ".yml";
-
-        /// <summary>
-        /// Set the health status of the agent, but only update changed values.
-        /// </summary>
-        /// <param name="healthy"></param>
-        /// <param name="healthStatus"></param>
-        /// <param name="statusParams"></param>
-        public void TrySetHealth((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams)
+        lock (this)
         {
-            lock (this)
+            if (IsHealthy != healthStatus.IsHealthy)
             {
-                if (IsHealthy != healthStatus.IsHealthy)
-                {
-                    IsHealthy = healthStatus.IsHealthy;
-                }
-
-                if (string.IsNullOrEmpty(Status) || !Status.Equals(healthStatus.Code, StringComparison.OrdinalIgnoreCase))
-                {
-                    Status = statusParams is { Length: > 0 } ?
-                        string.Format(healthStatus.Status, statusParams)
-                        :
-                        healthStatus.Status;
-                }
-
-                if (string.IsNullOrEmpty(LastError) || !LastError.Equals(healthStatus.Code, StringComparison.OrdinalIgnoreCase))
-                {
-                    LastError = healthStatus.Code;
-                }
-
-                StatusTime = DateTime.UtcNow;
+                IsHealthy = healthStatus.IsHealthy;
             }
+
+            if (string.IsNullOrEmpty(Status) || !Status.Equals(healthStatus.Code, StringComparison.OrdinalIgnoreCase))
+            {
+                Status = statusParams is { Length: > 0 } ?
+                    string.Format(healthStatus.Status, statusParams)
+                    :
+                    healthStatus.Status;
+            }
+
+            if (string.IsNullOrEmpty(LastError) || !LastError.Equals(healthStatus.Code, StringComparison.OrdinalIgnoreCase))
+            {
+                LastError = healthStatus.Code;
+            }
+
+            StatusTime = DateTime.UtcNow;
         }
+    }
 
-        public string ToYaml(string entityGuid)
+    public string ToYaml(string entityGuid)
+    {
+        lock (this)
         {
-            lock (this)
-            {
-                return
-                    $"entity_guid: {entityGuid}\nhealthy: {IsHealthy}\nstatus: {Status}\nlast_error: {LastError}\nstart_time_unix_nano: {StartTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}\nstatus_time_unix_nano: {StatusTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}";
-            }
+            return
+                $"entity_guid: {entityGuid}\nhealthy: {IsHealthy}\nstatus: {Status}\nlast_error: {LastError}\nstart_time_unix_nano: {StartTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}\nstatus_time_unix_nano: {StatusTime.ToUnixTimeMilliseconds() * NanoSecondsPerMillisecond}";
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCodes.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/HealthCodes.cs
@@ -1,84 +1,83 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public static class HealthCodes
 {
-    public static class HealthCodes
-    {
-        /// <summary>
-        /// Healthy
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) Healthy = (true, "NR-APM-000",
-            "Healthy");
+    /// <summary>
+    /// Healthy
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) Healthy = (true, "NR-APM-000",
+        "Healthy");
 
-        /// <summary>
-        /// Invalid license key (HTTP status code 401)
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) LicenseKeyInvalid = (false, "NR-APM-001",
-            "Invalid license key (HTTP status code 401)");
+    /// <summary>
+    /// Invalid license key (HTTP status code 401)
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) LicenseKeyInvalid = (false, "NR-APM-001",
+        "Invalid license key (HTTP status code 401)");
 
-        /// <summary>
-        /// License key missing in configuration
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) LicenseKeyMissing = (false, "NR-APM-002",
-            "License key missing in configuration");
+    /// <summary>
+    /// License key missing in configuration
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) LicenseKeyMissing = (false, "NR-APM-002",
+        "License key missing in configuration");
 
-        /// <summary>
-        /// Forced disconnect received from New Relic (HTTP status code 410)
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) ForceDisconnect = (false, "NR-APM-003",
-            "Forced disconnect received from New Relic (HTTP status code 410)");
+    /// <summary>
+    /// Forced disconnect received from New Relic (HTTP status code 410)
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) ForceDisconnect = (false, "NR-APM-003",
+        "Forced disconnect received from New Relic (HTTP status code 410)");
 
-        /// <summary>
-        /// HTTP error response code [%s] received from New Relic while sending data type [%s]
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) HttpError = (false, "NR-APM-004",
-            "HTTP error response code {0} received from New Relic while sending data type {1}");
+    /// <summary>
+    /// HTTP error response code [%s] received from New Relic while sending data type [%s]
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) HttpError = (false, "NR-APM-004",
+        "HTTP error response code {0} received from New Relic while sending data type {1}");
 
-        /// <summary>
-        /// Missing application name in agent configuration
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) ApplicationNameMissing = (false, "NR-APM-005",
-            "Missing application name in agent configuration");
+    /// <summary>
+    /// Missing application name in agent configuration
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) ApplicationNameMissing = (false, "NR-APM-005",
+        "Missing application name in agent configuration");
 
-        /// <summary>
-        /// The maximum number of configured app names (3) exceeded
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) MaxApplicationNamesExceeded = (false, "NR-APM-006",
-            "The maximum number of configured app names (3) exceeded");
+    /// <summary>
+    /// The maximum number of configured app names (3) exceeded
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) MaxApplicationNamesExceeded = (false, "NR-APM-006",
+        "The maximum number of configured app names (3) exceeded");
 
-        /// <summary>
-        /// HTTP Proxy configuration error; response code [%s]
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) HttpProxyError = (false, "NR-APM-007",
-            "HTTP Proxy configuration error; response code {0}");
+    /// <summary>
+    /// HTTP Proxy configuration error; response code [%s]
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) HttpProxyError = (false, "NR-APM-007",
+        "HTTP Proxy configuration error; response code {0}");
 
-        /// <summary>
-        /// Agent is disabled via configuration
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) AgentDisabledByConfiguration = (false, "NR-APM-008",
-            "Agent is disabled via configuration");
+    /// <summary>
+    /// Agent is disabled via configuration
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) AgentDisabledByConfiguration = (false, "NR-APM-008",
+        "Agent is disabled via configuration");
 
-        /// <summary>
-        /// Failed to connect to New Relic data collector
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) FailedToConnect = (false, "NR-APM-009",
-            "Failed to connect to New Relic data collector");
+    /// <summary>
+    /// Failed to connect to New Relic data collector
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) FailedToConnect = (false, "NR-APM-009",
+        "Failed to connect to New Relic data collector");
 
-        /// <summary>
-        /// Agent has shutdown
-        /// Only be reported if agent is "healthy" on shutdown.
-        /// If the agent status is not Healthy on agent shutdown, the existing error MUST not be overwritten.
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) AgentShutdownHealthy = (true, "NR-APM-099",
-            "Agent has shutdown");
+    /// <summary>
+    /// Agent has shutdown
+    /// Only be reported if agent is "healthy" on shutdown.
+    /// If the agent status is not Healthy on agent shutdown, the existing error MUST not be overwritten.
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) AgentShutdownHealthy = (true, "NR-APM-099",
+        "Agent has shutdown");
 
-        // Agent health codes for the .NET agent are 200-299
+    // Agent health codes for the .NET agent are 200-299
 
-        /// <summary>
-        /// Agent has shutdown with exception [%s]
-        /// </summary>
-        public static readonly (bool IsHealthy, string Code, string Status) AgentShutdownError = (false, "NR-APM-200",
-            "Agent has shutdown with exception {0}");
-    }
+    /// <summary>
+    /// Agent has shutdown with exception [%s]
+    /// </summary>
+    public static readonly (bool IsHealthy, string Code, string Status) AgentShutdownError = (false, "NR-APM-200",
+        "Agent has shutdown with exception {0}");
 }

--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/IAgentHealthReporter.cs
@@ -1,160 +1,159 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Net;
 using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
-using System;
-using System.Net;
 
-namespace NewRelic.Agent.Core.AgentHealth
+namespace NewRelic.Agent.Core.AgentHealth;
+
+public interface IAgentHealthReporter : IOutOfBandMetricSource
 {
-    public interface IAgentHealthReporter : IOutOfBandMetricSource
-    {
-        void ReportDotnetVersion();
+    void ReportDotnetVersion();
 
-        void ReportAgentVersion(string agentVersion);
+    void ReportAgentVersion(string agentVersion);
 
-        void ReportLibraryVersion(string assemblyName, string assemblyVersion);
+    void ReportLibraryVersion(string assemblyName, string assemblyVersion);
 
-        void ReportCustomInstrumentation(string assemblyName, string className, string method);
+    void ReportCustomInstrumentation(string assemblyName, string className, string method);
 
-        void ReportTransactionEventReservoirResized(int newSize);
+    void ReportTransactionEventReservoirResized(int newSize);
 
-        void ReportTransactionEventCollected();
+    void ReportTransactionEventCollected();
 
-        void ReportTransactionEventsRecollected(int count);
+    void ReportTransactionEventsRecollected(int count);
 
-        void ReportTransactionEventsSent(int count);
+    void ReportTransactionEventsSent(int count);
 
-        void ReportCustomEventReservoirResized(int newSize);
+    void ReportCustomEventReservoirResized(int newSize);
 
-        void ReportCustomEventCollected();
+    void ReportCustomEventCollected();
 
-        void ReportCustomEventsRecollected(int count);
+    void ReportCustomEventsRecollected(int count);
 
-        void ReportCustomEventsSent(int count);
+    void ReportCustomEventsSent(int count);
 
-        void ReportErrorTraceCollected();
+    void ReportErrorTraceCollected();
 
-        void ReportErrorTracesRecollected(int count);
+    void ReportErrorTracesRecollected(int count);
 
-        void ReportErrorTracesSent(int count);
+    void ReportErrorTracesSent(int count);
 
-        void ReportErrorEventSeen();
+    void ReportErrorEventSeen();
 
-        void ReportErrorEventsSent(int count);
+    void ReportErrorEventsSent(int count);
 
-        void ReportSqlTracesRecollected(int count);
+    void ReportSqlTracesRecollected(int count);
 
-        void ReportSqlTracesSent(int count);
+    void ReportSqlTracesSent(int count);
 
-        void ReportTransactionGarbageCollected(string transactionGuid, TransactionMetricName transactionMetricName, string lastStartedSegmentName, string lastFinishedSegmentName);
+    void ReportTransactionGarbageCollected(string transactionGuid, TransactionMetricName transactionMetricName, string lastStartedSegmentName, string lastFinishedSegmentName);
 
-        void ReportWrapperShutdown(IWrapper wrapper, Method method);
+    void ReportWrapperShutdown(IWrapper wrapper, Method method);
 
-        void ReportIfHostIsLinuxOs();
+    void ReportIfHostIsLinuxOs();
 
-        void ReportBootIdError();
-        void ReportKubernetesUtilizationError();
-        void ReportAwsUtilizationError();
-        void ReportAzureUtilizationError();
-        void ReportPcfUtilizationError();
-        void ReportGcpUtilizationError();
-        void ReportAgentTimingMetric(string timerName, TimeSpan stopWatchElapsedMilliseconds);
+    void ReportBootIdError();
+    void ReportKubernetesUtilizationError();
+    void ReportAwsUtilizationError();
+    void ReportAzureUtilizationError();
+    void ReportPcfUtilizationError();
+    void ReportGcpUtilizationError();
+    void ReportAgentTimingMetric(string timerName, TimeSpan stopWatchElapsedMilliseconds);
 
-        /// <summary>Created when AcceptDistributedTracePayload was called successfully</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadSuccess();
+    /// <summary>Created when AcceptDistributedTracePayload was called successfully</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadSuccess();
 
-        /// <summary>Created when AcceptDistributedTracePayload had a generic exception</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadException();
+    /// <summary>Created when AcceptDistributedTracePayload had a generic exception</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadException();
 
-        /// <summary>Created when AcceptDistributedTracePayload had a parsing exception</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadParseException();
+    /// <summary>Created when AcceptDistributedTracePayload had a parsing exception</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadParseException();
 
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because CreatePayload had already been called</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredCreateBeforeAccept();
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because CreatePayload had already been called</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredCreateBeforeAccept();
 
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because AcceptPayload had already been called</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMultiple();
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because AcceptPayload had already been called</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMultiple();
 
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload's major version was greater than the agent's</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMajorVersion();
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload's major version was greater than the agent's</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredMajorVersion();
 
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was null</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredNull();
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was null</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredNull();
 
-        /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was untrusted</summary>
-        void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredUntrustedAccount();
+    /// <summary>Created when AcceptDistributedTracePayload was ignored because the payload was untrusted</summary>
+    void ReportSupportabilityDistributedTraceAcceptPayloadIgnoredUntrustedAccount();
 
-        /// <summary>Created when CreateDistributedTracePayload was called successfully</summary>
-        void ReportSupportabilityDistributedTraceCreatePayloadSuccess();
+    /// <summary>Created when CreateDistributedTracePayload was called successfully</summary>
+    void ReportSupportabilityDistributedTraceCreatePayloadSuccess();
 
-        /// <summary>Created when CreateDistributedTracePayload had a generic exception</summary>
-        void ReportSupportabilityDistributedTraceCreatePayloadException();
+    /// <summary>Created when CreateDistributedTracePayload had a generic exception</summary>
+    void ReportSupportabilityDistributedTraceCreatePayloadException();
 
-        /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
-        void ReportSupportabilityTraceContextAcceptSuccess();
+    /// <summary>Incremented when the agent successfuly processes inbound tracestate and traceparent headers</summary>
+    void ReportSupportabilityTraceContextAcceptSuccess();
 
-        /// <summary>Incremented when the agent successfully creates outbound trace context payloads</summary>
-        void ReportSupportabilityTraceContextCreateSuccess();
+    /// <summary>Incremented when the agent successfully creates outbound trace context payloads</summary>
+    void ReportSupportabilityTraceContextCreateSuccess();
 
-        /// <summary>Created when a generic exception occurred unrelated to parsing while accepting either payload.</summary>
-        void ReportSupportabilityTraceContextAcceptException();
+    /// <summary>Created when a generic exception occurred unrelated to parsing while accepting either payload.</summary>
+    void ReportSupportabilityTraceContextAcceptException();
 
-        /// <summary>Created when the inbound traceparent header could not be parsed.</summary>
-        void ReportSupportabilityTraceContextTraceParentParseException();
+    /// <summary>Created when the inbound traceparent header could not be parsed.</summary>
+    void ReportSupportabilityTraceContextTraceParentParseException();
 
-        /// <summary>Created when the inbound tracestate header could not be parsed.</summary>
-        void ReportSupportabilityTraceContextTraceStateParseException();
+    /// <summary>Created when the inbound tracestate header could not be parsed.</summary>
+    void ReportSupportabilityTraceContextTraceStateParseException();
 
-        /// <summary>Created when a generic exception occurred while creating the outbound payloads.</summary>
-        void ReportSupportabilityTraceContextCreateException();
+    /// <summary>Created when a generic exception occurred while creating the outbound payloads.</summary>
+    void ReportSupportabilityTraceContextCreateException();
 
-        /// <summary>Created when the inbound tracestate header exists, and was accepted, but the New Relic entry was invalid.</summary>
-        void ReportSupportabilityTraceContextTraceStateInvalidNrEntry();
+    /// <summary>Created when the inbound tracestate header exists, and was accepted, but the New Relic entry was invalid.</summary>
+    void ReportSupportabilityTraceContextTraceStateInvalidNrEntry();
 
-        /// <summary>Created when the traceparent header exists, and was accepted, but the tracestate header did not contain a trusted New Relic entry.</summary>
-        void ReportSupportabilityTraceContextTraceStateNoNrEntry();
+    /// <summary>Created when the traceparent header exists, and was accepted, but the tracestate header did not contain a trusted New Relic entry.</summary>
+    void ReportSupportabilityTraceContextTraceStateNoNrEntry();
 
-        void ReportSupportabilityCollectorErrorException(string endpointMethod, TimeSpan responseDuration, HttpStatusCode? statusCode);
+    void ReportSupportabilityCollectorErrorException(string endpointMethod, TimeSpan responseDuration, HttpStatusCode? statusCode);
 
-        void ReportSpanEventCollected(int count);
+    void ReportSpanEventCollected(int count);
 
-        void ReportSpanEventsSent(int count);
+    void ReportSpanEventsSent(int count);
 
-        void CollectDistributedTraceMetrics();
+    void CollectDistributedTraceMetrics();
 
-        void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint);
+    void ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(string endpoint);
 
-        void ReportAgentInfo();
+    void ReportAgentInfo();
 
-        void ReportSupportabilityCountMetric(string metricName, long count = 1);
-        void ReportCountMetric(string metricName, long count = 1);
+    void ReportSupportabilityCountMetric(string metricName, long count = 1);
+    void ReportCountMetric(string metricName, long count = 1);
 
-        void ReportInfiniteTracingSpanResponseError();
-        void ReportInfiniteTracingSpanEventsSeen(long count = 1);
-        void ReportInfiniteTracingSpanEventsSent(long count = 1);
-        void ReportInfiniteTracingSpanEventsReceived(ulong count);
-        void ReportInfiniteTracingSpanEventsDropped(long count = 1);
-        void ReportInfiniteTracingSpanGrpcError(string status);
-        void ReportInfiniteTracingSpanGrpcTimeout();
-        void ReportInfiniteTracingSpanQueueSize(int queueSize);
+    void ReportInfiniteTracingSpanResponseError();
+    void ReportInfiniteTracingSpanEventsSeen(long count = 1);
+    void ReportInfiniteTracingSpanEventsSent(long count = 1);
+    void ReportInfiniteTracingSpanEventsReceived(ulong count);
+    void ReportInfiniteTracingSpanEventsDropped(long count = 1);
+    void ReportInfiniteTracingSpanGrpcError(string status);
+    void ReportInfiniteTracingSpanGrpcTimeout();
+    void ReportInfiniteTracingSpanQueueSize(int queueSize);
 		
-        void ReportSupportabilityDataUsage(string api, string apiArea, long dataSent, long dataReceived);
+    void ReportSupportabilityDataUsage(string api, string apiArea, long dataSent, long dataReceived);
 
-        void IncrementLogLinesCount(string logLevel);
-        void IncrementLogDeniedCount(string logLevel);
-        void ReportLoggingEventCollected();
-        void ReportLoggingEventsSent(int count);
-        void ReportLoggingEventsDropped(int droppedCount);
-        void ReportLogForwardingFramework(string logFramework);
-        void ReportLogForwardingEnabledWithFramework(string logFramework);
-        void ReportByteMetric(string metricName, long totalBytes, long? exclusiveBytes = null);
-        void ReportLoggingEventsEmpty(int count = 1);
-        void SetAgentControlStatus((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams);
-        void PublishAgentControlHealthCheck();
-        void ReportSupportabilityDistributedTraceHeadersAcceptedLate();
-        bool ValidateAgentConfiguration();
-    }
+    void IncrementLogLinesCount(string logLevel);
+    void IncrementLogDeniedCount(string logLevel);
+    void ReportLoggingEventCollected();
+    void ReportLoggingEventsSent(int count);
+    void ReportLoggingEventsDropped(int droppedCount);
+    void ReportLogForwardingFramework(string logFramework);
+    void ReportLogForwardingEnabledWithFramework(string logFramework);
+    void ReportByteMetric(string metricName, long totalBytes, long? exclusiveBytes = null);
+    void ReportLoggingEventsEmpty(int count = 1);
+    void SetAgentControlStatus((bool IsHealthy, string Code, string Status) healthStatus, params string[] statusParams);
+    void PublishAgentControlHealthCheck();
+    void ReportSupportabilityDistributedTraceHeadersAcceptedLate();
+    bool ValidateAgentConfiguration();
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/AbstractAggregator.cs
@@ -4,87 +4,86 @@
 using System;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Core.SharedInterfaces;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public abstract class AbstractAggregator<T> : ConfigurationBasedService
 {
-    public abstract class AbstractAggregator<T> : ConfigurationBasedService
+    protected readonly IDataTransportService DataTransportService;
+    protected readonly IServerlessModeDataTransportService ServerlessModeDataTransportService;
+    private readonly IScheduler _scheduler;
+    private readonly IProcessStatic _processStatic;
+
+    protected AbstractAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic)
     {
-        protected readonly IDataTransportService DataTransportService;
-        protected readonly IServerlessModeDataTransportService ServerlessModeDataTransportService;
-        private readonly IScheduler _scheduler;
-        private readonly IProcessStatic _processStatic;
+        DataTransportService = dataTransportService;
 
-        protected AbstractAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic)
-        {
-            DataTransportService = dataTransportService;
+        if (dataTransportService is IServerlessModeDataTransportService service)
+            ServerlessModeDataTransportService = service;
 
-            if (dataTransportService is IServerlessModeDataTransportService service)
-                ServerlessModeDataTransportService = service;
+        _scheduler = scheduler;
+        _processStatic = processStatic;
 
-            _scheduler = scheduler;
-            _processStatic = processStatic;
+        _subscriptions.Add<StopHarvestEvent>(OnStopHarvestEvent);
+        _subscriptions.Add<AgentConnectedEvent>(OnAgentConnected);
+        _subscriptions.Add<PreCleanShutdownEvent>(OnPreCleanShutdown);
 
-            _subscriptions.Add<StopHarvestEvent>(OnStopHarvestEvent);
-            _subscriptions.Add<AgentConnectedEvent>(OnAgentConnected);
-            _subscriptions.Add<PreCleanShutdownEvent>(OnPreCleanShutdown);
-
-            _subscriptions.Add<ManualHarvestEvent>(OnManualHarvest);
-        }
-
-        private void OnManualHarvest(ManualHarvestEvent manualHarvestEvent)
-        {
-            ManualHarvest(manualHarvestEvent.TransactionId);
-        }
-
-        private void OnStopHarvestEvent(StopHarvestEvent obj)
-        {
-            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
-        }
-
-        public abstract void Collect(T wireModel);
-
-        protected abstract void Harvest();
-
-        protected abstract void ManualHarvest(string transactionId);
-
-        protected abstract bool IsEnabled { get; }
-
-        protected virtual TimeSpan HarvestCycle => _configuration.DefaultHarvestCycle;
-
-        private void OnAgentConnected(AgentConnectedEvent _)
-        {
-            if (IsEnabled)
-            {
-                _scheduler.ExecuteEvery(Harvest, HarvestCycle);
-            }
-            else
-            {
-                _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
-            }
-        }
-
-        private void OnPreCleanShutdown(PreCleanShutdownEvent obj)
-        {
-            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
-
-            if (!_configuration.CollectorSendDataOnExit || !IsEnabled)
-                return;
-
-            var uptime = DateTime.Now - _processStatic.GetCurrentProcess().StartTime;
-            if (!(uptime.TotalMilliseconds > _configuration.CollectorSendDataOnExitThreshold))
-                return;
-
-            Harvest();
-        }
-
-        public override void Dispose()
-        {
-            _scheduler.StopExecuting(Harvest);
-            base.Dispose();
-        }
-
+        _subscriptions.Add<ManualHarvestEvent>(OnManualHarvest);
     }
+
+    private void OnManualHarvest(ManualHarvestEvent manualHarvestEvent)
+    {
+        ManualHarvest(manualHarvestEvent.TransactionId);
+    }
+
+    private void OnStopHarvestEvent(StopHarvestEvent obj)
+    {
+        _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
+    }
+
+    public abstract void Collect(T wireModel);
+
+    protected abstract void Harvest();
+
+    protected abstract void ManualHarvest(string transactionId);
+
+    protected abstract bool IsEnabled { get; }
+
+    protected virtual TimeSpan HarvestCycle => _configuration.DefaultHarvestCycle;
+
+    private void OnAgentConnected(AgentConnectedEvent _)
+    {
+        if (IsEnabled)
+        {
+            _scheduler.ExecuteEvery(Harvest, HarvestCycle);
+        }
+        else
+        {
+            _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
+        }
+    }
+
+    private void OnPreCleanShutdown(PreCleanShutdownEvent obj)
+    {
+        _scheduler.StopExecuting(Harvest, TimeSpan.FromSeconds(2));
+
+        if (!_configuration.CollectorSendDataOnExit || !IsEnabled)
+            return;
+
+        var uptime = DateTime.Now - _processStatic.GetCurrentProcess().StartTime;
+        if (!(uptime.TotalMilliseconds > _configuration.CollectorSendDataOnExitThreshold))
+            return;
+
+        Harvest();
+    }
+
+    public override void Dispose()
+    {
+        _scheduler.StopExecuting(Harvest);
+        base.Dispose();
+    }
+
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/CustomEventAggregator.cs
@@ -1,163 +1,162 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.AgentHealth;
-using NewRelic.Agent.Core.DataTransport;
-using NewRelic.Agent.Core.Events;
-using NewRelic.Agent.Core.Time;
-using NewRelic.Agent.Core.WireModels;
-using NewRelic.Agent.Extensions.Collections;
-using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Core.WireModels;
+using NewRelic.Agent.Extensions.Collections;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ICustomEventAggregator
 {
-    public interface ICustomEventAggregator
+    void Collect(CustomEventWireModel customEventWireModel);
+}
+
+/// <summary>
+/// An service for collecting and managing custom events.
+/// </summary>
+public class CustomEventAggregator : AbstractAggregator<CustomEventWireModel>, ICustomEventAggregator
+{
+    private const double ReservoirReductionSizeMultiplier = 0.5;
+
+    private readonly IAgentHealthReporter _agentHealthReporter;
+
+    private readonly ReaderWriterLockSlim _readerWriterLockSlim = new ReaderWriterLockSlim();
+
+    private ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> _customEvents = new ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>>(0);
+
+    public CustomEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
+        : base(dataTransportService, scheduler, processStatic)
     {
-        void Collect(CustomEventWireModel customEventWireModel);
+        _agentHealthReporter = agentHealthReporter;
+        GetAndResetCollection(_configuration.CustomEventsMaximumSamplesStored);
     }
 
-    /// <summary>
-    /// An service for collecting and managing custom events.
-    /// </summary>
-    public class CustomEventAggregator : AbstractAggregator<CustomEventWireModel>, ICustomEventAggregator
+    public override void Dispose()
     {
-        private const double ReservoirReductionSizeMultiplier = 0.5;
+        _readerWriterLockSlim.Dispose();
 
-        private readonly IAgentHealthReporter _agentHealthReporter;
+        base.Dispose();
+    }
 
-        private readonly ReaderWriterLockSlim _readerWriterLockSlim = new ReaderWriterLockSlim();
+    protected override TimeSpan HarvestCycle => _configuration.CustomEventsHarvestCycle;
+    protected override bool IsEnabled => _configuration.CustomEventsEnabled;
 
-        private ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> _customEvents = new ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>>(0);
+    public override void Collect(CustomEventWireModel customEventWireModel)
+    {
+        _agentHealthReporter.ReportCustomEventCollected();
 
-        public CustomEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
-            : base(dataTransportService, scheduler, processStatic)
+        _readerWriterLockSlim.EnterReadLock();
+        try
         {
-            _agentHealthReporter = agentHealthReporter;
-            GetAndResetCollection(_configuration.CustomEventsMaximumSamplesStored);
+            _customEvents.Add(new PrioritizedNode<CustomEventWireModel>(customEventWireModel));
+        }
+        finally
+        {
+            _readerWriterLockSlim.ExitReadLock();
+        }
+    }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Custom Event harvest starting.");
+
+        ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> originalCustomEvents;
+
+        _readerWriterLockSlim.EnterWriteLock();
+        try
+        {
+            originalCustomEvents = GetAndResetCollection(_customEvents.Size);
+        }
+        finally
+        {
+            _readerWriterLockSlim.ExitWriteLock();
         }
 
-        public override void Dispose()
-        {
-            _readerWriterLockSlim.Dispose();
+        var customEvents = originalCustomEvents.Where(node => node != null).Select(node => node.Data).ToList();
 
-            base.Dispose();
+        // if we don't have any events to publish then don't
+        var eventCount = customEvents.Count;
+        if (eventCount > 0)
+        {
+            var responseStatus = DataTransportService.Send(customEvents, transactionId);
+
+            HandleResponse(responseStatus, customEvents);
         }
 
-        protected override TimeSpan HarvestCycle => _configuration.CustomEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.CustomEventsEnabled;
+        Log.Finest("Custom Event harvest finished.");
+    }
 
-        public override void Collect(CustomEventWireModel customEventWireModel)
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        GetAndResetCollection(_configuration.CustomEventsMaximumSamplesStored);
+    }
+
+    private ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> GetAndResetCollection(int customEventCollectionCapacity)
+    {
+        return Interlocked.Exchange(ref _customEvents, new ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>>(customEventCollectionCapacity));
+    }
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<CustomEventWireModel> customEvents)
+    {
+        switch (responseStatus)
         {
-            _agentHealthReporter.ReportCustomEventCollected();
-
-            _readerWriterLockSlim.EnterReadLock();
-            try
-            {
-                _customEvents.Add(new PrioritizedNode<CustomEventWireModel>(customEventWireModel));
-            }
-            finally
-            {
-                _readerWriterLockSlim.ExitReadLock();
-            }
+            case DataTransportResponseStatus.RequestSuccessful:
+                _agentHealthReporter.ReportCustomEventsSent(customEvents.Count);
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainEvents(customEvents);
+                Log.Debug("Retaining {count} custom events.", customEvents.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                var newSize = (int)(customEvents.Count * ReservoirReductionSizeMultiplier);
+                ReduceReservoirSize(newSize);
+                RetainEvents(customEvents);
+                Log.Debug("Reservoir size reduced. Retaining {count} custom events.", customEvents.Count);
+                break;
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} custom events.", customEvents.Count);
+                break;
         }
+    }
 
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+    private void RetainEvents(IEnumerable<CustomEventWireModel> customEvents)
+    {
+        customEvents = customEvents.ToList();
+        _agentHealthReporter.ReportCustomEventsRecollected(customEvents.Count());
 
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
+        foreach (var customEvent in customEvents)
         {
-            Log.Finest("Custom Event harvest starting.");
-
-            ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> originalCustomEvents;
-
-            _readerWriterLockSlim.EnterWriteLock();
-            try
+            if (customEvent != null)
             {
-                originalCustomEvents = GetAndResetCollection(_customEvents.Size);
-            }
-            finally
-            {
-                _readerWriterLockSlim.ExitWriteLock();
-            }
-
-            var customEvents = originalCustomEvents.Where(node => node != null).Select(node => node.Data).ToList();
-
-            // if we don't have any events to publish then don't
-            var eventCount = customEvents.Count;
-            if (eventCount > 0)
-            {
-                var responseStatus = DataTransportService.Send(customEvents, transactionId);
-
-                HandleResponse(responseStatus, customEvents);
-            }
-
-            Log.Finest("Custom Event harvest finished.");
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            GetAndResetCollection(_configuration.CustomEventsMaximumSamplesStored);
-        }
-
-        private ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>> GetAndResetCollection(int customEventCollectionCapacity)
-        {
-            return Interlocked.Exchange(ref _customEvents, new ConcurrentPriorityQueue<PrioritizedNode<CustomEventWireModel>>(customEventCollectionCapacity));
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<CustomEventWireModel> customEvents)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    _agentHealthReporter.ReportCustomEventsSent(customEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainEvents(customEvents);
-                    Log.Debug("Retaining {count} custom events.", customEvents.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                    var newSize = (int)(customEvents.Count * ReservoirReductionSizeMultiplier);
-                    ReduceReservoirSize(newSize);
-                    RetainEvents(customEvents);
-                    Log.Debug("Reservoir size reduced. Retaining {count} custom events.", customEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} custom events.", customEvents.Count);
-                    break;
+                _customEvents.Add(new PrioritizedNode<CustomEventWireModel>(customEvent));
             }
         }
+    }
 
-        private void RetainEvents(IEnumerable<CustomEventWireModel> customEvents)
-        {
-            customEvents = customEvents.ToList();
-            _agentHealthReporter.ReportCustomEventsRecollected(customEvents.Count());
+    private void ReduceReservoirSize(int newSize)
+    {
+        if (newSize >= _customEvents.Size)
+            return;
 
-            foreach (var customEvent in customEvents)
-            {
-                if (customEvent != null)
-                {
-                    _customEvents.Add(new PrioritizedNode<CustomEventWireModel>(customEvent));
-                }
-            }
-        }
-
-        private void ReduceReservoirSize(int newSize)
-        {
-            if (newSize >= _customEvents.Size)
-                return;
-
-            _customEvents.Resize(newSize);
-            _agentHealthReporter.ReportCustomEventReservoirResized(newSize);
-        }
+        _customEvents.Resize(newSize);
+        _agentHealthReporter.ReportCustomEventReservoirResized(newSize);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/ErrorEventAggregator.cs
@@ -1,202 +1,200 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Transactions;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Threading;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface IErrorEventAggregator
 {
-    public interface IErrorEventAggregator
+    void Collect(ErrorEventWireModel errorEventWireModel);
+}
+
+/// <summary>
+/// An service for collecting and managing error events.
+/// </summary>
+public class ErrorEventAggregator : AbstractAggregator<ErrorEventWireModel>, IErrorEventAggregator
+{
+    private readonly IAgentHealthReporter _agentHealthReporter;
+    private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
+
+    private ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> _errorEvents = new ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>>(0);
+
+    // Note that Synthetics events must be recorded, and thus are stored in their own unique reservoir to ensure that they
+    // are never pushed out by non-Synthetics events.
+    private ConcurrentList<ErrorEventWireModel> _syntheticsErrorEvents = new ConcurrentList<ErrorEventWireModel>();
+
+    private const double ReservoirReductionSizeMultiplier = 0.5;
+
+    public ErrorEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
+        : base(dataTransportService, scheduler, processStatic)
     {
-        void Collect(ErrorEventWireModel errorEventWireModel);
+        _agentHealthReporter = agentHealthReporter;
+        ResetCollections(_configuration.ErrorCollectorMaxEventSamplesStored);
     }
 
-    /// <summary>
-    /// An service for collecting and managing error events.
-    /// </summary>
-    public class ErrorEventAggregator : AbstractAggregator<ErrorEventWireModel>, IErrorEventAggregator
+    protected override TimeSpan HarvestCycle => _configuration.ErrorEventsHarvestCycle;
+    protected override bool IsEnabled => _configuration.ErrorCollectorCaptureEvents;
+
+    public override void Dispose()
     {
-        private readonly IAgentHealthReporter _agentHealthReporter;
-        private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
-
-        private ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> _errorEvents = new ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>>(0);
-
-        // Note that Synthetics events must be recorded, and thus are stored in their own unique reservoir to ensure that they
-        // are never pushed out by non-Synthetics events.
-        private ConcurrentList<ErrorEventWireModel> _syntheticsErrorEvents = new ConcurrentList<ErrorEventWireModel>();
-
-        private const double ReservoirReductionSizeMultiplier = 0.5;
-
-        public ErrorEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
-            : base(dataTransportService, scheduler, processStatic)
-        {
-            _agentHealthReporter = agentHealthReporter;
-            ResetCollections(_configuration.ErrorCollectorMaxEventSamplesStored);
-        }
-
-        protected override TimeSpan HarvestCycle => _configuration.ErrorEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.ErrorCollectorCaptureEvents;
-
-        public override void Dispose()
-        {
-            _readerWriterLock.Dispose();
-            base.Dispose();
-        }
-
-        public override void Collect(ErrorEventWireModel errorEventWireModel)
-        {
-            _agentHealthReporter.ReportErrorEventSeen();
-
-            _readerWriterLock.EnterReadLock();
-            try
-            {
-                AddEventToCollection(errorEventWireModel);
-            }
-            finally
-            {
-                _readerWriterLock.ExitReadLock();
-            }
-        }
-
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Error Event harvest starting.");
-
-            ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> originalErrorEvents;
-            ConcurrentList<ErrorEventWireModel> originalSyntheticsErrorEvents;
-
-            _readerWriterLock.EnterWriteLock();
-            try
-            {
-                originalErrorEvents = GetAndResetErrorEvents(GetReservoirSize());
-                originalSyntheticsErrorEvents = GetAndResetSyntheticsErrorEvents();
-            }
-            finally
-            {
-                _readerWriterLock.ExitWriteLock();
-            }
-
-            var errorEvents = originalErrorEvents.Where(node => node != null).Select(node => node.Data).ToList();
-            var aggregatedEvents = errorEvents.Union(originalSyntheticsErrorEvents).ToList();
-
-            // Retrieve the number of add attempts before resetting the collection.
-            var eventHarvestData = new EventHarvestData(originalErrorEvents.Size, originalErrorEvents.GetAddAttemptsCount());
-
-            // if we don't have any events to publish then don't
-            var eventCount = aggregatedEvents.Count;
-            if (eventCount > 0)
-            {
-                var responseStatus = DataTransportService.Send(eventHarvestData, aggregatedEvents, transactionId);
-
-                HandleResponse(responseStatus, aggregatedEvents);
-            }
-
-            Log.Finest("Error Event harvest finished.");
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            ResetCollections(_configuration.ErrorCollectorMaxEventSamplesStored);
-        }
-
-        #region Private Helpers
-
-        private void ResetCollections(int errorEventCollectionCapacity)
-        {
-            GetAndResetErrorEvents(errorEventCollectionCapacity);
-            GetAndResetSyntheticsErrorEvents();
-        }
-
-        private ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> GetAndResetErrorEvents(int errorEventCollectionCapacity)
-        {
-            return Interlocked.Exchange(ref _errorEvents, new ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>>(errorEventCollectionCapacity));
-        }
-
-        private ConcurrentList<ErrorEventWireModel> GetAndResetSyntheticsErrorEvents()
-        {
-            return Interlocked.Exchange(ref _syntheticsErrorEvents, new ConcurrentList<ErrorEventWireModel>());
-        }
-
-        private void AddEventToCollection(ErrorEventWireModel errorEvent)
-        {
-            if (errorEvent.IsSynthetics && _syntheticsErrorEvents.Count < SyntheticsHeader.MaxEventCount)
-            {
-                _syntheticsErrorEvents.Add(errorEvent);
-            }
-            else
-            {
-                _errorEvents.Add(new PrioritizedNode<ErrorEventWireModel>(errorEvent));
-            }
-        }
-
-        private int GetReservoirSize()
-        {
-            return _errorEvents.Size;
-        }
-
-        private void ReduceReservoirSize(int newSize)
-        {
-            if (newSize >= GetReservoirSize())
-                return;
-
-            _errorEvents.Resize(newSize);
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<ErrorEventWireModel> errorEvents)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    _agentHealthReporter.ReportErrorEventsSent(errorEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainEvents(errorEvents);
-                    Log.Debug("Retaining {count} error events.", errorEvents.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                    ReduceReservoirSize((int)(errorEvents.Count * ReservoirReductionSizeMultiplier));
-                    RetainEvents(errorEvents);
-                    Log.Debug("Reservoir size reduced. Retaining {count} error events.", errorEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} transaction events.", errorEvents.Count);
-                    break;
-            }
-        }
-
-        private void RetainEvents(IEnumerable<ErrorEventWireModel> errorEvents)
-        {
-            errorEvents = errorEvents.ToList();
-
-            foreach (var errorEvent in errorEvents)
-            {
-                if (errorEvent != null)
-                {
-                    AddEventToCollection(errorEvent);
-                }
-            }
-        }
-
-        #endregion
+        _readerWriterLock.Dispose();
+        base.Dispose();
     }
+
+    public override void Collect(ErrorEventWireModel errorEventWireModel)
+    {
+        _agentHealthReporter.ReportErrorEventSeen();
+
+        _readerWriterLock.EnterReadLock();
+        try
+        {
+            AddEventToCollection(errorEventWireModel);
+        }
+        finally
+        {
+            _readerWriterLock.ExitReadLock();
+        }
+    }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Error Event harvest starting.");
+
+        ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> originalErrorEvents;
+        ConcurrentList<ErrorEventWireModel> originalSyntheticsErrorEvents;
+
+        _readerWriterLock.EnterWriteLock();
+        try
+        {
+            originalErrorEvents = GetAndResetErrorEvents(GetReservoirSize());
+            originalSyntheticsErrorEvents = GetAndResetSyntheticsErrorEvents();
+        }
+        finally
+        {
+            _readerWriterLock.ExitWriteLock();
+        }
+
+        var errorEvents = originalErrorEvents.Where(node => node != null).Select(node => node.Data).ToList();
+        var aggregatedEvents = errorEvents.Union(originalSyntheticsErrorEvents).ToList();
+
+        // Retrieve the number of add attempts before resetting the collection.
+        var eventHarvestData = new EventHarvestData(originalErrorEvents.Size, originalErrorEvents.GetAddAttemptsCount());
+
+        // if we don't have any events to publish then don't
+        var eventCount = aggregatedEvents.Count;
+        if (eventCount > 0)
+        {
+            var responseStatus = DataTransportService.Send(eventHarvestData, aggregatedEvents, transactionId);
+
+            HandleResponse(responseStatus, aggregatedEvents);
+        }
+
+        Log.Finest("Error Event harvest finished.");
+    }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        ResetCollections(_configuration.ErrorCollectorMaxEventSamplesStored);
+    }
+
+    #region Private Helpers
+
+    private void ResetCollections(int errorEventCollectionCapacity)
+    {
+        GetAndResetErrorEvents(errorEventCollectionCapacity);
+        GetAndResetSyntheticsErrorEvents();
+    }
+
+    private ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>> GetAndResetErrorEvents(int errorEventCollectionCapacity)
+    {
+        return Interlocked.Exchange(ref _errorEvents, new ConcurrentPriorityQueue<PrioritizedNode<ErrorEventWireModel>>(errorEventCollectionCapacity));
+    }
+
+    private ConcurrentList<ErrorEventWireModel> GetAndResetSyntheticsErrorEvents()
+    {
+        return Interlocked.Exchange(ref _syntheticsErrorEvents, new ConcurrentList<ErrorEventWireModel>());
+    }
+
+    private void AddEventToCollection(ErrorEventWireModel errorEvent)
+    {
+        if (errorEvent.IsSynthetics && _syntheticsErrorEvents.Count < SyntheticsHeader.MaxEventCount)
+        {
+            _syntheticsErrorEvents.Add(errorEvent);
+        }
+        else
+        {
+            _errorEvents.Add(new PrioritizedNode<ErrorEventWireModel>(errorEvent));
+        }
+    }
+
+    private int GetReservoirSize()
+    {
+        return _errorEvents.Size;
+    }
+
+    private void ReduceReservoirSize(int newSize)
+    {
+        if (newSize >= GetReservoirSize())
+            return;
+
+        _errorEvents.Resize(newSize);
+    }
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<ErrorEventWireModel> errorEvents)
+    {
+        switch (responseStatus)
+        {
+            case DataTransportResponseStatus.RequestSuccessful:
+                _agentHealthReporter.ReportErrorEventsSent(errorEvents.Count);
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainEvents(errorEvents);
+                Log.Debug("Retaining {count} error events.", errorEvents.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                ReduceReservoirSize((int)(errorEvents.Count * ReservoirReductionSizeMultiplier));
+                RetainEvents(errorEvents);
+                Log.Debug("Reservoir size reduced. Retaining {count} error events.", errorEvents.Count);
+                break;
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} transaction events.", errorEvents.Count);
+                break;
+        }
+    }
+
+    private void RetainEvents(IEnumerable<ErrorEventWireModel> errorEvents)
+    {
+        errorEvents = errorEvents.ToList();
+
+        foreach (var errorEvent in errorEvents)
+        {
+            if (errorEvent != null)
+            {
+                AddEventToCollection(errorEvent);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/EventHarvestData.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/EventHarvestData.cs
@@ -3,19 +3,18 @@
 
 using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.Aggregators
-{
-    public struct EventHarvestData
-    {
-        [JsonProperty("reservoir_size")]
-        public int ReservoirSize { get; private set; }
-        [JsonProperty("events_seen")]
-        public int EventsSeen { get; private set; }
+namespace NewRelic.Agent.Core.Aggregators;
 
-        public EventHarvestData(int reservoirSize, int eventsSeen)
-        {
-            ReservoirSize = reservoirSize;
-            EventsSeen = eventsSeen;
-        }
+public struct EventHarvestData
+{
+    [JsonProperty("reservoir_size")]
+    public int ReservoirSize { get; private set; }
+    [JsonProperty("events_seen")]
+    public int EventsSeen { get; private set; }
+
+    public EventHarvestData(int reservoirSize, int eventsSeen)
+    {
+        ReservoirSize = reservoirSize;
+        EventsSeen = eventsSeen;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/IAllMetricStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/IAllMetricStatsCollection.cs
@@ -1,13 +1,12 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+/// <summary>
+/// Used to pass metric data to the Metric Aggregator.
+/// </summary>
+public interface IAllMetricStatsCollection
 {
-    /// <summary>
-    /// Used to pass metric data to the Metric Aggregator.
-    /// </summary>
-    public interface IAllMetricStatsCollection
-    {
-        void AddMetricsToCollection(MetricStatsCollection collection);
-    }
+    void AddMetricsToCollection(MetricStatsCollection collection);
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/LogEventAggregator.cs
@@ -8,198 +8,197 @@ using System.Threading;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Labels;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
-using NewRelic.Agent.Core.Labels;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ILogEventAggregator : IDisposable
 {
-    public interface ILogEventAggregator : IDisposable
-    {
-        void Collect(LogEventWireModel loggingEventWireModel);
+    void Collect(LogEventWireModel loggingEventWireModel);
 
-        void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority);
+    void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority);
+}
+
+/// <summary>
+/// An service for collecting and managing logging events.
+/// </summary>
+public class LogEventAggregator : AbstractAggregator<LogEventWireModel>, ILogEventAggregator
+{
+    private const double ReservoirReductionSizeMultiplier = 0.5;
+
+    private readonly IAgentHealthReporter _agentHealthReporter;
+    private readonly ILabelsService _labelsService;
+
+    private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> _logEvents = new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(0);
+    private int _logsDroppedCount;
+
+    public LogEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter,
+        ILabelsService labelsService)
+        : base(dataTransportService, scheduler, processStatic)
+    {
+        _agentHealthReporter = agentHealthReporter;
+        _labelsService = labelsService;
+        ResetCollections(_configuration.LogEventsMaxSamplesStored);
     }
 
-    /// <summary>
-    /// An service for collecting and managing logging events.
-    /// </summary>
-    public class LogEventAggregator : AbstractAggregator<LogEventWireModel>, ILogEventAggregator
+    protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
+    protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
+
+    public override void Collect(LogEventWireModel loggingEventWireModel)
     {
-        private const double ReservoirReductionSizeMultiplier = 0.5;
+        _agentHealthReporter.ReportLoggingEventCollected();
+        AddEventToCollection(loggingEventWireModel);
+    }
 
-        private readonly IAgentHealthReporter _agentHealthReporter;
-        private readonly ILabelsService _labelsService;
-
-        private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> _logEvents = new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(0);
-        private int _logsDroppedCount;
-
-        public LogEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter,
-            ILabelsService labelsService)
-            : base(dataTransportService, scheduler, processStatic)
+    public void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority)
+    {
+        if (logEventWireModels == null)
         {
-            _agentHealthReporter = agentHealthReporter;
-            _labelsService = labelsService;
-            ResetCollections(_configuration.LogEventsMaxSamplesStored);
+            return;
         }
 
-        protected override TimeSpan HarvestCycle => _configuration.LogEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.LogEventCollectorEnabled;
-
-        public override void Collect(LogEventWireModel loggingEventWireModel)
+        for (int i = 0; i < logEventWireModels.Count; i++)
         {
             _agentHealthReporter.ReportLoggingEventCollected();
-            AddEventToCollection(loggingEventWireModel);
+            logEventWireModels[i].Priority = priority;
+            AddEventToCollection(logEventWireModels[i]);
         }
-
-        public void CollectWithPriority(IList<LogEventWireModel> logEventWireModels, float priority)
-        {
-            if (logEventWireModels == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < logEventWireModels.Count; i++)
-            {
-                _agentHealthReporter.ReportLoggingEventCollected();
-                logEventWireModels[i].Priority = priority;
-                AddEventToCollection(logEventWireModels[i]);
-            }
-        }
-
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Log Event harvest starting.");
-
-            var originalLogEvents = GetAndResetLogEvents(GetReservoirSize());
-            var aggregatedEvents = originalLogEvents.Where(node => node != null).Select(node => node.Data).ToList();
-
-            // Retrieve the number of add attempts before resetting the collection.
-            var eventHarvestData = new EventHarvestData(originalLogEvents.Size, originalLogEvents.GetAddAttemptsCount());
-
-            // increment the count of logs dropped since we last reported
-            Interlocked.Add(ref _logsDroppedCount, originalLogEvents.GetAndResetDroppedItemCount());
-
-            // if we don't have any events to publish then don't
-            var eventCount = aggregatedEvents.Count;
-            if (eventCount > 0)
-            {
-                // matches metadata so that utilization and this match
-                var hostname = !string.IsNullOrEmpty(_configuration.UtilizationFullHostName)
-                    ? _configuration.UtilizationFullHostName
-                    : _configuration.UtilizationHostName;
-
-                var modelsCollection = new LogEventWireModelCollection(
-                    _configuration.ApplicationNames.ElementAt(0),
-                    _configuration.EntityGuid,
-                    hostname,
-                    _configuration.LabelsEnabled ? _labelsService.GetFilteredLabels(_configuration.LabelsExclude) : [],
-                    aggregatedEvents);
-
-                var responseStatus = DataTransportService.Send(modelsCollection, transactionId);
-
-                HandleResponse(responseStatus, aggregatedEvents);
-            }
-
-            Log.Finest("Log Event harvest finished.");
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            ResetCollections(_configuration.LogEventsMaxSamplesStored);
-        }
-
-        #region Private Helpers
-
-        private void ResetCollections(int logEventCollectionCapacity)
-        {
-            GetAndResetLogEvents(logEventCollectionCapacity);
-        }
-
-        private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> GetAndResetLogEvents(int logEventCollectionCapacity)
-        {
-            return Interlocked.Exchange(ref _logEvents, new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(logEventCollectionCapacity));
-        }
-
-        private void AddEventToCollection(LogEventWireModel logEventWireModel)
-        {
-            _logEvents.Add(new PrioritizedNode<LogEventWireModel>(logEventWireModel));
-        }
-
-        private int GetReservoirSize()
-        {
-            return _logEvents.Size;
-        }
-
-        private void ReduceReservoirSize(int newSize)
-        {
-            if (newSize >= GetReservoirSize())
-                return;
-
-            _logEvents.Resize(newSize);
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<LogEventWireModel> logEvents)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    _agentHealthReporter.ReportLoggingEventsSent(logEvents.Count);
-                    Log.Debug("Successfully sent {count} log events.", logEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainEvents(logEvents);
-                    Log.Debug("Retaining {count} log events.", logEvents.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                    ReduceReservoirSize((int)(logEvents.Count * ReservoirReductionSizeMultiplier));
-                    RetainEvents(logEvents);
-                    Log.Debug("Reservoir size reduced. Retaining {count} log events.", logEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} log events.", logEvents.Count);
-                    break;
-            }
-
-            // always report (and reset) the count of dropped logs, if any
-            ReportDroppedLogCount();
-        }
-
-        private void ReportDroppedLogCount()
-        {
-            var droppedLogsCount = Interlocked.Exchange(ref _logsDroppedCount, 0);
-
-            if (droppedLogsCount > 0)
-            {
-                _agentHealthReporter.ReportLoggingEventsDropped(droppedLogsCount);
-            }
-
-        }
-
-        private void RetainEvents(IEnumerable<LogEventWireModel> logEvents)
-        {
-            logEvents = logEvents.ToList();
-
-            foreach (var logEvent in logEvents)
-            {
-                if (logEvent != null)
-                {
-                    AddEventToCollection(logEvent);
-                }
-            }
-        }
-
-        #endregion
     }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Log Event harvest starting.");
+
+        var originalLogEvents = GetAndResetLogEvents(GetReservoirSize());
+        var aggregatedEvents = originalLogEvents.Where(node => node != null).Select(node => node.Data).ToList();
+
+        // Retrieve the number of add attempts before resetting the collection.
+        var eventHarvestData = new EventHarvestData(originalLogEvents.Size, originalLogEvents.GetAddAttemptsCount());
+
+        // increment the count of logs dropped since we last reported
+        Interlocked.Add(ref _logsDroppedCount, originalLogEvents.GetAndResetDroppedItemCount());
+
+        // if we don't have any events to publish then don't
+        var eventCount = aggregatedEvents.Count;
+        if (eventCount > 0)
+        {
+            // matches metadata so that utilization and this match
+            var hostname = !string.IsNullOrEmpty(_configuration.UtilizationFullHostName)
+                ? _configuration.UtilizationFullHostName
+                : _configuration.UtilizationHostName;
+
+            var modelsCollection = new LogEventWireModelCollection(
+                _configuration.ApplicationNames.ElementAt(0),
+                _configuration.EntityGuid,
+                hostname,
+                _configuration.LabelsEnabled ? _labelsService.GetFilteredLabels(_configuration.LabelsExclude) : [],
+                aggregatedEvents);
+
+            var responseStatus = DataTransportService.Send(modelsCollection, transactionId);
+
+            HandleResponse(responseStatus, aggregatedEvents);
+        }
+
+        Log.Finest("Log Event harvest finished.");
+    }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        ResetCollections(_configuration.LogEventsMaxSamplesStored);
+    }
+
+    #region Private Helpers
+
+    private void ResetCollections(int logEventCollectionCapacity)
+    {
+        GetAndResetLogEvents(logEventCollectionCapacity);
+    }
+
+    private ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>> GetAndResetLogEvents(int logEventCollectionCapacity)
+    {
+        return Interlocked.Exchange(ref _logEvents, new ConcurrentPriorityQueue<PrioritizedNode<LogEventWireModel>>(logEventCollectionCapacity));
+    }
+
+    private void AddEventToCollection(LogEventWireModel logEventWireModel)
+    {
+        _logEvents.Add(new PrioritizedNode<LogEventWireModel>(logEventWireModel));
+    }
+
+    private int GetReservoirSize()
+    {
+        return _logEvents.Size;
+    }
+
+    private void ReduceReservoirSize(int newSize)
+    {
+        if (newSize >= GetReservoirSize())
+            return;
+
+        _logEvents.Resize(newSize);
+    }
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<LogEventWireModel> logEvents)
+    {
+        switch (responseStatus)
+        {
+            case DataTransportResponseStatus.RequestSuccessful:
+                _agentHealthReporter.ReportLoggingEventsSent(logEvents.Count);
+                Log.Debug("Successfully sent {count} log events.", logEvents.Count);
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainEvents(logEvents);
+                Log.Debug("Retaining {count} log events.", logEvents.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                ReduceReservoirSize((int)(logEvents.Count * ReservoirReductionSizeMultiplier));
+                RetainEvents(logEvents);
+                Log.Debug("Reservoir size reduced. Retaining {count} log events.", logEvents.Count);
+                break;
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} log events.", logEvents.Count);
+                break;
+        }
+
+        // always report (and reset) the count of dropped logs, if any
+        ReportDroppedLogCount();
+    }
+
+    private void ReportDroppedLogCount()
+    {
+        var droppedLogsCount = Interlocked.Exchange(ref _logsDroppedCount, 0);
+
+        if (droppedLogsCount > 0)
+        {
+            _agentHealthReporter.ReportLoggingEventsDropped(droppedLogsCount);
+        }
+
+    }
+
+    private void RetainEvents(IEnumerable<LogEventWireModel> logEvents)
+    {
+        logEvents = logEvents.ToList();
+
+        foreach (var logEvent in logEvents)
+        {
+            if (logEvent != null)
+            {
+                AddEventToCollection(logEvent);
+            }
+        }
+    }
+
+    #endregion
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricAggregator.cs
@@ -12,140 +12,139 @@ using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface IMetricAggregator
 {
-    public interface IMetricAggregator
+    void Collect(IAllMetricStatsCollection metric);
+}
+
+public class MetricAggregator : AbstractAggregator<IAllMetricStatsCollection>, IMetricAggregator
+{
+    private MetricStatsCollectionQueue _metricStatsCollectionQueue;
+    private readonly IMetricBuilder _metricBuilder;
+    private readonly IMetricNameService _metricNameService;
+    private readonly IEnumerable<IOutOfBandMetricSource> _outOfBandMetricSources;
+
+    public MetricAggregator(IDataTransportService dataTransportService, IMetricBuilder metricBuilder, IMetricNameService metricNameService, IEnumerable<IOutOfBandMetricSource> outOfBandMetricSources, IProcessStatic processStatic, IScheduler scheduler)
+        : base(dataTransportService, scheduler, processStatic)
     {
-        void Collect(IAllMetricStatsCollection metric);
+        _metricBuilder = metricBuilder;
+        _metricNameService = metricNameService;
+        _outOfBandMetricSources = outOfBandMetricSources;
+
+        foreach (var source in outOfBandMetricSources)
+        {
+            if (source != null)
+            {
+                source.RegisterPublishMetricHandler(Collect);
+            }
+        }
+
+        _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
     }
 
-    public class MetricAggregator : AbstractAggregator<IAllMetricStatsCollection>, IMetricAggregator
+    protected override TimeSpan HarvestCycle => _configuration.MetricsHarvestCycle;
+
+    public MetricStatsCollectionQueue StatsCollectionQueue => _metricStatsCollectionQueue;
+
+    protected override bool IsEnabled => true;
+
+    #region interface and abstract override required methods
+
+    public override void Collect(IAllMetricStatsCollection metric)
     {
-        private MetricStatsCollectionQueue _metricStatsCollectionQueue;
-        private readonly IMetricBuilder _metricBuilder;
-        private readonly IMetricNameService _metricNameService;
-        private readonly IEnumerable<IOutOfBandMetricSource> _outOfBandMetricSources;
-
-        public MetricAggregator(IDataTransportService dataTransportService, IMetricBuilder metricBuilder, IMetricNameService metricNameService, IEnumerable<IOutOfBandMetricSource> outOfBandMetricSources, IProcessStatic processStatic, IScheduler scheduler)
-            : base(dataTransportService, scheduler, processStatic)
+        bool done = false;
+        while (!done)
         {
-            _metricBuilder = metricBuilder;
-            _metricNameService = metricNameService;
-            _outOfBandMetricSources = outOfBandMetricSources;
+            done = _metricStatsCollectionQueue.MergeMetrics(metric);
+        }
+    }
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
 
-            foreach (var source in outOfBandMetricSources)
-            {
-                if (source != null)
-                {
-                    source.RegisterPublishMetricHandler(Collect);
-                }
-            }
+    protected override void Harvest() => InternalHarvest();
 
-            _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Metric harvest starting.");
+
+        foreach (var source in _outOfBandMetricSources)
+        {
+            source.CollectMetrics();
         }
 
-        protected override TimeSpan HarvestCycle => _configuration.MetricsHarvestCycle;
+        var oldMetrics = GetStatsCollectionForHarvest();
 
-        public MetricStatsCollectionQueue StatsCollectionQueue => _metricStatsCollectionQueue;
+        oldMetrics.MergeUnscopedStats(MetricNames.SupportabilityMetricHarvestTransmit, MetricDataWireModel.BuildCountData());
+        var metricsToSend = oldMetrics.ConvertToJsonForSending(_metricNameService).ToList();
 
-        protected override bool IsEnabled => true;
-
-        #region interface and abstract override required methods
-
-        public override void Collect(IAllMetricStatsCollection metric)
+        var metricCount = metricsToSend.Count;
+        if (metricCount > 0)
         {
-            bool done = false;
-            while (!done)
-            {
-                done = _metricStatsCollectionQueue.MergeMetrics(metric);
-            }
-        }
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Metric harvest starting.");
-
-            foreach (var source in _outOfBandMetricSources)
-            {
-                source.CollectMetrics();
-            }
-
-            var oldMetrics = GetStatsCollectionForHarvest();
-
-            oldMetrics.MergeUnscopedStats(MetricNames.SupportabilityMetricHarvestTransmit, MetricDataWireModel.BuildCountData());
-            var metricsToSend = oldMetrics.ConvertToJsonForSending(_metricNameService).ToList();
-
-            var metricCount = metricsToSend.Count;
-            if (metricCount > 0)
-            {
-                var responseStatus = DataTransportService.Send(metricsToSend, transactionId);
-                HandleResponse(responseStatus, metricsToSend);
-            }
-
-            Log.Finest("Metric harvest finished.");
+            var responseStatus = DataTransportService.Send(metricsToSend, transactionId);
+            HandleResponse(responseStatus, metricsToSend);
         }
 
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+        Log.Finest("Metric harvest finished.");
+    }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        ReplaceStatsCollectionQueue();
+    }
+
+    #endregion
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<MetricWireModel> unsuccessfulSendMetrics)
+    {
+        switch (responseStatus)
         {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            ReplaceStatsCollectionQueue();
+            case DataTransportResponseStatus.RequestSuccessful:
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainMetricData(unsuccessfulSendMetrics);
+                Log.Debug("Retaining {count} metrics.", unsuccessfulSendMetrics.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} metrics.", unsuccessfulSendMetrics.Count);
+                break;
         }
+    }
 
-        #endregion
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<MetricWireModel> unsuccessfulSendMetrics)
+    private void RetainMetricData(IEnumerable<MetricWireModel> unsuccessfulSendMetrics)
+    {
+        foreach (var metric in unsuccessfulSendMetrics)
         {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainMetricData(unsuccessfulSendMetrics);
-                    Log.Debug("Retaining {count} metrics.", unsuccessfulSendMetrics.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} metrics.", unsuccessfulSendMetrics.Count);
-                    break;
-            }
+            Collect(metric);
         }
+    }
 
-        private void RetainMetricData(IEnumerable<MetricWireModel> unsuccessfulSendMetrics)
-        {
-            foreach (var metric in unsuccessfulSendMetrics)
-            {
-                Collect(metric);
-            }
-        }
+    /// <summary>
+    /// Replaces the current MetricStatsCollectionQueue with a new one and combines all the MetricStatsCollections in the 
+    /// old queue into a single MetricStatsCollection that can serve as the source of aggregated metrics to
+    /// send to the collector.
+    /// </summary>
+    /// <returns></returns>
+    private MetricStatsCollection GetStatsCollectionForHarvest()
+    {
+        MetricStatsCollectionQueue oldMetricStatsCollectionQueue = ReplaceStatsCollectionQueue();
+        return oldMetricStatsCollectionQueue.GetStatsCollectionForHarvest();
+    }
 
-        /// <summary>
-        /// Replaces the current MetricStatsCollectionQueue with a new one and combines all the MetricStatsCollections in the 
-        /// old queue into a single MetricStatsCollection that can serve as the source of aggregated metrics to
-        /// send to the collector.
-        /// </summary>
-        /// <returns></returns>
-        private MetricStatsCollection GetStatsCollectionForHarvest()
-        {
-            MetricStatsCollectionQueue oldMetricStatsCollectionQueue = ReplaceStatsCollectionQueue();
-            return oldMetricStatsCollectionQueue.GetStatsCollectionForHarvest();
-        }
+    private MetricStatsCollectionQueue ReplaceStatsCollectionQueue()
+    {
+        MetricStatsCollectionQueue oldMetricStatsCollectionQueue = _metricStatsCollectionQueue;
+        _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
+        return oldMetricStatsCollectionQueue;
+    }
 
-        private MetricStatsCollectionQueue ReplaceStatsCollectionQueue()
-        {
-            MetricStatsCollectionQueue oldMetricStatsCollectionQueue = _metricStatsCollectionQueue;
-            _metricStatsCollectionQueue = CreateMetricStatsCollectionQueue();
-            return oldMetricStatsCollectionQueue;
-        }
-
-        private MetricStatsCollectionQueue CreateMetricStatsCollectionQueue()
-        {
-            return new MetricStatsCollectionQueue();
-        }
+    private MetricStatsCollectionQueue CreateMetricStatsCollectionQueue()
+    {
+        return new MetricStatsCollectionQueue();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollection.cs
@@ -1,92 +1,91 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.Metrics;
-using NewRelic.Agent.Core.WireModels;
 using System;
 using System.Collections.Generic;
+using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Core.WireModels;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public class MetricStatsCollection
 {
-    public class MetricStatsCollection
+    //stores unscoped stats reported during a transaction 
+    private MetricStatsDictionary<string, MetricDataWireModel> _unscopedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
+
+    //store scoped stats reported during a transaction
+    // The String key is the scope.
+    private Dictionary<string, MetricStatsDictionary<string, MetricDataWireModel>> _scopedStats = new Dictionary<string, MetricStatsDictionary<string, MetricDataWireModel>>();
+
+    private Func<MetricDataWireModel, MetricDataWireModel, MetricDataWireModel> _mergeFunction = MetricDataWireModel.BuildAggregateData;
+
+    public void Merge(MetricStatsCollection engine)
     {
-        //stores unscoped stats reported during a transaction 
-        private MetricStatsDictionary<string, MetricDataWireModel> _unscopedStats = new MetricStatsDictionary<string, MetricDataWireModel>();
-
-        //store scoped stats reported during a transaction
-        // The String key is the scope.
-        private Dictionary<string, MetricStatsDictionary<string, MetricDataWireModel>> _scopedStats = new Dictionary<string, MetricStatsDictionary<string, MetricDataWireModel>>();
-
-        private Func<MetricDataWireModel, MetricDataWireModel, MetricDataWireModel> _mergeFunction = MetricDataWireModel.BuildAggregateData;
-
-        public void Merge(MetricStatsCollection engine)
+        _unscopedStats.Merge(engine._unscopedStats, _mergeFunction);
+        foreach (KeyValuePair<string, MetricStatsDictionary<string, MetricDataWireModel>> current in engine._scopedStats)
         {
-            _unscopedStats.Merge(engine._unscopedStats, _mergeFunction);
-            foreach (KeyValuePair<string, MetricStatsDictionary<string, MetricDataWireModel>> current in engine._scopedStats)
+            MergeScopedStats(current.Key, current.Value);
+        }
+    }
+
+    public void MergeUnscopedStats(IEnumerable<KeyValuePair<string, MetricDataWireModel>> unscoped)
+    {
+        _unscopedStats.Merge(unscoped, _mergeFunction);
+    }
+
+    public void MergeUnscopedStats(string name, MetricDataWireModel metric)
+    {
+        _unscopedStats.Merge(name, metric, _mergeFunction);
+    }
+
+    public void MergeScopedStats(string scope, string name, MetricDataWireModel metric)
+    {
+        MetricStatsDictionary<string, MetricDataWireModel> alreadyScoped;
+        if (_scopedStats.TryGetValue(scope, out alreadyScoped))
+        {
+            alreadyScoped.Merge(name, metric, _mergeFunction);
+        }
+        else
+        {
+            alreadyScoped = new MetricStatsDictionary<string, MetricDataWireModel>();
+            alreadyScoped.Merge(name, metric, _mergeFunction);
+            _scopedStats[scope] = alreadyScoped;
+        }
+    }
+
+    public void MergeScopedStats(string scope, IEnumerable<KeyValuePair<string, MetricDataWireModel>> metrics)
+    {
+        MetricStatsDictionary<string, MetricDataWireModel> alreadyScoped;
+        if (_scopedStats.TryGetValue(scope, out alreadyScoped))
+        {
+            alreadyScoped.Merge(metrics, _mergeFunction);
+        }
+        else
+        {
+            alreadyScoped = new MetricStatsDictionary<string, MetricDataWireModel>(metrics);
+            _scopedStats[scope] = alreadyScoped;
+        }
+    }
+
+    public IEnumerable<MetricWireModel> ConvertToJsonForSending(IMetricNameService nameService)
+    {
+        foreach (KeyValuePair<string, MetricDataWireModel> current in _unscopedStats)
+        {
+            var metric = MetricWireModel.BuildMetric(nameService, current.Key, null, current.Value);
+            if (metric != null)
             {
-                MergeScopedStats(current.Key, current.Value);
+                yield return metric;
             }
         }
 
-        public void MergeUnscopedStats(IEnumerable<KeyValuePair<string, MetricDataWireModel>> unscoped)
+        foreach (KeyValuePair<string, MetricStatsDictionary<string, MetricDataWireModel>> currentScope in _scopedStats)
         {
-            _unscopedStats.Merge(unscoped, _mergeFunction);
-        }
-
-        public void MergeUnscopedStats(string name, MetricDataWireModel metric)
-        {
-            _unscopedStats.Merge(name, metric, _mergeFunction);
-        }
-
-        public void MergeScopedStats(string scope, string name, MetricDataWireModel metric)
-        {
-            MetricStatsDictionary<string, MetricDataWireModel> alreadyScoped;
-            if (_scopedStats.TryGetValue(scope, out alreadyScoped))
+            foreach (KeyValuePair<string, MetricDataWireModel> currentMetric in currentScope.Value)
             {
-                alreadyScoped.Merge(name, metric, _mergeFunction);
-            }
-            else
-            {
-                alreadyScoped = new MetricStatsDictionary<string, MetricDataWireModel>();
-                alreadyScoped.Merge(name, metric, _mergeFunction);
-                _scopedStats[scope] = alreadyScoped;
-            }
-        }
-
-        public void MergeScopedStats(string scope, IEnumerable<KeyValuePair<string, MetricDataWireModel>> metrics)
-        {
-            MetricStatsDictionary<string, MetricDataWireModel> alreadyScoped;
-            if (_scopedStats.TryGetValue(scope, out alreadyScoped))
-            {
-                alreadyScoped.Merge(metrics, _mergeFunction);
-            }
-            else
-            {
-                alreadyScoped = new MetricStatsDictionary<string, MetricDataWireModel>(metrics);
-                _scopedStats[scope] = alreadyScoped;
-            }
-        }
-
-        public IEnumerable<MetricWireModel> ConvertToJsonForSending(IMetricNameService nameService)
-        {
-            foreach (KeyValuePair<string, MetricDataWireModel> current in _unscopedStats)
-            {
-                var metric = MetricWireModel.BuildMetric(nameService, current.Key, null, current.Value);
+                var metric = MetricWireModel.BuildMetric(nameService, currentMetric.Key, currentScope.Key, currentMetric.Value);
                 if (metric != null)
                 {
                     yield return metric;
-                }
-            }
-
-            foreach (KeyValuePair<string, MetricStatsDictionary<string, MetricDataWireModel>> currentScope in _scopedStats)
-            {
-                foreach (KeyValuePair<string, MetricDataWireModel> currentMetric in currentScope.Value)
-                {
-                    var metric = MetricWireModel.BuildMetric(nameService, currentMetric.Key, currentScope.Key, currentMetric.Value);
-                    if (metric != null)
-                    {
-                        yield return metric;
-                    }
                 }
             }
         }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsCollectionQueue.cs
@@ -5,95 +5,94 @@ using System;
 using System.Collections.Concurrent;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+/// <summary>
+/// Ported, with some tweaks, from the Java Agent.  Allows the agent to use multiple MetricStatsCollections to aggregate
+/// metrics between harvests, so that a lock on a single MetricStatsCollection does not become a throughput bottleneck at high load.
+/// At harvest time all the MetricStatsCollections are combined.
+/// </summary>
+public class MetricStatsCollectionQueue
 {
-    /// <summary>
-    /// Ported, with some tweaks, from the Java Agent.  Allows the agent to use multiple MetricStatsCollections to aggregate
-    /// metrics between harvests, so that a lock on a single MetricStatsCollection does not become a throughput bottleneck at high load.
-    /// At harvest time all the MetricStatsCollections are combined.
-    /// </summary>
-    public class MetricStatsCollectionQueue
+    private ConcurrentQueue<MetricStatsCollection> _statsCollectionQueue;
+
+    internal MetricStatsCollectionQueue()
     {
-        private ConcurrentQueue<MetricStatsCollection> _statsCollectionQueue;
+        _statsCollectionQueue = new ConcurrentQueue<MetricStatsCollection>();
+    }
 
-        internal MetricStatsCollectionQueue()
+    /// <summary>
+    /// This MetricStatsCollectionQueue uses a ConcurrentQueue (allows multiple readers, but only one writer, at a time) to mediate
+    /// between metrics that need to merge into one of the collections (readers), and the harvest job (writer), which replaces the 
+    /// queue and merges the collections in the old queue to create the harvest payload.
+    /// 
+    /// </summary>
+    /// <param name="metrics"></param>
+    /// <returns></returns>
+    public bool MergeMetrics(IAllMetricStatsCollection metrics)
+    {
+        var statsCollectionQueue = _statsCollectionQueue;
+        if (statsCollectionQueue == null)
         {
-            _statsCollectionQueue = new ConcurrentQueue<MetricStatsCollection>();
+            // We've already been harvested.  Caller should try again, at which point a whole new MetricStatsCollectionQueue
+            // will have been created for the next harvest cycle.
+            return false;
         }
 
-        /// <summary>
-        /// This MetricStatsCollectionQueue uses a ConcurrentQueue (allows multiple readers, but only one writer, at a time) to mediate
-        /// between metrics that need to merge into one of the collections (readers), and the harvest job (writer), which replaces the 
-        /// queue and merges the collections in the old queue to create the harvest payload.
-        /// 
-        /// </summary>
-        /// <param name="metrics"></param>
-        /// <returns></returns>
-        public bool MergeMetrics(IAllMetricStatsCollection metrics)
+        AddMetricsToCollection(statsCollectionQueue, metrics);
+        return true;
+    }
+
+    /// <summary>
+    /// Take a MetricStatsCollection off the queue and merge metric(s) into it, then put it back
+    /// on the queue.  Create one if all the existing ones are "checked out" -- others can use it later.
+    ///  
+    /// We are one of (possibly) several readers of the MetricStatsCollection, so harvest will
+    /// wait for us to finish before fetching/replacing the entire queue
+    /// </summary>
+    /// <param name="statsCollectionQueue"></param>
+    /// <param name="metric"></param>
+    private void AddMetricsToCollection(ConcurrentQueue<MetricStatsCollection> statsCollectionQueue, IAllMetricStatsCollection metrics)
+    {
+        MetricStatsCollection statsCollectionToMergeWith = null;
+        try
         {
-            var statsCollectionQueue = _statsCollectionQueue;
-            if (statsCollectionQueue == null)
+            if (!statsCollectionQueue.TryDequeue(out statsCollectionToMergeWith))
             {
-                // We've already been harvested.  Caller should try again, at which point a whole new MetricStatsCollectionQueue
-                // will have been created for the next harvest cycle.
-                return false;
+                statsCollectionToMergeWith = new MetricStatsCollection();
             }
 
-            AddMetricsToCollection(statsCollectionQueue, metrics);
-            return true;
+            metrics.AddMetricsToCollection(statsCollectionToMergeWith);
+        }
+        catch (Exception e)
+        {
+            Log.Warn(e, "Exception dequeueing/creating stats collection");
+        }
+        finally
+        {
+            statsCollectionQueue.Enqueue(statsCollectionToMergeWith);
+        }
+    }
+
+    /// <summary>
+    /// Null out the ConcurrentQueue contained in this MetricStatsCollectionQueue so that any subsequent
+    /// attempts to read from the queue before this MetricStatsCollectionQueue is replaced will fail.  Combine
+    /// all the MetricStatsCollections in the old ConcurrentQueue according to the merge function, and return the result. 
+    /// </summary>
+    /// <returns></returns>
+    public MetricStatsCollection GetStatsCollectionForHarvest()
+    {
+        var statsCollectionQueue = _statsCollectionQueue;
+
+        // Clear the reference to the queue so that future calls to MergeMetric() get short-circuited.
+        _statsCollectionQueue = null;
+
+        var harvestMetricsStatsCollection = new MetricStatsCollection();
+        foreach (var statsCollection in statsCollectionQueue)
+        {
+            harvestMetricsStatsCollection.Merge(statsCollection);
         }
 
-        /// <summary>
-        /// Take a MetricStatsCollection off the queue and merge metric(s) into it, then put it back
-        /// on the queue.  Create one if all the existing ones are "checked out" -- others can use it later.
-        ///  
-        /// We are one of (possibly) several readers of the MetricStatsCollection, so harvest will
-        /// wait for us to finish before fetching/replacing the entire queue
-        /// </summary>
-        /// <param name="statsCollectionQueue"></param>
-        /// <param name="metric"></param>
-        private void AddMetricsToCollection(ConcurrentQueue<MetricStatsCollection> statsCollectionQueue, IAllMetricStatsCollection metrics)
-        {
-            MetricStatsCollection statsCollectionToMergeWith = null;
-            try
-            {
-                if (!statsCollectionQueue.TryDequeue(out statsCollectionToMergeWith))
-                {
-                    statsCollectionToMergeWith = new MetricStatsCollection();
-                }
-
-                metrics.AddMetricsToCollection(statsCollectionToMergeWith);
-            }
-            catch (Exception e)
-            {
-                Log.Warn(e, "Exception dequeueing/creating stats collection");
-            }
-            finally
-            {
-                statsCollectionQueue.Enqueue(statsCollectionToMergeWith);
-            }
-        }
-
-        /// <summary>
-        /// Null out the ConcurrentQueue contained in this MetricStatsCollectionQueue so that any subsequent
-        /// attempts to read from the queue before this MetricStatsCollectionQueue is replaced will fail.  Combine
-        /// all the MetricStatsCollections in the old ConcurrentQueue according to the merge function, and return the result. 
-        /// </summary>
-        /// <returns></returns>
-        public MetricStatsCollection GetStatsCollectionForHarvest()
-        {
-            var statsCollectionQueue = _statsCollectionQueue;
-
-            // Clear the reference to the queue so that future calls to MergeMetric() get short-circuited.
-            _statsCollectionQueue = null;
-
-            var harvestMetricsStatsCollection = new MetricStatsCollection();
-            foreach (var statsCollection in statsCollectionQueue)
-            {
-                harvestMetricsStatsCollection.Merge(statsCollection);
-            }
-
-            return harvestMetricsStatsCollection;
-        }
+        return harvestMetricsStatsCollection;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsDictionary.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/MetricStatsDictionary.cs
@@ -4,59 +4,58 @@
 using System;
 using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+/// <summary>
+/// A Dictionary subclass used to accumulate (merge) and hold aggregated metrics.  Given a supplied merge function,
+/// knows how to merge a single new metric (Collect) or an entire ScopedMetricsStatsEngine (Harvest).
+/// </summary>
+/// <typeparam name="TKey"></typeparam>
+/// <typeparam name="TValue"></typeparam>
+public class MetricStatsDictionary<TKey, TValue> : Dictionary<TKey, TValue>
 {
-    /// <summary>
-    /// A Dictionary subclass used to accumulate (merge) and hold aggregated metrics.  Given a supplied merge function,
-    /// knows how to merge a single new metric (Collect) or an entire ScopedMetricsStatsEngine (Harvest).
-    /// </summary>
-    /// <typeparam name="TKey"></typeparam>
-    /// <typeparam name="TValue"></typeparam>
-    public class MetricStatsDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+    public MetricStatsDictionary()
     {
-        public MetricStatsDictionary()
-        {
-        }
+    }
 
-        public MetricStatsDictionary(IEnumerable<KeyValuePair<TKey, TValue>> keyValuesPairs)
+    public MetricStatsDictionary(IEnumerable<KeyValuePair<TKey, TValue>> keyValuesPairs)
+    {
+        foreach (var kvp in keyValuesPairs)
         {
-            foreach (var kvp in keyValuesPairs)
-            {
-                this[kvp.Key] = kvp.Value;
-            }
+            this[kvp.Key] = kvp.Value;
         }
+    }
 
-        /// <summary>
-        /// Adds <paramref name="value"/> to the dictionary under <paramref name="key"/>. If there is no existing value for <paramref name="key"/> then it will be set to <paramref name="value"/>. If there is already a value for <paramref name="key"/>, the new value will be merged with the existing value using <paramref name="mergeFunction"/>.
-        /// 
-        /// For safety, be sure to account for null values in <paramref name="mergeFunction"/>
-        /// </summary>
-        /// <param name="key">The key to merge with.</param>
-        /// <param name="value">The value to merge.</param>
-        /// <param name="mergeFunction">A function that will merge two values (existingValue, newValue) if an existing value is found.</param>
-        public void Merge(TKey key, TValue value, Func<TValue, TValue, TValue> mergeFunction)
+    /// <summary>
+    /// Adds <paramref name="value"/> to the dictionary under <paramref name="key"/>. If there is no existing value for <paramref name="key"/> then it will be set to <paramref name="value"/>. If there is already a value for <paramref name="key"/>, the new value will be merged with the existing value using <paramref name="mergeFunction"/>.
+    /// 
+    /// For safety, be sure to account for null values in <paramref name="mergeFunction"/>
+    /// </summary>
+    /// <param name="key">The key to merge with.</param>
+    /// <param name="value">The value to merge.</param>
+    /// <param name="mergeFunction">A function that will merge two values (existingValue, newValue) if an existing value is found.</param>
+    public void Merge(TKey key, TValue value, Func<TValue, TValue, TValue> mergeFunction)
+    {
+        if (TryGetValue(key, out TValue existing))
         {
-            if (TryGetValue(key, out TValue existing))
-            {
-                this[key] = mergeFunction(existing, value);
-            }
-            else
-            {
-                Add(key, value);
-            }
+            this[key] = mergeFunction(existing, value);
         }
-
-        /// <summary>
-        /// Helper function that merges each metric in another ScopedMetricsStatsEngine with this ScopedMetricsStatsEngine
-        /// </summary>
-        /// <param name="metricsToMerge"></param>
-        /// <param name="mergeFunction">A function that will merge two values (existingValue, newValue) if an existing value is found.</param>
-        public void Merge(IEnumerable<KeyValuePair<TKey, TValue>> metricsToMerge, Func<TValue, TValue, TValue> mergeFunction)
+        else
         {
-            foreach (var metric in metricsToMerge)
-            {
-                Merge(metric.Key, metric.Value, mergeFunction);
-            }
+            Add(key, value);
+        }
+    }
+
+    /// <summary>
+    /// Helper function that merges each metric in another ScopedMetricsStatsEngine with this ScopedMetricsStatsEngine
+    /// </summary>
+    /// <param name="metricsToMerge"></param>
+    /// <param name="mergeFunction">A function that will merge two values (existingValue, newValue) if an existing value is found.</param>
+    public void Merge(IEnumerable<KeyValuePair<TKey, TValue>> metricsToMerge, Func<TValue, TValue, TValue> mergeFunction)
+    {
+        foreach (var metric in metricsToMerge)
+        {
+            Merge(metric.Key, metric.Value, mergeFunction);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregator.cs
@@ -1,183 +1,182 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.AgentHealth;
-using NewRelic.Agent.Core.DataTransport;
-using NewRelic.Agent.Core.Events;
-using NewRelic.Agent.Core.Time;
-using NewRelic.Agent.Core.Segments;
-using NewRelic.Agent.Extensions.Collections;
-using NewRelic.Agent.Core.SharedInterfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Segments;
+using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Time;
+using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ISpanEventAggregator
 {
-    public interface ISpanEventAggregator
+    void Collect(ISpanEventWireModel wireModel);
+    void Collect(IEnumerable<ISpanEventWireModel> wireModels);
+    bool IsServiceEnabled { get; }
+    bool IsServiceAvailable { get; }
+}
+
+public class SpanEventAggregator : AbstractAggregator<ISpanEventWireModel>, ISpanEventAggregator
+{
+    private const double ReservoirReductionSizeMultiplier = 0.5;
+    private readonly IAgentHealthReporter _agentHealthReporter;
+    private readonly ReaderWriterLockSlim _readerWriterLockSlim = new ReaderWriterLockSlim();
+
+    private ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> _spanEvents = new ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>>(0);
+
+    protected override TimeSpan HarvestCycle => _configuration.SpanEventsHarvestCycle;
+
+    protected override bool IsEnabled => _configuration.SpanEventsEnabled
+                                         && _configuration.SpanEventsMaxSamplesStored > 0
+                                         && _configuration.DistributedTracingEnabled;
+
+    public bool IsServiceEnabled => IsEnabled;
+    public bool IsServiceAvailable => IsEnabled;
+
+    /// <summary>
+    /// Atomically set a new ConcurrentPriorityQueue to _spanEvents and return the previous ConcurrentPriorityQueue reference;
+    /// </summary>
+    /// <returns>A reference to the previous ConcurrentPriorityQueue</returns>
+    private ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> GetAndResetCollection()
     {
-        void Collect(ISpanEventWireModel wireModel);
-        void Collect(IEnumerable<ISpanEventWireModel> wireModels);
-        bool IsServiceEnabled { get; }
-        bool IsServiceAvailable { get; }
+        return Interlocked.Exchange(ref _spanEvents, new ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>>(_configuration.SpanEventsMaxSamplesStored));
     }
 
-    public class SpanEventAggregator : AbstractAggregator<ISpanEventWireModel>, ISpanEventAggregator
+    private int AddWireModels(IEnumerable<ISpanEventWireModel> wireModels)
     {
-        private const double ReservoirReductionSizeMultiplier = 0.5;
-        private readonly IAgentHealthReporter _agentHealthReporter;
-        private readonly ReaderWriterLockSlim _readerWriterLockSlim = new ReaderWriterLockSlim();
+        var nodes = wireModels.Where(model => null != model)
+            .Select(model => new PrioritizedNode<ISpanEventWireModel>(model));
+        return _spanEvents.Add(nodes);
+    }
 
-        private ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> _spanEvents = new ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>>(0);
+    public SpanEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
+        : base(dataTransportService, scheduler, processStatic)
+    {
+        _agentHealthReporter = agentHealthReporter;
+        //we don't care about the returned CPQ because it was initialized with zero size.
+        GetAndResetCollection();
+    }
 
-        protected override TimeSpan HarvestCycle => _configuration.SpanEventsHarvestCycle;
+    public override void Dispose()
+    {
+        _readerWriterLockSlim.Dispose();
+        base.Dispose();
+    }
 
-        protected override bool IsEnabled => _configuration.SpanEventsEnabled
-            && _configuration.SpanEventsMaxSamplesStored > 0
-            && _configuration.DistributedTracingEnabled;
+    public override void Collect(ISpanEventWireModel wireModel)
+    {
+        _agentHealthReporter.ReportSpanEventCollected(1);
 
-        public bool IsServiceEnabled => IsEnabled;
-        public bool IsServiceAvailable => IsEnabled;
-
-        /// <summary>
-        /// Atomically set a new ConcurrentPriorityQueue to _spanEvents and return the previous ConcurrentPriorityQueue reference;
-        /// </summary>
-        /// <returns>A reference to the previous ConcurrentPriorityQueue</returns>
-        private ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> GetAndResetCollection()
+        _readerWriterLockSlim.EnterReadLock();
+        try
         {
-            return Interlocked.Exchange(ref _spanEvents, new ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>>(_configuration.SpanEventsMaxSamplesStored));
+            _spanEvents.Add(new PrioritizedNode<ISpanEventWireModel>(wireModel));
+        }
+        finally
+        {
+            _readerWriterLockSlim.ExitReadLock();
+        }
+    }
+
+    public void Collect(IEnumerable<ISpanEventWireModel> wireModels)
+    {
+        int added;
+        _readerWriterLockSlim.EnterReadLock();
+        try
+        {
+            added = AddWireModels(wireModels);
+        }
+        finally
+        {
+            _readerWriterLockSlim.ExitReadLock();
+        }
+        _agentHealthReporter.ReportSpanEventCollected(added);
+    }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Span Event harvest starting.");
+
+        ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> spanEventsPriorityQueue;
+
+        _readerWriterLockSlim.EnterWriteLock();
+        try
+        {
+            spanEventsPriorityQueue = GetAndResetCollection();
+        }
+        finally
+        {
+            _readerWriterLockSlim.ExitWriteLock();
         }
 
-        private int AddWireModels(IEnumerable<ISpanEventWireModel> wireModels)
+        var eventHarvestData = new EventHarvestData(spanEventsPriorityQueue.Size, spanEventsPriorityQueue.GetAddAttemptsCount());
+        var wireModels = spanEventsPriorityQueue.Where(node => null != node).Select(node => node.Data).ToList();
+
+        // if we don't have any events to publish then don't
+        var eventCount = wireModels.Count;
+        if (eventCount > 0)
         {
-            var nodes = wireModels.Where(model => null != model)
-                .Select(model => new PrioritizedNode<ISpanEventWireModel>(model));
-            return _spanEvents.Add(nodes);
+            var responseStatus = DataTransportService.Send(eventHarvestData, wireModels, transactionId);
+            HandleResponse(responseStatus, wireModels);
         }
 
-        public SpanEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
-            : base(dataTransportService, scheduler, processStatic)
+        Log.Finest("Span Event harvest finished.");
+    }
+
+    private void ReduceReservoirSize(int newSize)
+    {
+        if (newSize >= _spanEvents.Size)
+            return;
+
+        _spanEvents.Resize(newSize);
+    }
+
+    private void RetainEvents(IEnumerable<ISpanEventWireModel> wireModels)
+    {
+        AddWireModels(wireModels);
+    }
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<ISpanEventWireModel> spanEvents)
+    {
+        switch (responseStatus)
         {
-            _agentHealthReporter = agentHealthReporter;
-            //we don't care about the returned CPQ because it was initialized with zero size.
+            case DataTransportResponseStatus.RequestSuccessful:
+                _agentHealthReporter.ReportSpanEventsSent(spanEvents.Count);
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainEvents(spanEvents);
+                Log.Debug("Retaining {count} span events.", spanEvents.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                ReduceReservoirSize((int)(spanEvents.Count * ReservoirReductionSizeMultiplier));
+                RetainEvents(spanEvents);
+                Log.Debug("Reservoir size reduced. Retaining {count} span events.", spanEvents.Count);
+                break;
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} span events.", spanEvents.Count);
+                break;
+        }
+    }
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        if (configurationUpdateSource == ConfigurationUpdateSource.Local && _configuration.SpanEventsMaxSamplesStored != _spanEvents.Size)
+        {
+            //we might have received server configuration that says we should not have collected the
+            //events that we have, drop them on the floor by ignoring the returned collection.
             GetAndResetCollection();
-        }
-
-        public override void Dispose()
-        {
-            _readerWriterLockSlim.Dispose();
-            base.Dispose();
-        }
-
-        public override void Collect(ISpanEventWireModel wireModel)
-        {
-            _agentHealthReporter.ReportSpanEventCollected(1);
-
-            _readerWriterLockSlim.EnterReadLock();
-            try
-            {
-                _spanEvents.Add(new PrioritizedNode<ISpanEventWireModel>(wireModel));
-            }
-            finally
-            {
-                _readerWriterLockSlim.ExitReadLock();
-            }
-        }
-
-        public void Collect(IEnumerable<ISpanEventWireModel> wireModels)
-        {
-            int added;
-            _readerWriterLockSlim.EnterReadLock();
-            try
-            {
-                added = AddWireModels(wireModels);
-            }
-            finally
-            {
-                _readerWriterLockSlim.ExitReadLock();
-            }
-            _agentHealthReporter.ReportSpanEventCollected(added);
-        }
-
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Span Event harvest starting.");
-
-            ConcurrentPriorityQueue<PrioritizedNode<ISpanEventWireModel>> spanEventsPriorityQueue;
-
-            _readerWriterLockSlim.EnterWriteLock();
-            try
-            {
-                spanEventsPriorityQueue = GetAndResetCollection();
-            }
-            finally
-            {
-                _readerWriterLockSlim.ExitWriteLock();
-            }
-
-            var eventHarvestData = new EventHarvestData(spanEventsPriorityQueue.Size, spanEventsPriorityQueue.GetAddAttemptsCount());
-            var wireModels = spanEventsPriorityQueue.Where(node => null != node).Select(node => node.Data).ToList();
-
-            // if we don't have any events to publish then don't
-            var eventCount = wireModels.Count;
-            if (eventCount > 0)
-            {
-                var responseStatus = DataTransportService.Send(eventHarvestData, wireModels, transactionId);
-                HandleResponse(responseStatus, wireModels);
-            }
-
-            Log.Finest("Span Event harvest finished.");
-        }
-
-        private void ReduceReservoirSize(int newSize)
-        {
-            if (newSize >= _spanEvents.Size)
-                return;
-
-            _spanEvents.Resize(newSize);
-        }
-
-        private void RetainEvents(IEnumerable<ISpanEventWireModel> wireModels)
-        {
-            AddWireModels(wireModels);
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<ISpanEventWireModel> spanEvents)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    _agentHealthReporter.ReportSpanEventsSent(spanEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainEvents(spanEvents);
-                    Log.Debug("Retaining {count} span events.", spanEvents.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                    ReduceReservoirSize((int)(spanEvents.Count * ReservoirReductionSizeMultiplier));
-                    RetainEvents(spanEvents);
-                    Log.Debug("Reservoir size reduced. Retaining {count} span events.", spanEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} span events.", spanEvents.Count);
-                    break;
-            }
-        }
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            if (configurationUpdateSource == ConfigurationUpdateSource.Local && _configuration.SpanEventsMaxSamplesStored != _spanEvents.Size)
-            {
-                //we might have received server configuration that says we should not have collected the
-                //events that we have, drop them on the floor by ignoring the returned collection.
-                GetAndResetCollection();
-            }
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SpanEventAggregatorInfiniteTracing.cs
@@ -1,6 +1,10 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
@@ -10,188 +14,183 @@ using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ISpanEventAggregatorInfiniteTracing
 {
-    public interface ISpanEventAggregatorInfiniteTracing
-    {
-        void Collect(ISpanEventWireModel wireModel);
-        void Collect(IEnumerable<ISpanEventWireModel> wireModels);
-        bool IsServiceEnabled { get; }
-        bool IsServiceAvailable { get; }
-        bool HasCapacity(int proposedItems);
-        void RecordDroppedSpans(int countDroppedSpans);
-        void RecordSeenSpans(int countSeenSpans);
-        void ReportSupportabilityMetrics();
-        int Capacity { get; }
+    void Collect(ISpanEventWireModel wireModel);
+    void Collect(IEnumerable<ISpanEventWireModel> wireModels);
+    bool IsServiceEnabled { get; }
+    bool IsServiceAvailable { get; }
+    bool HasCapacity(int proposedItems);
+    void RecordDroppedSpans(int countDroppedSpans);
+    void RecordSeenSpans(int countSeenSpans);
+    void ReportSupportabilityMetrics();
+    int Capacity { get; }
+}
+
+public class SpanEventAggregatorInfiniteTracing : DisposableService, ISpanEventAggregatorInfiniteTracing
+{
+    private PartitionedBlockingCollection<Span> _spanEvents;
+    private readonly IDataStreamingService<Span, SpanBatch, RecordStatus> _spanStreamingService;
+    private readonly IAgentHealthReporter _agentHealthReporter;
+    private readonly IConfigurationService _configSvc;
+    private readonly IScheduler _schedulerSvc;
+
+    private IConfiguration _configuration => _configSvc?.Configuration;
+
+    public int Capacity => (_spanEvents?.Capacity).GetValueOrDefault(0);
+
+    public SpanEventAggregatorInfiniteTracing(IDataStreamingService<Span, SpanBatch, RecordStatus> spanStreamingService, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IScheduler scheduler)
+    {   
+        _spanStreamingService = spanStreamingService;
+        _subscriptions.Add<AgentConnectedEvent>(AgentConnected);
+        _subscriptions.Add<PreCleanShutdownEvent>(OnPreCleanShutdown);
+        _agentHealthReporter = agentHealthReporter;
+        _configSvc = configSvc;
+        _schedulerSvc = scheduler;
     }
 
-    public class SpanEventAggregatorInfiniteTracing : DisposableService, ISpanEventAggregatorInfiniteTracing
+    /// <summary>
+    /// This executes every time a local configuration change is made.  It is more convenient
+    /// that OnConfigurationChanged
+    /// </summary>
+    /// <param name="_"></param>
+    private void AgentConnected(AgentConnectedEvent _)
     {
-        private PartitionedBlockingCollection<Span> _spanEvents;
-        private readonly IDataStreamingService<Span, SpanBatch, RecordStatus> _spanStreamingService;
-        private readonly IAgentHealthReporter _agentHealthReporter;
-        private readonly IConfigurationService _configSvc;
-        private readonly IScheduler _schedulerSvc;
+        _spanStreamingService.Shutdown(false);
+        _schedulerSvc.StopExecuting(ReportSupportabilityMetrics);
 
-        private IConfiguration _configuration => _configSvc?.Configuration;
+        var oldCapacity = (_spanEvents?.Capacity).GetValueOrDefault(0);
+        var oldPartitionCount = (_spanEvents?.PartitionCount).GetValueOrDefault(0);
+        var oldCount = (_spanEvents?.Count).GetValueOrDefault(0);
 
-        public int Capacity => (_spanEvents?.Capacity).GetValueOrDefault(0);
+        var oldCollection = _spanEvents != null
+            ? Interlocked.Exchange(ref _spanEvents, null)
+            : null;
 
-        public SpanEventAggregatorInfiniteTracing(IDataStreamingService<Span, SpanBatch, RecordStatus> spanStreamingService, IConfigurationService configSvc, IAgentHealthReporter agentHealthReporter, IScheduler scheduler)
-        {   
-            _spanStreamingService = spanStreamingService;
-            _subscriptions.Add<AgentConnectedEvent>(AgentConnected);
-            _subscriptions.Add<PreCleanShutdownEvent>(OnPreCleanShutdown);
-            _agentHealthReporter = agentHealthReporter;
-            _configSvc = configSvc;
-            _schedulerSvc = scheduler;
-        }
+        var newCapacity = _configuration.InfiniteTracingQueueSizeSpans;
+        var newPartitionCount = Math.Min(_configuration.InfiniteTracingQueueSizeSpans, _configuration.InfiniteTracingPartitionCountSpans);
 
-        /// <summary>
-        /// This executes every time a local configuration change is made.  It is more convenient
-        /// that OnConfigurationChanged
-        /// </summary>
-        /// <param name="_"></param>
-        private void AgentConnected(AgentConnectedEvent _)
+        if (!IsServiceEnabled || newCapacity <= 0 || newPartitionCount <= 0 || newPartitionCount > 62)
         {
-            _spanStreamingService.Shutdown(false);
-            _schedulerSvc.StopExecuting(ReportSupportabilityMetrics);
-
-            var oldCapacity = (_spanEvents?.Capacity).GetValueOrDefault(0);
-            var oldPartitionCount = (_spanEvents?.PartitionCount).GetValueOrDefault(0);
-            var oldCount = (_spanEvents?.Count).GetValueOrDefault(0);
-
-            var oldCollection = _spanEvents != null
-                ? Interlocked.Exchange(ref _spanEvents, null)
-                : null;
-
-            var newCapacity = _configuration.InfiniteTracingQueueSizeSpans;
-            var newPartitionCount = Math.Min(_configuration.InfiniteTracingQueueSizeSpans, _configuration.InfiniteTracingPartitionCountSpans);
-
-            if (!IsServiceEnabled || newCapacity <= 0 || newPartitionCount <= 0 || newPartitionCount > 62)
+            if (oldCount > 0)
             {
-                if (oldCount > 0)
-                {
-                    RecordDroppedSpans(oldCount);
-                }
-
-                if(IsServiceEnabled)
-                {
-
-                    Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration is invalid - Infinite Tracing will NOT be enabled.");
-                    LogConfiguration();
-                }
-
-                return;
+                RecordDroppedSpans(oldCount);
             }
 
-            if (oldCapacity == newCapacity && oldPartitionCount == newPartitionCount && oldCollection != null)
+            if(IsServiceEnabled)
             {
-                _spanEvents = oldCollection;
-            }
-            else
-            {
-                var overflowCount = oldCount - newCapacity;
-                if (overflowCount > 0)
-                {
-                    RecordDroppedSpans(overflowCount);
-                }
 
-                _spanEvents = oldCollection != null
-                    ? new PartitionedBlockingCollection<Span>(newCapacity, newPartitionCount, oldCollection)
-                    : new PartitionedBlockingCollection<Span>(newCapacity, newPartitionCount);
-            }
-
-            LogConfiguration();
-
-            _schedulerSvc.ExecuteEvery(ReportSupportabilityMetrics, TimeSpan.FromMinutes(1));
-            _spanStreamingService.StartConsumingCollection(_spanEvents);
-        }
-
-        private void OnPreCleanShutdown(PreCleanShutdownEvent obj)
-        {
-            if (_configuration.CollectorSendDataOnExit)
-            {
-                _spanStreamingService.Wait(_configuration.InfiniteTracingExitTimeoutMs);
+                Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration is invalid - Infinite Tracing will NOT be enabled.");
+                LogConfiguration();
             }
 
             return;
         }
 
-        public void ReportSupportabilityMetrics()
+        if (oldCapacity == newCapacity && oldPartitionCount == newPartitionCount && oldCollection != null)
         {
-            _agentHealthReporter.ReportInfiniteTracingSpanQueueSize(_spanEvents.Count);
+            _spanEvents = oldCollection;
         }
-
-        /// <summary>
-        /// Allows the transformer to check to see if the aggregator has the capacity
-        /// to store a proposed number of items.  If the streaming service has not been
-        /// able to stream an item, set the capacity at 10% to avoid building up a large
-        /// backlog of items during the time it takes to connect.
-        /// </summary>
-        /// <param name="proposedItems"></param>
-        /// <returns></returns>
-        public bool HasCapacity(int proposedItems)
+        else
         {
-            var capacityFactor = _spanStreamingService.IsStreaming
-                ? .9
-                : .1;
-
-            return _spanEvents != null && (_spanEvents.Count + proposedItems) < (Capacity * capacityFactor);
-        }
-
-        private void LogConfiguration()
-        {
-            Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration Setting - Queue Size - {_configuration.InfiniteTracingQueueSizeSpans}");
-            Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration Setting - Queue Partitions - {_configuration.InfiniteTracingPartitionCountSpans}");
-        }
-
-        public bool IsServiceEnabled => _configuration.SpanEventsEnabled
-            && _configuration.DistributedTracingEnabled
-            && _spanStreamingService.IsServiceEnabled;
-        public bool IsServiceAvailable => IsServiceEnabled && _spanEvents != null && _spanStreamingService.IsServiceAvailable;
-
-        public void RecordDroppedSpans(int countDroppedSpans)
-        {
-            _agentHealthReporter.ReportInfiniteTracingSpanEventsDropped(countDroppedSpans);
-        }
-
-        public void RecordSeenSpans(int countSeenSpans)
-        {
-            _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(countSeenSpans);
-        }
-
-        public void Collect(ISpanEventWireModel wireModel)
-        {
-            RecordSeenSpans(1);
-
-            if (_spanEvents == null || !_spanEvents.TryAdd(wireModel.Span))
+            var overflowCount = oldCount - newCapacity;
+            if (overflowCount > 0)
             {
-                RecordDroppedSpans(1);
-            }
-        }
-
-        public void Collect(IEnumerable<ISpanEventWireModel> wireModels)
-        {
-            if (_spanEvents == null)
-            {
-                var countSpans = wireModels.Count();
-
-                _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(countSpans);
-                RecordDroppedSpans(countSpans);
-
-                return;
+                RecordDroppedSpans(overflowCount);
             }
 
-            foreach (var span in wireModels)
-            {
-                Collect(span);
-            }
+            _spanEvents = oldCollection != null
+                ? new PartitionedBlockingCollection<Span>(newCapacity, newPartitionCount, oldCollection)
+                : new PartitionedBlockingCollection<Span>(newCapacity, newPartitionCount);
+        }
+
+        LogConfiguration();
+
+        _schedulerSvc.ExecuteEvery(ReportSupportabilityMetrics, TimeSpan.FromMinutes(1));
+        _spanStreamingService.StartConsumingCollection(_spanEvents);
+    }
+
+    private void OnPreCleanShutdown(PreCleanShutdownEvent obj)
+    {
+        if (_configuration.CollectorSendDataOnExit)
+        {
+            _spanStreamingService.Wait(_configuration.InfiniteTracingExitTimeoutMs);
+        }
+
+        return;
+    }
+
+    public void ReportSupportabilityMetrics()
+    {
+        _agentHealthReporter.ReportInfiniteTracingSpanQueueSize(_spanEvents.Count);
+    }
+
+    /// <summary>
+    /// Allows the transformer to check to see if the aggregator has the capacity
+    /// to store a proposed number of items.  If the streaming service has not been
+    /// able to stream an item, set the capacity at 10% to avoid building up a large
+    /// backlog of items during the time it takes to connect.
+    /// </summary>
+    /// <param name="proposedItems"></param>
+    /// <returns></returns>
+    public bool HasCapacity(int proposedItems)
+    {
+        var capacityFactor = _spanStreamingService.IsStreaming
+            ? .9
+            : .1;
+
+        return _spanEvents != null && (_spanEvents.Count + proposedItems) < (Capacity * capacityFactor);
+    }
+
+    private void LogConfiguration()
+    {
+        Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration Setting - Queue Size - {_configuration.InfiniteTracingQueueSizeSpans}");
+        Log.Info($"SpanEventAggregatorInfiniteTracing: Configuration Setting - Queue Partitions - {_configuration.InfiniteTracingPartitionCountSpans}");
+    }
+
+    public bool IsServiceEnabled => _configuration.SpanEventsEnabled
+                                    && _configuration.DistributedTracingEnabled
+                                    && _spanStreamingService.IsServiceEnabled;
+    public bool IsServiceAvailable => IsServiceEnabled && _spanEvents != null && _spanStreamingService.IsServiceAvailable;
+
+    public void RecordDroppedSpans(int countDroppedSpans)
+    {
+        _agentHealthReporter.ReportInfiniteTracingSpanEventsDropped(countDroppedSpans);
+    }
+
+    public void RecordSeenSpans(int countSeenSpans)
+    {
+        _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(countSeenSpans);
+    }
+
+    public void Collect(ISpanEventWireModel wireModel)
+    {
+        RecordSeenSpans(1);
+
+        if (_spanEvents == null || !_spanEvents.TryAdd(wireModel.Span))
+        {
+            RecordDroppedSpans(1);
+        }
+    }
+
+    public void Collect(IEnumerable<ISpanEventWireModel> wireModels)
+    {
+        if (_spanEvents == null)
+        {
+            var countSpans = wireModels.Count();
+
+            _agentHealthReporter.ReportInfiniteTracingSpanEventsSeen(countSpans);
+            RecordDroppedSpans(countSpans);
+
+            return;
+        }
+
+        foreach (var span in wireModels)
+        {
+            Collect(span);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceStatsCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/SqlTraceStatsCollection.cs
@@ -1,141 +1,140 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
-using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+// NOTE: There is no thread safety built in to this class. If using it across multiple threads (as in SqlTraceAggregator),
+// lock before calling Insert() or Merge().
+public class SqlTraceStatsCollection
 {
-    // NOTE: There is no thread safety built in to this class. If using it across multiple threads (as in SqlTraceAggregator),
-    // lock before calling Insert() or Merge().
-    public class SqlTraceStatsCollection
+    private IDictionary<long, SqlTraceWireModel> _sqlTraceWireModels = new Dictionary<long, SqlTraceWireModel>();
+
+    private int _maxTraces;
+    private int _tracesCollected = 0;
+    private SqlTraceWireModel _shortestMax;
+
+    public SqlTraceStatsCollection(int maxTraces = 100)
     {
-        private IDictionary<long, SqlTraceWireModel> _sqlTraceWireModels = new Dictionary<long, SqlTraceWireModel>();
+        _maxTraces = maxTraces;
+    }
 
-        private int _maxTraces;
-        private int _tracesCollected = 0;
-        private SqlTraceWireModel _shortestMax;
+    public IDictionary<long, SqlTraceWireModel> Collection => _sqlTraceWireModels;
 
-        public SqlTraceStatsCollection(int maxTraces = 100)
+    public int TracesCollected => _tracesCollected;
+
+    public void Merge(SqlTraceStatsCollection newTraces)
+    {
+        foreach (var item in newTraces.Collection)
         {
-            _maxTraces = maxTraces;
+            Insert(item.Value);
+        }
+    }
+
+    public void Insert(SqlTraceWireModel newSqlTrace)
+    {
+        _tracesCollected++;
+
+        // If there is no SQL trace already stored with this ID then just store it
+        var existingSqlTrace = _sqlTraceWireModels.GetValueOrDefault(newSqlTrace.SqlId);
+        if (existingSqlTrace == null)
+        {
+            TryAdd(newSqlTrace);
+            return;
         }
 
-        public IDictionary<long, SqlTraceWireModel> Collection => _sqlTraceWireModels;
-
-        public int TracesCollected => _tracesCollected;
-
-        public void Merge(SqlTraceStatsCollection newTraces)
+        // If there is already a SQL trace stored with the given SqlId then we need to aggregate the new trace into the existing one
+        SqlTraceWireModel dominantSqlTrace;
+        if (newSqlTrace.MaxCallTime > existingSqlTrace.MaxCallTime)
         {
-            foreach (var item in newTraces.Collection)
+            if (_shortestMax != null && _shortestMax.SqlId == newSqlTrace.SqlId)
             {
-                Insert(item.Value);
+                _shortestMax = null; // invalidate the cache
             }
+            dominantSqlTrace = newSqlTrace;
+        }
+        else
+        {
+            dominantSqlTrace = existingSqlTrace;
+        }
+        var transactionName = dominantSqlTrace.TransactionName;
+        var uri = dominantSqlTrace.Uri;
+        var sqlId = dominantSqlTrace.SqlId;
+        var sql = dominantSqlTrace.Sql;
+        var metricName = dominantSqlTrace.DatastoreMetricName;
+        var callCount = newSqlTrace.CallCount + existingSqlTrace.CallCount;
+        var totalCallTime = newSqlTrace.TotalCallTime + existingSqlTrace.TotalCallTime;
+        var minCallTime = (newSqlTrace.MinCallTime < existingSqlTrace.MinCallTime) ? newSqlTrace.MinCallTime : existingSqlTrace.MinCallTime;
+        var maxCallTime = dominantSqlTrace.MaxCallTime;
+        var parameterData = dominantSqlTrace.ParameterData;
+
+        var mergedSqlTrace = new SqlTraceWireModel(transactionName, uri, sqlId, sql, metricName, callCount, totalCallTime, minCallTime, maxCallTime, parameterData);
+        _sqlTraceWireModels[mergedSqlTrace.SqlId] = mergedSqlTrace;
+    }
+
+    // Adds the new trace: 1. if fewer than max; or 2. if the list max reached but the new trace is slowest one on the list;
+    private void TryAdd(SqlTraceWireModel newSqlTrace)
+    {
+        // Add new one if the list is not full
+        if (_sqlTraceWireModels.Count < _maxTraces)
+        {
+            _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
+            return;
         }
 
-        public void Insert(SqlTraceWireModel newSqlTrace)
+        if (_shortestMax == null)
         {
-            _tracesCollected++;
+            SqlTraceWireModel shortest = null;
+            SqlTraceWireModel secondShortest = null;
 
-            // If there is no SQL trace already stored with this ID then just store it
-            var existingSqlTrace = _sqlTraceWireModels.GetValueOrDefault(newSqlTrace.SqlId);
-            if (existingSqlTrace == null)
+            // get the 2 shortest values: 1 to  remove, and 1 to replace cached _shortestMax
+            foreach (SqlTraceWireModel trace in _sqlTraceWireModels.Values)
             {
-                TryAdd(newSqlTrace);
-                return;
-            }
-
-            // If there is already a SQL trace stored with the given SqlId then we need to aggregate the new trace into the existing one
-            SqlTraceWireModel dominantSqlTrace;
-            if (newSqlTrace.MaxCallTime > existingSqlTrace.MaxCallTime)
-            {
-                if (_shortestMax != null && _shortestMax.SqlId == newSqlTrace.SqlId)
+                if (shortest == null)
                 {
-                    _shortestMax = null; // invalidate the cache
+                    shortest = trace;
                 }
-                dominantSqlTrace = newSqlTrace;
+                else if (trace.MaxCallTime < shortest.MaxCallTime)
+                {
+                    secondShortest = shortest;
+                    shortest = trace;
+                }
+                else if (secondShortest == null)
+                {
+                    secondShortest = trace;
+                }
+                else if (trace.MaxCallTime < secondShortest.MaxCallTime)
+                {
+                    secondShortest = trace;
+                }
             }
-            else
-            {
-                dominantSqlTrace = existingSqlTrace;
-            }
-            var transactionName = dominantSqlTrace.TransactionName;
-            var uri = dominantSqlTrace.Uri;
-            var sqlId = dominantSqlTrace.SqlId;
-            var sql = dominantSqlTrace.Sql;
-            var metricName = dominantSqlTrace.DatastoreMetricName;
-            var callCount = newSqlTrace.CallCount + existingSqlTrace.CallCount;
-            var totalCallTime = newSqlTrace.TotalCallTime + existingSqlTrace.TotalCallTime;
-            var minCallTime = (newSqlTrace.MinCallTime < existingSqlTrace.MinCallTime) ? newSqlTrace.MinCallTime : existingSqlTrace.MinCallTime;
-            var maxCallTime = dominantSqlTrace.MaxCallTime;
-            var parameterData = dominantSqlTrace.ParameterData;
 
-            var mergedSqlTrace = new SqlTraceWireModel(transactionName, uri, sqlId, sql, metricName, callCount, totalCallTime, minCallTime, maxCallTime, parameterData);
-            _sqlTraceWireModels[mergedSqlTrace.SqlId] = mergedSqlTrace;
+            _sqlTraceWireModels.Remove(shortest.SqlId);
+            _shortestMax = secondShortest;
+            _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
         }
-
-        // Adds the new trace: 1. if fewer than max; or 2. if the list max reached but the new trace is slowest one on the list;
-        private void TryAdd(SqlTraceWireModel newSqlTrace)
+        else if (newSqlTrace.MaxCallTime > _shortestMax.MaxCallTime)
         {
-            // Add new one if the list is not full
-            if (_sqlTraceWireModels.Count < _maxTraces)
-            {
-                _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
-                return;
-            }
+            _sqlTraceWireModels.Remove(_shortestMax.SqlId);
+            _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
 
-            if (_shortestMax == null)
-            {
-                SqlTraceWireModel shortest = null;
-                SqlTraceWireModel secondShortest = null;
+            _shortestMax = null;
 
-                // get the 2 shortest values: 1 to  remove, and 1 to replace cached _shortestMax
-                foreach (SqlTraceWireModel trace in _sqlTraceWireModels.Values)
+            foreach (var trace in _sqlTraceWireModels.Values)
+            {
+                if (_shortestMax == null)
                 {
-                    if (shortest == null)
-                    {
-                        shortest = trace;
-                    }
-                    else if (trace.MaxCallTime < shortest.MaxCallTime)
-                    {
-                        secondShortest = shortest;
-                        shortest = trace;
-                    }
-                    else if (secondShortest == null)
-                    {
-                        secondShortest = trace;
-                    }
-                    else if (trace.MaxCallTime < secondShortest.MaxCallTime)
-                    {
-                        secondShortest = trace;
-                    }
+                    _shortestMax = trace;
                 }
-
-                _sqlTraceWireModels.Remove(shortest.SqlId);
-                _shortestMax = secondShortest;
-                _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
-            }
-            else if (newSqlTrace.MaxCallTime > _shortestMax.MaxCallTime)
-            {
-                _sqlTraceWireModels.Remove(_shortestMax.SqlId);
-                _sqlTraceWireModels[newSqlTrace.SqlId] = newSqlTrace;
-
-                _shortestMax = null;
-
-                foreach (var trace in _sqlTraceWireModels.Values)
+                else if (_shortestMax.MaxCallTime > trace.MaxCallTime)
                 {
-                    if (_shortestMax == null)
-                    {
-                        _shortestMax = trace;
-                    }
-                    else if (_shortestMax.MaxCallTime > trace.MaxCallTime)
-                    {
-                        _shortestMax = trace;
-                    }
+                    _shortestMax = trace;
                 }
-
             }
+
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionEventAggregator.cs
@@ -1,197 +1,196 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Transactions;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.Extensions.Collections;
 using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ITransactionEventAggregator
 {
-    public interface ITransactionEventAggregator
+    void Collect(TransactionEventWireModel transactionEventWireModel);
+}
+
+/// <summary>
+/// An service for collecting and managing transaction events.
+/// </summary>
+public class TransactionEventAggregator : AbstractAggregator<TransactionEventWireModel>, ITransactionEventAggregator
+{
+    private readonly IAgentHealthReporter _agentHealthReporter;
+    private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
+
+    // Note that synthetics events must be recorded, and thus are stored in their own unique reservoir to ensure that they are never pushed out by non-synthetics events.
+    private IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> _transactionEvents = new ConcurrentPriorityQueue<PrioritizedNode<TransactionEventWireModel>>(0);
+
+    private ConcurrentList<TransactionEventWireModel> _syntheticsTransactionEvents = new ConcurrentList<TransactionEventWireModel>();
+
+    private const double ReservoirReductionSizeMultiplier = 0.5;
+
+    public TransactionEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
+        : base(dataTransportService, scheduler, processStatic)
     {
-        void Collect(TransactionEventWireModel transactionEventWireModel);
+        _agentHealthReporter = agentHealthReporter;
+        ResetCollections(_configuration.TransactionEventsMaximumSamplesStored);
     }
 
-    /// <summary>
-    /// An service for collecting and managing transaction events.
-    /// </summary>
-    public class TransactionEventAggregator : AbstractAggregator<TransactionEventWireModel>, ITransactionEventAggregator
+    protected override TimeSpan HarvestCycle => _configuration.TransactionEventsHarvestCycle;
+    protected override bool IsEnabled => _configuration.TransactionEventsEnabled;
+
+    public override void Dispose()
     {
-        private readonly IAgentHealthReporter _agentHealthReporter;
-        private readonly ReaderWriterLockSlim _readerWriterLock = new ReaderWriterLockSlim();
+        _readerWriterLock.Dispose();
+        base.Dispose();
+    }
 
-        // Note that synthetics events must be recorded, and thus are stored in their own unique reservoir to ensure that they are never pushed out by non-synthetics events.
-        private IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> _transactionEvents = new ConcurrentPriorityQueue<PrioritizedNode<TransactionEventWireModel>>(0);
+    public override void Collect(TransactionEventWireModel transactionEventWireModel)
+    {
+        _agentHealthReporter.ReportTransactionEventCollected();
 
-        private ConcurrentList<TransactionEventWireModel> _syntheticsTransactionEvents = new ConcurrentList<TransactionEventWireModel>();
-
-        private const double ReservoirReductionSizeMultiplier = 0.5;
-
-        public TransactionEventAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IAgentHealthReporter agentHealthReporter)
-            : base(dataTransportService, scheduler, processStatic)
+        _readerWriterLock.EnterReadLock();
+        try
         {
-            _agentHealthReporter = agentHealthReporter;
-            ResetCollections(_configuration.TransactionEventsMaximumSamplesStored);
+            AddEventToCollection(transactionEventWireModel);
+        }
+        finally
+        {
+            _readerWriterLock.ExitReadLock();
+        }
+    }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Transaction Event harvest starting.");
+
+        IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> originalTransactionEvents;
+        ConcurrentList<TransactionEventWireModel> originalSyntheticsTransactionEvents;
+        _readerWriterLock.EnterWriteLock();
+        try
+        {
+            originalTransactionEvents = GetAndResetRegularTransactionEvents(_transactionEvents.Size);
+            originalSyntheticsTransactionEvents = GetAndResetSyntheticsTransactionEvents();
+        }
+        finally
+        {
+            _readerWriterLock.ExitWriteLock();
         }
 
-        protected override TimeSpan HarvestCycle => _configuration.TransactionEventsHarvestCycle;
-        protected override bool IsEnabled => _configuration.TransactionEventsEnabled;
+        var transactionEvents = originalTransactionEvents.Where(node => node != null).Select(node => node.Data).ToList();
+        var aggregatedEvents = transactionEvents.Union(originalSyntheticsTransactionEvents).ToList();
 
-        public override void Dispose()
+        // EventHarvestData is required for extrapolation in the UI.
+        var eventHarvestData = new EventHarvestData(originalTransactionEvents.Size, originalTransactionEvents.GetAddAttemptsCount());
+
+        // if we don't have any events to publish then don't
+        var eventCount = aggregatedEvents.Count;
+        if (eventCount > 0)
         {
-            _readerWriterLock.Dispose();
-            base.Dispose();
+            var responseStatus = DataTransportService.Send(eventHarvestData, aggregatedEvents, transactionId);
+
+            HandleResponse(responseStatus, aggregatedEvents);
         }
 
-        public override void Collect(TransactionEventWireModel transactionEventWireModel)
-        {
-            _agentHealthReporter.ReportTransactionEventCollected();
+        Log.Finest("Transaction Event harvest finished.");
 
-            _readerWriterLock.EnterReadLock();
-            try
+    }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        ResetCollections(_configuration.TransactionEventsMaximumSamplesStored);
+    }
+
+    private void ResetCollections(int transactionEventCollectionCapacity)
+    {
+        GetAndResetRegularTransactionEvents(transactionEventCollectionCapacity);
+        GetAndResetSyntheticsTransactionEvents();
+    }
+
+    private IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> GetAndResetRegularTransactionEvents(int transactionEventCollectionCapacity)
+    {
+        return Interlocked.Exchange(ref _transactionEvents, new ConcurrentPriorityQueue<PrioritizedNode<TransactionEventWireModel>>(transactionEventCollectionCapacity));
+    }
+
+    private ConcurrentList<TransactionEventWireModel> GetAndResetSyntheticsTransactionEvents()
+    {
+        return Interlocked.Exchange(ref _syntheticsTransactionEvents, new ConcurrentList<TransactionEventWireModel>());
+    }
+
+    private void AddEventToCollection(TransactionEventWireModel transactionEvent)
+    {
+        if (transactionEvent.IsSynthetics && _syntheticsTransactionEvents.Count < SyntheticsHeader.MaxEventCount)
+        {
+            _syntheticsTransactionEvents.Add(transactionEvent);
+        }
+        else
+        {
+            _transactionEvents.Add(new PrioritizedNode<TransactionEventWireModel>(transactionEvent));
+        }
+    }
+
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionEventWireModel> transactionEvents)
+    {
+        switch (responseStatus)
+        {
+            case DataTransportResponseStatus.RequestSuccessful:
+                _agentHealthReporter.ReportTransactionEventsSent(transactionEvents.Count);
+                break;
+            case DataTransportResponseStatus.Retain:
+                RetainEvents(transactionEvents);
+                Log.Debug("Retaining {count} transaction events.", transactionEvents.Count);
+                break;
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+                ReduceReservoirSize((int)(transactionEvents.Count * ReservoirReductionSizeMultiplier));
+                RetainEvents(transactionEvents);
+                Log.Debug("Reservoir size reduced. Retaining {count} transaction events.", transactionEvents.Count);
+                break;
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Debug("Discarding {count} transaction events.", transactionEvents.Count); break;
+        }
+    }
+
+    private void RetainEvents(IEnumerable<TransactionEventWireModel> transactionEvents)
+    {
+        transactionEvents = transactionEvents.ToList();
+        _agentHealthReporter.ReportTransactionEventsRecollected(transactionEvents.Count());
+
+        foreach (var transactionEvent in transactionEvents)
+        {
+            if (transactionEvent != null)
             {
-                AddEventToCollection(transactionEventWireModel);
-            }
-            finally
-            {
-                _readerWriterLock.ExitReadLock();
-            }
-        }
-
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Transaction Event harvest starting.");
-
-            IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> originalTransactionEvents;
-            ConcurrentList<TransactionEventWireModel> originalSyntheticsTransactionEvents;
-            _readerWriterLock.EnterWriteLock();
-            try
-            {
-                originalTransactionEvents = GetAndResetRegularTransactionEvents(_transactionEvents.Size);
-                originalSyntheticsTransactionEvents = GetAndResetSyntheticsTransactionEvents();
-            }
-            finally
-            {
-                _readerWriterLock.ExitWriteLock();
-            }
-
-            var transactionEvents = originalTransactionEvents.Where(node => node != null).Select(node => node.Data).ToList();
-            var aggregatedEvents = transactionEvents.Union(originalSyntheticsTransactionEvents).ToList();
-
-            // EventHarvestData is required for extrapolation in the UI.
-            var eventHarvestData = new EventHarvestData(originalTransactionEvents.Size, originalTransactionEvents.GetAddAttemptsCount());
-
-            // if we don't have any events to publish then don't
-            var eventCount = aggregatedEvents.Count;
-            if (eventCount > 0)
-            {
-                var responseStatus = DataTransportService.Send(eventHarvestData, aggregatedEvents, transactionId);
-
-                HandleResponse(responseStatus, aggregatedEvents);
-            }
-
-            Log.Finest("Transaction Event harvest finished.");
-
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            ResetCollections(_configuration.TransactionEventsMaximumSamplesStored);
-        }
-
-        private void ResetCollections(int transactionEventCollectionCapacity)
-        {
-            GetAndResetRegularTransactionEvents(transactionEventCollectionCapacity);
-            GetAndResetSyntheticsTransactionEvents();
-        }
-
-        private IResizableCappedCollection<PrioritizedNode<TransactionEventWireModel>> GetAndResetRegularTransactionEvents(int transactionEventCollectionCapacity)
-        {
-            return Interlocked.Exchange(ref _transactionEvents, new ConcurrentPriorityQueue<PrioritizedNode<TransactionEventWireModel>>(transactionEventCollectionCapacity));
-        }
-
-        private ConcurrentList<TransactionEventWireModel> GetAndResetSyntheticsTransactionEvents()
-        {
-            return Interlocked.Exchange(ref _syntheticsTransactionEvents, new ConcurrentList<TransactionEventWireModel>());
-        }
-
-        private void AddEventToCollection(TransactionEventWireModel transactionEvent)
-        {
-            if (transactionEvent.IsSynthetics && _syntheticsTransactionEvents.Count < SyntheticsHeader.MaxEventCount)
-            {
-                _syntheticsTransactionEvents.Add(transactionEvent);
-            }
-            else
-            {
-                _transactionEvents.Add(new PrioritizedNode<TransactionEventWireModel>(transactionEvent));
-            }
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionEventWireModel> transactionEvents)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    _agentHealthReporter.ReportTransactionEventsSent(transactionEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Retain:
-                    RetainEvents(transactionEvents);
-                    Log.Debug("Retaining {count} transaction events.", transactionEvents.Count);
-                    break;
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                    ReduceReservoirSize((int)(transactionEvents.Count * ReservoirReductionSizeMultiplier));
-                    RetainEvents(transactionEvents);
-                    Log.Debug("Reservoir size reduced. Retaining {count} transaction events.", transactionEvents.Count);
-                    break;
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Debug("Discarding {count} transaction events.", transactionEvents.Count); break;
+                AddEventToCollection(transactionEvent);
             }
         }
+    }
 
-        private void RetainEvents(IEnumerable<TransactionEventWireModel> transactionEvents)
-        {
-            transactionEvents = transactionEvents.ToList();
-            _agentHealthReporter.ReportTransactionEventsRecollected(transactionEvents.Count());
+    private int GetReservoirSize()
+    {
+        return _transactionEvents.Size;
+    }
 
-            foreach (var transactionEvent in transactionEvents)
-            {
-                if (transactionEvent != null)
-                {
-                    AddEventToCollection(transactionEvent);
-                }
-            }
-        }
+    private void ReduceReservoirSize(int newSize)
+    {
+        if (newSize >= GetReservoirSize())
+            return;
 
-        private int GetReservoirSize()
-        {
-            return _transactionEvents.Size;
-        }
-
-        private void ReduceReservoirSize(int newSize)
-        {
-            if (newSize >= GetReservoirSize())
-                return;
-
-            _transactionEvents.Resize(newSize);
-            _agentHealthReporter.ReportTransactionEventReservoirResized(newSize);
-        }
+        _transactionEvents.Resize(newSize);
+        _agentHealthReporter.ReportTransactionEventReservoirResized(newSize);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
+++ b/src/Agent/NewRelic/Agent/Core/Aggregators/TransactionTraceAggregator.cs
@@ -6,133 +6,132 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.TransactionTraces;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 using NewRelic.Agent.Core.WireModels;
-using NewRelic.Agent.Core.SharedInterfaces;
-using Newtonsoft.Json;
 using NewRelic.Agent.Extensions.Logging;
+using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.Aggregators
+namespace NewRelic.Agent.Core.Aggregators;
+
+public interface ITransactionTraceAggregator
 {
-    public interface ITransactionTraceAggregator
+    void Collect(TransactionTraceWireModelComponents transactionTraceWireModel);
+}
+
+public class TransactionTraceAggregator : AbstractAggregator<TransactionTraceWireModelComponents>, ITransactionTraceAggregator
+{
+    private readonly IEnumerable<ITransactionCollector> _transactionCollectors;
+
+    public TransactionTraceAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IEnumerable<ITransactionCollector> transactionCollectors)
+        : base(dataTransportService, scheduler, processStatic)
     {
-        void Collect(TransactionTraceWireModelComponents transactionTraceWireModel);
+        _transactionCollectors = transactionCollectors;
     }
 
-    public class TransactionTraceAggregator : AbstractAggregator<TransactionTraceWireModelComponents>, ITransactionTraceAggregator
+    protected override bool IsEnabled => _configuration.TransactionTracerEnabled;
+
+    protected override TimeSpan HarvestCycle => _configuration.TransactionTracesHarvestCycle;
+
+    public override void Collect(TransactionTraceWireModelComponents transactionTraceWireModel)
     {
-        private readonly IEnumerable<ITransactionCollector> _transactionCollectors;
-
-        public TransactionTraceAggregator(IDataTransportService dataTransportService, IScheduler scheduler, IProcessStatic processStatic, IEnumerable<ITransactionCollector> transactionCollectors)
-            : base(dataTransportService, scheduler, processStatic)
+        foreach (var transactionCollector in _transactionCollectors)
         {
-            _transactionCollectors = transactionCollectors;
+            transactionCollector?.Collect(transactionTraceWireModel);
+        }
+    }
+
+    protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
+
+    protected override void Harvest() => InternalHarvest();
+
+    protected void InternalHarvest(string transactionId = null)
+    {
+        Log.Finest("Transaction Trace harvest starting.");
+
+        var traceSamples = _transactionCollectors
+            .Where(t => t != null)
+            .SelectMany(t => t.GetCollectedSamples())
+            .Distinct()
+            .ToList();
+
+        var traceWireModels = traceSamples
+            .Select(t => t.CreateWireModel())
+            .ToList();
+
+        // if we don't have any traces to publish then don't
+        var traceCount = traceWireModels.Count;
+        if (traceCount > 0)
+        {
+            LogUnencodedTraceData(traceWireModels);
+
+            var responseStatus = DataTransportService.Send(traceWireModels, transactionId);
+            HandleResponse(responseStatus, traceSamples);
         }
 
-        protected override bool IsEnabled => _configuration.TransactionTracerEnabled;
+        Log.Finest("Transaction Trace harvest finished.");
+    }
 
-        protected override TimeSpan HarvestCycle => _configuration.TransactionTracesHarvestCycle;
-
-        public override void Collect(TransactionTraceWireModelComponents transactionTraceWireModel)
+    private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModelComponents> traceSamples)
+    {
+        switch (responseStatus)
         {
-            foreach (var transactionCollector in _transactionCollectors)
-            {
-                transactionCollector?.Collect(transactionTraceWireModel);
-            }
-        }
+            case DataTransportResponseStatus.RequestSuccessful:
+                break;
 
-        protected override void ManualHarvest(string transactionId) => InternalHarvest(transactionId);
-
-        protected override void Harvest() => InternalHarvest();
-
-        protected void InternalHarvest(string transactionId = null)
-        {
-            Log.Finest("Transaction Trace harvest starting.");
-
-            var traceSamples = _transactionCollectors
-                .Where(t => t != null)
-                .SelectMany(t => t.GetCollectedSamples())
-                .Distinct()
-                .ToList();
-
-            var traceWireModels = traceSamples
-                .Select(t => t.CreateWireModel())
-                .ToList();
-
-            // if we don't have any traces to publish then don't
-            var traceCount = traceWireModels.Count;
-            if (traceCount > 0)
-            {
-                LogUnencodedTraceData(traceWireModels);
-
-                var responseStatus = DataTransportService.Send(traceWireModels, transactionId);
-                HandleResponse(responseStatus, traceSamples);
-            }
-
-            Log.Finest("Transaction Trace harvest finished.");
-        }
-
-        private void HandleResponse(DataTransportResponseStatus responseStatus, ICollection<TransactionTraceWireModelComponents> traceSamples)
-        {
-            switch (responseStatus)
-            {
-                case DataTransportResponseStatus.RequestSuccessful:
-                    break;
-
-                case DataTransportResponseStatus.Retain:
-                    // Retain collected samples if applicable
-                    foreach (var traceSample in traceSamples)
-                    {
-                        Collect(traceSample);
-                    }
-                    Log.Debug("Retaining {count} transaction traces.", traceSamples.Count);
-                    break;
-
-                case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
-                case DataTransportResponseStatus.Discard:
-                default:
-                    Log.Warn("Discarding {count} transaction traces.", traceSamples.Count);
-                    break;
-            }
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
-            // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
-
-            foreach (var transactionCollector in _transactionCollectors)
-            {
-                transactionCollector?.GetCollectedSamples();
-            }
-        }
-
-        private void LogUnencodedTraceData(IEnumerable<TransactionTraceWireModel> samples)
-        {
-            if (Log.IsDebugEnabled)
-            {
-                foreach (var sample in samples)
+            case DataTransportResponseStatus.Retain:
+                // Retain collected samples if applicable
+                foreach (var traceSample in traceSamples)
                 {
-                    if (sample != null)
-                    {
-                        Log.Debug("TransactionTraceData: {0}", SerializeTransactionTraceData(sample));
-                    }
+                    Collect(traceSample);
+                }
+                Log.Debug("Retaining {count} transaction traces.", traceSamples.Count);
+                break;
+
+            case DataTransportResponseStatus.ReduceSizeIfPossibleOtherwiseDiscard:
+            case DataTransportResponseStatus.Discard:
+            default:
+                Log.Warn("Discarding {count} transaction traces.", traceSamples.Count);
+                break;
+        }
+    }
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        // It is *CRITICAL* that this method never do anything more complicated than clearing data and starting and ending subscriptions.
+        // If this method ends up trying to send data synchronously (even indirectly via the EventBus or RequestBus) then the user's application will deadlock (!!!).
+
+        foreach (var transactionCollector in _transactionCollectors)
+        {
+            transactionCollector?.GetCollectedSamples();
+        }
+    }
+
+    private void LogUnencodedTraceData(IEnumerable<TransactionTraceWireModel> samples)
+    {
+        if (Log.IsDebugEnabled)
+        {
+            foreach (var sample in samples)
+            {
+                if (sample != null)
+                {
+                    Log.Debug("TransactionTraceData: {0}", SerializeTransactionTraceData(sample));
                 }
             }
         }
+    }
 
-        private static string SerializeTransactionTraceData(TransactionTraceWireModel transactionTraceWireModel)
+    private static string SerializeTransactionTraceData(TransactionTraceWireModel transactionTraceWireModel)
+    {
+        try
         {
-            try
-            {
-                return JsonConvert.SerializeObject(transactionTraceWireModel.TransactionTraceData);
-            }
-            catch (Exception exception)
-            {
-                return "Caught exception when trying to serialize TransactionTraceData: " + exception;
-            }
+            return JsonConvert.SerializeObject(transactionTraceWireModel.TransactionTraceData);
+        }
+        catch (Exception exception)
+        {
+            return "Caught exception when trying to serialize TransactionTraceData: " + exception;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApi.cs
@@ -3,11 +3,11 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Core.Metrics;
 using NewRelic.Agent.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 
 // The AgentApi is the only interface we expose to our customers.
 //
@@ -22,659 +22,660 @@ using System.Collections.Generic;
 // So, to avoid drift and confusion, do NOT document the API in this file; document it in the NewRelic.Api.Agent/NewRelic.cs file.
 
 // The namespace of this method CANNOT be changed. The profiler hard-codes "NewRelic.Agent.Core" as the expected namespace for the agent API.
-namespace NewRelic.Agent.Core
+#pragma warning disable IDE0130
+namespace NewRelic.Agent.Core;
+#pragma warning restore IDE0130
+
+/// <summary>
+/// The interface we expose to our customers.
+/// All public functions here must be static.
+/// All public functions here must have the EXACTLY the same type signature as their stub counterparts in NewRelic.Api.Agent/NewRelic.cs
+/// </summary>
+public static class AgentApi
 {
-    /// <summary>
-    /// The interface we expose to our customers.
-    /// All public functions here must be static.
-    /// All public functions here must have the EXACTLY the same type signature as their stub counterparts in NewRelic.Api.Agent/NewRelic.cs
-    /// </summary>
-    public static class AgentApi
+    static AgentApi()
     {
-        static AgentApi()
+        // Ensure the agent is initialized before any Agent API methods are used
+        AgentInitializer.InitializeAgent();
+    }
+
+    private static IApiSupportabilityMetricCounters? _apiSupportabilityMetricCounters;
+
+    public static void SetSupportabilityMetricCounters(IApiSupportabilityMetricCounters apiSupportabilityMetricCounters)
+    {
+        _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
+    }
+
+    public static void InitializePublicAgent(object publicAgent)
+    {
+        InternalApi.InitializePublicAgent(publicAgent);
+    }
+
+    private static void LogApiError(string methodName, Exception ex)
+    {
+        try
         {
-            // Ensure the agent is initialized before any Agent API methods are used
-            AgentInitializer.InitializeAgent();
+            Log.Warn($"Agent API Error: An error occurred invoking API method \"{methodName}\" - \"{ex}\"");
         }
-
-        private static IApiSupportabilityMetricCounters? _apiSupportabilityMetricCounters;
-
-        public static void SetSupportabilityMetricCounters(IApiSupportabilityMetricCounters apiSupportabilityMetricCounters)
+        catch (Exception) // swallow errors
         {
-            _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
         }
+    }
 
-        public static void InitializePublicAgent(object publicAgent)
-        {
-            InternalApi.InitializePublicAgent(publicAgent);
-        }
+    private static void RecordSupportabilityMetric(ApiMethod apiMethod)
+    {
+        _apiSupportabilityMetricCounters?.Record(apiMethod);
+    }
 
-        private static void LogApiError(string methodName, Exception ex)
+    /// <summary> Increment the supportability metric counter for specific API. Update our thread state
+    /// as performing work that should not be traced. Execute an action and catch/log any exceptions
+    /// thrown by the action. </summary>
+    /// <param name="action">	  An action to perform. </param>
+    /// <param name="methodName"> A string identifying the API name. </param>
+    /// <param name="apiMethod">  An enum value identifying the supportability metric to create. </param>
+    private static void TryInvoke(Action action, string methodName, ApiMethod apiMethod)
+    {
+        try
         {
-            try
+            using (new IgnoreWork())  //do not trace activity on this call tree
             {
-                Log.Warn($"Agent API Error: An error occurred invoking API method \"{methodName}\" - \"{ex}\"");
-            }
-            catch (Exception) // swallow errors
-            {
-            }
-        }
-
-        private static void RecordSupportabilityMetric(ApiMethod apiMethod)
-        {
-            _apiSupportabilityMetricCounters?.Record(apiMethod);
-        }
-
-        /// <summary> Increment the supportability metric counter for specific API. Update our thread state
-        /// as performing work that should not be traced. Execute an action and catch/log any exceptions
-        /// thrown by the action. </summary>
-        /// <param name="action">	  An action to perform. </param>
-        /// <param name="methodName"> A string identifying the API name. </param>
-        /// <param name="apiMethod">  An enum value identifying the supportability metric to create. </param>
-        private static void TryInvoke(Action action, string methodName, ApiMethod apiMethod)
-        {
-            try
-            {
-                using (new IgnoreWork())  //do not trace activity on this call tree
-                {
-                    RecordSupportabilityMetric(apiMethod);
-                    action();
-                }
-            }
-            catch (Exception ex)
-            {
-                LogApiError(methodName, ex);
+                RecordSupportabilityMetric(apiMethod);
+                action();
             }
         }
-
-        /// <summary> Increment the supportability metric counter for specific API. Update our thread state
-        /// as performing work that should not be traced. Execute an function and catch/log any
-        /// exceptions thrown by the action. On failure a default(T) is returned and no exceptions are
-        /// thrown. </summary>
-        /// <typeparam name="T"> Generic type parameter specifying the return type of the action. </typeparam>
-        /// <param name="action">	  An action to perform. </param>
-        /// <param name="methodName"> A string identifying the API name. </param>
-        /// <param name="apiMethod">  An enum value identifying the supportability metric to create. </param>
-        /// <returns> A value of the generic type T. </returns>
-        public static T? TryInvoke<T>(Func<T> action, string methodName, ApiMethod apiMethod)
-            where T : class
+        catch (Exception ex)
         {
-            try
-            {
-                using (new IgnoreWork())  //do not trace activity on this call tree
-                {
-                    RecordSupportabilityMetric(apiMethod);
-                    return action();
-                }
-            }
-            catch (Exception ex)
-            {
-                LogApiError(methodName, ex);
-            }
-            return default(T);
+            LogApiError(methodName, ex);
         }
+    }
 
-        /// <summary> Record a custom analytics event. </summary>
-        /// <param name="eventType">  The name of the metric to record. Only the first 255 characters (256
-        /// including the null terminator) are retained. </param>
-        /// <param name="attributes"> The value to record. Only the first 1000 characters are retained. </param>
-        public static void RecordCustomEvent(string eventType, IEnumerable<KeyValuePair<string, object>> attributes)
+    /// <summary> Increment the supportability metric counter for specific API. Update our thread state
+    /// as performing work that should not be traced. Execute an function and catch/log any
+    /// exceptions thrown by the action. On failure a default(T) is returned and no exceptions are
+    /// thrown. </summary>
+    /// <typeparam name="T"> Generic type parameter specifying the return type of the action. </typeparam>
+    /// <param name="action">	  An action to perform. </param>
+    /// <param name="methodName"> A string identifying the API name. </param>
+    /// <param name="apiMethod">  An enum value identifying the supportability metric to create. </param>
+    /// <returns> A value of the generic type T. </returns>
+    public static T? TryInvoke<T>(Func<T> action, string methodName, ApiMethod apiMethod)
+        where T : class
+    {
+        try
         {
-            const ApiMethod apiMetric = ApiMethod.RecordCustomEvent;
-            const string apiName = nameof(RecordCustomEvent);
-            void work()
+            using (new IgnoreWork())  //do not trace activity on this call tree
             {
-                InternalApi.RecordCustomEvent(eventType, attributes);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary> Record a metric value for the given name. </summary>
-        /// <param name="name">  The name of the metric to record. Only the first 1000 characters are
-        /// retained. </param>
-        /// <param name="value"> The value to record. Only the first 1000 characters are retained. </param>
-        public static void RecordMetric(string name, float value)
-        {
-            const ApiMethod apiMetric = ApiMethod.RecordMetric;
-            const string apiName = nameof(RecordMetric);
-            void work()
-            {
-                InternalApi.RecordMetric(name, value);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Record a response time in milliseconds for the given metric name.
-        /// </summary>
-        /// <param name="name">The name of the response time metric to record.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        /// <param name="millis">The response time to record in milliseconds.</param>
-        public static void RecordResponseTimeMetric(string name, long millis)
-        {
-            const ApiMethod apiMetric = ApiMethod.RecordResponseTimeMetric;
-            const string apiName = nameof(RecordResponseTimeMetric);
-            void work()
-            {
-                InternalApi.RecordResponseTimeMetric(name, millis);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Increment the metric counter for the given name.
-        /// </summary>
-        /// <param name="name">The name of the metric to increment.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        public static void IncrementCounter(string name)
-        {
-            const ApiMethod apiMetric = ApiMethod.IncrementCounter;
-            const string apiName = nameof(IncrementCounter);
-            void work()
-            {
-                InternalApi.IncrementCounter(name);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by an exception report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="exception">The exception to be reported.
-        /// Only part of the exception's information may be retained to prevent the report from being too large.
-        /// </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        public static void NoticeError(Exception exception, IDictionary<string, string>? customAttributes)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(exception, customAttributes);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by an exception report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="exception">The exception to be reported.
-        /// Only part of the exception's information may be retained to prevent the report from being too large.
-        /// </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        public static void NoticeError(Exception exception, IDictionary<string, object>? customAttributes)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(exception, customAttributes);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by an exception and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="exception">The exception to be reported.
-        /// Only part of the exception's information may be retained to prevent the report from being too large.
-        /// </param>
-        public static void NoticeError(Exception exception)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(exception);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
-        /// </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        public static void NoticeError(string message, IDictionary<string, string>? customAttributes)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(message, customAttributes);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
-        public static void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(message, customAttributes, isExpected);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
-        /// </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        public static void NoticeError(string message, IDictionary<string, object>? customAttributes)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(message, customAttributes);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
-        public static void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
-        {
-            const ApiMethod apiMetric = ApiMethod.NoticeError;
-            const string apiName = nameof(NoticeError);
-            void work()
-            {
-                InternalApi.NoticeError(message, customAttributes, isExpected);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Add a key/value pair to the current transaction.  These are reported in errors and transaction traces.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="key">The key name to add to the transaction parameters.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        /// <param name="value">The numeric value to add to the current transaction.</param>
-        [Obsolete("This method does nothing in version 9.x+ of the Agent.  Use Transaction.AddCustomAttribute instead")]
-        public static void AddCustomParameter(string key, IConvertible value)
-        {
-            try
-            {
-                Log.Warn("AddCustomParameter was called by an outdated version of the Agent API. Use Transaction.AddCustomAttribute instead.");
-            }
-            catch (Exception)
-            {
+                RecordSupportabilityMetric(apiMethod);
+                return action();
             }
         }
-
-        /// <summary>
-        /// Add a key/value pair to the current transaction.  These are reported in errors and transaction traces.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="key">The key.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        /// <param name="value">The value.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        [Obsolete("This method does nothing in version 9.x+ of the Agent. Use Transaction.AddCustomAttribute instead")]
-        public static void AddCustomParameter(string key, string value)
+        catch (Exception ex)
         {
-            try
-            {
-                Log.Warn("AddCustomParameter was called by an outdated version of the Agent API. Use Transaction.AddCustomAttribute instead.");
-            }
-            catch (Exception)
-            {
-            }
+            LogApiError(methodName, ex);
+        }
+        return default(T);
+    }
+
+    /// <summary> Record a custom analytics event. </summary>
+    /// <param name="eventType">  The name of the metric to record. Only the first 255 characters (256
+    /// including the null terminator) are retained. </param>
+    /// <param name="attributes"> The value to record. Only the first 1000 characters are retained. </param>
+    public static void RecordCustomEvent(string eventType, IEnumerable<KeyValuePair<string, object>> attributes)
+    {
+        const ApiMethod apiMetric = ApiMethod.RecordCustomEvent;
+        const string apiName = nameof(RecordCustomEvent);
+        void work()
+        {
+            InternalApi.RecordCustomEvent(eventType, attributes);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary> Record a metric value for the given name. </summary>
+    /// <param name="name">  The name of the metric to record. Only the first 1000 characters are
+    /// retained. </param>
+    /// <param name="value"> The value to record. Only the first 1000 characters are retained. </param>
+    public static void RecordMetric(string name, float value)
+    {
+        const ApiMethod apiMetric = ApiMethod.RecordMetric;
+        const string apiName = nameof(RecordMetric);
+        void work()
+        {
+            InternalApi.RecordMetric(name, value);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Record a response time in milliseconds for the given metric name.
+    /// </summary>
+    /// <param name="name">The name of the response time metric to record.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    /// <param name="millis">The response time to record in milliseconds.</param>
+    public static void RecordResponseTimeMetric(string name, long millis)
+    {
+        const ApiMethod apiMetric = ApiMethod.RecordResponseTimeMetric;
+        const string apiName = nameof(RecordResponseTimeMetric);
+        void work()
+        {
+            InternalApi.RecordResponseTimeMetric(name, millis);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Increment the metric counter for the given name.
+    /// </summary>
+    /// <param name="name">The name of the metric to increment.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    public static void IncrementCounter(string name)
+    {
+        const ApiMethod apiMetric = ApiMethod.IncrementCounter;
+        const string apiName = nameof(IncrementCounter);
+        void work()
+        {
+            InternalApi.IncrementCounter(name);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by an exception report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="exception">The exception to be reported.
+    /// Only part of the exception's information may be retained to prevent the report from being too large.
+    /// </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    public static void NoticeError(Exception exception, IDictionary<string, string>? customAttributes)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(exception, customAttributes);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by an exception report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="exception">The exception to be reported.
+    /// Only part of the exception's information may be retained to prevent the report from being too large.
+    /// </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    public static void NoticeError(Exception exception, IDictionary<string, object>? customAttributes)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(exception, customAttributes);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by an exception and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the exception/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="exception">The exception to be reported.
+    /// Only part of the exception's information may be retained to prevent the report from being too large.
+    /// </param>
+    public static void NoticeError(Exception exception)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(exception);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
+    /// </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    public static void NoticeError(string message, IDictionary<string, string>? customAttributes)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(message, customAttributes);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
+    public static void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(message, customAttributes, isExpected);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message.
+    /// </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    public static void NoticeError(string message, IDictionary<string, object>? customAttributes)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(message, customAttributes);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
+    public static void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
+    {
+        const ApiMethod apiMetric = ApiMethod.NoticeError;
+        const string apiName = nameof(NoticeError);
+        void work()
+        {
+            InternalApi.NoticeError(message, customAttributes, isExpected);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Add a key/value pair to the current transaction.  These are reported in errors and transaction traces.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="key">The key name to add to the transaction parameters.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    /// <param name="value">The numeric value to add to the current transaction.</param>
+    [Obsolete("This method does nothing in version 9.x+ of the Agent.  Use Transaction.AddCustomAttribute instead")]
+    public static void AddCustomParameter(string key, IConvertible value)
+    {
+        try
+        {
+            Log.Warn("AddCustomParameter was called by an outdated version of the Agent API. Use Transaction.AddCustomAttribute instead.");
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Add a key/value pair to the current transaction.  These are reported in errors and transaction traces.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="key">The key.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    /// <param name="value">The value.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    [Obsolete("This method does nothing in version 9.x+ of the Agent. Use Transaction.AddCustomAttribute instead")]
+    public static void AddCustomParameter(string key, string value)
+    {
+        try
+        {
+            Log.Warn("AddCustomParameter was called by an outdated version of the Agent API. Use Transaction.AddCustomAttribute instead.");
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Set the name of the current transaction.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="category">The category of this transaction, used to distinguish different types of transactions.
+    /// Defaults to <code>Custom</code>.
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    /// <param name="name">The name of the transaction starting with a forward slash.  example: /store/order
+    /// Only the first 1000 characters are retained.
+    /// </param>
+    public static void SetTransactionName(string? category, string name)
+    {
+        const ApiMethod apiMetric = ApiMethod.SetTransactionName;
+        const string apiName = nameof(SetTransactionName);
+        void work()
+        {
+            InternalApi.SetTransactionName(category, name);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Set the URI of the current transaction.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="uri">The URI of this transaction.</param>
+    public static void SetTransactionUri(Uri uri)
+    {
+        const ApiMethod apiMetric = ApiMethod.SetTransactionUri;
+        const string apiName = nameof(SetTransactionUri);
+        void work()
+        {
+            InternalApi.SetTransactionUri(uri);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Sets the User Name, Account Name and Product Name to associate with the RUM JavaScript footer for the current web transaction.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="userName"> Name of the user to be associated with the transaction.</param>
+    /// <param name="accountName">Name of the account to be associated with the transaction.</param>
+    /// <param name="productName">Name of the product to be associated with the transaction.</param>
+    public static void SetUserParameters(string? userName, string? accountName, string? productName)
+    {
+        const ApiMethod apiMetric = ApiMethod.SetUserParameters;
+        const string apiName = nameof(SetUserParameters);
+        void work()
+        {
+            InternalApi.SetUserParameters(userName, accountName, productName);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Ignore the transaction that is currently in process.
+    /// Supports web applications only.
+    /// </summary>
+    public static void IgnoreTransaction()
+    {
+        const ApiMethod apiMetric = ApiMethod.IgnoreTransaction;
+        const string apiName = nameof(IgnoreTransaction);
+        TryInvoke(InternalApi.IgnoreTransaction, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Ignore the current transaction in the apdex computation.
+    /// Supports web applications only.
+    /// </summary>
+    public static void IgnoreApdex()
+    {
+        const ApiMethod apiMetric = ApiMethod.IgnoreApdex;
+        const string apiName = nameof(IgnoreApdex);
+        TryInvoke(InternalApi.IgnoreApdex, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Returns the html snippet to be inserted into the header of html pages to enable Real User Monitoring.
+    /// The html will instruct the browser to fetch a small JavaScript file and start the page timer.
+    /// Supports web applications only.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// &lt;html>
+    ///   &lt;head>
+    ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()&#37;>
+    ///   &lt;/head>
+    ///   &lt;body>
+    ///   ...
+    /// </code>
+    /// </example>
+    /// <returns>An html string to be embedded in a page header.</returns>
+    public static string GetBrowserTimingHeader()
+    {
+        const ApiMethod apiMetric = ApiMethod.GetBrowserTimingHeader;
+        const string apiName = nameof(GetBrowserTimingHeader);
+        return TryInvoke(() => InternalApi.GetBrowserTimingHeader(), apiName, apiMetric) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Returns the html snippet to be inserted into the header of html pages to enable Real User Monitoring.
+    /// The html will instruct the browser to fetch a small JavaScript file and start the page timer.
+    /// Supports web applications only.
+    /// </summary>
+    /// <param name="nonce">An optional per-request, cryptographic nonce used by a <c>Content-Security-Policy</c> <c>script-src</c> policy.</param>
+    /// <example>
+    /// <code>
+    /// &lt;html>
+    ///   &lt;head>
+    ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("random-nonce")&#37;>
+    ///   &lt;/head>
+    ///   &lt;body>
+    ///   ...
+    /// </code>
+    /// </example>
+    /// <returns>An html string to be embedded in a page header.</returns>
+    public static string GetBrowserTimingHeader(string nonce)
+    {
+        const ApiMethod apiMetric = ApiMethod.GetBrowserTimingHeader;
+        const string apiName = nameof(GetBrowserTimingHeader);
+        return TryInvoke(() => InternalApi.GetBrowserTimingHeader(nonce), apiName, apiMetric) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Obsolete method that used to return the html snippet to be inserted into the footer of html pages as part of Real User Monitoring.
+    /// Now only returns and empty string.
+    /// Supports web applications only.
+    /// <returns>An empty string.</returns>
+    [Obsolete("This method does nothing in version 9.x+ of the Agent.")]
+    public static string GetBrowserTimingFooter()
+    {
+        try
+        {
+            Log.Warn("GetBrowserTimingFooter was called by an outdated version of the Agent API.");
+        }
+        catch (Exception)
+        {
+        }
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Disables the automatic instrumentation of browser monitoring hooks in individual pages
+    /// Supports web applications only.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring()
+    /// </code>
+    /// </example>
+    /// <param name="overrideManual">(Optional) True to override manual instrumentation.</param>
+    public static void DisableBrowserMonitoring(bool overrideManual = false)
+    {
+        const ApiMethod apiMetric = ApiMethod.DisableBrowserMonitoring;
+        const string apiName = nameof(DisableBrowserMonitoring);
+        void work()
+        {
+            InternalApi.DisableBrowserMonitoring(overrideManual);
+        }
+        TryInvoke(work, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Starts the agent (i.e. begin capturing data). Does nothing if the agent is already started.
+    /// Useful if agent autostart is disabled via configuration, or if you want to ensure the agent
+    /// is started before using other methods in the Agent API.
+    /// </summary>
+    /// <example>
+    /// <code>
+    ///   NewRelic.Api.Agent.NewRelic.StartAgent();
+    /// </code>
+    /// </example>
+    public static void StartAgent()
+    {
+        const ApiMethod apiMetric = ApiMethod.StartAgent;
+        const string apiName = nameof(StartAgent);
+        TryInvoke(InternalApi.StartAgent, apiName, apiMetric);
+    }
+
+    /// <summary>
+    /// Sets the name of the application to <paramref name="applicationName"/>. At least one given name must not be null.
+    /// 
+    /// An application may also have up to two additional names. This can be useful, for example, to have multiple 
+    /// applications report under the same roll-up name.
+    /// </summary>
+    /// <param name="applicationName">The main application name.</param>
+    /// <param name="applicationName2">An optional second application name.</param>
+    /// <param name="applicationName3">An optional third application name.</param>
+    public static void SetApplicationName(string applicationName, string? applicationName2 = null, string? applicationName3 = null)
+    {
+        const string apiName = nameof(SetApplicationName);
+        void work()
+        {
+            InternalApi.SetApplicationName(applicationName, applicationName2, applicationName3);
         }
 
-        /// <summary>
-        /// Set the name of the current transaction.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="category">The category of this transaction, used to distinguish different types of transactions.
-        /// Defaults to <code>Custom</code>.
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        /// <param name="name">The name of the transaction starting with a forward slash.  example: /store/order
-        /// Only the first 1000 characters are retained.
-        /// </param>
-        public static void SetTransactionName(string? category, string name)
-        {
-            const ApiMethod apiMetric = ApiMethod.SetTransactionName;
-            const string apiName = nameof(SetTransactionName);
-            void work()
-            {
-                InternalApi.SetTransactionName(category, name);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
+        TryInvoke(work, apiName, ApiMethod.SetApplicationName);
+    }
 
-        /// <summary>
-        /// Set the URI of the current transaction.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="uri">The URI of this transaction.</param>
-        public static void SetTransactionUri(Uri uri)
-        {
-            const ApiMethod apiMetric = ApiMethod.SetTransactionUri;
-            const string apiName = nameof(SetTransactionUri);
-            void work()
-            {
-                InternalApi.SetTransactionUri(uri);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
+    /// <summary>
+    /// Get the request metadata for the current transaction.
+    /// If Distributed Tracing is enabled this returns an empty list.
+    /// </summary>
+    /// <returns>A list of key-value pairs representing the request metadata.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> GetRequestMetadata()
+    {
+        return InternalApi.GetRequestMetadata() ?? new Dictionary<string, string>();
+    }
 
-        /// <summary>
-        /// Sets the User Name, Account Name and Product Name to associate with the RUM JavaScript footer for the current web transaction.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="userName"> Name of the user to be associated with the transaction.</param>
-        /// <param name="accountName">Name of the account to be associated with the transaction.</param>
-        /// <param name="productName">Name of the product to be associated with the transaction.</param>
-        public static void SetUserParameters(string? userName, string? accountName, string? productName)
-        {
-            const ApiMethod apiMetric = ApiMethod.SetUserParameters;
-            const string apiName = nameof(SetUserParameters);
-            void work()
-            {
-                InternalApi.SetUserParameters(userName, accountName, productName);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
+    /// <summary>
+    /// Get the response metadata for the current transaction.
+    /// If Distributed Tracing is enabled this returns an empty list.
+    /// </summary>
+    /// <returns>A list of key-value pairs representing the response metadata.</returns>
+    public static IEnumerable<KeyValuePair<string, string>> GetResponseMetadata()
+    {
+        return InternalApi.GetResponseMetadata() ?? new Dictionary<string, string>();
+    }
 
-        /// <summary>
-        /// Ignore the transaction that is currently in process.
-        /// Supports web applications only.
-        /// </summary>
-        public static void IgnoreTransaction()
+    /// <summary> Sets the method that will be invoked to define the error group that an exception
+    /// should belong to.
+    ///
+    /// The callback takes an an IReadOnlyDictionary of attributes, the stack trace, and Exception,
+    /// and returns the name of the error group to use. Return values
+    /// that are null, empty, or whitespace will not associate the Exception to an error group.
+    /// </summary>
+    /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
+    public static void SetErrorGroupCallback(Func<IReadOnlyDictionary<string, object>, string> callback)
+    {
+        const string apiName = nameof(SetErrorGroupCallback);
+        void work()
         {
-            const ApiMethod apiMetric = ApiMethod.IgnoreTransaction;
-            const string apiName = nameof(IgnoreTransaction);
-            TryInvoke(InternalApi.IgnoreTransaction, apiName, apiMetric);
+            InternalApi.SetErrorGroupCallback(callback);
         }
+        TryInvoke(work, apiName, ApiMethod.SetErrorGroupCallback);
+    }
 
-        /// <summary>
-        /// Ignore the current transaction in the apdex computation.
-        /// Supports web applications only.
-        /// </summary>
-        public static void IgnoreApdex()
+    /// <summary> Sets the method that will be invoked to define the token count of completion.
+    ///
+    /// The callback takes the model name and input value, and returns an integer of the token count.
+    /// A value returned from the callback that is less than or equal to 0 will be ignored.
+    /// </summary>
+    /// <param name="callback">The callback to invoke to generate the token count based on the model and input..</param>
+    public static void SetLlmTokenCountingCallback(Func<string, string, int> callback)
+    {
+        const string apiName = nameof(SetLlmTokenCountingCallback);
+        void work()
         {
-            const ApiMethod apiMetric = ApiMethod.IgnoreApdex;
-            const string apiName = nameof(IgnoreApdex);
-            TryInvoke(InternalApi.IgnoreApdex, apiName, apiMetric);
+            InternalApi.SetLlmTokenCountingCallback(callback);
         }
+        TryInvoke(work, apiName, ApiMethod.SetLlmTokenCountingCallback);
+    }
 
-        /// <summary>
-        /// Returns the html snippet to be inserted into the header of html pages to enable Real User Monitoring.
-        /// The html will instruct the browser to fetch a small JavaScript file and start the page timer.
-        /// Supports web applications only.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// &lt;html>
-        ///   &lt;head>
-        ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()&#37;>
-        ///   &lt;/head>
-        ///   &lt;body>
-        ///   ...
-        /// </code>
-        /// </example>
-        /// <returns>An html string to be embedded in a page header.</returns>
-        public static string GetBrowserTimingHeader()
+    /// <summary>
+    /// Creates an event with the customer feedback on the LLM interaction.
+    /// </summary>
+    /// <param name="traceId">Required. ID of the trace where the chat completion(s) related to the feedback occurred</param>
+    /// <param name="rating">Required. Rating provided by an end user. Must be string or int</param>
+    /// <param name="category">Optional. Category of the feedback as provided by the end user</param>
+    /// <param name="message">Optional. Freeform text feedback from an end user</param>
+    /// <param name="metadata">Optional. Set of key-value pairs to store any other desired data to submit with the feedback event</param>
+    public static void RecordLlmFeedbackEvent(string traceId, object rating, string category = "", string message = "", IDictionary<string, object>? metadata = null)
+    {
+        const string apiName = nameof(RecordLlmFeedbackEvent);
+        void work()
         {
-            const ApiMethod apiMetric = ApiMethod.GetBrowserTimingHeader;
-            const string apiName = nameof(GetBrowserTimingHeader);
-            return TryInvoke(() => InternalApi.GetBrowserTimingHeader(), apiName, apiMetric) ?? string.Empty;
+            InternalApi.RecordLlmFeedbackEvent(traceId, rating, category, message, metadata);
         }
-
-        /// <summary>
-        /// Returns the html snippet to be inserted into the header of html pages to enable Real User Monitoring.
-        /// The html will instruct the browser to fetch a small JavaScript file and start the page timer.
-        /// Supports web applications only.
-        /// </summary>
-        /// <param name="nonce">An optional per-request, cryptographic nonce used by a <c>Content-Security-Policy</c> <c>script-src</c> policy.</param>
-        /// <example>
-        /// <code>
-        /// &lt;html>
-        ///   &lt;head>
-        ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("random-nonce")&#37;>
-        ///   &lt;/head>
-        ///   &lt;body>
-        ///   ...
-        /// </code>
-        /// </example>
-        /// <returns>An html string to be embedded in a page header.</returns>
-        public static string GetBrowserTimingHeader(string nonce)
-        {
-            const ApiMethod apiMetric = ApiMethod.GetBrowserTimingHeader;
-            const string apiName = nameof(GetBrowserTimingHeader);
-            return TryInvoke(() => InternalApi.GetBrowserTimingHeader(nonce), apiName, apiMetric) ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Obsolete method that used to return the html snippet to be inserted into the footer of html pages as part of Real User Monitoring.
-        /// Now only returns and empty string.
-        /// Supports web applications only.
-        /// <returns>An empty string.</returns>
-        [Obsolete("This method does nothing in version 9.x+ of the Agent.")]
-        public static string GetBrowserTimingFooter()
-        {
-            try
-            {
-                Log.Warn("GetBrowserTimingFooter was called by an outdated version of the Agent API.");
-            }
-            catch (Exception)
-            {
-            }
-            return string.Empty;
-        }
-
-        /// <summary>
-        /// Disables the automatic instrumentation of browser monitoring hooks in individual pages
-        /// Supports web applications only.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring()
-        /// </code>
-        /// </example>
-        /// <param name="overrideManual">(Optional) True to override manual instrumentation.</param>
-        public static void DisableBrowserMonitoring(bool overrideManual = false)
-        {
-            const ApiMethod apiMetric = ApiMethod.DisableBrowserMonitoring;
-            const string apiName = nameof(DisableBrowserMonitoring);
-            void work()
-            {
-                InternalApi.DisableBrowserMonitoring(overrideManual);
-            }
-            TryInvoke(work, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Starts the agent (i.e. begin capturing data). Does nothing if the agent is already started.
-        /// Useful if agent autostart is disabled via configuration, or if you want to ensure the agent
-        /// is started before using other methods in the Agent API.
-        /// </summary>
-        /// <example>
-        /// <code>
-        ///   NewRelic.Api.Agent.NewRelic.StartAgent();
-        /// </code>
-        /// </example>
-        public static void StartAgent()
-        {
-            const ApiMethod apiMetric = ApiMethod.StartAgent;
-            const string apiName = nameof(StartAgent);
-            TryInvoke(InternalApi.StartAgent, apiName, apiMetric);
-        }
-
-        /// <summary>
-        /// Sets the name of the application to <paramref name="applicationName"/>. At least one given name must not be null.
-        /// 
-        /// An application may also have up to two additional names. This can be useful, for example, to have multiple 
-        /// applications report under the same roll-up name.
-        /// </summary>
-        /// <param name="applicationName">The main application name.</param>
-        /// <param name="applicationName2">An optional second application name.</param>
-        /// <param name="applicationName3">An optional third application name.</param>
-        public static void SetApplicationName(string applicationName, string? applicationName2 = null, string? applicationName3 = null)
-        {
-            const string apiName = nameof(SetApplicationName);
-            void work()
-            {
-                InternalApi.SetApplicationName(applicationName, applicationName2, applicationName3);
-            }
-
-            TryInvoke(work, apiName, ApiMethod.SetApplicationName);
-        }
-
-        /// <summary>
-        /// Get the request metadata for the current transaction.
-        /// If Distributed Tracing is enabled this returns an empty list.
-        /// </summary>
-        /// <returns>A list of key-value pairs representing the request metadata.</returns>
-        public static IEnumerable<KeyValuePair<string, string>> GetRequestMetadata()
-        {
-            return InternalApi.GetRequestMetadata() ?? new Dictionary<string, string>();
-        }
-
-        /// <summary>
-        /// Get the response metadata for the current transaction.
-        /// If Distributed Tracing is enabled this returns an empty list.
-        /// </summary>
-        /// <returns>A list of key-value pairs representing the response metadata.</returns>
-        public static IEnumerable<KeyValuePair<string, string>> GetResponseMetadata()
-        {
-            return InternalApi.GetResponseMetadata() ?? new Dictionary<string, string>();
-        }
-
-        /// <summary> Sets the method that will be invoked to define the error group that an exception
-        /// should belong to.
-        ///
-        /// The callback takes an an IReadOnlyDictionary of attributes, the stack trace, and Exception,
-        /// and returns the name of the error group to use. Return values
-        /// that are null, empty, or whitespace will not associate the Exception to an error group.
-        /// </summary>
-        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
-        public static void SetErrorGroupCallback(Func<IReadOnlyDictionary<string, object>, string> callback)
-        {
-            const string apiName = nameof(SetErrorGroupCallback);
-            void work()
-            {
-                InternalApi.SetErrorGroupCallback(callback);
-            }
-            TryInvoke(work, apiName, ApiMethod.SetErrorGroupCallback);
-        }
-
-        /// <summary> Sets the method that will be invoked to define the token count of completion.
-        ///
-        /// The callback takes the model name and input value, and returns an integer of the token count.
-        /// A value returned from the callback that is less than or equal to 0 will be ignored.
-        /// </summary>
-        /// <param name="callback">The callback to invoke to generate the token count based on the model and input..</param>
-        public static void SetLlmTokenCountingCallback(Func<string, string, int> callback)
-        {
-            const string apiName = nameof(SetLlmTokenCountingCallback);
-            void work()
-            {
-                InternalApi.SetLlmTokenCountingCallback(callback);
-            }
-            TryInvoke(work, apiName, ApiMethod.SetLlmTokenCountingCallback);
-        }
-
-        /// <summary>
-        /// Creates an event with the customer feedback on the LLM interaction.
-        /// </summary>
-        /// <param name="traceId">Required. ID of the trace where the chat completion(s) related to the feedback occurred</param>
-        /// <param name="rating">Required. Rating provided by an end user. Must be string or int</param>
-        /// <param name="category">Optional. Category of the feedback as provided by the end user</param>
-        /// <param name="message">Optional. Freeform text feedback from an end user</param>
-        /// <param name="metadata">Optional. Set of key-value pairs to store any other desired data to submit with the feedback event</param>
-        public static void RecordLlmFeedbackEvent(string traceId, object rating, string category = "", string message = "", IDictionary<string, object>? metadata = null)
-        {
-            const string apiName = nameof(RecordLlmFeedbackEvent);
-            void work()
-            {
-                InternalApi.RecordLlmFeedbackEvent(traceId, rating, category, message, metadata);
-            }
-            TryInvoke(work, apiName, ApiMethod.RecordLlmFeedbackEvent);
-        }
+        TryInvoke(work, apiName, ApiMethod.RecordLlmFeedbackEvent);
     }
 }
 

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentApiImplementation.cs
@@ -3,6 +3,12 @@
 
 #nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using NewRelic.Agent.Api;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Aggregators;
 using NewRelic.Agent.Core.BrowserMonitoring;
@@ -14,798 +20,791 @@ using NewRelic.Agent.Core.Transactions;
 using NewRelic.Agent.Core.Transformers;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Core.WireModels;
-using NewRelic.Agent.Extensions.Providers.Wrapper;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Reflection;
 using NewRelic.Agent.Core.Wrapper.AgentWrapperApi.Builders;
 using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Api;
-using System.Linq;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 
-namespace NewRelic.Agent.Core.Api
+namespace NewRelic.Agent.Core.Api;
+
+public class AgentApiImplementation : IAgentApi
 {
-    public class AgentApiImplementation : IAgentApi
+    private static readonly char[] TrimPathChar = new[] { MetricNames.PathSeparatorChar };
+    private const string CustomMetricNamePrefixAndSeparator = MetricNames.Custom + MetricNames.PathSeparator;
+    private const string DistributedTracingIsEnabledIgnoringCall = "Distributed tracing is enabled. Ignoring {0} call.";
+    // Special case value for Path in ErrorTraceWireModel for errors outside Transactions
+    private const string NoticeErrorPath = "NewRelic.Api.Agent.NoticeError API Call";
+
+    private readonly ITransactionService _transactionService;
+    private readonly ICustomEventTransformer _customEventTransformer;
+    private readonly IMetricBuilder _metricBuilder;
+    private readonly IMetricAggregator _metricAggregator;
+    private readonly ICustomErrorDataTransformer _customErrorDataTransformer;
+    private readonly IBrowserMonitoringPrereqChecker _browserMonitoringPrereqChecker;
+    private readonly IBrowserMonitoringScriptMaker _browserMonitoringScriptMaker;
+    private readonly IConfigurationService _configurationService;
+    private readonly IAgent _agent;
+    private readonly AgentBridgeApi _agentBridgeApi;
+    private readonly ITracePriorityManager _tracePriorityManager;
+    private readonly IErrorService _errorService;
+
+    public AgentApiImplementation(ITransactionService transactionService, ICustomEventTransformer customEventTransformer, IMetricBuilder metricBuilder, IMetricAggregator metricAggregator, ICustomErrorDataTransformer customErrorDataTransformer, IBrowserMonitoringPrereqChecker browserMonitoringPrereqChecker, IBrowserMonitoringScriptMaker browserMonitoringScriptMaker, IConfigurationService configurationService, IAgent agent, ITracePriorityManager tracePriorityManager, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IErrorService errorService)
     {
-        private static readonly char[] TrimPathChar = new[] { MetricNames.PathSeparatorChar };
-        private const string CustomMetricNamePrefixAndSeparator = MetricNames.Custom + MetricNames.PathSeparator;
-        private const string DistributedTracingIsEnabledIgnoringCall = "Distributed tracing is enabled. Ignoring {0} call.";
-        // Special case value for Path in ErrorTraceWireModel for errors outside Transactions
-        private const string NoticeErrorPath = "NewRelic.Api.Agent.NoticeError API Call";
+        _transactionService = transactionService;
+        _customEventTransformer = customEventTransformer;
+        _metricBuilder = metricBuilder;
+        _metricAggregator = metricAggregator;
+        _customErrorDataTransformer = customErrorDataTransformer;
+        _browserMonitoringPrereqChecker = browserMonitoringPrereqChecker;
+        _browserMonitoringScriptMaker = browserMonitoringScriptMaker;
+        _configurationService = configurationService;
+        _agent = agent;
+        _agentBridgeApi = new AgentBridgeApi(_agent, apiSupportabilityMetricCounters, _configurationService);
+        _tracePriorityManager = tracePriorityManager;
+        _errorService = errorService;
+    }
 
-        private readonly ITransactionService _transactionService;
-        private readonly ICustomEventTransformer _customEventTransformer;
-        private readonly IMetricBuilder _metricBuilder;
-        private readonly IMetricAggregator _metricAggregator;
-        private readonly ICustomErrorDataTransformer _customErrorDataTransformer;
-        private readonly IBrowserMonitoringPrereqChecker _browserMonitoringPrereqChecker;
-        private readonly IBrowserMonitoringScriptMaker _browserMonitoringScriptMaker;
-        private readonly IConfigurationService _configurationService;
-        private readonly IAgent _agent;
-        private readonly AgentBridgeApi _agentBridgeApi;
-        private readonly ITracePriorityManager _tracePriorityManager;
-        private readonly IErrorService _errorService;
-
-        public AgentApiImplementation(ITransactionService transactionService, ICustomEventTransformer customEventTransformer, IMetricBuilder metricBuilder, IMetricAggregator metricAggregator, ICustomErrorDataTransformer customErrorDataTransformer, IBrowserMonitoringPrereqChecker browserMonitoringPrereqChecker, IBrowserMonitoringScriptMaker browserMonitoringScriptMaker, IConfigurationService configurationService, IAgent agent, ITracePriorityManager tracePriorityManager, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IErrorService errorService)
+    public void InitializePublicAgent(object publicAgent)
+    {
+        try
         {
-            _transactionService = transactionService;
-            _customEventTransformer = customEventTransformer;
-            _metricBuilder = metricBuilder;
-            _metricAggregator = metricAggregator;
-            _customErrorDataTransformer = customErrorDataTransformer;
-            _browserMonitoringPrereqChecker = browserMonitoringPrereqChecker;
-            _browserMonitoringScriptMaker = browserMonitoringScriptMaker;
-            _configurationService = configurationService;
-            _agent = agent;
-            _agentBridgeApi = new AgentBridgeApi(_agent, apiSupportabilityMetricCounters, _configurationService);
-            _tracePriorityManager = tracePriorityManager;
-            _errorService = errorService;
+            using (new IgnoreWork())
+            {
+                Log.Info("Initializing the Agent API");
+                var method = publicAgent.GetType().GetMethod("SetWrappedAgent", BindingFlags.NonPublic | BindingFlags.Instance);
+                method.Invoke(publicAgent, new[] { _agentBridgeApi });
+            }
         }
-
-        public void InitializePublicAgent(object publicAgent)
+        catch (Exception ex)
         {
             try
             {
-                using (new IgnoreWork())
-                {
-                    Log.Info("Initializing the Agent API");
-                    var method = publicAgent.GetType().GetMethod("SetWrappedAgent", BindingFlags.NonPublic | BindingFlags.Instance);
-                    method.Invoke(publicAgent, new[] { _agentBridgeApi });
-                }
+                Log.Error(ex, "Failed to initialize the Agent API");
             }
-            catch (Exception ex)
+            catch (Exception)//Swallow the error
             {
-                try
-                {
-                    Log.Error(ex, "Failed to initialize the Agent API");
-                }
-                catch (Exception)//Swallow the error
-                {
-                }
             }
         }
+    }
 
-        /// <summary> Record a custom analytics event represented by a name and a list of key-value pairs. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="eventType"/> or
-        /// <paramref name="attributes"/> are null. </exception>
-        ///
-        /// <param name="eventType">  The name of the event to record. Only the first 255 characters (256
-        /// including the null terminator) are retained. </param>
-        /// <param name="attributes"> The attributes to associate with this event. </param>
-        public void RecordCustomEvent(string eventType, IEnumerable<KeyValuePair<string, object>> attributes)
+    /// <summary> Record a custom analytics event represented by a name and a list of key-value pairs. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="eventType"/> or
+    /// <paramref name="attributes"/> are null. </exception>
+    ///
+    /// <param name="eventType">  The name of the event to record. Only the first 255 characters (256
+    /// including the null terminator) are retained. </param>
+    /// <param name="attributes"> The attributes to associate with this event. </param>
+    public void RecordCustomEvent(string eventType, IEnumerable<KeyValuePair<string, object>> attributes)
+    {
+        eventType = eventType ?? throw new ArgumentNullException(nameof(eventType));
+        attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+
+        using (new IgnoreWork())
         {
-            eventType = eventType ?? throw new ArgumentNullException(nameof(eventType));
-            attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+            var transaction = TryGetCurrentInternalTransaction();
+            float priority = transaction?.Priority ?? _tracePriorityManager.Create();
 
-            using (new IgnoreWork())
+            _customEventTransformer.Transform(eventType, attributes, priority);
+        }
+    }
+
+    /// <summary> Record a named metric with the given duration. </summary>
+    ///
+    /// <param name="name">  The name of the metric to record. Only the first 1000 characters are
+    /// retained. </param>
+    /// <param name="value"> The number of seconds to associate with the named attribute. This can be
+    /// negative, 0, or positive. </param>
+    public void RecordMetric(string name, float value)
+    {
+        using (new IgnoreWork())
+        {
+            var metricName = GetCustomMetricSuffix(name); //throws if name is null or empty
+            var time = TimeSpan.FromSeconds(value); //throws if value is NaN, Neg Inf, or Pos Inf, < TimeSpan.MinValue, > TimeSpan.MaxValue
+            var metric = _metricBuilder.TryBuildCustomTimingMetric(metricName, time);
+
+            if (metric != null)
             {
-                var transaction = TryGetCurrentInternalTransaction();
-                float priority = transaction?.Priority ?? _tracePriorityManager.Create();
-
-                _customEventTransformer.Transform(eventType, attributes, priority);
+                _metricAggregator.Collect(metric);
             }
         }
+    }
 
-        /// <summary> Record a named metric with the given duration. </summary>
-        ///
-        /// <param name="name">  The name of the metric to record. Only the first 1000 characters are
-        /// retained. </param>
-        /// <param name="value"> The number of seconds to associate with the named attribute. This can be
-        /// negative, 0, or positive. </param>
-        public void RecordMetric(string name, float value)
+    /// <summary> Record response time metric. </summary>
+    ///
+    /// <param name="name">   The name of the metric to record. Only the first 1000 characters are
+    /// retained. </param>
+    /// <param name="millis"> The milliseconds duration of the response time. </param>
+    public void RecordResponseTimeMetric(string name, long millis)
+    {
+        using (new IgnoreWork())
         {
-            using (new IgnoreWork())
+            var metricName = GetCustomMetricSuffix(name); //throws if name is null or empty
+            var time = TimeSpan.FromMilliseconds(millis);
+            var metric = _metricBuilder.TryBuildCustomTimingMetric(metricName, time);
+
+            if (metric != null)
             {
-                var metricName = GetCustomMetricSuffix(name); //throws if name is null or empty
-                var time = TimeSpan.FromSeconds(value); //throws if value is NaN, Neg Inf, or Pos Inf, < TimeSpan.MinValue, > TimeSpan.MaxValue
-                var metric = _metricBuilder.TryBuildCustomTimingMetric(metricName, time);
-
-                if (metric != null)
-                {
-                    _metricAggregator.Collect(metric);
-                }
+                _metricAggregator.Collect(metric);
             }
         }
+    }
 
-        /// <summary> Record response time metric. </summary>
-        ///
-        /// <param name="name">   The name of the metric to record. Only the first 1000 characters are
-        /// retained. </param>
-        /// <param name="millis"> The milliseconds duration of the response time. </param>
-        public void RecordResponseTimeMetric(string name, long millis)
+    /// <summary> Increment the metric counter for the given name. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="name"/> is null. </exception>
+    ///
+    /// <param name="name"> The name of the metric to record. Only the first 1000 characters are
+    /// retained. </param>
+    public void IncrementCounter(string name)
+    {
+        name = name ?? throw new ArgumentNullException(nameof(name));
+
+        using (new IgnoreWork())
         {
-            using (new IgnoreWork())
+            // NOTE: Unlike Custom timing metrics, Custom count metrics are NOT restricted to only the "Custom" namespace.
+            // This is probably a historical blunder -- it's not a good thing that we allow users to use whatever text they want for the first segment.
+            // However, that is what the API currently allows and it would be difficult to take that feature away.
+            var metric = _metricBuilder.TryBuildCustomCountMetric(name);
+
+            if (metric != null)
             {
-                var metricName = GetCustomMetricSuffix(name); //throws if name is null or empty
-                var time = TimeSpan.FromMilliseconds(millis);
-                var metric = _metricBuilder.TryBuildCustomTimingMetric(metricName, time);
-
-                if (metric != null)
-                {
-                    _metricAggregator.Collect(metric);
-                }
+                _metricAggregator.Collect(metric);
             }
         }
+    }
 
-        /// <summary> Increment the metric counter for the given name. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="name"/> is null. </exception>
-        ///
-        /// <param name="name"> The name of the metric to record. Only the first 1000 characters are
-        /// retained. </param>
-        public void IncrementCounter(string name)
+    /// <summary> Notice an error identified by an exception report it to the New Relic service. If
+    /// this method is called within a transaction, the exception will be reported with the
+    /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+    /// be created and reported to the New Relic service. Only the exception/parameter pair for the
+    /// first call to NoticeError during the course of a transaction is retained. Supports web
+    /// applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
+    ///
+    /// <param name="exception">	    The exception to be reported. Only part of the exception's
+    /// information may be retained to prevent the report from being too large. </param>
+    /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+    /// null. Only 10,000 characters of combined key/value data is retained. </param>
+    public void NoticeError(Exception exception, IDictionary<string, string>? customAttributes)
+    {
+        exception = exception ?? throw new ArgumentNullException(nameof(exception));
+
+        using (new IgnoreWork())
         {
-            name = name ?? throw new ArgumentNullException(nameof(name));
+            var transaction = TryGetCurrentInternalTransaction();
+            if (IsCustomExceptionIgnored(exception, transaction)) return;
+            var errorData = _errorService.FromException(exception, customAttributes);
+            ProcessNoticedError(errorData, transaction);
+        }
+    }
 
-            using (new IgnoreWork())
+    /// <summary> Notice an error identified by an exception report it to the New Relic service. If
+    /// this method is called within a transaction, the exception will be reported with the
+    /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+    /// be created and reported to the New Relic service. Only the exception/parameter pair for the
+    /// first call to NoticeError during the course of a transaction is retained. Supports web
+    /// applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
+    ///
+    /// <param name="exception">	    The exception to be reported. Only part of the exception's
+    /// information may be retained to prevent the report from being too large. </param>
+    /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+    /// null. Only 10,000 characters of combined key/value data is retained. </param>
+    public void NoticeError(Exception exception, IDictionary<string, object>? customAttributes)
+    {
+        exception = exception ?? throw new ArgumentNullException(nameof(exception));
+
+        using (new IgnoreWork())
+        {
+            var transaction = TryGetCurrentInternalTransaction();
+            if (IsCustomExceptionIgnored(exception, transaction)) return;
+            var errorData = _errorService.FromException(exception, customAttributes);
+            ProcessNoticedError(errorData, transaction);
+        }
+    }
+
+    /// <summary> Notice an error identified by an exception report it to the New Relic service. If
+    /// this method is called within a transaction, the exception will be reported with the
+    /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
+    /// be created and reported to the New Relic service. Only the exception/parameter pair for the
+    /// first call to NoticeError during the course of a transaction is retained. Supports web
+    /// applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
+    ///
+    /// <param name="exception">	    The exception to be reported. Only part of the exception's
+    /// information may be retained to prevent the report from being too large. </param>
+    public void NoticeError(Exception exception)
+    {
+        exception = exception ?? throw new ArgumentNullException(nameof(exception));
+
+        using (new IgnoreWork())
+        {
+            var transaction = TryGetCurrentInternalTransaction();
+            if (IsCustomExceptionIgnored(exception, transaction)) return;
+            var errorData = _errorService.FromException(exception);
+            ProcessNoticedError(errorData, transaction);
+        }
+    }
+
+    /// <summary> Notice an error identified by a simple message and report it to the New Relic
+    /// service. If this method is called within a transaction, the exception will be reported with
+    /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+    /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+    /// first call to NoticeError during the course of a transaction is retained. Supports web
+    /// applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+    ///
+    /// <param name="message">		    The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+    /// null. Only 10,000 characters of combined key/value data is retained. </param>
+    public void NoticeError(string message, IDictionary<string, string>? customAttributes)
+    {
+        NoticeError(message, customAttributes, false);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+    /// 
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
+    public void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
+    {
+        message = message ?? throw new ArgumentNullException(nameof(message));
+
+        using (new IgnoreWork())
+        {
+            var transaction = TryGetCurrentInternalTransaction();
+            if (IsErrorMessageIgnored(message)) return;
+            var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
+            ProcessNoticedError(errorData, transaction);
+        }
+    }
+
+    /// <summary> Notice an error identified by a simple message and report it to the New Relic
+    /// service. If this method is called within a transaction, the exception will be reported with
+    /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
+    /// will be created and reported to the New Relic service. Only the string/parameter pair for the
+    /// first call to NoticeError during the course of a transaction is retained. Supports web
+    /// applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+    ///
+    /// <param name="message">		    The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
+    /// null. Only 10,000 characters of combined key/value data is retained. </param>
+    public void NoticeError(string message, IDictionary<string, object>? customAttributes)
+    {
+        NoticeError(message, customAttributes, false);
+    }
+
+    /// <summary>
+    /// Notice an error identified by a simple message and report it to the New Relic service.
+    /// If this method is called within a transaction,
+    /// the exception will be reported with the transaction when it finishes.  
+    /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
+    /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
+    /// Supports web applications only. 
+    /// </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
+    /// 
+    /// <param name="message">The message to be displayed in the traced error.
+    /// This method creates both Error Events and Error Traces.
+    /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
+    /// <param name="customAttributes">Custom parameters to include in the traced error.
+    /// May be null.
+    /// Only 10,000 characters of combined key/value data is retained.
+    /// </param>
+    /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
+    public void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
+    {
+        message = message ?? throw new ArgumentNullException(nameof(message));
+
+        using (new IgnoreWork())
+        {
+            var transaction = TryGetCurrentInternalTransaction();
+            if (IsErrorMessageIgnored(message)) return;
+            var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
+            ProcessNoticedError(errorData, transaction);
+        }
+    }
+
+    private void ProcessNoticedError(ErrorData errorData, IInternalTransaction transaction)
+    {
+        if (transaction != null)
+        {
+            transaction.NoticeError(errorData);
+        }
+        else
+        {
+            errorData.Path = NoticeErrorPath;
+            _customErrorDataTransformer.Transform(errorData, _tracePriorityManager.Create(), null);
+        }
+    }
+
+    private bool IsCustomExceptionIgnored(Exception exception, IInternalTransaction transaction)
+    {
+        if (_errorService.ShouldIgnoreException(exception))
+        {
+            if (transaction != null) transaction.TransactionMetadata.TransactionErrorState.SetIgnoreCustomErrors();
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsErrorMessageIgnored(string message)
+    {
+        // The agent does not currently implement ignoring errors by error message.
+        // The spec allows for this functionality: https://source.datanerd.us/agents/agent-specs/blob/master/Errors.md#ignore--expected-errors
+        return false;
+    }
+
+    /// <summary> Add a key/value pair to the current transaction.  These are reported in errors and
+    /// transaction traces. Supports web applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> or
+    /// <paramref name="value"/> is null. </exception>
+    ///
+    /// <param name="key">   The key name for the custom parameter. </param>
+    /// <param name="value"> The value associated with the custom parameter. If the value is a float
+    /// it is recorded as a number, otherwise, <paramref name="value"/> is converted to a string.
+    /// (via <c>value.ToString(CultureInfo.InvariantCulture);</c> </param>
+    [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
+    public void AddCustomParameter(string key, IConvertible value)
+    {
+        key = key ?? throw new ArgumentNullException(nameof(key));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+
+        using (new IgnoreWork())
+        {
+            // float (32-bit) precision numbers are specially handled and actually stored as floating point numbers. Everything else is stored as a string. This is for historical reasons -- in the past Dirac only stored single-precision numbers, so integers and doubles had to be stored as strings to avoid losing precision. Now Dirac DOES support integers and doubles, but we can't just blindly start passing up integers and doubles where we used to pass strings because it could break customer queries.
+            var normalizedValue = value is float
+                ? value
+                : value.ToString(CultureInfo.InvariantCulture);
+
+            AddUserAttributeToCurrentTransaction(key, normalizedValue);
+        }
+    }
+
+    /// <summary> A Add a key/value pair to the current transaction.  These are reported in errors and
+    /// transaction traces. Supports web applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> or
+    /// <paramref name="value"/> is null. </exception>
+    ///
+    /// <param name="key">   The key name for the custom parameter.  Only the first 1000 characters
+    /// are retained. </param>
+    /// <param name="value"> The value associated with the custom parameter. Only the first 1000
+    /// characters are retained. </param>
+    [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
+    public void AddCustomParameter(string key, string value)
+    {
+        key = key ?? throw new ArgumentNullException(nameof(key));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+        using (new IgnoreWork())
+        {
+            AddUserAttributeToCurrentTransaction(key, value);
+        }
+    }
+
+    [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
+    private void AddUserAttributeToCurrentTransaction(string key, object value)
+    {
+        if (_configurationService.Configuration.CaptureCustomParameters)
+        {
+            var transaction = GetCurrentInternalTransaction();
+            transaction.AddCustomAttribute(key, value);
+        }
+    }
+
+    /// <summary> Set the name of the current transaction. Supports web applications only. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> is null. </exception>
+    ///
+    /// <param name="category"> The category of this transaction, used to distinguish different types
+    /// of transactions. Only the first 1000 characters are retained.  If null is passed, the
+    /// category defaults to "Custom". </param>
+    /// <param name="name">	    The name of the transaction starting with a forward slash.  example:
+    /// /store/order Only the first 1000 characters are retained. </param>
+    public void SetTransactionName(string? category, string name)
+    {
+        name = name ?? throw new ArgumentNullException(nameof(name));
+
+        using (new IgnoreWork())
+        {
+            // Default to "Custom" category if none provided
+            if (category == null || string.IsNullOrWhiteSpace(category))
             {
-                // NOTE: Unlike Custom timing metrics, Custom count metrics are NOT restricted to only the "Custom" namespace.
-                // This is probably a historical blunder -- it's not a good thing that we allow users to use whatever text they want for the first segment.
-                // However, that is what the API currently allows and it would be difficult to take that feature away.
-                var metric = _metricBuilder.TryBuildCustomCountMetric(name);
-
-                if (metric != null)
-                {
-                    _metricAggregator.Collect(metric);
-                }
+                category = MetricNames.Custom;
             }
+
+            // Get rid of any slashes
+            category = category.Trim(TrimPathChar);
+            name = name.Trim(TrimPathChar);
+
+            // Clamp the category and name to a predetermined length
+            category = Clamper.ClampLength(category);
+            name = Clamper.ClampLength(name);
+
+            var transaction = GetCurrentInternalTransaction();
+
+            var currentTransactionName = transaction.CandidateTransactionName.CurrentTransactionName;
+
+            var newTransactionName = currentTransactionName.IsWeb
+                ? TransactionName.ForWebTransaction(category, name)
+                : TransactionName.ForOtherTransaction(category, name);
+
+            transaction.CandidateTransactionName.TrySet(newTransactionName, TransactionNamePriority.UserTransactionName);
         }
+    }
 
-        /// <summary> Notice an error identified by an exception report it to the New Relic service. If
-        /// this method is called within a transaction, the exception will be reported with the
-        /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-        /// be created and reported to the New Relic service. Only the exception/parameter pair for the
-        /// first call to NoticeError during the course of a transaction is retained. Supports web
-        /// applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
-        ///
-        /// <param name="exception">	    The exception to be reported. Only part of the exception's
-        /// information may be retained to prevent the report from being too large. </param>
-        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
-        /// null. Only 10,000 characters of combined key/value data is retained. </param>
-        public void NoticeError(Exception exception, IDictionary<string, string>? customAttributes)
+    /// <summary> Sets transaction URI. </summary>
+    ///
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="uri"/> is null. </exception>
+    ///
+    /// <param name="uri"> URI to be associated with the transaction. </param>
+    public void SetTransactionUri(Uri uri)
+    {
+        uri = uri ?? throw new ArgumentNullException(nameof(uri));
+
+        using (new IgnoreWork())
         {
-            exception = exception ?? throw new ArgumentNullException(nameof(exception));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsCustomExceptionIgnored(exception, transaction)) return;
-                var errorData = _errorService.FromException(exception, customAttributes);
-                ProcessNoticedError(errorData, transaction);
-            }
-        }
-
-        /// <summary> Notice an error identified by an exception report it to the New Relic service. If
-        /// this method is called within a transaction, the exception will be reported with the
-        /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-        /// be created and reported to the New Relic service. Only the exception/parameter pair for the
-        /// first call to NoticeError during the course of a transaction is retained. Supports web
-        /// applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
-        ///
-        /// <param name="exception">	    The exception to be reported. Only part of the exception's
-        /// information may be retained to prevent the report from being too large. </param>
-        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
-        /// null. Only 10,000 characters of combined key/value data is retained. </param>
-        public void NoticeError(Exception exception, IDictionary<string, object>? customAttributes)
-        {
-            exception = exception ?? throw new ArgumentNullException(nameof(exception));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsCustomExceptionIgnored(exception, transaction)) return;
-                var errorData = _errorService.FromException(exception, customAttributes);
-                ProcessNoticedError(errorData, transaction);
-            }
-        }
-
-        /// <summary> Notice an error identified by an exception report it to the New Relic service. If
-        /// this method is called within a transaction, the exception will be reported with the
-        /// transaction when it finishes. If it is invoked outside of a transaction, a traced error will
-        /// be created and reported to the New Relic service. Only the exception/parameter pair for the
-        /// first call to NoticeError during the course of a transaction is retained. Supports web
-        /// applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="exception"/> is null. </exception>
-        ///
-        /// <param name="exception">	    The exception to be reported. Only part of the exception's
-        /// information may be retained to prevent the report from being too large. </param>
-        public void NoticeError(Exception exception)
-        {
-            exception = exception ?? throw new ArgumentNullException(nameof(exception));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsCustomExceptionIgnored(exception, transaction)) return;
-                var errorData = _errorService.FromException(exception);
-                ProcessNoticedError(errorData, transaction);
-            }
-        }
-
-        /// <summary> Notice an error identified by a simple message and report it to the New Relic
-        /// service. If this method is called within a transaction, the exception will be reported with
-        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
-        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
-        /// first call to NoticeError during the course of a transaction is retained. Supports web
-        /// applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
-        ///
-        /// <param name="message">		    The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
-        /// null. Only 10,000 characters of combined key/value data is retained. </param>
-        public void NoticeError(string message, IDictionary<string, string>? customAttributes)
-        {
-            NoticeError(message, customAttributes, false);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
-        /// 
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
-        public void NoticeError(string message, IDictionary<string, string>? customAttributes, bool isExpected)
-        {
-            message = message ?? throw new ArgumentNullException(nameof(message));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsErrorMessageIgnored(message)) return;
-                var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
-                ProcessNoticedError(errorData, transaction);
-            }
-        }
-
-        /// <summary> Notice an error identified by a simple message and report it to the New Relic
-        /// service. If this method is called within a transaction, the exception will be reported with
-        /// the transaction when it finishes. If it is invoked outside of a transaction, a traced error
-        /// will be created and reported to the New Relic service. Only the string/parameter pair for the
-        /// first call to NoticeError during the course of a transaction is retained. Supports web
-        /// applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
-        ///
-        /// <param name="message">		    The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes"> Custom parameters to include in the traced error. May be
-        /// null. Only 10,000 characters of combined key/value data is retained. </param>
-        public void NoticeError(string message, IDictionary<string, object>? customAttributes)
-        {
-            NoticeError(message, customAttributes, false);
-        }
-
-        /// <summary>
-        /// Notice an error identified by a simple message and report it to the New Relic service.
-        /// If this method is called within a transaction,
-        /// the exception will be reported with the transaction when it finishes.  
-        /// If it is invoked outside of a transaction, a traced error will be created and reported to the New Relic service.
-        /// Only the string/parameter pair for the first call to NoticeError during the course of a transaction is retained.
-        /// Supports web applications only. 
-        /// </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message"/> is null. </exception>
-        /// 
-        /// <param name="message">The message to be displayed in the traced error.
-        /// This method creates both Error Events and Error Traces.
-        /// Only the first 255 characters are retained in Error Events while Error Traces will retain the full message. </param>
-        /// <param name="customAttributes">Custom parameters to include in the traced error.
-        /// May be null.
-        /// Only 10,000 characters of combined key/value data is retained.
-        /// </param>
-        /// <param name="isExpected">Mark error as expected so that it won't affect Apdex score and error rate.</param>
-        public void NoticeError(string message, IDictionary<string, object>? customAttributes, bool isExpected)
-        {
-            message = message ?? throw new ArgumentNullException(nameof(message));
-
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (IsErrorMessageIgnored(message)) return;
-                var errorData = _errorService.FromMessage(message, customAttributes, isExpected);
-                ProcessNoticedError(errorData, transaction);
-            }
-        }
-
-        private void ProcessNoticedError(ErrorData errorData, IInternalTransaction transaction)
-        {
+            var transaction = _agent.CurrentTransaction;
             if (transaction != null)
             {
-                transaction.NoticeError(errorData);
-            }
-            else
-            {
-                errorData.Path = NoticeErrorPath;
-                _customErrorDataTransformer.Transform(errorData, _tracePriorityManager.Create(), null);
+                transaction.SetUri(uri.AbsolutePath);
+                transaction.SetOriginalUri(uri.AbsolutePath);
+                transaction.SetWebTransactionNameFromPath(WebTransactionType.Custom, uri.AbsolutePath);
             }
         }
+    }
 
-        private bool IsCustomExceptionIgnored(Exception exception, IInternalTransaction transaction)
-        {
-            if (_errorService.ShouldIgnoreException(exception))
-            {
-                if (transaction != null) transaction.TransactionMetadata.TransactionErrorState.SetIgnoreCustomErrors();
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool IsErrorMessageIgnored(string message)
-        {
-            // The agent does not currently implement ignoring errors by error message.
-            // The spec allows for this functionality: https://source.datanerd.us/agents/agent-specs/blob/master/Errors.md#ignore--expected-errors
-            return false;
-        }
-
-        /// <summary> Add a key/value pair to the current transaction.  These are reported in errors and
-        /// transaction traces. Supports web applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> or
-        /// <paramref name="value"/> is null. </exception>
-        ///
-        /// <param name="key">   The key name for the custom parameter. </param>
-        /// <param name="value"> The value associated with the custom parameter. If the value is a float
-        /// it is recorded as a number, otherwise, <paramref name="value"/> is converted to a string.
-        /// (via <c>value.ToString(CultureInfo.InvariantCulture);</c> </param>
-        [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
-        public void AddCustomParameter(string key, IConvertible value)
-        {
-            key = key ?? throw new ArgumentNullException(nameof(key));
-            value = value ?? throw new ArgumentNullException(nameof(value));
-
-            using (new IgnoreWork())
-            {
-                // float (32-bit) precision numbers are specially handled and actually stored as floating point numbers. Everything else is stored as a string. This is for historical reasons -- in the past Dirac only stored single-precision numbers, so integers and doubles had to be stored as strings to avoid losing precision. Now Dirac DOES support integers and doubles, but we can't just blindly start passing up integers and doubles where we used to pass strings because it could break customer queries.
-                var normalizedValue = value is float
-                    ? value
-                    : value.ToString(CultureInfo.InvariantCulture);
-
-                AddUserAttributeToCurrentTransaction(key, normalizedValue);
-            }
-        }
-
-        /// <summary> A Add a key/value pair to the current transaction.  These are reported in errors and
-        /// transaction traces. Supports web applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> or
-        /// <paramref name="value"/> is null. </exception>
-        ///
-        /// <param name="key">   The key name for the custom parameter.  Only the first 1000 characters
-        /// are retained. </param>
-        /// <param name="value"> The value associated with the custom parameter. Only the first 1000
-        /// characters are retained. </param>
-        [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
-        public void AddCustomParameter(string key, string value)
-        {
-            key = key ?? throw new ArgumentNullException(nameof(key));
-            value = value ?? throw new ArgumentNullException(nameof(value));
-            using (new IgnoreWork())
-            {
-                AddUserAttributeToCurrentTransaction(key, value);
-            }
-        }
-
-        [ToBeRemovedInFutureRelease("Use TransactionBridgeApi.AddCustomAttribute(string, object) instead")]
-        private void AddUserAttributeToCurrentTransaction(string key, object value)
+    /// <summary> Sets the User Name, Account Name and Product Name to associate with the RUM
+    /// JavaScript footer for the current web transaction. Supports web applications only. </summary>
+    ///
+    /// <param name="userName">    Name of the user to be associated with the transaction. </param>
+    /// <param name="accountName"> Name of the account to be associated with the transaction. </param>
+    /// <param name="productName"> Name of the product to be associated with the transaction. </param>
+    public void SetUserParameters(string? userName, string? accountName, string? productName)
+    {
+        using (new IgnoreWork())
         {
             if (_configurationService.Configuration.CaptureCustomParameters)
             {
+                //var transactionMetadata = GetCurrentInternalTransaction().TransactionMetadata;
                 var transaction = GetCurrentInternalTransaction();
-                transaction.AddCustomAttribute(key, value);
-            }
-        }
-
-        /// <summary> Set the name of the current transaction. Supports web applications only. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="key"/> is null. </exception>
-        ///
-        /// <param name="category"> The category of this transaction, used to distinguish different types
-        /// of transactions. Only the first 1000 characters are retained.  If null is passed, the
-        /// category defaults to "Custom". </param>
-        /// <param name="name">	    The name of the transaction starting with a forward slash.  example:
-        /// /store/order Only the first 1000 characters are retained. </param>
-        public void SetTransactionName(string? category, string name)
-        {
-            name = name ?? throw new ArgumentNullException(nameof(name));
-
-            using (new IgnoreWork())
-            {
-                // Default to "Custom" category if none provided
-                if (category == null || string.IsNullOrWhiteSpace(category))
+                if (userName != null && !string.IsNullOrEmpty(userName))
                 {
-                    category = MetricNames.Custom;
+                    transaction.AddCustomAttribute("user", userName.ToString(CultureInfo.InvariantCulture));
                 }
 
-                // Get rid of any slashes
-                category = category.Trim(TrimPathChar);
-                name = name.Trim(TrimPathChar);
-
-                // Clamp the category and name to a predetermined length
-                category = Clamper.ClampLength(category);
-                name = Clamper.ClampLength(name);
-
-                var transaction = GetCurrentInternalTransaction();
-
-                var currentTransactionName = transaction.CandidateTransactionName.CurrentTransactionName;
-
-                var newTransactionName = currentTransactionName.IsWeb
-                    ? TransactionName.ForWebTransaction(category, name)
-                    : TransactionName.ForOtherTransaction(category, name);
-
-                transaction.CandidateTransactionName.TrySet(newTransactionName, TransactionNamePriority.UserTransactionName);
-            }
-        }
-
-        /// <summary> Sets transaction URI. </summary>
-        ///
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="uri"/> is null. </exception>
-        ///
-        /// <param name="uri"> URI to be associated with the transaction. </param>
-        public void SetTransactionUri(Uri uri)
-        {
-            uri = uri ?? throw new ArgumentNullException(nameof(uri));
-
-            using (new IgnoreWork())
-            {
-                var transaction = _agent.CurrentTransaction;
-                if (transaction != null)
+                if (accountName != null && !string.IsNullOrEmpty(accountName))
                 {
-                    transaction.SetUri(uri.AbsolutePath);
-                    transaction.SetOriginalUri(uri.AbsolutePath);
-                    transaction.SetWebTransactionNameFromPath(WebTransactionType.Custom, uri.AbsolutePath);
+                    transaction.AddCustomAttribute("account", accountName.ToString(CultureInfo.InvariantCulture));
+                }
+
+                if (productName != null && !string.IsNullOrEmpty(productName))
+                {
+                    transaction.AddCustomAttribute("product", productName.ToString(CultureInfo.InvariantCulture));
                 }
             }
         }
+    }
 
-        /// <summary> Sets the User Name, Account Name and Product Name to associate with the RUM
-        /// JavaScript footer for the current web transaction. Supports web applications only. </summary>
-        ///
-        /// <param name="userName">    Name of the user to be associated with the transaction. </param>
-        /// <param name="accountName"> Name of the account to be associated with the transaction. </param>
-        /// <param name="productName"> Name of the product to be associated with the transaction. </param>
-        public void SetUserParameters(string? userName, string? accountName, string? productName)
+    /// <summary> Ignore the transaction that is currently in process. Supports web applications only. </summary>
+    public void IgnoreTransaction()
+    {
+        using (new IgnoreWork())
         {
-            using (new IgnoreWork())
-            {
-                if (_configurationService.Configuration.CaptureCustomParameters)
-                {
-                    //var transactionMetadata = GetCurrentInternalTransaction().TransactionMetadata;
-                    var transaction = GetCurrentInternalTransaction();
-                    if (userName != null && !string.IsNullOrEmpty(userName))
-                    {
-                        transaction.AddCustomAttribute("user", userName.ToString(CultureInfo.InvariantCulture));
-                    }
-
-                    if (accountName != null && !string.IsNullOrEmpty(accountName))
-                    {
-                        transaction.AddCustomAttribute("account", accountName.ToString(CultureInfo.InvariantCulture));
-                    }
-
-                    if (productName != null && !string.IsNullOrEmpty(productName))
-                    {
-                        transaction.AddCustomAttribute("product", productName.ToString(CultureInfo.InvariantCulture));
-                    }
-                }
-            }
+            _agent.CurrentTransaction.Ignore();
         }
+    }
 
-        /// <summary> Ignore the transaction that is currently in process. Supports web applications only. </summary>
-        public void IgnoreTransaction()
+    /// <summary> Ignore the current transaction in the apdex computation. Supports web applications
+    /// only. </summary>
+    public void IgnoreApdex()
+    {
+        using (new IgnoreWork())
         {
-            using (new IgnoreWork())
-            {
-                _agent.CurrentTransaction.Ignore();
-            }
+            GetCurrentInternalTransaction().IgnoreApdex();
         }
+    }
 
-        /// <summary> Ignore the current transaction in the apdex computation. Supports web applications
-        /// only. </summary>
-        public void IgnoreApdex()
+    /// <summary> Returns the HTML snippet to be inserted into the header of HTML pages to enable Real
+    /// User Monitoring. The HTML will instruct the browser to fetch a small JavaScript file and
+    /// start the page timer. Supports web applications only. </summary>
+    ///
+    /// <returns> An HTML string to be embedded in a page header. </returns>
+    ///
+    /// <example> <code>
+    /// &lt;html&gt;
+    ///   &lt;head&gt;
+    ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()&#37;&gt;
+    ///   &lt;/head&gt;
+    ///   &lt;body&gt;
+    ///   ...
+    /// </code></example>
+    public string GetBrowserTimingHeader()
+    {
+        return GetBrowserTimingHeader(string.Empty);
+    }
+
+    /// <summary> Returns the HTML snippet to be inserted into the header of HTML pages to enable Real
+    /// User Monitoring. The HTML will instruct the browser to fetch a small JavaScript file and
+    /// start the page timer. Supports web applications only. </summary>
+    ///
+    /// <returns> An HTML string to be embedded in a page header. </returns>
+    ///
+    /// <example> <code>
+    /// &lt;html&gt;
+    ///   &lt;head&gt;
+    ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("random-nonce")&#37;&gt;
+    ///   &lt;/head&gt;
+    ///   &lt;body&gt;
+    ///   ...
+    /// </code></example>
+    public string GetBrowserTimingHeader(string nonce)
+    {
+        using (new IgnoreWork())
         {
-            using (new IgnoreWork())
-            {
-                GetCurrentInternalTransaction().IgnoreApdex();
-            }
+            var transaction = TryGetCurrentInternalTransaction();
+            if (transaction == null)
+                return string.Empty;
+
+            var shouldInject = _browserMonitoringPrereqChecker.ShouldManuallyInject(transaction);
+            if (!shouldInject)
+                return string.Empty;
+
+            transaction.IgnoreAllBrowserMonitoringForThisTx();
+
+            // The transaction's name must be frozen if we're going to generate a RUM script
+            transaction.CandidateTransactionName.Freeze(TransactionNameFreezeReason.ManualBrowserScriptInjection);
+
+            return _browserMonitoringScriptMaker.GetScript(transaction, nonce) ?? string.Empty;
         }
+    }
 
-        /// <summary> Returns the HTML snippet to be inserted into the header of HTML pages to enable Real
-        /// User Monitoring. The HTML will instruct the browser to fetch a small JavaScript file and
-        /// start the page timer. Supports web applications only. </summary>
-        ///
-        /// <returns> An HTML string to be embedded in a page header. </returns>
-        ///
-        /// <example> <code>
-        /// &lt;html&gt;
-        ///   &lt;head&gt;
-        ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()&#37;&gt;
-        ///   &lt;/head&gt;
-        ///   &lt;body&gt;
-        ///   ...
-        /// </code></example>
-        public string GetBrowserTimingHeader()
+    /// <summary> Disables the automatic instrumentation of browser monitoring hooks in individual
+    /// pages Supports web applications only. </summary>
+    ///
+    /// <param name="overrideManual"> (Optional) True to override manual. </param>
+    ///
+    /// <example><code>
+    /// NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring()
+    /// </code></example>
+    public void DisableBrowserMonitoring(bool overrideManual = false)
+    {
+        using (new IgnoreWork())
         {
-            return GetBrowserTimingHeader(string.Empty);
-        }
+            var transaction = GetCurrentInternalTransaction();
 
-        /// <summary> Returns the HTML snippet to be inserted into the header of HTML pages to enable Real
-        /// User Monitoring. The HTML will instruct the browser to fetch a small JavaScript file and
-        /// start the page timer. Supports web applications only. </summary>
-        ///
-        /// <returns> An HTML string to be embedded in a page header. </returns>
-        ///
-        /// <example> <code>
-        /// &lt;html&gt;
-        ///   &lt;head&gt;
-        ///     &lt;&#37;= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("random-nonce")&#37;&gt;
-        ///   &lt;/head&gt;
-        ///   &lt;body&gt;
-        ///   ...
-        /// </code></example>
-        public string GetBrowserTimingHeader(string nonce)
-        {
-            using (new IgnoreWork())
-            {
-                var transaction = TryGetCurrentInternalTransaction();
-                if (transaction == null)
-                    return string.Empty;
-
-                var shouldInject = _browserMonitoringPrereqChecker.ShouldManuallyInject(transaction);
-                if (!shouldInject)
-                    return string.Empty;
-
+            if (overrideManual)
                 transaction.IgnoreAllBrowserMonitoringForThisTx();
+            else
+                transaction.IgnoreAutoBrowserMonitoringForThisTx();
+        }
+    }
 
-                // The transaction's name must be frozen if we're going to generate a RUM script
-                transaction.CandidateTransactionName.Freeze(TransactionNameFreezeReason.ManualBrowserScriptInjection);
+    /// <summary> (This API should only be used from the public API)  Starts the agent (i.e. begin
+    /// capturing data). Does nothing if the agent is already started. Useful if agent autostart is
+    /// disabled via configuration, or if you want to ensure the agent is started before using other
+    /// methods in the Agent API. </summary>
+    ///
+    /// <example><code>
+    ///   NewRelic.Api.Agent.NewRelic.StartAgent();
+    /// </code></example>
+    public void StartAgent()
+    {
+        using (new IgnoreWork())
+        {
+            EventBus<StartAgentEvent>.Publish(new StartAgentEvent());
+        }
+    }
 
-                return _browserMonitoringScriptMaker.GetScript(transaction, nonce) ?? string.Empty;
-            }
+    /// <summary> Sets the name of the application to <paramref name="applicationName"/>. At least one
+    /// given name must not be null.
+    /// 
+    /// An application may also have up to two additional names. This can be useful, for example, to
+    /// have multiple applications report under the same roll-up name. </summary>
+    ///
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="applicationName"/>,
+    /// <paramref name="applicationName2"/> and <paramref name="applicationName3"/> are all null. </exception>
+    ///
+    /// <param name="applicationName">  The main application name. </param>
+    /// <param name="applicationName2"> (Optional) The second application name. </param>
+    /// <param name="applicationName3"> (Optional) The third application name. </param>
+    public void SetApplicationName(string applicationName, string? applicationName2 = null, string? applicationName3 = null)
+    {
+        var appNames = new List<string>();
+        if (applicationName != null)
+        {
+            appNames.Add(applicationName);
         }
 
-        /// <summary> Disables the automatic instrumentation of browser monitoring hooks in individual
-        /// pages Supports web applications only. </summary>
-        ///
-        /// <param name="overrideManual"> (Optional) True to override manual. </param>
-        ///
-        /// <example><code>
-        /// NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring()
-        /// </code></example>
-        public void DisableBrowserMonitoring(bool overrideManual = false)
+        if (applicationName2 != null)
         {
-            using (new IgnoreWork())
-            {
-                var transaction = GetCurrentInternalTransaction();
-
-                if (overrideManual)
-                    transaction.IgnoreAllBrowserMonitoringForThisTx();
-                else
-                    transaction.IgnoreAutoBrowserMonitoringForThisTx();
-            }
+            appNames.Add(applicationName2);
         }
 
-        /// <summary> (This API should only be used from the public API)  Starts the agent (i.e. begin
-        /// capturing data). Does nothing if the agent is already started. Useful if agent autostart is
-        /// disabled via configuration, or if you want to ensure the agent is started before using other
-        /// methods in the Agent API. </summary>
-        ///
-        /// <example><code>
-        ///   NewRelic.Api.Agent.NewRelic.StartAgent();
-        /// </code></example>
-        public void StartAgent()
+        if (applicationName3 != null)
         {
-            using (new IgnoreWork())
-            {
-                EventBus<StartAgentEvent>.Publish(new StartAgentEvent());
-            }
+            appNames.Add(applicationName3);
         }
 
-        /// <summary> Sets the name of the application to <paramref name="applicationName"/>. At least one
-        /// given name must not be null.
-        /// 
-        /// An application may also have up to two additional names. This can be useful, for example, to
-        /// have multiple applications report under the same roll-up name. </summary>
-        ///
-        /// <exception cref="ArgumentException"> Thrown when <paramref name="applicationName"/>,
-        /// <paramref name="applicationName2"/> and <paramref name="applicationName3"/> are all null. </exception>
-        ///
-        /// <param name="applicationName">  The main application name. </param>
-        /// <param name="applicationName2"> (Optional) The second application name. </param>
-        /// <param name="applicationName3"> (Optional) The third application name. </param>
-        public void SetApplicationName(string applicationName, string? applicationName2 = null, string? applicationName3 = null)
+        if (appNames.Count == 0)
         {
-            var appNames = new List<string>();
-            if (applicationName != null)
-            {
-                appNames.Add(applicationName);
-            }
-
-            if (applicationName2 != null)
-            {
-                appNames.Add(applicationName2);
-            }
-
-            if (applicationName3 != null)
-            {
-                appNames.Add(applicationName3);
-            }
-
-            if (appNames.Count == 0)
-            {
-                throw new ArgumentException("At least one application name must be non-null.");
-            }
-
-            using (new IgnoreWork())
-            {
-                EventBus<AppNameUpdateEvent>.Publish(new AppNameUpdateEvent(appNames));
-            }
+            throw new ArgumentException("At least one application name must be non-null.");
         }
 
-        private IInternalTransaction TryGetCurrentInternalTransaction()
+        using (new IgnoreWork())
         {
-            return _transactionService.GetCurrentInternalTransaction();
+            EventBus<AppNameUpdateEvent>.Publish(new AppNameUpdateEvent(appNames));
+        }
+    }
+
+    private IInternalTransaction TryGetCurrentInternalTransaction()
+    {
+        return _transactionService.GetCurrentInternalTransaction();
+    }
+
+    /// <summary> Gets the current transaction. Throws an exception if a transaction could not be
+    /// found. Use TryGetCurrentInternlTransaction if you prefer getting a null return. </summary>
+    ///
+    /// <exception cref="InvalidOperationException"> . </exception>
+    ///
+    /// <returns> A transaction. </returns>
+    private IInternalTransaction GetCurrentInternalTransaction()
+    {
+        return TryGetCurrentInternalTransaction() ??
+               throw new InvalidOperationException("The API method called is only valid from within a transaction. This error can occur if you call the API method from a thread other than the one the transaction started on.");
+    }
+
+    /// <summary> Gets custom metric suffix. </summary>
+    /// <exception cref="ArgumentException"> Thrown if <paramref name="name"/> is null or empty. </exception>
+    /// <param name="name"> The name to process. </param>
+    /// <returns> The custom metric suffix. </returns>
+    private static string GetCustomMetricSuffix(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException("The name parameter must have a value that is not null or empty.");
+
+        name = Clamper.ClampLength(name);
+
+        // If the name provided already contains the "Custom/" prefix, remove it and use the remaining segment as the "name"
+        if (name.StartsWith(CustomMetricNamePrefixAndSeparator, StringComparison.InvariantCultureIgnoreCase))
+            name = name.Substring(CustomMetricNamePrefixAndSeparator.Length);
+
+        return name;
+    }
+
+    /// <summary> Gets the request metadata for the current transaction. </summary>
+    ///
+    /// <returns> A list of key-value pairs representing the request metadata. </returns>
+    public IEnumerable<KeyValuePair<string, string>> GetRequestMetadata()
+    {
+        if (_configurationService.Configuration.DistributedTracingEnabled)
+        {
+            Log.Finest(DistributedTracingIsEnabledIgnoringCall, nameof(GetRequestMetadata));
+            return Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
-        /// <summary> Gets the current transaction. Throws an exception if a transaction could not be
-        /// found. Use TryGetCurrentInternlTransaction if you prefer getting a null return. </summary>
-        ///
-        /// <exception cref="InvalidOperationException"> . </exception>
-        ///
-        /// <returns> A transaction. </returns>
-        private IInternalTransaction GetCurrentInternalTransaction()
+        return _agent.CurrentTransaction.GetRequestMetadata();
+    }
+
+    /// <summary> Gets the response metadata for the current transaction. </summary>
+    ///
+    /// <returns> A list of key-value pairs representing the request metadata. </returns>
+    public IEnumerable<KeyValuePair<string, string>> GetResponseMetadata()
+    {
+        if (_configurationService.Configuration.DistributedTracingEnabled)
         {
-            return TryGetCurrentInternalTransaction() ??
-                throw new InvalidOperationException("The API method called is only valid from within a transaction. This error can occur if you call the API method from a thread other than the one the transaction started on.");
+            Log.Finest(DistributedTracingIsEnabledIgnoringCall, nameof(GetResponseMetadata));
+            return Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
-        /// <summary> Gets custom metric suffix. </summary>
-        /// <exception cref="ArgumentException"> Thrown if <paramref name="name"/> is null or empty. </exception>
-        /// <param name="name"> The name to process. </param>
-        /// <returns> The custom metric suffix. </returns>
-        private static string GetCustomMetricSuffix(string name)
+        return _agent.CurrentTransaction.GetResponseMetadata();
+    }
+
+    /// <summary> Sets the method that will be invoked to define the error group that an exception
+    /// should belong to.
+    ///
+    /// The callback takes an an IReadOnlyDictionary of attributes, the stack trace, and Exception,
+    /// and returns the name of the error group to use. Return values
+    /// that are null, empty, or whitespace will not associate the Exception to an error group.
+    /// </summary>
+    /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
+    public void SetErrorGroupCallback(Func<IReadOnlyDictionary<string, object>, string> callback)
+    {
+        using (new IgnoreWork())
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentException("The name parameter must have a value that is not null or empty.");
-
-            name = Clamper.ClampLength(name);
-
-            // If the name provided already contains the "Custom/" prefix, remove it and use the remaining segment as the "name"
-            if (name.StartsWith(CustomMetricNamePrefixAndSeparator, StringComparison.InvariantCultureIgnoreCase))
-                name = name.Substring(CustomMetricNamePrefixAndSeparator.Length);
-
-            return name;
+            EventBus<ErrorGroupCallbackUpdateEvent>.Publish(new ErrorGroupCallbackUpdateEvent(callback));
         }
+    }
 
-        /// <summary> Gets the request metadata for the current transaction. </summary>
-        ///
-        /// <returns> A list of key-value pairs representing the request metadata. </returns>
-        public IEnumerable<KeyValuePair<string, string>> GetRequestMetadata()
+    /// <summary> Sets the method that will be invoked to define the token count of completion.
+    ///
+    /// The callback takes the model name and input value, and returns an integer of the token count.
+    /// A value returned from the callback that is less than or equal to 0 will be ignored.
+    /// </summary>
+    /// <param name="callback">The callback to invoke to generate the token count based on the model and input..</param>
+    public void SetLlmTokenCountingCallback(Func<string, string, int> callback)
+    {
+        using (new IgnoreWork())
         {
-            if (_configurationService.Configuration.DistributedTracingEnabled)
+            EventBus<LlmTokenCountingCallbackUpdateEvent>.Publish(new LlmTokenCountingCallbackUpdateEvent(callback));
+        }
+    }
+
+    public void RecordLlmFeedbackEvent(string traceId, object rating, string category = "", string message = "", IDictionary<string, object>? metadata = null)
+    {
+        using (new IgnoreWork())
+        {
+            var attributes = new Dictionary<string, object>
             {
-                Log.Finest(DistributedTracingIsEnabledIgnoringCall, nameof(GetRequestMetadata));
-                return Enumerable.Empty<KeyValuePair<string, string>>();
+                { "trace_id", traceId },
+                { "rating", rating },
+                { "ingest_source",  "DotNet" }
+            };
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                attributes.Add("category", category);
             }
 
-            return _agent.CurrentTransaction.GetRequestMetadata();
-        }
-
-        /// <summary> Gets the response metadata for the current transaction. </summary>
-        ///
-        /// <returns> A list of key-value pairs representing the request metadata. </returns>
-        public IEnumerable<KeyValuePair<string, string>> GetResponseMetadata()
-        {
-            if (_configurationService.Configuration.DistributedTracingEnabled)
+            if (!string.IsNullOrWhiteSpace(message))
             {
-                Log.Finest(DistributedTracingIsEnabledIgnoringCall, nameof(GetResponseMetadata));
-                return Enumerable.Empty<KeyValuePair<string, string>>();
+                attributes.Add("message", message);
             }
 
-            return _agent.CurrentTransaction.GetResponseMetadata();
-        }
-
-        /// <summary> Sets the method that will be invoked to define the error group that an exception
-        /// should belong to.
-        ///
-        /// The callback takes an an IReadOnlyDictionary of attributes, the stack trace, and Exception,
-        /// and returns the name of the error group to use. Return values
-        /// that are null, empty, or whitespace will not associate the Exception to an error group.
-        /// </summary>
-        /// <param name="callback">The callback to invoke to define the error group that an Exception belongs to.</param>
-        public void SetErrorGroupCallback(Func<IReadOnlyDictionary<string, object>, string> callback)
-        {
-            using (new IgnoreWork())
+            foreach (var pair in metadata ?? new Dictionary<string, object>())
             {
-                EventBus<ErrorGroupCallbackUpdateEvent>.Publish(new ErrorGroupCallbackUpdateEvent(callback));
+                attributes[pair.Key] = pair.Value;
             }
-        }
 
-        /// <summary> Sets the method that will be invoked to define the token count of completion.
-        ///
-        /// The callback takes the model name and input value, and returns an integer of the token count.
-        /// A value returned from the callback that is less than or equal to 0 will be ignored.
-        /// </summary>
-        /// <param name="callback">The callback to invoke to generate the token count based on the model and input..</param>
-        public void SetLlmTokenCountingCallback(Func<string, string, int> callback)
-        {
-            using (new IgnoreWork())
-            {
-                EventBus<LlmTokenCountingCallbackUpdateEvent>.Publish(new LlmTokenCountingCallbackUpdateEvent(callback));
-            }
-        }
-
-        public void RecordLlmFeedbackEvent(string traceId, object rating, string category = "", string message = "", IDictionary<string, object>? metadata = null)
-        {
-            using (new IgnoreWork())
-            {
-                var attributes = new Dictionary<string, object>
-                {
-                    { "trace_id", traceId },
-                    { "rating", rating },
-                    { "ingest_source",  "DotNet" }
-                };
-
-                if (!string.IsNullOrWhiteSpace(category))
-                {
-                    attributes.Add("category", category);
-                }
-
-                if (!string.IsNullOrWhiteSpace(message))
-                {
-                    attributes.Add("message", message);
-                }
-
-                foreach (var pair in metadata ?? new Dictionary<string, object>())
-                {
-                    attributes[pair.Key] = pair.Value;
-                }
-
-                RecordCustomEvent("LlmFeedbackMessage", attributes);
-            }
+            RecordCustomEvent("LlmFeedbackMessage", attributes);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Api/AgentBridgeApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/AgentBridgeApi.cs
@@ -2,107 +2,106 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using NewRelic.Agent.Api;
-using NewRelic.Agent.Core.Metrics;
-using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Extensions.Logging;
 using System.Collections.Generic;
+using NewRelic.Agent.Api;
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Api
+namespace NewRelic.Agent.Core.Api;
+
+public class AgentBridgeApi
 {
-    public class AgentBridgeApi
+    private readonly IAgent _agent;
+    private readonly IApiSupportabilityMetricCounters _apiSupportabilityMetricCounters;
+    private readonly IConfigurationService _configSvc;
+
+    public AgentBridgeApi(IAgent agent, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IConfigurationService configSvc)
     {
-        private readonly IAgent _agent;
-        private readonly IApiSupportabilityMetricCounters _apiSupportabilityMetricCounters;
-        private readonly IConfigurationService _configSvc;
+        _agent = agent;
+        _configSvc = configSvc;
+        _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
+    }
 
-        public AgentBridgeApi(IAgent agent, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IConfigurationService configSvc)
-        {
-            _agent = agent;
-            _configSvc = configSvc;
-            _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
-        }
-
-        public TransactionBridgeApi CurrentTransaction
-        {
-            get
-            {
-                try
-                {
-                    using (new IgnoreWork())
-                    {
-                        _apiSupportabilityMetricCounters.Record(ApiMethod.CurrentTransaction);
-                        var transaction = _agent.CurrentTransaction;
-                        return new TransactionBridgeApi(transaction, _apiSupportabilityMetricCounters, _configSvc);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    try
-                    {
-                        Log.Error(ex, "Failed to get CurrentTransaction");
-                    }
-                    catch (Exception)
-                    {
-                        //Swallow the error
-                    }
-                    return null;
-                }
-            }
-        }
-
-        public object TraceMetadata
-        {
-            get
-            {
-                try
-                {
-                    using (new IgnoreWork())
-                    {
-                        _apiSupportabilityMetricCounters.Record(ApiMethod.TraceMetadata);
-                        return _agent.TraceMetadata;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    try
-                    {
-                        Log.Error(ex, "Failed to get TraceMetadata");
-                    }
-                    catch (Exception)
-                    {
-                        //Swallow the error
-                    }
-                    return null;
-                }
-
-            }
-        }
-
-        public Dictionary<string, string> GetLinkingMetadata()
+    public TransactionBridgeApi CurrentTransaction
+    {
+        get
         {
             try
             {
                 using (new IgnoreWork())
                 {
-                    _apiSupportabilityMetricCounters.Record(ApiMethod.GetLinkingMetadata);
-                    return _agent.GetLinkingMetadata();
+                    _apiSupportabilityMetricCounters.Record(ApiMethod.CurrentTransaction);
+                    var transaction = _agent.CurrentTransaction;
+                    return new TransactionBridgeApi(transaction, _apiSupportabilityMetricCounters, _configSvc);
                 }
             }
             catch (Exception ex)
             {
                 try
                 {
-                    Log.Error(ex, "Error in GetLinkingMetadata");
+                    Log.Error(ex, "Failed to get CurrentTransaction");
                 }
                 catch (Exception)
                 {
                     //Swallow the error
                 }
+                return null;
+            }
+        }
+    }
 
+    public object TraceMetadata
+    {
+        get
+        {
+            try
+            {
+                using (new IgnoreWork())
+                {
+                    _apiSupportabilityMetricCounters.Record(ApiMethod.TraceMetadata);
+                    return _agent.TraceMetadata;
+                }
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    Log.Error(ex, "Failed to get TraceMetadata");
+                }
+                catch (Exception)
+                {
+                    //Swallow the error
+                }
                 return null;
             }
 
         }
+    }
+
+    public Dictionary<string, string> GetLinkingMetadata()
+    {
+        try
+        {
+            using (new IgnoreWork())
+            {
+                _apiSupportabilityMetricCounters.Record(ApiMethod.GetLinkingMetadata);
+                return _agent.GetLinkingMetadata();
+            }
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                Log.Error(ex, "Error in GetLinkingMetadata");
+            }
+            catch (Exception)
+            {
+                //Swallow the error
+            }
+
+            return null;
+        }
+
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Api/DistributedTraceApiModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/DistributedTraceApiModel.cs
@@ -1,64 +1,63 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
-using System;
 
-namespace NewRelic.Agent.Core.Api
+namespace NewRelic.Agent.Core.Api;
+
+public class DistributedTraceApiModel : IDistributedTracePayload
 {
-    public class DistributedTraceApiModel : IDistributedTracePayload
+    public static readonly DistributedTraceApiModel EmptyModel = new DistributedTraceApiModel(string.Empty);
+
+    private readonly Lazy<string> _text;
+    private bool _isEmpty = true;
+    private string _httpSafe = string.Empty;
+
+    public DistributedTraceApiModel(string encodedPayload)
     {
-        public static readonly DistributedTraceApiModel EmptyModel = new DistributedTraceApiModel(string.Empty);
+        _httpSafe = encodedPayload;
+        _text = new Lazy<string>(DecodePayload);
+        _isEmpty = string.IsNullOrEmpty(_httpSafe);
 
-        private readonly Lazy<string> _text;
-        private bool _isEmpty = true;
-        private string _httpSafe = string.Empty;
-
-        public DistributedTraceApiModel(string encodedPayload)
+        string DecodePayload()
         {
-            _httpSafe = encodedPayload;
-            _text = new Lazy<string>(DecodePayload);
-            _isEmpty = string.IsNullOrEmpty(_httpSafe);
-
-            string DecodePayload()
+            try
+            {
+                using (new IgnoreWork())
+                {
+                    return Strings.Base64Decode(encodedPayload);
+                }
+            }
+            catch (Exception ex)
             {
                 try
                 {
-                    using (new IgnoreWork())
-                    {
-                        return Strings.Base64Decode(encodedPayload);
-                    }
+                    Log.Error(ex, "Failed to get DistributedTraceApiModel.Text");
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    try
-                    {
-                        Log.Error(ex, "Failed to get DistributedTraceApiModel.Text");
-                    }
-                    catch (Exception)
-                    {
-                        //Swallow the error
-                    }
-                    return string.Empty;
+                    //Swallow the error
                 }
+                return string.Empty;
             }
         }
+    }
 
-        public string HttpSafe()
-        {
-            return _httpSafe;
-        }
+    public string HttpSafe()
+    {
+        return _httpSafe;
+    }
 
-        public string Text()
-        {
-            return _text.Value;
-        }
+    public string Text()
+    {
+        return _text.Value;
+    }
 
-        public bool IsEmpty()
-        {
-            return _isEmpty;
-        }
+    public bool IsEmpty()
+    {
+        return _isEmpty;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Api/TraceMetadataFactory.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/TraceMetadataFactory.cs
@@ -2,51 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using NewRelic.Agent.Api;
-using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Core.DistributedTracing.Samplers;
 using NewRelic.Agent.Core.Transactions;
 
-namespace NewRelic.Agent.Core.Api
+namespace NewRelic.Agent.Core.Api;
+
+public class TraceMetadata : ITraceMetadata
 {
-    public class TraceMetadata : ITraceMetadata
+    public static readonly ITraceMetadata EmptyModel = new TraceMetadata(string.Empty, string.Empty, false);
+
+    public string TraceId { get; private set; }
+
+    public string SpanId { get; private set; }
+
+    public bool IsSampled { get; private set; }
+
+    public TraceMetadata(string traceId, string spanId, bool isSampled)
     {
-        public static readonly ITraceMetadata EmptyModel = new TraceMetadata(string.Empty, string.Empty, false);
-
-        public string TraceId { get; private set; }
-
-        public string SpanId { get; private set; }
-
-        public bool IsSampled { get; private set; }
-
-        public TraceMetadata(string traceId, string spanId, bool isSampled)
-        {
-            TraceId = traceId;
-            SpanId = spanId;
-            IsSampled = isSampled;
-        }
+        TraceId = traceId;
+        SpanId = spanId;
+        IsSampled = isSampled;
     }
+}
 
-    public interface ITraceMetadataFactory
-    {
-        ITraceMetadata CreateTraceMetadata(IInternalTransaction transaction);
-    }
+public interface ITraceMetadataFactory
+{
+    ITraceMetadata CreateTraceMetadata(IInternalTransaction transaction);
+}
 
-    public class TraceMetadataFactory : ITraceMetadataFactory
+public class TraceMetadataFactory : ITraceMetadataFactory
+{
+    public ITraceMetadata CreateTraceMetadata(IInternalTransaction transaction)
     {
-        public ITraceMetadata CreateTraceMetadata(IInternalTransaction transaction)
+        var traceId = transaction.TraceId;
+        var spanId = transaction.CurrentSegment.SpanId;
+
+        // if Sampled has not been set, compute it now
+        if (transaction.Sampled is null)
         {
-            var traceId = transaction.TraceId;
-            var spanId = transaction.CurrentSegment.SpanId;
-
-            // if Sampled has not been set, compute it now
-            if (transaction.Sampled is null)
-            {
-                transaction.SetSampled();
-            }
-
-            var isSampled = transaction.Sampled ?? false;
-
-            return new TraceMetadata(traceId, spanId, isSampled);
+            transaction.SetSampled();
         }
+
+        var isSampled = transaction.Sampled ?? false;
+
+        return new TraceMetadata(traceId, spanId, isSampled);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Api/TransactionBridgeApi.cs
+++ b/src/Agent/NewRelic/Agent/Core/Api/TransactionBridgeApi.cs
@@ -6,249 +6,248 @@ using System.Collections.Generic;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Parsing;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
-using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Api
+namespace NewRelic.Agent.Core.Api;
+
+public class TransactionBridgeApi
 {
-    public class TransactionBridgeApi
+    public static readonly TransportType[] TransportTypeMapping = new[]
     {
-        public static readonly TransportType[] TransportTypeMapping = new[]
-        {
-            TransportType.Unknown,
-            TransportType.HTTP,
-            TransportType.HTTPS,
-            TransportType.Kafka,
-            TransportType.JMS,
-            TransportType.IronMQ,
-            TransportType.AMQP,
-            TransportType.Queue,
-            TransportType.Other
-        };
+        TransportType.Unknown,
+        TransportType.HTTP,
+        TransportType.HTTPS,
+        TransportType.Kafka,
+        TransportType.JMS,
+        TransportType.IronMQ,
+        TransportType.AMQP,
+        TransportType.Queue,
+        TransportType.Other
+    };
 
-        private readonly ITransaction _transaction;
-        private readonly IApiSupportabilityMetricCounters _apiSupportabilityMetricCounters;
-        private readonly IConfigurationService _configSvc;
+    private readonly ITransaction _transaction;
+    private readonly IApiSupportabilityMetricCounters _apiSupportabilityMetricCounters;
+    private readonly IConfigurationService _configSvc;
 
-        public TransactionBridgeApi(ITransaction transaction, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IConfigurationService configSvc)
+    public TransactionBridgeApi(ITransaction transaction, IApiSupportabilityMetricCounters apiSupportabilityMetricCounters, IConfigurationService configSvc)
+    {
+        _transaction = transaction;
+        _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
+        _configSvc = configSvc;
+    }
+
+    [Obsolete("This method does nothing in version 9.x+ of the Agent.")]
+
+    public object CreateDistributedTracePayload()
+    {
+        try
         {
-            _transaction = transaction;
-            _apiSupportabilityMetricCounters = apiSupportabilityMetricCounters;
-            _configSvc = configSvc;
+            Log.Warn("CreateDistributedTracePayload was called by an outdated version of the AgentAPI. This method does nothing in version 9.x+ of the Agent.");
+        }
+        catch (Exception)
+        {
         }
 
-        [Obsolete("This method does nothing in version 9.x+ of the Agent.")]
+        // I hope people are null checking as this will always return null now
+        return null;
+    }
 
-        public object CreateDistributedTracePayload()
+    [Obsolete("This method does nothing in version 9.x+ of the Agent")]
+    public void AcceptDistributedTracePayload(string payload, int transportType)
+    {
+        try
+        {
+            Log.Warn("AcceptDistributedTracePayload was called by an outdated version of the AgentAPI. This method does nothing in version 9.x+ of the Agent");
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    public void InsertDistributedTraceHeaders<T>(T carrier, Action<T, string, string> setter)
+    {
+        try
+        {
+            using (new IgnoreWork())
+            {
+                _apiSupportabilityMetricCounters.Record(ApiMethod.InsertDistributedTraceHeaders);
+                _transaction.InsertDistributedTraceHeaders(carrier, setter);
+            }
+        }
+        catch (Exception ex)
         {
             try
             {
-                Log.Warn("CreateDistributedTracePayload was called by an outdated version of the AgentAPI. This method does nothing in version 9.x+ of the Agent.");
+                Log.Error(ex, "Error in InsertDistributedTraceHeaders<T>(T, Action<T, string, string>)");
             }
             catch (Exception)
             {
+                //Swallow the error
             }
-
-            // I hope people are null checking as this will always return null now
-            return null;
         }
+    }
 
-        [Obsolete("This method does nothing in version 9.x+ of the Agent")]
-        public void AcceptDistributedTracePayload(string payload, int transportType)
+    public void AcceptDistributedTraceHeaders<T>(T carrier, Func<T, string, IEnumerable<string>> getter, int transportType)
+    {
+        try
+        {
+            using (new IgnoreWork())
+            {
+                _apiSupportabilityMetricCounters.Record(ApiMethod.AcceptDistributedTraceHeaders);
+                _transaction.AcceptDistributedTraceHeaders(carrier, getter, GetTransportTypeValue(transportType));
+            }
+        }
+        catch (Exception ex)
         {
             try
             {
-                Log.Warn("AcceptDistributedTracePayload was called by an outdated version of the AgentAPI. This method does nothing in version 9.x+ of the Agent");
+                Log.Error(ex, "Error in AcceptDistributedTraceHeaders<T>(T, Func<T, string, IEnumerable<string>>, TransportType)");
             }
             catch (Exception)
             {
+                //Swallow the error
             }
         }
+    }
 
-        public void InsertDistributedTraceHeaders<T>(T carrier, Action<T, string, string> setter)
+    private static TransportType GetTransportTypeValue(int transportType)
+    {
+        if (transportType >= 0 && transportType < TransportTypeMapping.Length)
+        {
+            return TransportTypeMapping[transportType];
+        }
+
+        return TransportType.Unknown;
+    }
+
+    public object AddCustomAttribute(string key, object value)
+    {
+        try
+        {
+            _apiSupportabilityMetricCounters.Record(ApiMethod.TransactionAddCustomAttribute);
+
+            if (!_configSvc.Configuration.CaptureCustomParameters)
+            {
+                return _transaction;
+            }
+
+            _transaction.AddCustomAttribute(key, value);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                Log.Error(ex, "Error in AddCustomAttribute");
+            }
+            catch (Exception)
+            {
+                //Swallow the error
+            }
+
+        }
+
+        return _transaction;
+    }
+
+    public SpanBridgeApi CurrentSpan
+    {
+        get
         {
             try
             {
                 using (new IgnoreWork())
                 {
-                    _apiSupportabilityMetricCounters.Record(ApiMethod.InsertDistributedTraceHeaders);
-                    _transaction.InsertDistributedTraceHeaders(carrier, setter);
+                    _apiSupportabilityMetricCounters.Record(ApiMethod.TransactionGetCurrentSpan);
+                    var segment = _transaction.CurrentSegment;
+                    return new SpanBridgeApi(segment, _apiSupportabilityMetricCounters, _configSvc);
                 }
             }
             catch (Exception ex)
             {
                 try
                 {
-                    Log.Error(ex, "Error in InsertDistributedTraceHeaders<T>(T, Action<T, string, string>)");
+                    Log.Error(ex, "Failed to get CurrentSpan");
                 }
                 catch (Exception)
                 {
                     //Swallow the error
                 }
+                return null;
             }
         }
+    }
 
-        public void AcceptDistributedTraceHeaders<T>(T carrier, Func<T, string, IEnumerable<string>> getter, int transportType)
+    /// <summary>
+    /// Sets a User Id to be associated with this transaction.
+    /// </summary>
+    /// <param name="userid">The User Id for this transaction.</param>
+    public void SetUserId(string userid)
+    {
+
+        try
+        {
+            _apiSupportabilityMetricCounters.Record(ApiMethod.SetUserId);
+
+            _transaction.SetUserId(userid);
+        }
+        catch (Exception ex)
         {
             try
             {
-                using (new IgnoreWork())
-                {
-                    _apiSupportabilityMetricCounters.Record(ApiMethod.AcceptDistributedTraceHeaders);
-                    _transaction.AcceptDistributedTraceHeaders(carrier, getter, GetTransportTypeValue(transportType));
-                }
+                Log.Error(ex, "Error in SetUserId");
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                try
-                {
-                    Log.Error(ex, "Error in AcceptDistributedTraceHeaders<T>(T, Func<T, string, IEnumerable<string>>, TransportType)");
-                }
-                catch (Exception)
-                {
-                    //Swallow the error
-                }
+                //Swallow the error
             }
         }
+    }
 
-        private static TransportType GetTransportTypeValue(int transportType)
+    /// <summary>
+    /// Records a datastore segment.
+    /// This function allows an unsupported datastore to be instrumented in the same way as the .NET agent automatically instruments its supported datastores.
+    /// </summary>
+    /// <param name="vendor">Datastore vendor name, for example MySQL, MSSQL, MongoDB.</param>
+    /// <param name="model">Table name or similar in non-relational datastores.</param>
+    /// <param name="operation">Operation being performed, for example "SELECT" or "UPDATE" for SQL databases.</param>
+    /// <param name="commandText">Optional. Query or similar in non-relational datastores.</param>
+    /// <param name="host">Optional. Server hosting the datastore</param>
+    /// <param name="portPathOrID">Optional. Port, path or other ID to aid in identifying the datastore.</param>
+    /// <param name="databaseName">Optional. Datastore name.</param>
+    /// <returns>Segment that was created.</returns>
+    public ISegment StartDatastoreSegment(string vendor, string model, string operation,
+        string commandText = null, string host = null, string portPathOrID =  null, string databaseName = null)
+    {
+        try
         {
-            if (transportType >= 0 && transportType < TransportTypeMapping.Length)
-            {
-                return TransportTypeMapping[transportType];
-            }
-
-            return TransportType.Unknown;
+            _apiSupportabilityMetricCounters.Record(ApiMethod.StartDatastoreSegment);
+            var method = new Method(typeof(object), "StartDatastoreSegment", string.Empty);
+            var methodCall = new MethodCall(method, null, null, false);
+            var parsedSqlStatement = new ParsedSqlStatement(DatastoreVendor.Other, model, operation);
+            var connectionInfo = new ConnectionInfo(host, portPathOrID, databaseName);
+            return _transaction.StartDatastoreSegment(
+                methodCall: methodCall,
+                parsedSqlStatement: parsedSqlStatement,
+                connectionInfo: connectionInfo,
+                commandText: commandText,
+                queryParameters: null,
+                isLeaf: false
+            );
         }
-
-        public object AddCustomAttribute(string key, object value)
-        {
-            try
-            {
-                _apiSupportabilityMetricCounters.Record(ApiMethod.TransactionAddCustomAttribute);
-
-                if (!_configSvc.Configuration.CaptureCustomParameters)
-                {
-                    return _transaction;
-                }
-
-                _transaction.AddCustomAttribute(key, value);
-            }
-            catch (Exception ex)
-            {
-                try
-                {
-                    Log.Error(ex, "Error in AddCustomAttribute");
-                }
-                catch (Exception)
-                {
-                    //Swallow the error
-                }
-
-            }
-
-            return _transaction;
-        }
-
-        public SpanBridgeApi CurrentSpan
-        {
-            get
-            {
-                try
-                {
-                    using (new IgnoreWork())
-                    {
-                        _apiSupportabilityMetricCounters.Record(ApiMethod.TransactionGetCurrentSpan);
-                        var segment = _transaction.CurrentSegment;
-                        return new SpanBridgeApi(segment, _apiSupportabilityMetricCounters, _configSvc);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    try
-                    {
-                        Log.Error(ex, "Failed to get CurrentSpan");
-                    }
-                    catch (Exception)
-                    {
-                        //Swallow the error
-                    }
-                    return null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sets a User Id to be associated with this transaction.
-        /// </summary>
-        /// <param name="userid">The User Id for this transaction.</param>
-        public void SetUserId(string userid)
-        {
-
-            try
-            {
-                _apiSupportabilityMetricCounters.Record(ApiMethod.SetUserId);
-
-                _transaction.SetUserId(userid);
-            }
-            catch (Exception ex)
-            {
-                try
-                {
-                    Log.Error(ex, "Error in SetUserId");
-                }
-                catch (Exception)
-                {
-                    //Swallow the error
-                }
-            }
-        }
-
-        /// <summary>
-        /// Records a datastore segment.
-        /// This function allows an unsupported datastore to be instrumented in the same way as the .NET agent automatically instruments its supported datastores.
-        /// </summary>
-        /// <param name="vendor">Datastore vendor name, for example MySQL, MSSQL, MongoDB.</param>
-        /// <param name="model">Table name or similar in non-relational datastores.</param>
-        /// <param name="operation">Operation being performed, for example "SELECT" or "UPDATE" for SQL databases.</param>
-        /// <param name="commandText">Optional. Query or similar in non-relational datastores.</param>
-        /// <param name="host">Optional. Server hosting the datastore</param>
-        /// <param name="portPathOrID">Optional. Port, path or other ID to aid in identifying the datastore.</param>
-        /// <param name="databaseName">Optional. Datastore name.</param>
-        /// <returns>Segment that was created.</returns>
-        public ISegment StartDatastoreSegment(string vendor, string model, string operation,
-             string commandText = null, string host = null, string portPathOrID =  null, string databaseName = null)
+        catch (Exception ex)
         {
             try
             {
-                _apiSupportabilityMetricCounters.Record(ApiMethod.StartDatastoreSegment);
-                var method = new Method(typeof(object), "StartDatastoreSegment", string.Empty);
-                var methodCall = new MethodCall(method, null, null, false);
-                var parsedSqlStatement = new ParsedSqlStatement(DatastoreVendor.Other, model, operation);
-                var connectionInfo = new ConnectionInfo(host, portPathOrID, databaseName);
-                return _transaction.StartDatastoreSegment(
-                    methodCall: methodCall,
-                    parsedSqlStatement: parsedSqlStatement,
-                    connectionInfo: connectionInfo,
-                    commandText: commandText,
-                    queryParameters: null,
-                    isLeaf: false
-                );
+                Log.Error(ex, "Error in StartDatastoreSegment");
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                try
-                {
-                    Log.Error(ex, "Error in StartDatastoreSegment");
-                }
-                catch (Exception)
-                {
-                    //Swallow the error
-                }
+                //Swallow the error
             }
-
-            return null;
         }
+
+        return null;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/AssemblyLoading/AssemblyResolutionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/AssemblyLoading/AssemblyResolutionService.cs
@@ -6,86 +6,85 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
-namespace NewRelic.Agent.Core.AssemblyLoading
+namespace NewRelic.Agent.Core.AssemblyLoading;
+
+/// <summary>
+/// This service registers an AssemblyResolve handler that will be fired whenever assembly resolution fails. The handler essentially acts as an assembly version redirect for any assembly that loaded by NewRelic code.
+/// </summary>
+public class AssemblyResolutionService : IDisposable
 {
-    /// <summary>
-    /// This service registers an AssemblyResolve handler that will be fired whenever assembly resolution fails. The handler essentially acts as an assembly version redirect for any assembly that loaded by NewRelic code.
-    /// </summary>
-    public class AssemblyResolutionService : IDisposable
+    public AssemblyResolutionService()
     {
-        public AssemblyResolutionService()
-        {
-            AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolutionFailure;
-        }
+        AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolutionFailure;
+    }
 
-        public void Dispose()
-        {
-            AppDomain.CurrentDomain.AssemblyResolve -= OnAssemblyResolutionFailure;
-        }
+    public void Dispose()
+    {
+        AppDomain.CurrentDomain.AssemblyResolve -= OnAssemblyResolutionFailure;
+    }
 
-        private static Assembly OnAssemblyResolutionFailure(object sender, ResolveEventArgs args)
-        {
-            if (args == null)
-                return null;
-            if (!IsWrapperServiceOrTracerInStack())
-                return null;
+    private static Assembly OnAssemblyResolutionFailure(object sender, ResolveEventArgs args)
+    {
+        if (args == null)
+            return null;
+        if (!IsWrapperServiceOrTracerInStack())
+            return null;
 
-            return TryGetAlreadyLoadedAssemblyFromFullName(args.Name);
-        }
+        return TryGetAlreadyLoadedAssemblyFromFullName(args.Name);
+    }
 
-        private static Assembly TryGetAlreadyLoadedAssemblyFromFullName(string fullAssemblyName)
-        {
-            if (fullAssemblyName == null)
-                return null;
+    private static Assembly TryGetAlreadyLoadedAssemblyFromFullName(string fullAssemblyName)
+    {
+        if (fullAssemblyName == null)
+            return null;
 
-            var simpleAssemblyName = new AssemblyName(fullAssemblyName).Name;
-            if (simpleAssemblyName == null)
-                return null;
+        var simpleAssemblyName = new AssemblyName(fullAssemblyName).Name;
+        if (simpleAssemblyName == null)
+            return null;
 
-            return TryGetAlreadyLoadedAssemblyBySimpleName(simpleAssemblyName);
-        }
+        return TryGetAlreadyLoadedAssemblyBySimpleName(simpleAssemblyName);
+    }
 
-        private static Assembly TryGetAlreadyLoadedAssemblyBySimpleName(string simpleAssemblyName)
-        {
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .Where(assembly => assembly != null)
-                .Where(assembly => assembly.GetName().Name == simpleAssemblyName)
-                .FirstOrDefault();
-        }
+    private static Assembly TryGetAlreadyLoadedAssemblyBySimpleName(string simpleAssemblyName)
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => assembly != null)
+            .Where(assembly => assembly.GetName().Name == simpleAssemblyName)
+            .FirstOrDefault();
+    }
 
-        private static bool IsWrapperServiceOrTracerInStack()
-        {
-            var stackFrames = new StackTrace().GetFrames();
-            if (stackFrames == null)
-                return false;
+    private static bool IsWrapperServiceOrTracerInStack()
+    {
+        var stackFrames = new StackTrace().GetFrames();
+        if (stackFrames == null)
+            return false;
 
-            return stackFrames
-                .Select(GetFrameType)
-                .Where(type => type != null)
-                .Where(type => type != typeof(AssemblyResolutionService))
-                .Where(IsNewRelicType)
-                .Any();
-        }
+        return stackFrames
+            .Select(GetFrameType)
+            .Where(type => type != null)
+            .Where(type => type != typeof(AssemblyResolutionService))
+            .Where(IsNewRelicType)
+            .Any();
+    }
 
-        private static Type GetFrameType(StackFrame stackFrame)
-        {
-            if (stackFrame == null)
-                return null;
+    private static Type GetFrameType(StackFrame stackFrame)
+    {
+        if (stackFrame == null)
+            return null;
 
-            var method = stackFrame.GetMethod();
-            if (method == null)
-                return null;
+        var method = stackFrame.GetMethod();
+        if (method == null)
+            return null;
 
-            return method.DeclaringType;
-        }
+        return method.DeclaringType;
+    }
 
-        private static bool IsNewRelicType(Type type)
-        {
-            var typeName = type.FullName;
-            if (typeName == null)
-                return false;
+    private static bool IsNewRelicType(Type type)
+    {
+        var typeName = type.FullName;
+        if (typeName == null)
+            return false;
 
-            return typeName.StartsWith("NewRelic");
-        }
+        return typeName.StartsWith("NewRelic");
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeClassification.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeClassification.cs
@@ -1,12 +1,11 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public enum AttributeClassification
 {
-    public enum AttributeClassification
-    {
-        AgentAttributes = 0,
-        UserAttributes = 1,
-        Intrinsics = 2
-    }
+    AgentAttributes = 0,
+    UserAttributes = 1,
+    Intrinsics = 2
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDefinitionService.cs
@@ -1,1261 +1,1260 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
-using NewRelic.Agent.Extensions.Parsing;
-using NewRelic.Agent.Core.Spans;
-using NewRelic.Agent.Extensions.Providers.Wrapper;
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Core.Events;
 using System.Linq;
-using System;
 using NewRelic.Agent.Core.DistributedTracing;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.Spans;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Parsing;
+using NewRelic.Agent.Extensions.Providers.Wrapper;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public interface IAttributeDefinitionService : IDisposable
 {
-    public interface IAttributeDefinitionService : IDisposable
+    IAttributeDefinitions AttributeDefs { get; }
+}
+
+public interface IAttributeDefinitions
+{
+    AttributeDefinition<string, string> ApdexPerfZone { get; }
+    AttributeDefinition<string, string> BrowserTripId { get; }
+    AttributeDefinition<IEnumerable<string>, string> CatAlternativePathHashes { get; }
+    AttributeDefinition<string, string> CatNrPathHash { get; }
+    AttributeDefinition<string, string> CatNrTripId { get; }
+    AttributeDefinition<string, string> CatPathHash { get; }
+    AttributeDefinition<string, string> CatReferringPathHash { get; }
+    AttributeDefinition<string, string> CatReferringTransactionGuidForEvents { get; }
+    AttributeDefinition<string, string> CatReferringTransactionGuidForTraces { get; }
+    AttributeDefinition<string, string> ClientCrossProcessId { get; }
+    AttributeDefinition<string, string> CodeFunction { get; }
+    AttributeDefinition<string, string> CodeNamespace { get; }
+    AttributeDefinition<string, string> Component { get; }
+    AttributeDefinition<TimeSpan, double> CpuTime { get; }
+    AttributeDefinition<string, string> CustomEventType { get; }
+    AttributeDefinition<long, double> DatabaseCallCount { get; }
+    AttributeDefinition<float, double> DatabaseDuration { get; }
+    AttributeDefinition<string, string> DbCollection { get; }
+    AttributeDefinition<string, string> DbInstance { get; }
+    AttributeDefinition<string, string> DbOperation { get; }
+    AttributeDefinition<string, string> DbServerAddress { get; }
+    AttributeDefinition<long, long> DbServerPort { get; }
+    AttributeDefinition<string, string> DbStatement { get; }
+    AttributeDefinition<string, string> DbSystem { get; }
+    AttributeDefinition<string, string> DistributedTraceId { get; }
+    AttributeDefinition<TimeSpan, double> Duration { get; }
+    AttributeDefinition<bool, bool> IsErrorExpected { get; }
+    AttributeDefinition<bool, bool> SpanIsErrorExpected { get; }
+    AttributeDefinition<string, string> ErrorClass { get; }
+    AttributeDefinition<string, string> ErrorDotMessage { get; }
+    AttributeDefinition<string, string> ErrorMessage { get; }
+    AttributeDefinition<string, string> ErrorType { get; }
+    AttributeDefinition<string, string> ErrorEventSpanId { get; }
+    AttributeDefinition<string, string> ErrorGroup { get; }
+    AttributeDefinition<string, string> EndUserId { get; }
+    AttributeDefinition<float, double> ExternalCallCount { get; }
+    AttributeDefinition<float, double> ExternalDuration { get; }
+    AttributeDefinition<string, string> Guid { get; }
+    AttributeDefinition<string, string> HostDisplayName { get; }
+    AttributeDefinition<string, string> HttpMethod { get; }
+    AttributeDefinition<long?, long> HttpStatusCode { get; }
+    AttributeDefinition<string, string> HttpStatusText { get; }
+    AttributeDefinition<Uri, string> HttpUrl { get; }
+    AttributeDefinition<bool, bool> IsError { get; }
+    AttributeDefinition<string, string> NameForSpan { get; }
+    AttributeDefinition<bool, bool> NrEntryPoint { get; }
+    AttributeDefinition<string, string> NrGuid { get; }
+    AttributeDefinition<string, string> OriginalUrl { get; }
+    AttributeDefinition<string, string> ParentAccount { get; }
+    AttributeDefinition<string, string> ParentAccountForSpan { get; }
+    AttributeDefinition<string, string> ParentApp { get; }
+    AttributeDefinition<string, string> ParentAppForSpan { get; }
+    AttributeDefinition<string, string> ParentId { get; }
+    AttributeDefinition<string, string> ParentSpanId { get; }
+    AttributeDefinition<TimeSpan, double> ParentTransportDuration { get; }
+    AttributeDefinition<TimeSpan, double> ParentTransportDurationForSpan { get; }
+    AttributeDefinition<TransportType, string> ParentTransportType { get; }
+    AttributeDefinition<TransportType, string> ParentTransportTypeForSpan { get; }
+    AttributeDefinition<TypeAttributeValue, string> ParentType { get; }
+    AttributeDefinition<TypeAttributeValue, string> ParentTypeForSpan { get; }
+    AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracing { get; }
+    AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracingForSpan { get; }
+    AttributeDefinition<string, string> PeerAddress { get; }
+    AttributeDefinition<string, string> PeerHostname { get; }
+    AttributeDefinition<float, double> Priority { get; }
+    AttributeDefinition<TimeSpan?, double> QueueDuration { get; }
+    AttributeDefinition<TimeSpan?, string> QueueWaitTime { get; }
+    AttributeDefinition<string, string> RequestReferrer { get; }
+    AttributeDefinition<string, string> RequestMethod { get; }
+    AttributeDefinition<string, string> RequestUri { get; }
+    AttributeDefinition<int?, string> ResponseStatus { get; }
+    AttributeDefinition<bool, bool> Sampled { get; }
+    AttributeDefinition<string, string> ServerAddress { get; }
+    AttributeDefinition<long, long> ServerPort { get; }
+    AttributeDefinition<SpanCategory, string> SpanCategory { get; }
+    AttributeDefinition<string, string> SpanErrorClass { get; }
+    AttributeDefinition<string, string> SpanErrorMessage { get; }
+    AttributeDefinition<string, string> SpanId { get; }
+    AttributeDefinition<string, string> SpanKind { get; }
+    AttributeDefinition<string, string> SyntheticsJobId { get; }
+    AttributeDefinition<string, string> SyntheticsJobIdForTraces { get; }
+    AttributeDefinition<string, string> SyntheticsMonitorId { get; }
+    AttributeDefinition<string, string> SyntheticsMonitorIdForTraces { get; }
+    AttributeDefinition<string, string> SyntheticsResourceId { get; }
+    AttributeDefinition<string, string> SyntheticsResourceIdForTraces { get; }
+    AttributeDefinition<long, long> ThreadId { get; }
+    AttributeDefinition<DateTime, long> Timestamp { get; }
+    AttributeDefinition<DateTime, long> TimestampForError { get; }
+    AttributeDefinition<TimeSpan, double> TotalTime { get; }
+    AttributeDefinition<string, string> TransactionId { get; }
+    AttributeDefinition<IEnumerable<string>, string> TracingVendors { get; }
+    AttributeDefinition<string, string> TransactionName { get; }
+    AttributeDefinition<string, string> TransactionNameForSpan { get; }
+    AttributeDefinition<string, string> TransactionNameForError { get; }
+    AttributeDefinition<string, string> TripId { get; }
+    AttributeDefinition<string, string> TrustedParentId { get; }
+    AttributeDefinition<TimeSpan, double> WebDuration { get; }
+
+    AttributeDefinition<object, object> GetCustomAttributeForCustomEvent(string name);
+    AttributeDefinition<object, object> GetCustomAttributeForError(string name);
+    AttributeDefinition<object, object> GetCustomAttributeForSpan(string name);
+    AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name);
+
+    AttributeDefinition<object, object> GetAgentAttributeForSpan(string key);
+
+    AttributeDefinition<object, object> GetLambdaAttribute(string name);
+    AttributeDefinition<object, object> GetFaasAttribute(string name);
+    AttributeDefinition<object, object> GetCloudSdkAttribute(string name);
+
+    AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName);
+
+    AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName);
+
+    AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue destination);
+
+    AttributeDefinition<bool, bool> LlmTransaction { get; }
+
+    AttributeDefinition<string, string> CloudAccountId { get; }
+    AttributeDefinition<string, string> CloudRegion { get; }
+    AttributeDefinition<string, string> MessagingSystemName { get; }
+    AttributeDefinition<string, string> MessagingDestinationName { get; }
+    AttributeDefinition<string, string> BrokerServerAddress { get; }
+    AttributeDefinition<int, int> BrokerServerPort { get; }
+    AttributeDefinition<string, string> MessageQueueName { get; }
+    AttributeDefinition<string, string> MessageRoutingKey { get; }
+    AttributeDefinition<string, string> MessagingRabbitMqDestinationRoutingKey { get; }
+    AttributeDefinition<string, string> MessagingDestinationPublishName { get; }
+    AttributeDefinition<string, string> LinkedTraceId { get; }
+    AttributeDefinition<string, string> LinkedSpanId { get; }
+    AttributeDefinition<string, string> SpanIdForSpanLink { get; }
+    AttributeDefinition<string, string> TraceIdForSpanData { get; }
+    AttributeDefinition<string, string> SpanIdForSpanEvent { get; }
+}
+
+public class AttributeDefinitionService : ConfigurationBasedService, IAttributeDefinitionService
+{
+    public IAttributeDefinitions AttributeDefs { get; private set; }
+
+    private readonly Func<IAttributeFilter, IAttributeDefinitions> _attribDefinitionsFactory;
+
+    public AttributeDefinitionService(Func<IAttributeFilter, IAttributeDefinitions> attribDefinitionFactory)
     {
-        IAttributeDefinitions AttributeDefs { get; }
+        _attribDefinitionsFactory = attribDefinitionFactory;
+        ResetAttributeDefinitions();
     }
 
-    public interface IAttributeDefinitions
+    private void ResetAttributeDefinitions()
     {
-        AttributeDefinition<string, string> ApdexPerfZone { get; }
-        AttributeDefinition<string, string> BrowserTripId { get; }
-        AttributeDefinition<IEnumerable<string>, string> CatAlternativePathHashes { get; }
-        AttributeDefinition<string, string> CatNrPathHash { get; }
-        AttributeDefinition<string, string> CatNrTripId { get; }
-        AttributeDefinition<string, string> CatPathHash { get; }
-        AttributeDefinition<string, string> CatReferringPathHash { get; }
-        AttributeDefinition<string, string> CatReferringTransactionGuidForEvents { get; }
-        AttributeDefinition<string, string> CatReferringTransactionGuidForTraces { get; }
-        AttributeDefinition<string, string> ClientCrossProcessId { get; }
-        AttributeDefinition<string, string> CodeFunction { get; }
-        AttributeDefinition<string, string> CodeNamespace { get; }
-        AttributeDefinition<string, string> Component { get; }
-        AttributeDefinition<TimeSpan, double> CpuTime { get; }
-        AttributeDefinition<string, string> CustomEventType { get; }
-        AttributeDefinition<long, double> DatabaseCallCount { get; }
-        AttributeDefinition<float, double> DatabaseDuration { get; }
-        AttributeDefinition<string, string> DbCollection { get; }
-        AttributeDefinition<string, string> DbInstance { get; }
-        AttributeDefinition<string, string> DbOperation { get; }
-        AttributeDefinition<string, string> DbServerAddress { get; }
-        AttributeDefinition<long, long> DbServerPort { get; }
-        AttributeDefinition<string, string> DbStatement { get; }
-        AttributeDefinition<string, string> DbSystem { get; }
-        AttributeDefinition<string, string> DistributedTraceId { get; }
-        AttributeDefinition<TimeSpan, double> Duration { get; }
-        AttributeDefinition<bool, bool> IsErrorExpected { get; }
-        AttributeDefinition<bool, bool> SpanIsErrorExpected { get; }
-        AttributeDefinition<string, string> ErrorClass { get; }
-        AttributeDefinition<string, string> ErrorDotMessage { get; }
-        AttributeDefinition<string, string> ErrorMessage { get; }
-        AttributeDefinition<string, string> ErrorType { get; }
-        AttributeDefinition<string, string> ErrorEventSpanId { get; }
-        AttributeDefinition<string, string> ErrorGroup { get; }
-        AttributeDefinition<string, string> EndUserId { get; }
-        AttributeDefinition<float, double> ExternalCallCount { get; }
-        AttributeDefinition<float, double> ExternalDuration { get; }
-        AttributeDefinition<string, string> Guid { get; }
-        AttributeDefinition<string, string> HostDisplayName { get; }
-        AttributeDefinition<string, string> HttpMethod { get; }
-        AttributeDefinition<long?, long> HttpStatusCode { get; }
-        AttributeDefinition<string, string> HttpStatusText { get; }
-        AttributeDefinition<Uri, string> HttpUrl { get; }
-        AttributeDefinition<bool, bool> IsError { get; }
-        AttributeDefinition<string, string> NameForSpan { get; }
-        AttributeDefinition<bool, bool> NrEntryPoint { get; }
-        AttributeDefinition<string, string> NrGuid { get; }
-        AttributeDefinition<string, string> OriginalUrl { get; }
-        AttributeDefinition<string, string> ParentAccount { get; }
-        AttributeDefinition<string, string> ParentAccountForSpan { get; }
-        AttributeDefinition<string, string> ParentApp { get; }
-        AttributeDefinition<string, string> ParentAppForSpan { get; }
-        AttributeDefinition<string, string> ParentId { get; }
-        AttributeDefinition<string, string> ParentSpanId { get; }
-        AttributeDefinition<TimeSpan, double> ParentTransportDuration { get; }
-        AttributeDefinition<TimeSpan, double> ParentTransportDurationForSpan { get; }
-        AttributeDefinition<TransportType, string> ParentTransportType { get; }
-        AttributeDefinition<TransportType, string> ParentTransportTypeForSpan { get; }
-        AttributeDefinition<TypeAttributeValue, string> ParentType { get; }
-        AttributeDefinition<TypeAttributeValue, string> ParentTypeForSpan { get; }
-        AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracing { get; }
-        AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracingForSpan { get; }
-        AttributeDefinition<string, string> PeerAddress { get; }
-        AttributeDefinition<string, string> PeerHostname { get; }
-        AttributeDefinition<float, double> Priority { get; }
-        AttributeDefinition<TimeSpan?, double> QueueDuration { get; }
-        AttributeDefinition<TimeSpan?, string> QueueWaitTime { get; }
-        AttributeDefinition<string, string> RequestReferrer { get; }
-        AttributeDefinition<string, string> RequestMethod { get; }
-        AttributeDefinition<string, string> RequestUri { get; }
-        AttributeDefinition<int?, string> ResponseStatus { get; }
-        AttributeDefinition<bool, bool> Sampled { get; }
-        AttributeDefinition<string, string> ServerAddress { get; }
-        AttributeDefinition<long, long> ServerPort { get; }
-        AttributeDefinition<SpanCategory, string> SpanCategory { get; }
-        AttributeDefinition<string, string> SpanErrorClass { get; }
-        AttributeDefinition<string, string> SpanErrorMessage { get; }
-        AttributeDefinition<string, string> SpanId { get; }
-        AttributeDefinition<string, string> SpanKind { get; }
-        AttributeDefinition<string, string> SyntheticsJobId { get; }
-        AttributeDefinition<string, string> SyntheticsJobIdForTraces { get; }
-        AttributeDefinition<string, string> SyntheticsMonitorId { get; }
-        AttributeDefinition<string, string> SyntheticsMonitorIdForTraces { get; }
-        AttributeDefinition<string, string> SyntheticsResourceId { get; }
-        AttributeDefinition<string, string> SyntheticsResourceIdForTraces { get; }
-        AttributeDefinition<long, long> ThreadId { get; }
-        AttributeDefinition<DateTime, long> Timestamp { get; }
-        AttributeDefinition<DateTime, long> TimestampForError { get; }
-        AttributeDefinition<TimeSpan, double> TotalTime { get; }
-        AttributeDefinition<string, string> TransactionId { get; }
-        AttributeDefinition<IEnumerable<string>, string> TracingVendors { get; }
-        AttributeDefinition<string, string> TransactionName { get; }
-        AttributeDefinition<string, string> TransactionNameForSpan { get; }
-        AttributeDefinition<string, string> TransactionNameForError { get; }
-        AttributeDefinition<string, string> TripId { get; }
-        AttributeDefinition<string, string> TrustedParentId { get; }
-        AttributeDefinition<TimeSpan, double> WebDuration { get; }
-
-        AttributeDefinition<object, object> GetCustomAttributeForCustomEvent(string name);
-        AttributeDefinition<object, object> GetCustomAttributeForError(string name);
-        AttributeDefinition<object, object> GetCustomAttributeForSpan(string name);
-        AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name);
-
-        AttributeDefinition<object, object> GetAgentAttributeForSpan(string key);
-
-        AttributeDefinition<object, object> GetLambdaAttribute(string name);
-        AttributeDefinition<object, object> GetFaasAttribute(string name);
-        AttributeDefinition<object, object> GetCloudSdkAttribute(string name);
-
-        AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName);
-
-        AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName);
-
-        AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue destination);
-
-        AttributeDefinition<bool, bool> LlmTransaction { get; }
-
-        AttributeDefinition<string, string> CloudAccountId { get; }
-        AttributeDefinition<string, string> CloudRegion { get; }
-        AttributeDefinition<string, string> MessagingSystemName { get; }
-        AttributeDefinition<string, string> MessagingDestinationName { get; }
-        AttributeDefinition<string, string> BrokerServerAddress { get; }
-        AttributeDefinition<int, int> BrokerServerPort { get; }
-        AttributeDefinition<string, string> MessageQueueName { get; }
-        AttributeDefinition<string, string> MessageRoutingKey { get; }
-        AttributeDefinition<string, string> MessagingRabbitMqDestinationRoutingKey { get; }
-        AttributeDefinition<string, string> MessagingDestinationPublishName { get; }
-        AttributeDefinition<string, string> LinkedTraceId { get; }
-        AttributeDefinition<string, string> LinkedSpanId { get; }
-        AttributeDefinition<string, string> SpanIdForSpanLink { get; }
-        AttributeDefinition<string, string> TraceIdForSpanData { get; }
-        AttributeDefinition<string, string> SpanIdForSpanEvent { get; }
+        var filterSettings = new AttributeFilter.Settings(_configuration);
+        var filter = new AttributeFilter(filterSettings);
+        AttributeDefs = _attribDefinitionsFactory(filter);
     }
 
-    public class AttributeDefinitionService : ConfigurationBasedService, IAttributeDefinitionService
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
     {
-        public IAttributeDefinitions AttributeDefs { get; private set; }
+        ResetAttributeDefinitions();
+    }
+}
 
-        private readonly Func<IAttributeFilter, IAttributeDefinitions> _attribDefinitionsFactory;
+public class AttributeDefinitions : IAttributeDefinitions
+{
+    private readonly IAttributeFilter _attribFilter;
 
-        public AttributeDefinitionService(Func<IAttributeFilter, IAttributeDefinitions> attribDefinitionFactory)
-        {
-            _attribDefinitionsFactory = attribDefinitionFactory;
-            ResetAttributeDefinitions();
-        }
-
-        private void ResetAttributeDefinitions()
-        {
-            var filterSettings = new AttributeFilter.Settings(_configuration);
-            var filter = new AttributeFilter(filterSettings);
-            AttributeDefs = _attribDefinitionsFactory(filter);
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            ResetAttributeDefinitions();
-        }
+    public AttributeDefinitions(IAttributeFilter attribFilter)
+    {
+        _attribFilter = attribFilter;
     }
 
-    public class AttributeDefinitions : IAttributeDefinitions
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _trxCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _spanCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _errorCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _customEventCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestParameterAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestHeadersAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _lambdaAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _faasAttributes = new();
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _cloudSdkAttributes = new();
+
+    private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _spanAgentAttributes = new();
+
+
+    private readonly ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>> _typeAttributes = new ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>>();
+
+
+    private AttributeDefinition<object, object> CreateCustomAttributeForTransaction(string name)
     {
-        private readonly IAttributeFilter _attribFilter;
+        return AttributeDefinitionBuilder
+            .CreateCustomAttribute(name, AttributeDestinations.All)
+            .Build(_attribFilter);
+    }
 
-        public AttributeDefinitions(IAttributeFilter attribFilter)
+    private AttributeDefinition<object, object> CreateCustomAttributeForCustomEvent(string name)
+    {
+        return AttributeDefinitionBuilder
+            .CreateCustomAttribute(name, AttributeDestinations.CustomEvent)
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<object, object> CreateCustomAttributeForError(string name)
+    {
+        return AttributeDefinitionBuilder
+            .CreateCustomAttribute(name, AttributeDestinations.ErrorEvent | AttributeDestinations.ErrorTrace)
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<object, object> CreateCustomAttributeForSpan(string name)
+    {
+        return AttributeDefinitionBuilder
+            .CreateCustomAttribute(name, AttributeDestinations.SpanEvent)
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<object, object> CreateAgentAttributeForSpan(string name)
+    {
+        return AttributeDefinitionBuilder
+            .CreateAgentAttribute(name, AttributeDestinations.SpanEvent)
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<string, string> CreateRequestParameterAttribute(string paramName)
+    {
+        var attribName = $"request.parameters.{paramName}";
+
+        return AttributeDefinitionBuilder
+            .CreateString(attribName, AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
+            .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
+            .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
+            .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
+            .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<string, string> CreateRequestHeadersAttribute(string paramName)
+    {
+        var attribName = $"request.headers.{paramName}";
+
+        return AttributeDefinitionBuilder
+            .CreateString(attribName, AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
+            .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
+            .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
+            .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
+            .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
+            .Build(_attribFilter);
+    }
+
+    private AttributeDefinition<object, object> CreateLambdaAttribute(string attribName)
+    {
+        return AttributeDefinitionBuilder
+            .Create<object, object>(attribName, AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter);
+    }
+
+    public AttributeDefinition<object, object> GetLambdaAttribute(string name)
+    {
+        return _lambdaAttributes.GetOrAdd(name, CreateLambdaAttribute);
+    }
+
+    private AttributeDefinition<object, object> CreateFaasAttribute(string attribName)
+    {
+        return AttributeDefinitionBuilder
+            .Create<object, object>(attribName, AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter);
+    }
+
+    public AttributeDefinition<object, object> GetFaasAttribute(string name)
+    {
+        return _faasAttributes.GetOrAdd(name, CreateFaasAttribute);
+    }
+
+
+    private AttributeDefinition<object, object> CreateCloudSdkAttribute(string attribName)
+    {
+        return AttributeDefinitionBuilder
+            .Create<object, object>(attribName, AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert(x => x)
+            .Build(_attribFilter);
+    }
+
+    public AttributeDefinition<object, object> GetCloudSdkAttribute(string name)
+    {
+        return _cloudSdkAttributes.GetOrAdd(name, CreateCloudSdkAttribute);
+    }
+    public AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name)
+    {
+        return _trxCustomAttributes.GetOrAdd(name, CreateCustomAttributeForTransaction);
+    }
+
+    public AttributeDefinition<object, object> GetCustomAttributeForCustomEvent(string name)
+    {
+        return _customEventCustomAttributes.GetOrAdd(name, CreateCustomAttributeForCustomEvent);
+    }
+
+    public AttributeDefinition<object, object> GetCustomAttributeForError(string name)
+    {
+        return _errorCustomAttributes.GetOrAdd(name, CreateCustomAttributeForError);
+    }
+
+    public AttributeDefinition<object, object> GetCustomAttributeForSpan(string name)
+    {
+        return _spanCustomAttributes.GetOrAdd(name, CreateCustomAttributeForSpan);
+    }
+
+    public AttributeDefinition<object, object> GetAgentAttributeForSpan(string name)
+    {
+        return _spanAgentAttributes.GetOrAdd(name, CreateAgentAttributeForSpan);
+    }
+
+    public AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName)
+    {
+        return _requestParameterAttributes.GetOrAdd(paramName, CreateRequestParameterAttribute);
+    }
+
+    public AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName)
+    {
+        return _requestHeadersAttributes.GetOrAdd(paramName, CreateRequestHeadersAttribute);
+    }
+
+    private AttributeDefinition<TypeAttributeValue, string> CreateTypeAttribute(TypeAttributeValue tm)
+    {
+        var val = EnumNameCache<TypeAttributeValue>.GetName(tm);
+
+        var dest = AttributeDestinations.None;
+        switch (tm)
         {
-            _attribFilter = attribFilter;
+            case TypeAttributeValue.Transaction:
+                dest = AttributeDestinations.TransactionEvent;
+                break;
+
+            case TypeAttributeValue.TransactionError:
+                dest = AttributeDestinations.ErrorEvent;
+                break;
+
+            case TypeAttributeValue.Span:
+            case TypeAttributeValue.SpanLink:
+            case TypeAttributeValue.SpanEvent:
+                dest = AttributeDestinations.SpanEvent;
+                break;
         }
 
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _trxCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _spanCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _errorCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _customEventCustomAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestParameterAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<string, string>> _requestHeadersAttributes = new ConcurrentDictionary<string, AttributeDefinition<string, string>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _lambdaAttributes = new ConcurrentDictionary<string, AttributeDefinition<object, object>>();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _faasAttributes = new();
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _cloudSdkAttributes = new();
+        return AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
+            .AppliesTo(dest)
+            .WithDefaultOutputValue(val)
+            .WithConvert((target) => val)
+            .Build(_attribFilter);
+    }
 
-        private readonly ConcurrentDictionary<string, AttributeDefinition<object, object>> _spanAgentAttributes = new();
+    public AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue targetModel)
+    {
+        return _typeAttributes.GetOrAdd(targetModel, CreateTypeAttribute);
+    }
 
+    private AttributeDefinition<TimeSpan?, string> _queueWaitTime;
+    public AttributeDefinition<TimeSpan?, string> QueueWaitTime => _queueWaitTime ?? (_queueWaitTime =
+        AttributeDefinitionBuilder.CreateString<TimeSpan?>("queue_wait_time_ms", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((v) => v.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture))
+            .Build(_attribFilter));
 
-        private readonly ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>> _typeAttributes = new ConcurrentDictionary<TypeAttributeValue, AttributeDefinition<TypeAttributeValue, string>>();
+    private AttributeDefinition<TimeSpan?, double> _queueDuration;
+    public AttributeDefinition<TimeSpan?, double> QueueDuration => _queueDuration ?? (_queueDuration =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan?>("queueDuration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((v) => v.Value.TotalSeconds)
+            .Build(_attribFilter));
 
+    private AttributeDefinition<string, string> _originalUrl;
+    public AttributeDefinition<string, string> OriginalUrl => _originalUrl ?? (_originalUrl =
+        AttributeDefinitionBuilder.CreateString("original_url", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.JavaScriptAgent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateCustomAttributeForTransaction(string name)
-        {
-            return AttributeDefinitionBuilder
-                .CreateCustomAttribute(name, AttributeDestinations.All)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _requestMethod;
+    public AttributeDefinition<string, string> RequestMethod => _requestMethod ?? (_requestMethod =
+        AttributeDefinitionBuilder.CreateString("request.method", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateCustomAttributeForCustomEvent(string name)
-        {
-            return AttributeDefinitionBuilder
-                .CreateCustomAttribute(name, AttributeDestinations.CustomEvent)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _requestUri;
+    public AttributeDefinition<string, string> RequestUri => _requestUri ?? (_requestUri =
+        AttributeDefinitionBuilder.CreateString("request.uri", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .WithDefaultOutputValue("/unknown")
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateCustomAttributeForError(string name)
-        {
-            return AttributeDefinitionBuilder
-                .CreateCustomAttribute(name, AttributeDestinations.ErrorEvent | AttributeDestinations.ErrorTrace)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _requestReferrer;
+    public AttributeDefinition<string, string> RequestReferrer => _requestReferrer ?? (_requestReferrer =
+        AttributeDefinitionBuilder.CreateString("request.referer", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateCustomAttributeForSpan(string name)
-        {
-            return AttributeDefinitionBuilder
-                .CreateCustomAttribute(name, AttributeDestinations.SpanEvent)
-                .Build(_attribFilter);
-        }
+    [ToBeRemovedInFutureRelease("To be removed v9+. Use BuildHttpStatusCodeAttribute instead.")]
+    private AttributeDefinition<int?, string> _responseStatus;
+    public AttributeDefinition<int?, string> ResponseStatus => _responseStatus ?? (_responseStatus =
+        AttributeDefinitionBuilder.CreateString<int?>("response.status", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .WithConvert(x => x.ToString())
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateAgentAttributeForSpan(string name)
-        {
-            return AttributeDefinitionBuilder
-                .CreateAgentAttribute(name, AttributeDestinations.SpanEvent)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<long?, long> _httpStatusCode;
+    public AttributeDefinition<long?, long> HttpStatusCode => _httpStatusCode ?? (_httpStatusCode =
+        AttributeDefinitionBuilder.CreateLong<long?>("http.statusCode", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .WithConvert(x => x.GetValueOrDefault())                //This is ok b/c we check for null input earlier
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> CreateRequestParameterAttribute(string paramName)
-        {
-            var attribName = $"request.parameters.{paramName}";
+    private AttributeDefinition<string, string> _httpStatusText;
+    public AttributeDefinition<string, string> HttpStatusText => _httpStatusText ??=
+        AttributeDefinitionBuilder.CreateString("http.statusText", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter);
 
-            return AttributeDefinitionBuilder
-                .CreateString(attribName, AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
-                .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
-                .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
-                .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
-                .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _clientCrossProcessId;
+    public AttributeDefinition<string, string> ClientCrossProcessId => _clientCrossProcessId ?? (_clientCrossProcessId =
+        AttributeDefinitionBuilder.CreateString("client_cross_process_id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> CreateRequestHeadersAttribute(string paramName)
-        {
-            var attribName = $"request.headers.{paramName}";
+    private AttributeDefinition<string, string> _tripId;        //TripUnderscoreId				
+    public AttributeDefinition<string, string> TripId => _tripId ?? (_tripId =
+        AttributeDefinitionBuilder.CreateString("trip_id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-            return AttributeDefinitionBuilder
-                .CreateString(attribName, AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionEvent))
-                .AppliesTo(AttributeDestinations.TransactionTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.TransactionTrace))
-                .AppliesTo(AttributeDestinations.ErrorTrace, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorTrace))
-                .AppliesTo(AttributeDestinations.ErrorEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.ErrorEvent))
-                .AppliesTo(AttributeDestinations.SpanEvent, _attribFilter.CheckOrAddAttributeClusionCache(attribName, AttributeDestinations.None, AttributeDestinations.SpanEvent))
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _catNrTripId;
+    public AttributeDefinition<string, string> CatNrTripId => _catNrTripId ?? (_catNrTripId =
+        AttributeDefinitionBuilder.CreateString("nr.tripId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateLambdaAttribute(string attribName)
-        {
-            return AttributeDefinitionBuilder
-                .Create<object, object>(attribName, AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _browserTripId;
+    public AttributeDefinition<string, string> BrowserTripId => _browserTripId ?? (_browserTripId =
+        AttributeDefinitionBuilder.CreateString("nr.tripId", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.JavaScriptAgent)
+            .Build(_attribFilter));
 
-        public AttributeDefinition<object, object> GetLambdaAttribute(string name)
-        {
-            return _lambdaAttributes.GetOrAdd(name, CreateLambdaAttribute);
-        }
+    private AttributeDefinition<string, string> _catPathHash;
+    public AttributeDefinition<string, string> CatPathHash => _catPathHash ?? (_catPathHash =
+        AttributeDefinitionBuilder.CreateString("path_hash", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateFaasAttribute(string attribName)
-        {
-            return AttributeDefinitionBuilder
-                .Create<object, object>(attribName, AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _catNrPathHash;
+    public AttributeDefinition<string, string> CatNrPathHash => _catNrPathHash ?? (_catNrPathHash =
+        AttributeDefinitionBuilder.CreateString("nr.pathHash", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        public AttributeDefinition<object, object> GetFaasAttribute(string name)
-        {
-            return _faasAttributes.GetOrAdd(name, CreateFaasAttribute);
-        }
+    private AttributeDefinition<string, string> _catReferringPathHash;
+    public AttributeDefinition<string, string> CatReferringPathHash => _catReferringPathHash ?? (_catReferringPathHash =
+        AttributeDefinitionBuilder.CreateString("nr.referringPathHash", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
+    private AttributeDefinition<string, string> _catReferringTransactionGuidForTraces;
+    public AttributeDefinition<string, string> CatReferringTransactionGuidForTraces => _catReferringTransactionGuidForTraces ?? (_catReferringTransactionGuidForTraces =
+        AttributeDefinitionBuilder.CreateString("referring_transaction_guid", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<object, object> CreateCloudSdkAttribute(string attribName)
-        {
-            return AttributeDefinitionBuilder
-                .Create<object, object>(attribName, AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert(x => x)
-                .Build(_attribFilter);
-        }
+    private AttributeDefinition<string, string> _catReferringTransactionGuidForEvents;
+    public AttributeDefinition<string, string> CatReferringTransactionGuidForEvents => _catReferringTransactionGuidForEvents ?? (_catReferringTransactionGuidForEvents =
+        AttributeDefinitionBuilder.CreateString("nr.referringTransactionGuid", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        public AttributeDefinition<object, object> GetCloudSdkAttribute(string name)
-        {
-            return _cloudSdkAttributes.GetOrAdd(name, CreateCloudSdkAttribute);
-        }
-        public AttributeDefinition<object, object> GetCustomAttributeForTransaction(string name)
-        {
-            return _trxCustomAttributes.GetOrAdd(name, CreateCustomAttributeForTransaction);
-        }
-
-        public AttributeDefinition<object, object> GetCustomAttributeForCustomEvent(string name)
-        {
-            return _customEventCustomAttributes.GetOrAdd(name, CreateCustomAttributeForCustomEvent);
-        }
-
-        public AttributeDefinition<object, object> GetCustomAttributeForError(string name)
-        {
-            return _errorCustomAttributes.GetOrAdd(name, CreateCustomAttributeForError);
-        }
-
-        public AttributeDefinition<object, object> GetCustomAttributeForSpan(string name)
-        {
-            return _spanCustomAttributes.GetOrAdd(name, CreateCustomAttributeForSpan);
-        }
-
-        public AttributeDefinition<object, object> GetAgentAttributeForSpan(string name)
-        {
-            return _spanAgentAttributes.GetOrAdd(name, CreateAgentAttributeForSpan);
-        }
-
-        public AttributeDefinition<string, string> GetRequestParameterAttribute(string paramName)
-        {
-            return _requestParameterAttributes.GetOrAdd(paramName, CreateRequestParameterAttribute);
-        }
-
-        public AttributeDefinition<string, string> GetRequestHeadersAttribute(string paramName)
-        {
-            return _requestHeadersAttributes.GetOrAdd(paramName, CreateRequestHeadersAttribute);
-        }
-
-        private AttributeDefinition<TypeAttributeValue, string> CreateTypeAttribute(TypeAttributeValue tm)
-        {
-            var val = EnumNameCache<TypeAttributeValue>.GetName(tm);
-
-            var dest = AttributeDestinations.None;
-            switch (tm)
+    private AttributeDefinition<IEnumerable<string>, string> _catAlternativePathHashes;
+    public AttributeDefinition<IEnumerable<string>, string> CatAlternativePathHashes => _catAlternativePathHashes ?? (_catAlternativePathHashes =
+        AttributeDefinitionBuilder.CreateString<IEnumerable<string>>("nr.alternatePathHashes", AttributeClassification.Intrinsics)
+            .WithConvert((hashes) =>
             {
-                case TypeAttributeValue.Transaction:
-                    dest = AttributeDestinations.TransactionEvent;
-                    break;
-
-                case TypeAttributeValue.TransactionError:
-                    dest = AttributeDestinations.ErrorEvent;
-                    break;
-
-                case TypeAttributeValue.Span:
-                case TypeAttributeValue.SpanLink:
-                case TypeAttributeValue.SpanEvent:
-                    dest = AttributeDestinations.SpanEvent;
-                    break;
-            }
-
-            return AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
-                .AppliesTo(dest)
-                .WithDefaultOutputValue(val)
-                .WithConvert((target) => val)
-                .Build(_attribFilter);
-        }
-
-        public AttributeDefinition<TypeAttributeValue, string> GetTypeAttribute(TypeAttributeValue targetModel)
-        {
-            return _typeAttributes.GetOrAdd(targetModel, CreateTypeAttribute);
-        }
-
-        private AttributeDefinition<TimeSpan?, string> _queueWaitTime;
-        public AttributeDefinition<TimeSpan?, string> QueueWaitTime => _queueWaitTime ?? (_queueWaitTime =
-            AttributeDefinitionBuilder.CreateString<TimeSpan?>("queue_wait_time_ms", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((v) => v.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan?, double> _queueDuration;
-        public AttributeDefinition<TimeSpan?, double> QueueDuration => _queueDuration ?? (_queueDuration =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan?>("queueDuration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((v) => v.Value.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _originalUrl;
-        public AttributeDefinition<string, string> OriginalUrl => _originalUrl ?? (_originalUrl =
-            AttributeDefinitionBuilder.CreateString("original_url", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.JavaScriptAgent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _requestMethod;
-        public AttributeDefinition<string, string> RequestMethod => _requestMethod ?? (_requestMethod =
-            AttributeDefinitionBuilder.CreateString("request.method", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _requestUri;
-        public AttributeDefinition<string, string> RequestUri => _requestUri ?? (_requestUri =
-            AttributeDefinitionBuilder.CreateString("request.uri", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .WithDefaultOutputValue("/unknown")
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _requestReferrer;
-        public AttributeDefinition<string, string> RequestReferrer => _requestReferrer ?? (_requestReferrer =
-            AttributeDefinitionBuilder.CreateString("request.referer", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        [ToBeRemovedInFutureRelease("To be removed v9+. Use BuildHttpStatusCodeAttribute instead.")]
-        private AttributeDefinition<int?, string> _responseStatus;
-        public AttributeDefinition<int?, string> ResponseStatus => _responseStatus ?? (_responseStatus =
-            AttributeDefinitionBuilder.CreateString<int?>("response.status", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .WithConvert(x => x.ToString())
-                .Build(_attribFilter));
-
-        private AttributeDefinition<long?, long> _httpStatusCode;
-        public AttributeDefinition<long?, long> HttpStatusCode => _httpStatusCode ?? (_httpStatusCode =
-            AttributeDefinitionBuilder.CreateLong<long?>("http.statusCode", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .WithConvert(x => x.GetValueOrDefault())                //This is ok b/c we check for null input earlier
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _httpStatusText;
-        public AttributeDefinition<string, string> HttpStatusText => _httpStatusText ??=
-            AttributeDefinitionBuilder.CreateString("http.statusText", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter);
-
-        private AttributeDefinition<string, string> _clientCrossProcessId;
-        public AttributeDefinition<string, string> ClientCrossProcessId => _clientCrossProcessId ?? (_clientCrossProcessId =
-            AttributeDefinitionBuilder.CreateString("client_cross_process_id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _tripId;        //TripUnderscoreId				
-        public AttributeDefinition<string, string> TripId => _tripId ?? (_tripId =
-            AttributeDefinitionBuilder.CreateString("trip_id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catNrTripId;
-        public AttributeDefinition<string, string> CatNrTripId => _catNrTripId ?? (_catNrTripId =
-            AttributeDefinitionBuilder.CreateString("nr.tripId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _browserTripId;
-        public AttributeDefinition<string, string> BrowserTripId => _browserTripId ?? (_browserTripId =
-            AttributeDefinitionBuilder.CreateString("nr.tripId", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.JavaScriptAgent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catPathHash;
-        public AttributeDefinition<string, string> CatPathHash => _catPathHash ?? (_catPathHash =
-            AttributeDefinitionBuilder.CreateString("path_hash", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catNrPathHash;
-        public AttributeDefinition<string, string> CatNrPathHash => _catNrPathHash ?? (_catNrPathHash =
-            AttributeDefinitionBuilder.CreateString("nr.pathHash", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catReferringPathHash;
-        public AttributeDefinition<string, string> CatReferringPathHash => _catReferringPathHash ?? (_catReferringPathHash =
-            AttributeDefinitionBuilder.CreateString("nr.referringPathHash", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catReferringTransactionGuidForTraces;
-        public AttributeDefinition<string, string> CatReferringTransactionGuidForTraces => _catReferringTransactionGuidForTraces ?? (_catReferringTransactionGuidForTraces =
-            AttributeDefinitionBuilder.CreateString("referring_transaction_guid", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _catReferringTransactionGuidForEvents;
-        public AttributeDefinition<string, string> CatReferringTransactionGuidForEvents => _catReferringTransactionGuidForEvents ?? (_catReferringTransactionGuidForEvents =
-            AttributeDefinitionBuilder.CreateString("nr.referringTransactionGuid", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<IEnumerable<string>, string> _catAlternativePathHashes;
-        public AttributeDefinition<IEnumerable<string>, string> CatAlternativePathHashes => _catAlternativePathHashes ?? (_catAlternativePathHashes =
-            AttributeDefinitionBuilder.CreateString<IEnumerable<string>>("nr.alternatePathHashes", AttributeClassification.Intrinsics)
-                .WithConvert((hashes) =>
+                if (hashes == null)
                 {
-                    if (hashes == null)
-                    {
-                        return null;
-                    }
+                    return null;
+                }
 
-                    var hashesArray = hashes.OrderBy(x => x).ToArray();
-                    if (hashesArray.Length == 0)
-                    {
-                        return null;
-                    }
+                var hashesArray = hashes.OrderBy(x => x).ToArray();
+                if (hashesArray.Length == 0)
+                {
+                    return null;
+                }
 
-                    return string.Join(",", hashesArray);
+                return string.Join(",", hashesArray);
 
-                })
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
+            })
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _transactionId;
-        public AttributeDefinition<string, string> TransactionId => _transactionId ?? (_transactionId =
-            AttributeDefinitionBuilder.CreateString("transactionId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _transactionId;
+    public AttributeDefinition<string, string> TransactionId => _transactionId ?? (_transactionId =
+        AttributeDefinitionBuilder.CreateString("transactionId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _nameForSpan;
-        public AttributeDefinition<string, string> NameForSpan => _nameForSpan ?? (_nameForSpan =
-            AttributeDefinitionBuilder.CreateString("name", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _nameForSpan;
+    public AttributeDefinition<string, string> NameForSpan => _nameForSpan ?? (_nameForSpan =
+        AttributeDefinitionBuilder.CreateString("name", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<SpanCategory, string> _spanCategory;
-        public AttributeDefinition<SpanCategory, string> SpanCategory => _spanCategory ?? (_spanCategory =
-            AttributeDefinitionBuilder.CreateString<SpanCategory>("category", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert(v => EnumNameCache<SpanCategory>.GetNameToLower(v))
-                .Build(_attribFilter));
+    private AttributeDefinition<SpanCategory, string> _spanCategory;
+    public AttributeDefinition<SpanCategory, string> SpanCategory => _spanCategory ?? (_spanCategory =
+        AttributeDefinitionBuilder.CreateString<SpanCategory>("category", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert(v => EnumNameCache<SpanCategory>.GetNameToLower(v))
+            .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _nrEntryPoint;
-        public AttributeDefinition<bool, bool> NrEntryPoint => _nrEntryPoint ?? (_nrEntryPoint =
-            AttributeDefinitionBuilder.CreateBool("nr.entryPoint", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _nrEntryPoint;
+    public AttributeDefinition<bool, bool> NrEntryPoint => _nrEntryPoint ?? (_nrEntryPoint =
+        AttributeDefinitionBuilder.CreateBool("nr.entryPoint", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<long, long> _threadId;
-        public AttributeDefinition<long, long> ThreadId => _threadId ?? (_threadId =
-            AttributeDefinitionBuilder.CreateLong("thread.id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<long, long> _threadId;
+    public AttributeDefinition<long, long> ThreadId => _threadId ?? (_threadId =
+        AttributeDefinitionBuilder.CreateLong("thread.id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _component;
-        public AttributeDefinition<string, string> Component => _component ?? (_component =
-            AttributeDefinitionBuilder.CreateString("component", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _component;
+    public AttributeDefinition<string, string> Component => _component ?? (_component =
+        AttributeDefinitionBuilder.CreateString("component", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanKind;
-        public AttributeDefinition<string, string> SpanKind => _spanKind ?? (_spanKind =
-            AttributeDefinitionBuilder.CreateString("span.kind", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithDefaultOutputValue("client")
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanKind;
+    public AttributeDefinition<string, string> SpanKind => _spanKind ?? (_spanKind =
+        AttributeDefinitionBuilder.CreateString("span.kind", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithDefaultOutputValue("client")
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanErrorClass;
-        public AttributeDefinition<string, string> SpanErrorClass => _spanErrorClass ?? (_spanErrorClass =
-            AttributeDefinitionBuilder.CreateString("error.class", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanErrorClass;
+    public AttributeDefinition<string, string> SpanErrorClass => _spanErrorClass ?? (_spanErrorClass =
+        AttributeDefinitionBuilder.CreateString("error.class", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanErrorMessage;
-        public AttributeDefinition<string, string> SpanErrorMessage => _spanErrorMessage ?? (_spanErrorMessage =
-            AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanErrorMessage;
+    public AttributeDefinition<string, string> SpanErrorMessage => _spanErrorMessage ?? (_spanErrorMessage =
+        AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanId;
-        public AttributeDefinition<string, string> SpanId => _spanId ?? (_spanId =
-            AttributeDefinitionBuilder.CreateString("spanId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanId;
+    public AttributeDefinition<string, string> SpanId => _spanId ?? (_spanId =
+        AttributeDefinitionBuilder.CreateString("spanId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbStatement;
-        public AttributeDefinition<string, string> DbStatement => _dbStatement ?? (_dbStatement =
-            AttributeDefinitionBuilder.CreateDBStatement("db.statement", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbStatement;
+    public AttributeDefinition<string, string> DbStatement => _dbStatement ?? (_dbStatement =
+        AttributeDefinitionBuilder.CreateDBStatement("db.statement", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbSystem;
-        public AttributeDefinition<string, string> DbSystem => _dbSystem ?? (_dbSystem =
-            AttributeDefinitionBuilder.CreateString("db.system", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbSystem;
+    public AttributeDefinition<string, string> DbSystem => _dbSystem ?? (_dbSystem =
+        AttributeDefinitionBuilder.CreateString("db.system", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbOperation;
-        public AttributeDefinition<string, string> DbOperation => _dbOperation ?? (_dbOperation =
-            AttributeDefinitionBuilder.CreateString("db.operation", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbOperation;
+    public AttributeDefinition<string, string> DbOperation => _dbOperation ?? (_dbOperation =
+        AttributeDefinitionBuilder.CreateString("db.operation", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbCollection;
-        public AttributeDefinition<string, string> DbCollection => _dbCollection ?? (_dbCollection =
-            AttributeDefinitionBuilder.CreateString("db.collection", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbCollection;
+    public AttributeDefinition<string, string> DbCollection => _dbCollection ?? (_dbCollection =
+        AttributeDefinitionBuilder.CreateString("db.collection", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbInstance;
-        public AttributeDefinition<string, string> DbInstance => _dbInstance ?? (_dbInstance =
-            AttributeDefinitionBuilder.CreateString("db.instance", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbInstance;
+    public AttributeDefinition<string, string> DbInstance => _dbInstance ?? (_dbInstance =
+        AttributeDefinitionBuilder.CreateString("db.instance", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _peerAddress;
-        public AttributeDefinition<string, string> PeerAddress => _peerAddress ?? (_peerAddress =
-            AttributeDefinitionBuilder.CreateString("peer.address", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _peerAddress;
+    public AttributeDefinition<string, string> PeerAddress => _peerAddress ?? (_peerAddress =
+        AttributeDefinitionBuilder.CreateString("peer.address", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _peerHostname;
-        public AttributeDefinition<string, string> PeerHostname => _peerHostname ?? (_peerHostname =
-            AttributeDefinitionBuilder.CreateString("peer.hostname", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _peerHostname;
+    public AttributeDefinition<string, string> PeerHostname => _peerHostname ?? (_peerHostname =
+        AttributeDefinitionBuilder.CreateString("peer.hostname", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<Uri, string> _httpUrl;
-        public AttributeDefinition<Uri, string> HttpUrl => _httpUrl ?? (_httpUrl =
-            AttributeDefinitionBuilder.CreateString<Uri>("http.url", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert((v) => StringsHelper.CleanUri(v))
-                .Build(_attribFilter));
+    private AttributeDefinition<Uri, string> _httpUrl;
+    public AttributeDefinition<Uri, string> HttpUrl => _httpUrl ?? (_httpUrl =
+        AttributeDefinitionBuilder.CreateString<Uri>("http.url", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert((v) => StringsHelper.CleanUri(v))
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _httpMethod;
-        public AttributeDefinition<string, string> HttpMethod => _httpMethod ?? (_httpMethod =
-            AttributeDefinitionBuilder.CreateString("http.request.method", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _httpMethod;
+    public AttributeDefinition<string, string> HttpMethod => _httpMethod ?? (_httpMethod =
+        AttributeDefinitionBuilder.CreateString("http.request.method", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _serverAddress;
-        public AttributeDefinition<string, string> ServerAddress => _serverAddress ?? (_serverAddress =
-            AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _serverAddress;
+    public AttributeDefinition<string, string> ServerAddress => _serverAddress ?? (_serverAddress =
+        AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<long, long> _serverPort;
-        public AttributeDefinition<long, long> ServerPort => _serverPort ?? (_serverPort =
-            AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<long, long> _serverPort;
+    public AttributeDefinition<long, long> ServerPort => _serverPort ?? (_serverPort =
+        AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _dbServerAddress;
-        public AttributeDefinition<string, string> DbServerAddress => _dbServerAddress ?? (_dbServerAddress =
-            AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _dbServerAddress;
+    public AttributeDefinition<string, string> DbServerAddress => _dbServerAddress ?? (_dbServerAddress =
+        AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<long, long> _dbServerPort;
-        public AttributeDefinition<long, long> DbServerPort => _dbServerPort ?? (_dbServerPort =
-            AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<long, long> _dbServerPort;
+    public AttributeDefinition<long, long> DbServerPort => _dbServerPort ?? (_dbServerPort =
+        AttributeDefinitionBuilder.CreateLong("server.port", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _errorEventSpanId;
-        public AttributeDefinition<string, string> ErrorEventSpanId => _errorEventSpanId ?? (_errorEventSpanId =
-           AttributeDefinitionBuilder.CreateString("spanId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _errorEventSpanId;
+    public AttributeDefinition<string, string> ErrorEventSpanId => _errorEventSpanId ?? (_errorEventSpanId =
+        AttributeDefinitionBuilder.CreateString("spanId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _errorType;
-        public AttributeDefinition<string, string> ErrorType => _errorType ?? (_errorType =
-            AttributeDefinitionBuilder.CreateString("errorType", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _errorType;
+    public AttributeDefinition<string, string> ErrorType => _errorType ?? (_errorType =
+        AttributeDefinitionBuilder.CreateString("errorType", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _errorMessage;
-        public AttributeDefinition<string, string> ErrorMessage => _errorMessage ?? (_errorMessage =
-            AttributeDefinitionBuilder.CreateString("errorMessage", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _errorMessage;
+    public AttributeDefinition<string, string> ErrorMessage => _errorMessage ?? (_errorMessage =
+        AttributeDefinitionBuilder.CreateString("errorMessage", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _isError;       //Error Attribute
-        public AttributeDefinition<bool, bool> IsError => _isError ?? (_isError =
-            AttributeDefinitionBuilder.CreateBool("error", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _isError;       //Error Attribute
+    public AttributeDefinition<bool, bool> IsError => _isError ?? (_isError =
+        AttributeDefinitionBuilder.CreateBool("error", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _isErrorExpected;
-        public AttributeDefinition<bool, bool> IsErrorExpected => _isErrorExpected ?? (_isErrorExpected =
-            AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorTrace, AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _isErrorExpected;
+    public AttributeDefinition<bool, bool> IsErrorExpected => _isErrorExpected ?? (_isErrorExpected =
+        AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorTrace, AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _spanIsErrorExpected;
-        public AttributeDefinition<bool, bool> SpanIsErrorExpected => _spanIsErrorExpected ?? (_spanIsErrorExpected =
-            AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _spanIsErrorExpected;
+    public AttributeDefinition<bool, bool> SpanIsErrorExpected => _spanIsErrorExpected ?? (_spanIsErrorExpected =
+        AttributeDefinitionBuilder.CreateBool("error.expected", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _errorGroup;
-        public AttributeDefinition<string, string> ErrorGroup => _errorGroup ?? (_errorGroup =
-            AttributeDefinitionBuilder.CreateString("error.group.name", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace)
-                .WithConvert(IgnoreEmptyAndWhitespaceErrorGroupValues)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _errorGroup;
+    public AttributeDefinition<string, string> ErrorGroup => _errorGroup ?? (_errorGroup =
+        AttributeDefinitionBuilder.CreateString("error.group.name", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace)
+            .WithConvert(IgnoreEmptyAndWhitespaceErrorGroupValues)
+            .Build(_attribFilter));
 
-        private static string IgnoreEmptyAndWhitespaceErrorGroupValues(string errorGroupValue)
+    private static string IgnoreEmptyAndWhitespaceErrorGroupValues(string errorGroupValue)
+    {
+        if (!string.IsNullOrWhiteSpace(errorGroupValue))
         {
-            if (!string.IsNullOrWhiteSpace(errorGroupValue))
+            return errorGroupValue;
+        }
+
+        return null;
+    }
+
+    private AttributeDefinition<string, string> _endUserId;
+    public AttributeDefinition<string, string> EndUserId => _endUserId ?? (_endUserId =
+        AttributeDefinitionBuilder.CreateString("enduser.id", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace,
+                AttributeDestinations.TransactionTrace, AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<DateTime, long> _timestamp;
+    public AttributeDefinition<DateTime, long> Timestamp => _timestamp ?? (_timestamp =
+        AttributeDefinitionBuilder.CreateLong<DateTime>("timestamp", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.CustomEvent)
+            .WithDefaultInputValue(DateTime.UtcNow)
+            .WithConvert((v) => v.ToUnixTimeMilliseconds())
+            .Build(_attribFilter));
+
+    private AttributeDefinition<DateTime, long> _timestampForError;
+    public AttributeDefinition<DateTime, long> TimestampForError => _timestampForError ?? (_timestampForError =
+        AttributeDefinitionBuilder.CreateLong<DateTime>("timestamp", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((v) => v.ToUnixTimeMilliseconds())
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _transactionName;
+    public AttributeDefinition<string, string> TransactionName => _transactionName ?? (_transactionName =
+        AttributeDefinitionBuilder.CreateString("name", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _transactionNameForSpan;
+    public AttributeDefinition<string, string> TransactionNameForSpan => _transactionNameForSpan ?? (_transactionNameForSpan =
+        AttributeDefinitionBuilder.CreateString("transaction.name", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _transactionNameForError;       //Covers case for Custom Error				
+    public AttributeDefinition<string, string> TransactionNameForError => _transactionNameForError ?? (_transactionNameForError =
+        AttributeDefinitionBuilder.CreateString("transactionName", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _nrGuid;
+    public AttributeDefinition<string, string> NrGuid => _nrGuid ?? (_nrGuid =
+        AttributeDefinitionBuilder.CreateString("nr.guid", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _guid;
+    public AttributeDefinition<string, string> Guid => _guid ?? (_guid =
+        AttributeDefinitionBuilder.CreateString(AttributeDefinition.KeyName_Guid, AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsResourceId;
+    public AttributeDefinition<string, string> SyntheticsResourceId => _syntheticsResourceId ?? (_syntheticsResourceId =
+        AttributeDefinitionBuilder.CreateString("nr.syntheticsResourceId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsResourceIdForTraces;
+    public AttributeDefinition<string, string> SyntheticsResourceIdForTraces => _syntheticsResourceIdForTraces ?? (_syntheticsResourceIdForTraces =
+        AttributeDefinitionBuilder.CreateString("synthetics_resource_id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsJobId;
+    public AttributeDefinition<string, string> SyntheticsJobId => _syntheticsJobId ?? (_syntheticsJobId =
+        AttributeDefinitionBuilder.CreateString("nr.syntheticsJobId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsJobIdForTraces;
+    public AttributeDefinition<string, string> SyntheticsJobIdForTraces => _syntheticsJobIdForTraces ?? (_syntheticsJobIdForTraces =
+        AttributeDefinitionBuilder.CreateString("synthetics_job_id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsMonitorId;
+    public AttributeDefinition<string, string> SyntheticsMonitorId => _syntheticsMonitorId ?? (_syntheticsMonitorId =
+        AttributeDefinitionBuilder.CreateString("nr.syntheticsMonitorId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _syntheticsMonitorIdForTraces;
+    public AttributeDefinition<string, string> SyntheticsMonitorIdForTraces => _syntheticsMonitorIdForTraces ?? (_syntheticsMonitorIdForTraces =
+        AttributeDefinitionBuilder.CreateString("synthetics_monitor_id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _duration;
+    public AttributeDefinition<TimeSpan, double> Duration => _duration ?? (_duration =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("duration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _webDuration;
+    public AttributeDefinition<TimeSpan, double> WebDuration => _webDuration ?? (_webDuration =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("webDuration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _totalTime;
+    public AttributeDefinition<TimeSpan, double> TotalTime => _totalTime ?? (_totalTime =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("totalTime", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _cpuTime;
+    public AttributeDefinition<TimeSpan, double> CpuTime => _cpuTime ?? (_cpuTime =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("cpuTime", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _apdexPerfZone;
+    public AttributeDefinition<string, string> ApdexPerfZone => _apdexPerfZone ?? (_apdexPerfZone =
+        AttributeDefinitionBuilder.CreateString("nr.apdexPerfZone", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<float, double> _externalDuration;
+    public AttributeDefinition<float, double> ExternalDuration => _externalDuration ?? (_externalDuration =
+        AttributeDefinitionBuilder.CreateDouble<float>("externalDuration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert(x => x)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<float, double> _externalCallCount;
+    public AttributeDefinition<float, double> ExternalCallCount => _externalCallCount ?? (_externalCallCount =
+        AttributeDefinitionBuilder.CreateDouble<float>("externalCallCount", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert(x => x)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<float, double> _databaseDuration;
+    public AttributeDefinition<float, double> DatabaseDuration => _databaseDuration ?? (_databaseDuration =
+        AttributeDefinitionBuilder.CreateDouble<float>("databaseDuration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((v) => v)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<long, double> _databaseCallCount;
+    public AttributeDefinition<long, double> DatabaseCallCount => _databaseCallCount ?? (_databaseCallCount =
+        AttributeDefinitionBuilder.CreateDouble<long>("databaseCallCount", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert(x => x)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _errorClass;
+    public AttributeDefinition<string, string> ErrorClass => _errorClass ?? (_errorClass =
+        AttributeDefinitionBuilder.CreateString("error.class", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TypeAttributeValue, string> _type;
+    public AttributeDefinition<TypeAttributeValue, string> Type => _type ?? (_type =
+        AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _errorDotMessage;
+    public AttributeDefinition<string, string> ErrorDotMessage => _errorDotMessage ?? (_errorDotMessage =
+        AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TypeAttributeValue, string> _parentType;
+    public AttributeDefinition<TypeAttributeValue, string> ParentType => _parentType ?? (_parentType =
+        AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("parent.type", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TypeAttributeValue, string> _parentTypeForSpan;
+    public AttributeDefinition<TypeAttributeValue, string> ParentTypeForSpan => _parentTypeForSpan ?? (_parentTypeForSpan =
+        AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("parent.type", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<DistributedTracingParentType, string> _parentTypeForDistributedTracing;
+    public AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracing => _parentTypeForDistributedTracing ?? (_parentTypeForDistributedTracing =
+        AttributeDefinitionBuilder.CreateString<DistributedTracingParentType>("parent.type", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert(v => EnumNameCache<DistributedTracingParentType>.GetName(v))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<DistributedTracingParentType, string> _parentTypeForDistributedTracingForSpan;
+    public AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracingForSpan => _parentTypeForDistributedTracingForSpan ?? (_parentTypeForDistributedTracingForSpan =
+        AttributeDefinitionBuilder.CreateString<DistributedTracingParentType>("parent.type", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert(v => EnumNameCache<DistributedTracingParentType>.GetName(v))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentAccount;
+    public AttributeDefinition<string, string> ParentAccount => _parentAccount ?? (_parentAccount =
+        AttributeDefinitionBuilder.CreateString("parent.account", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentAccountForSpan;
+    public AttributeDefinition<string, string> ParentAccountForSpan => _parentAccountForSpan ?? (_parentAccountForSpan =
+        AttributeDefinitionBuilder.CreateString("parent.account", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentApp;
+    public AttributeDefinition<string, string> ParentApp => _parentApp ?? (_parentApp =
+        AttributeDefinitionBuilder.CreateString("parent.app", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentAppForSpan;
+    public AttributeDefinition<string, string> ParentAppForSpan => _parentAppForSpan ?? (_parentAppForSpan =
+        AttributeDefinitionBuilder.CreateString("parent.app", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TransportType, string> _parentTransportType;
+    public AttributeDefinition<TransportType, string> ParentTransportType => _parentTransportType ?? (_parentTransportType =
+        AttributeDefinitionBuilder.CreateString<TransportType>("parent.transportType", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((transportType) => EnumNameCache<TransportType>.GetName(transportType))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TransportType, string> _parentTransportTypeForSpan;
+    public AttributeDefinition<TransportType, string> ParentTransportTypeForSpan => _parentTransportTypeForSpan ?? (_parentTransportTypeForSpan =
+        AttributeDefinitionBuilder.CreateString<TransportType>("parent.transportType", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert((transportType) => EnumNameCache<TransportType>.GetName(transportType))
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _parentTransportDuration;
+    public AttributeDefinition<TimeSpan, double> ParentTransportDuration => _parentTransportDuration ?? (_parentTransportDuration =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("parent.transportDuration", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<TimeSpan, double> _parentTransportDurationForSpan;
+    public AttributeDefinition<TimeSpan, double> ParentTransportDurationForSpan => _parentTransportDurationForSpan ?? (_parentTransportDurationForSpan =
+        AttributeDefinitionBuilder.CreateDouble<TimeSpan>("parent.transportDuration", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert((v) => v.TotalSeconds)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentSpanId;
+    public AttributeDefinition<string, string> ParentSpanId => _parentSpanId ?? (_parentSpanId =
+        AttributeDefinitionBuilder.CreateString("parentSpanId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _parentId;
+    public AttributeDefinition<string, string> ParentId => _parentId ?? (_parentId =
+        AttributeDefinitionBuilder.CreateString("parentId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+    private AttributeDefinition<string, string> _trustedParentId;
+    public AttributeDefinition<string, string> TrustedParentId => _trustedParentId ?? (_trustedParentId =
+        AttributeDefinitionBuilder.CreateString("trustedParentId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
+
+
+    private AttributeDefinition<IEnumerable<string>, string> _tracingVendors;
+    public AttributeDefinition<IEnumerable<string>, string> TracingVendors => _tracingVendors ?? (_tracingVendors =
+        AttributeDefinitionBuilder.CreateString<IEnumerable<string>>("tracingVendors", AttributeClassification.Intrinsics)
+            .WithConvert((vendors) =>
             {
-                return errorGroupValue;
-            }
-
-            return null;
-        }
-
-        private AttributeDefinition<string, string> _endUserId;
-        public AttributeDefinition<string, string> EndUserId => _endUserId ?? (_endUserId =
-            AttributeDefinitionBuilder.CreateString("enduser.id", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.ErrorEvent, AttributeDestinations.ErrorTrace,
-                           AttributeDestinations.TransactionTrace, AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<DateTime, long> _timestamp;
-        public AttributeDefinition<DateTime, long> Timestamp => _timestamp ?? (_timestamp =
-            AttributeDefinitionBuilder.CreateLong<DateTime>("timestamp", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.CustomEvent)
-                .WithDefaultInputValue(DateTime.UtcNow)
-                .WithConvert((v) => v.ToUnixTimeMilliseconds())
-                .Build(_attribFilter));
-
-        private AttributeDefinition<DateTime, long> _timestampForError;
-        public AttributeDefinition<DateTime, long> TimestampForError => _timestampForError ?? (_timestampForError =
-            AttributeDefinitionBuilder.CreateLong<DateTime>("timestamp", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((v) => v.ToUnixTimeMilliseconds())
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _transactionName;
-        public AttributeDefinition<string, string> TransactionName => _transactionName ?? (_transactionName =
-            AttributeDefinitionBuilder.CreateString("name", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _transactionNameForSpan;
-        public AttributeDefinition<string, string> TransactionNameForSpan => _transactionNameForSpan ?? (_transactionNameForSpan =
-            AttributeDefinitionBuilder.CreateString("transaction.name", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _transactionNameForError;       //Covers case for Custom Error				
-        public AttributeDefinition<string, string> TransactionNameForError => _transactionNameForError ?? (_transactionNameForError =
-            AttributeDefinitionBuilder.CreateString("transactionName", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _nrGuid;
-        public AttributeDefinition<string, string> NrGuid => _nrGuid ?? (_nrGuid =
-            AttributeDefinitionBuilder.CreateString("nr.guid", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _guid;
-        public AttributeDefinition<string, string> Guid => _guid ?? (_guid =
-            AttributeDefinitionBuilder.CreateString(AttributeDefinition.KeyName_Guid, AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsResourceId;
-        public AttributeDefinition<string, string> SyntheticsResourceId => _syntheticsResourceId ?? (_syntheticsResourceId =
-            AttributeDefinitionBuilder.CreateString("nr.syntheticsResourceId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsResourceIdForTraces;
-        public AttributeDefinition<string, string> SyntheticsResourceIdForTraces => _syntheticsResourceIdForTraces ?? (_syntheticsResourceIdForTraces =
-            AttributeDefinitionBuilder.CreateString("synthetics_resource_id", AttributeClassification.Intrinsics)
-                    .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsJobId;
-        public AttributeDefinition<string, string> SyntheticsJobId => _syntheticsJobId ?? (_syntheticsJobId =
-            AttributeDefinitionBuilder.CreateString("nr.syntheticsJobId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsJobIdForTraces;
-        public AttributeDefinition<string, string> SyntheticsJobIdForTraces => _syntheticsJobIdForTraces ?? (_syntheticsJobIdForTraces =
-            AttributeDefinitionBuilder.CreateString("synthetics_job_id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsMonitorId;
-        public AttributeDefinition<string, string> SyntheticsMonitorId => _syntheticsMonitorId ?? (_syntheticsMonitorId =
-            AttributeDefinitionBuilder.CreateString("nr.syntheticsMonitorId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _syntheticsMonitorIdForTraces;
-        public AttributeDefinition<string, string> SyntheticsMonitorIdForTraces => _syntheticsMonitorIdForTraces ?? (_syntheticsMonitorIdForTraces =
-            AttributeDefinitionBuilder.CreateString("synthetics_monitor_id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _duration;
-        public AttributeDefinition<TimeSpan, double> Duration => _duration ?? (_duration =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("duration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _webDuration;
-        public AttributeDefinition<TimeSpan, double> WebDuration => _webDuration ?? (_webDuration =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("webDuration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _totalTime;
-        public AttributeDefinition<TimeSpan, double> TotalTime => _totalTime ?? (_totalTime =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("totalTime", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _cpuTime;
-        public AttributeDefinition<TimeSpan, double> CpuTime => _cpuTime ?? (_cpuTime =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("cpuTime", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _apdexPerfZone;
-        public AttributeDefinition<string, string> ApdexPerfZone => _apdexPerfZone ?? (_apdexPerfZone =
-            AttributeDefinitionBuilder.CreateString("nr.apdexPerfZone", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<float, double> _externalDuration;
-        public AttributeDefinition<float, double> ExternalDuration => _externalDuration ?? (_externalDuration =
-            AttributeDefinitionBuilder.CreateDouble<float>("externalDuration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert(x => x)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<float, double> _externalCallCount;
-        public AttributeDefinition<float, double> ExternalCallCount => _externalCallCount ?? (_externalCallCount =
-            AttributeDefinitionBuilder.CreateDouble<float>("externalCallCount", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert(x => x)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<float, double> _databaseDuration;
-        public AttributeDefinition<float, double> DatabaseDuration => _databaseDuration ?? (_databaseDuration =
-            AttributeDefinitionBuilder.CreateDouble<float>("databaseDuration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((v) => v)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<long, double> _databaseCallCount;
-        public AttributeDefinition<long, double> DatabaseCallCount => _databaseCallCount ?? (_databaseCallCount =
-            AttributeDefinitionBuilder.CreateDouble<long>("databaseCallCount", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert(x => x)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _errorClass;
-        public AttributeDefinition<string, string> ErrorClass => _errorClass ?? (_errorClass =
-            AttributeDefinitionBuilder.CreateString("error.class", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TypeAttributeValue, string> _type;
-        public AttributeDefinition<TypeAttributeValue, string> Type => _type ?? (_type =
-            AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("type", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _errorDotMessage;
-        public AttributeDefinition<string, string> ErrorDotMessage => _errorDotMessage ?? (_errorDotMessage =
-            AttributeDefinitionBuilder.CreateErrorMessage("error.message", AttributeClassification.Intrinsics)
-                    .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TypeAttributeValue, string> _parentType;
-        public AttributeDefinition<TypeAttributeValue, string> ParentType => _parentType ?? (_parentType =
-            AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("parent.type", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TypeAttributeValue, string> _parentTypeForSpan;
-        public AttributeDefinition<TypeAttributeValue, string> ParentTypeForSpan => _parentTypeForSpan ?? (_parentTypeForSpan =
-            AttributeDefinitionBuilder.CreateString<TypeAttributeValue>("parent.type", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert(v => EnumNameCache<TypeAttributeValue>.GetName(v))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<DistributedTracingParentType, string> _parentTypeForDistributedTracing;
-        public AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracing => _parentTypeForDistributedTracing ?? (_parentTypeForDistributedTracing =
-            AttributeDefinitionBuilder.CreateString<DistributedTracingParentType>("parent.type", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert(v => EnumNameCache<DistributedTracingParentType>.GetName(v))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<DistributedTracingParentType, string> _parentTypeForDistributedTracingForSpan;
-        public AttributeDefinition<DistributedTracingParentType, string> ParentTypeForDistributedTracingForSpan => _parentTypeForDistributedTracingForSpan ?? (_parentTypeForDistributedTracingForSpan =
-            AttributeDefinitionBuilder.CreateString<DistributedTracingParentType>("parent.type", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert(v => EnumNameCache<DistributedTracingParentType>.GetName(v))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentAccount;
-        public AttributeDefinition<string, string> ParentAccount => _parentAccount ?? (_parentAccount =
-            AttributeDefinitionBuilder.CreateString("parent.account", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentAccountForSpan;
-        public AttributeDefinition<string, string> ParentAccountForSpan => _parentAccountForSpan ?? (_parentAccountForSpan =
-            AttributeDefinitionBuilder.CreateString("parent.account", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentApp;
-        public AttributeDefinition<string, string> ParentApp => _parentApp ?? (_parentApp =
-            AttributeDefinitionBuilder.CreateString("parent.app", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentAppForSpan;
-        public AttributeDefinition<string, string> ParentAppForSpan => _parentAppForSpan ?? (_parentAppForSpan =
-            AttributeDefinitionBuilder.CreateString("parent.app", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TransportType, string> _parentTransportType;
-        public AttributeDefinition<TransportType, string> ParentTransportType => _parentTransportType ?? (_parentTransportType =
-            AttributeDefinitionBuilder.CreateString<TransportType>("parent.transportType", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((transportType) => EnumNameCache<TransportType>.GetName(transportType))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TransportType, string> _parentTransportTypeForSpan;
-        public AttributeDefinition<TransportType, string> ParentTransportTypeForSpan => _parentTransportTypeForSpan ?? (_parentTransportTypeForSpan =
-            AttributeDefinitionBuilder.CreateString<TransportType>("parent.transportType", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert((transportType) => EnumNameCache<TransportType>.GetName(transportType))
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _parentTransportDuration;
-        public AttributeDefinition<TimeSpan, double> ParentTransportDuration => _parentTransportDuration ?? (_parentTransportDuration =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("parent.transportDuration", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<TimeSpan, double> _parentTransportDurationForSpan;
-        public AttributeDefinition<TimeSpan, double> ParentTransportDurationForSpan => _parentTransportDurationForSpan ?? (_parentTransportDurationForSpan =
-            AttributeDefinitionBuilder.CreateDouble<TimeSpan>("parent.transportDuration", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert((v) => v.TotalSeconds)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentSpanId;
-        public AttributeDefinition<string, string> ParentSpanId => _parentSpanId ?? (_parentSpanId =
-            AttributeDefinitionBuilder.CreateString("parentSpanId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _parentId;
-        public AttributeDefinition<string, string> ParentId => _parentId ?? (_parentId =
-            AttributeDefinitionBuilder.CreateString("parentId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-        private AttributeDefinition<string, string> _trustedParentId;
-        public AttributeDefinition<string, string> TrustedParentId => _trustedParentId ?? (_trustedParentId =
-            AttributeDefinitionBuilder.CreateString("trustedParentId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-
-
-        private AttributeDefinition<IEnumerable<string>, string> _tracingVendors;
-        public AttributeDefinition<IEnumerable<string>, string> TracingVendors => _tracingVendors ?? (_tracingVendors =
-            AttributeDefinitionBuilder.CreateString<IEnumerable<string>>("tracingVendors", AttributeClassification.Intrinsics)
-                .WithConvert((vendors) =>
+                var vendorNames = vendors.Select(vse => vse.Split('=')[0]).ToList();
+                if (vendorNames.Count == 0)
                 {
-                    var vendorNames = vendors.Select(vse => vse.Split('=')[0]).ToList();
-                    if (vendorNames.Count == 0)
-                    {
-                        return null;
-                    }
+                    return null;
+                }
 
-                    return string.Join(",", vendorNames);
-                })
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+                return string.Join(",", vendorNames);
+            })
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _distributedTraceId;
-        public AttributeDefinition<string, string> DistributedTraceId => _distributedTraceId ?? (_distributedTraceId =
-            AttributeDefinitionBuilder.CreateString(AttributeDefinition.KeyName_TraceId, AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _distributedTraceId;
+    public AttributeDefinition<string, string> DistributedTraceId => _distributedTraceId ?? (_distributedTraceId =
+        AttributeDefinitionBuilder.CreateString(AttributeDefinition.KeyName_TraceId, AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        //This is defined as a float->object because the translation between float to double
-        //causes the value to be changed during the conversion.
-        private AttributeDefinition<float, double> _priority;
-        public AttributeDefinition<float, double> Priority => _priority ?? (_priority =
-            AttributeDefinitionBuilder.CreateDouble<float>("priority", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .WithConvert((f) => f)
-                .Build(_attribFilter));
+    //This is defined as a float->object because the translation between float to double
+    //causes the value to be changed during the conversion.
+    private AttributeDefinition<float, double> _priority;
+    public AttributeDefinition<float, double> Priority => _priority ?? (_priority =
+        AttributeDefinitionBuilder.CreateDouble<float>("priority", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .WithConvert((f) => f)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<bool, bool> _sampled;
-        public AttributeDefinition<bool, bool> Sampled => _sampled ?? (_sampled =
-            AttributeDefinitionBuilder.CreateBool("sampled", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.SqlTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _sampled;
+    public AttributeDefinition<bool, bool> Sampled => _sampled ?? (_sampled =
+        AttributeDefinitionBuilder.CreateBool("sampled", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.SqlTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _hostDisplayName;
-        public AttributeDefinition<string, string> HostDisplayName => _hostDisplayName ?? (_hostDisplayName =
-            AttributeDefinitionBuilder.CreateString("host.displayName", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .AppliesTo(AttributeDestinations.ErrorTrace)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.ErrorEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _hostDisplayName;
+    public AttributeDefinition<string, string> HostDisplayName => _hostDisplayName ?? (_hostDisplayName =
+        AttributeDefinitionBuilder.CreateString("host.displayName", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .AppliesTo(AttributeDestinations.ErrorTrace)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.ErrorEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _customEventType;
-        public AttributeDefinition<string, string> CustomEventType => _customEventType ?? (_customEventType =
-            AttributeDefinitionBuilder.CreateString("type", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.CustomEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _customEventType;
+    public AttributeDefinition<string, string> CustomEventType => _customEventType ?? (_customEventType =
+        AttributeDefinitionBuilder.CreateString("type", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.CustomEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _codeFunction;
-        public AttributeDefinition<string, string> CodeFunction => _codeFunction ?? (
-            _codeFunction = AttributeDefinitionBuilder.CreateString(
+    private AttributeDefinition<string, string> _codeFunction;
+    public AttributeDefinition<string, string> CodeFunction => _codeFunction ?? (
+        _codeFunction = AttributeDefinitionBuilder.CreateString(
                 "code.function",
                 AttributeClassification.AgentAttributes
             )
             .AppliesTo(AttributeDestinations.SpanEvent)
             .Build(_attribFilter)
-        );
+    );
 
-        private AttributeDefinition<string, string> _codeNamespace;
-        public AttributeDefinition<string, string> CodeNamespace => _codeNamespace ?? (
-            _codeNamespace = AttributeDefinitionBuilder.CreateString(
+    private AttributeDefinition<string, string> _codeNamespace;
+    public AttributeDefinition<string, string> CodeNamespace => _codeNamespace ?? (
+        _codeNamespace = AttributeDefinitionBuilder.CreateString(
                 "code.namespace",
                 AttributeClassification.AgentAttributes
             )
             .AppliesTo(AttributeDestinations.SpanEvent)
             .Build(_attribFilter)
-        );
+    );
 
-        private AttributeDefinition<bool, bool> _llmTransaction;
-        public AttributeDefinition<bool, bool> LlmTransaction => _llmTransaction ?? (_llmTransaction =
-            AttributeDefinitionBuilder.CreateBool("llm", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.TransactionEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<bool, bool> _llmTransaction;
+    public AttributeDefinition<bool, bool> LlmTransaction => _llmTransaction ?? (_llmTransaction =
+        AttributeDefinitionBuilder.CreateBool("llm", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.TransactionEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _cloudAccountId;
-        public AttributeDefinition<string, string> CloudAccountId => _cloudAccountId ?? (_cloudAccountId =
-            AttributeDefinitionBuilder.CreateString("cloud.account.id", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _cloudAccountId;
+    public AttributeDefinition<string, string> CloudAccountId => _cloudAccountId ?? (_cloudAccountId =
+        AttributeDefinitionBuilder.CreateString("cloud.account.id", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _cloudRegion;
-        public AttributeDefinition<string, string> CloudRegion => _cloudRegion ?? (_cloudRegion =
-            AttributeDefinitionBuilder.CreateString("cloud.region", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _cloudRegion;
+    public AttributeDefinition<string, string> CloudRegion => _cloudRegion ?? (_cloudRegion =
+        AttributeDefinitionBuilder.CreateString("cloud.region", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messagingSystem;
-        public AttributeDefinition<string, string> MessagingSystemName => _messagingSystem ?? (_messagingSystem =
-            AttributeDefinitionBuilder.CreateString("messaging.system", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messagingSystem;
+    public AttributeDefinition<string, string> MessagingSystemName => _messagingSystem ?? (_messagingSystem =
+        AttributeDefinitionBuilder.CreateString("messaging.system", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messagingDestinationName;
-        public AttributeDefinition<string, string> MessagingDestinationName => _messagingDestinationName ?? (_messagingDestinationName =
-            AttributeDefinitionBuilder.CreateString("messaging.destination.name", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messagingDestinationName;
+    public AttributeDefinition<string, string> MessagingDestinationName => _messagingDestinationName ?? (_messagingDestinationName =
+        AttributeDefinitionBuilder.CreateString("messaging.destination.name", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        // new attribute for MessageBrokers - same name as the Externals attribute, but in Agent attributes.
-        // From messaging api spec.
-        private AttributeDefinition<string, string> _brokerServerAddress;
-        public AttributeDefinition<string, string> BrokerServerAddress => _brokerServerAddress ?? (_brokerServerAddress =
-            AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    // new attribute for MessageBrokers - same name as the Externals attribute, but in Agent attributes.
+    // From messaging api spec.
+    private AttributeDefinition<string, string> _brokerServerAddress;
+    public AttributeDefinition<string, string> BrokerServerAddress => _brokerServerAddress ?? (_brokerServerAddress =
+        AttributeDefinitionBuilder.CreateString("server.address", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<int, int> _brokerServerPort;
-        public AttributeDefinition<int, int> BrokerServerPort => _brokerServerPort ?? (_brokerServerPort =
-            AttributeDefinitionBuilder.CreateInt("server.port", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .AppliesTo(AttributeDestinations.TransactionTrace)
-                .Build(_attribFilter));
+    private AttributeDefinition<int, int> _brokerServerPort;
+    public AttributeDefinition<int, int> BrokerServerPort => _brokerServerPort ?? (_brokerServerPort =
+        AttributeDefinitionBuilder.CreateInt("server.port", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .AppliesTo(AttributeDestinations.TransactionTrace)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messageQueueName;
-        public AttributeDefinition<string, string> MessageQueueName => _messageQueueName ?? (_messageQueueName =
-            AttributeDefinitionBuilder.CreateString("message.queueName", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.All)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messageQueueName;
+    public AttributeDefinition<string, string> MessageQueueName => _messageQueueName ?? (_messageQueueName =
+        AttributeDefinitionBuilder.CreateString("message.queueName", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.All)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messageRoutingKey;
-        public AttributeDefinition<string, string> MessageRoutingKey => _messageRoutingKey ?? (_messageRoutingKey =
-            AttributeDefinitionBuilder.CreateString("message.routingKey", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.All)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messageRoutingKey;
+    public AttributeDefinition<string, string> MessageRoutingKey => _messageRoutingKey ?? (_messageRoutingKey =
+        AttributeDefinitionBuilder.CreateString("message.routingKey", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.All)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messagingRabbitMqDestinationRoutingKey;
-        public AttributeDefinition<string, string> MessagingRabbitMqDestinationRoutingKey => _messagingRabbitMqDestinationRoutingKey ?? (_messagingRabbitMqDestinationRoutingKey =
-            AttributeDefinitionBuilder.CreateString("messaging.rabbitmq.destination.routing_key", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messagingRabbitMqDestinationRoutingKey;
+    public AttributeDefinition<string, string> MessagingRabbitMqDestinationRoutingKey => _messagingRabbitMqDestinationRoutingKey ?? (_messagingRabbitMqDestinationRoutingKey =
+        AttributeDefinitionBuilder.CreateString("messaging.rabbitmq.destination.routing_key", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _messagingDestinationPublishName;
-        public AttributeDefinition<string, string> MessagingDestinationPublishName => _messagingDestinationPublishName ?? (_messagingDestinationPublishName =
-            AttributeDefinitionBuilder.CreateString("messaging.destination_publish.name", AttributeClassification.AgentAttributes)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _messagingDestinationPublishName;
+    public AttributeDefinition<string, string> MessagingDestinationPublishName => _messagingDestinationPublishName ?? (_messagingDestinationPublishName =
+        AttributeDefinitionBuilder.CreateString("messaging.destination_publish.name", AttributeClassification.AgentAttributes)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _linkedTraceId;
-        public AttributeDefinition<string, string> LinkedTraceId => _linkedTraceId ?? (_linkedTraceId =
-            AttributeDefinitionBuilder.CreateString("linkedTraceId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _linkedTraceId;
+    public AttributeDefinition<string, string> LinkedTraceId => _linkedTraceId ?? (_linkedTraceId =
+        AttributeDefinitionBuilder.CreateString("linkedTraceId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _linkedSpanId;
-        public AttributeDefinition<string, string> LinkedSpanId => _linkedSpanId ?? (_linkedSpanId =
-            AttributeDefinitionBuilder.CreateString("linkedSpanId", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _linkedSpanId;
+    public AttributeDefinition<string, string> LinkedSpanId => _linkedSpanId ?? (_linkedSpanId =
+        AttributeDefinitionBuilder.CreateString("linkedSpanId", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanIdForSpanLink;
-        public AttributeDefinition<string, string> SpanIdForSpanLink => _spanIdForSpanLink ?? (_spanIdForSpanLink =
-            AttributeDefinitionBuilder.CreateString("id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanIdForSpanLink;
+    public AttributeDefinition<string, string> SpanIdForSpanLink => _spanIdForSpanLink ?? (_spanIdForSpanLink =
+        AttributeDefinitionBuilder.CreateString("id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _spanIdForSpanEvent;
-        public AttributeDefinition<string, string> SpanIdForSpanEvent => _spanIdForSpanEvent ?? (_spanIdForSpanEvent =
-            AttributeDefinitionBuilder.CreateString("span.id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
+    private AttributeDefinition<string, string> _spanIdForSpanEvent;
+    public AttributeDefinition<string, string> SpanIdForSpanEvent => _spanIdForSpanEvent ?? (_spanIdForSpanEvent =
+        AttributeDefinitionBuilder.CreateString("span.id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 
-        private AttributeDefinition<string, string> _traceIdForSpanData;
-        public AttributeDefinition<string, string> TraceIdForSpanData => _traceIdForSpanData ?? (_traceIdForSpanData =
-            AttributeDefinitionBuilder.CreateString("trace.id", AttributeClassification.Intrinsics)
-                .AppliesTo(AttributeDestinations.SpanEvent)
-                .Build(_attribFilter));
-    }
+    private AttributeDefinition<string, string> _traceIdForSpanData;
+    public AttributeDefinition<string, string> TraceIdForSpanData => _traceIdForSpanData ?? (_traceIdForSpanData =
+        AttributeDefinitionBuilder.CreateString("trace.id", AttributeClassification.Intrinsics)
+            .AppliesTo(AttributeDestinations.SpanEvent)
+            .Build(_attribFilter));
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDestinations.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeDestinations.cs
@@ -3,20 +3,19 @@
 
 using System;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+[Flags]
+public enum AttributeDestinations : byte
 {
-    [Flags]
-    public enum AttributeDestinations : byte
-    {
-        None = 0,
-        TransactionTrace = 1 << 0,
-        TransactionEvent = 1 << 1,
-        ErrorTrace = 1 << 2,
-        JavaScriptAgent = 1 << 3,
-        ErrorEvent = 1 << 4,
-        SqlTrace = 1 << 5,
-        SpanEvent = 1 << 6,
-        CustomEvent = 1 << 7,
-        All = 0xFF,
-    }
+    None = 0,
+    TransactionTrace = 1 << 0,
+    TransactionEvent = 1 << 1,
+    ErrorTrace = 1 << 2,
+    JavaScriptAgent = 1 << 3,
+    ErrorEvent = 1 << 4,
+    SqlTrace = 1 << 5,
+    SpanEvent = 1 << 6,
+    CustomEvent = 1 << 7,
+    All = 0xFF,
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilter.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilter.cs
@@ -5,358 +5,354 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using NewRelic.Agent.Core.Logging;
 using NewRelic.Agent.Configuration;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public interface IAttributeFilter
 {
-    public interface IAttributeFilter
+    bool ShouldExcludeAttribute(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination);
+    bool ShouldFilterAttribute(AttributeDestinations targetObjectType);
+    bool CheckOrAddAttributeClusionCache(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination);
+}
+
+public class AttributeFilter : IAttributeFilter
+{
+    private const uint MaxCacheSize = 1000;
+
+    private readonly TrieNode<AttributeFilterNode> _explicitAttributeTrie;
+
+    private readonly TrieNode<AttributeFilterNode> _implicitAttributeTrie;
+
+    private readonly Settings _settings;
+
+    private readonly ConcurrentDictionary<string, bool> _cachedClusions = new ConcurrentDictionary<string, bool>();
+
+    public AttributeFilter(Settings settings)
     {
-        bool ShouldExcludeAttribute(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination);
-        bool ShouldFilterAttribute(AttributeDestinations targetObjectType);
-        bool CheckOrAddAttributeClusionCache(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination);
+        _settings = settings;
+        var explicitAttributeNodes = CreateExplicitAttributeNodes(settings);
+        var implicitAttributeNodes = CreateImplicitAttributeNodes(settings);
+        _explicitAttributeTrie = CreateAttributeNodeTrie(explicitAttributeNodes);
+        _implicitAttributeTrie = CreateAttributeNodeTrie(implicitAttributeNodes);
     }
 
-    public class AttributeFilter : IAttributeFilter
+    public bool ShouldFilterAttribute(AttributeDestinations targetObjectType)
     {
-        private const uint MaxCacheSize = 1000;
-
-        private readonly TrieNode<AttributeFilterNode> _explicitAttributeTrie;
-
-        private readonly TrieNode<AttributeFilterNode> _implicitAttributeTrie;
-
-        private readonly Settings _settings;
-
-        private readonly ConcurrentDictionary<string, bool> _cachedClusions = new ConcurrentDictionary<string, bool>();
-
-        public AttributeFilter(Settings settings)
-        {
-            _settings = settings;
-            var explicitAttributeNodes = CreateExplicitAttributeNodes(settings);
-            var implicitAttributeNodes = CreateImplicitAttributeNodes(settings);
-            _explicitAttributeTrie = CreateAttributeNodeTrie(explicitAttributeNodes);
-            _implicitAttributeTrie = CreateAttributeNodeTrie(implicitAttributeNodes);
-        }
-
-        public bool ShouldFilterAttribute(AttributeDestinations targetObjectType)
-        {
-            if (!_settings.AttributesEnabled)
-                return true;
-
-            switch (targetObjectType)
-            {
-                case AttributeDestinations.SpanEvent:
-                    if (!_settings.SpanEventsEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.ErrorTrace:
-                    if (!_settings.ErrorTraceEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.JavaScriptAgent:
-                    if (!_settings.JavaScriptAgentEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.TransactionEvent:
-                    if (!_settings.TransactionEventEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.TransactionTrace:
-                    if (!_settings.TransactionTraceEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.ErrorEvent:
-                    if (!_settings.ErrorEventsEnabled)
-                        return true;
-                    break;
-                case AttributeDestinations.SqlTrace:
-                    break;
-                case AttributeDestinations.CustomEvent:
-                    if (!_settings.CustomEventsEnabled)
-                        return true;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException("destination", "Unexpected destination: " + targetObjectType);
-            }
-
-            return false;
-        }
-
-        public bool CheckOrAddAttributeClusionCache(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
-        {
-            var cacheKey = GetAttributeClusionKey(name, defaultDestinations, destination);
-
-            if (!_cachedClusions.TryGetValue(cacheKey, out var result))
-            {
-                result = !ShouldExcludeAttribute(name, defaultDestinations, destination);
-
-                if (_cachedClusions.Count <= MaxCacheSize)
-                {
-                    _cachedClusions.TryAdd(cacheKey, result);
-                }
-            }
-
-            return result;
-        }
-
-        private static string GetAttributeClusionKey(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
-        {
-            // Enum is cast to byte to avoid enum.ToString which does reflection 
-            // The cache key includes both the intended destinations of the attribute (attribute.DefaultDestinations) 
-            // and the destination being tested.  This is because some attributes have the same name (like timestamp)
-            // but different destinations.  Without this cache key, the wrong value will be selected.
-            return name + (((byte)destination << 8) + (byte)defaultDestinations).ToString();
-        }
-
-        public bool ShouldExcludeAttribute(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
-        {
-            var explicitClusion = CheckForExplicitClusion(name, destination);
-            if (explicitClusion != Clude.Unknown)
-                return KnownCludeToBoolean(explicitClusion);
-
-            var implicitClusion = CheckForImplicitClusion(name, defaultDestinations, destination);
-            if (implicitClusion != Clude.Unknown)
-                return KnownCludeToBoolean(implicitClusion);
-
-            return false;
-        }
-
-        private Clude CheckForExplicitClusion(string name, AttributeDestinations destination)
-        {
-            return _explicitAttributeTrie.GetClusion(name, destination);
-        }
-
-        private Clude CheckForImplicitClusion(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
-        {
-            if ((defaultDestinations & destination) != destination)
-                return Clude.Exclude;
-
-            return _implicitAttributeTrie.GetClusion(name, destination);
-        }
-
-        private static bool KnownCludeToBoolean(Clude clude)
-        {
-            switch (clude)
-            {
-                case Clude.Exclude:
-                    return true;
-                case Clude.Include:
-                    return false;
-                case Clude.Unknown:
-                    throw new Exception("Expected exclude or include but found Unknown.");
-                default:
-                    throw new Exception("Expected exclude or include but found " + clude);
-            }
-        }
-
-        private static TrieNode<AttributeFilterNode> CreateAttributeNodeTrie(IEnumerable<AttributeFilterNode> nodes)
-        {
-            var trieBuilder = new TrieBuilder<AttributeFilterNode>(
-                rootNodeDataFactory: () => new AttributeFilterNode("*", AttributeDestinations.None, AttributeDestinations.None),
-                nodeDataMerger: MergeAttributeNodes,
-                nodeDataComparor: CompareAttributeNodes,
-                nodeDataHasher: HashAttributeNode,
-                canParentAcceptChildChecker: CanParentAcceptChild,
-                canNodeHaveChildrenChecker: CanNodeHaveChildren);
-
-            return trieBuilder.CreateTrie(nodes);
-        }
-
-        private static IEnumerable<AttributeFilterNode> CreateExplicitAttributeNodes(Settings settings)
-        {
-            var globalIncludes = CreateAttributeNodes(settings.Includes, AttributeDestinations.All, true);
-            var globalExcludes = CreateAttributeNodes(settings.Excludes, AttributeDestinations.All, false);
-            var errorTraceIncludes = CreateAttributeNodes(settings.ErrorTraceIncludes, AttributeDestinations.ErrorTrace, true);
-            var errorTraceExcludes = CreateAttributeNodes(settings.ErrorTraceExcludes, AttributeDestinations.ErrorTrace, false);
-            var javaScriptAgentIncludes = CreateAttributeNodes(settings.JavaScriptAgentIncludes, AttributeDestinations.JavaScriptAgent, true);
-            var javaScriptAgentExcludes = CreateAttributeNodes(settings.JavaScriptAgentExcludes, AttributeDestinations.JavaScriptAgent, false);
-            var transactionEventIncludes = CreateAttributeNodes(settings.TransactionEventIncludes, AttributeDestinations.TransactionEvent, true);
-            var transactionEventExcludes = CreateAttributeNodes(settings.TransactionEventExcludes, AttributeDestinations.TransactionEvent, false);
-            var transactionTraceIncludes = CreateAttributeNodes(settings.TransactionTraceIncludes, AttributeDestinations.TransactionTrace, true);
-            var transactionTraceExcludes = CreateAttributeNodes(settings.TransactionTraceExcludes, AttributeDestinations.TransactionTrace, false);
-            var eventErrorIncludes = CreateAttributeNodes(settings.ErrorEventIncludes, AttributeDestinations.ErrorEvent, true);
-            var eventErrorExcludes = CreateAttributeNodes(settings.ErrorEventExcludes, AttributeDestinations.ErrorEvent, false);
-            var spanEventIncludes = CreateAttributeNodes(settings.SpanEventIncludes, AttributeDestinations.SpanEvent, true);
-            var spanEventExcludes = CreateAttributeNodes(settings.SpanEventExcludes, AttributeDestinations.SpanEvent, false);
-
-            return globalIncludes
-                .Concat(globalExcludes)
-                .Concat(errorTraceIncludes)
-                .Concat(errorTraceExcludes)
-                .Concat(javaScriptAgentIncludes)
-                .Concat(javaScriptAgentExcludes)
-                .Concat(transactionEventIncludes)
-                .Concat(transactionEventExcludes)
-                .Concat(transactionTraceIncludes)
-                .Concat(transactionTraceExcludes)
-                .Concat(eventErrorIncludes)
-                .Concat(eventErrorExcludes)
-                .Concat(spanEventIncludes)
-                .Concat(spanEventExcludes);
-        }
-
-        private static IEnumerable<AttributeFilterNode> CreateImplicitAttributeNodes(Settings settings)
-        {
-            var globalIncludes = CreateAttributeNodes(settings.ImplicitIncludes, AttributeDestinations.All, true);
-            var globalExcludes = CreateAttributeNodes(settings.ImplicitExcludes, AttributeDestinations.All, false);
-
-            return globalIncludes.Concat(globalExcludes);
-        }
-
-        private static IEnumerable<AttributeFilterNode> CreateAttributeNodes(IEnumerable<string> keys, AttributeDestinations destinations, bool include)
-        {
-            return keys
-                .Where(key => key != null)
-                .Select(key => CreateAttributeNode(key, destinations, include));
-        }
-
-        private static AttributeFilterNode CreateAttributeNode(string key, AttributeDestinations destinations, bool include)
-        {
-            var includes = include ? destinations : AttributeDestinations.None;
-            var excludes = include ? AttributeDestinations.None : destinations;
-            return new AttributeFilterNode(key, includes, excludes);
-        }
-
-        private static AttributeFilterNode MergeAttributeNodes(IEnumerable<AttributeFilterNode> nodeBuilders)
-        {
-            var mergedNode = nodeBuilders.Aggregate(MergeAttributeNodes);
-            if (mergedNode == null)
-                throw new NullReferenceException("Attempt to merge attribute nodes yielded a null result.");
-            return mergedNode;
-        }
-
-        private static AttributeFilterNode MergeAttributeNodes(AttributeFilterNode left, AttributeFilterNode right)
-        {
-            var key = left.Wildcard ? left.Key + "*" : left.Key;
-            var includes = left.DestinationIncludes | right.DestinationIncludes;
-            var excludes = left.DestinationExcludes | right.DestinationExcludes;
-            return new AttributeFilterNode(key, includes, excludes);
-        }
-
-        private static int CompareAttributeNodes(AttributeFilterNode left, AttributeFilterNode right)
-        {
-            // keys are different, just use the key comparison result
-            if (left.Key != right.Key)
-            {
-                return string.Compare(left.Key, right.Key, StringComparison.Ordinal);
-            }
-
-            // keys match and wildcard is the same, the attribute nodes are the same (possibly different rules, will need merging)
-            if (left.Wildcard == right.Wildcard)
-            {
-                return 0;
-            }
-
-            // keys match, wildcards differ, the one with the wildcard comes first
-            return left.Wildcard ? -1 : 1;
-        }
-
-        private static int HashAttributeNode(AttributeFilterNode nodeBuilder)
-        {
-            var suffix = nodeBuilder.Wildcard ? "*" : "";
-            var stringToHash = nodeBuilder.Key + suffix;
-            return stringToHash.GetHashCode();
-        }
-
-        private static bool CanParentAcceptChild(AttributeFilterNode parent, AttributeFilterNode orphan)
-        {
-            if (!parent.Wildcard)
-            {
-                return false;
-            }
-
-            if (!orphan.Key.StartsWith(parent.Key))
-            {
-                return false;
-            }
-
+        if (!_settings.AttributesEnabled)
             return true;
+
+        switch (targetObjectType)
+        {
+            case AttributeDestinations.SpanEvent:
+                if (!_settings.SpanEventsEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.ErrorTrace:
+                if (!_settings.ErrorTraceEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.JavaScriptAgent:
+                if (!_settings.JavaScriptAgentEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.TransactionEvent:
+                if (!_settings.TransactionEventEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.TransactionTrace:
+                if (!_settings.TransactionTraceEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.ErrorEvent:
+                if (!_settings.ErrorEventsEnabled)
+                    return true;
+                break;
+            case AttributeDestinations.SqlTrace:
+                break;
+            case AttributeDestinations.CustomEvent:
+                if (!_settings.CustomEventsEnabled)
+                    return true;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException("destination", "Unexpected destination: " + targetObjectType);
         }
 
-        private static bool CanNodeHaveChildren(AttributeFilterNode node)
+        return false;
+    }
+
+    public bool CheckOrAddAttributeClusionCache(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
+    {
+        var cacheKey = GetAttributeClusionKey(name, defaultDestinations, destination);
+
+        if (!_cachedClusions.TryGetValue(cacheKey, out var result))
         {
-            return node.Wildcard;
+            result = !ShouldExcludeAttribute(name, defaultDestinations, destination);
+
+            if (_cachedClusions.Count <= MaxCacheSize)
+            {
+                _cachedClusions.TryAdd(cacheKey, result);
+            }
         }
 
-        public class Settings
+        return result;
+    }
+
+    private static string GetAttributeClusionKey(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
+    {
+        // Enum is cast to byte to avoid enum.ToString which does reflection 
+        // The cache key includes both the intended destinations of the attribute (attribute.DefaultDestinations) 
+        // and the destination being tested.  This is because some attributes have the same name (like timestamp)
+        // but different destinations.  Without this cache key, the wrong value will be selected.
+        return name + (((byte)destination << 8) + (byte)defaultDestinations).ToString();
+    }
+
+    public bool ShouldExcludeAttribute(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
+    {
+        var explicitClusion = CheckForExplicitClusion(name, destination);
+        if (explicitClusion != Clude.Unknown)
+            return KnownCludeToBoolean(explicitClusion);
+
+        var implicitClusion = CheckForImplicitClusion(name, defaultDestinations, destination);
+        if (implicitClusion != Clude.Unknown)
+            return KnownCludeToBoolean(implicitClusion);
+
+        return false;
+    }
+
+    private Clude CheckForExplicitClusion(string name, AttributeDestinations destination)
+    {
+        return _explicitAttributeTrie.GetClusion(name, destination);
+    }
+
+    private Clude CheckForImplicitClusion(string name, AttributeDestinations defaultDestinations, AttributeDestinations destination)
+    {
+        if ((defaultDestinations & destination) != destination)
+            return Clude.Exclude;
+
+        return _implicitAttributeTrie.GetClusion(name, destination);
+    }
+
+    private static bool KnownCludeToBoolean(Clude clude)
+    {
+        switch (clude)
         {
-            //Used for filtering intrinsic attributess (or not filtering them)
-            public Settings()
-            {
-            }
-
-            public Settings(IConfiguration _configuration)
-            {
-                AttributesEnabled = _configuration.CaptureAttributes;
-                Includes = _configuration.CaptureAttributesIncludes;
-                Excludes = _configuration.CaptureAttributesExcludes;
-
-                ErrorTraceEnabled = _configuration.CaptureErrorCollectorAttributes;
-                ErrorTraceIncludes = _configuration.CaptureErrorCollectorAttributesIncludes;
-                ErrorTraceExcludes = _configuration.CaptureErrorCollectorAttributesExcludes;
-
-                JavaScriptAgentEnabled = _configuration.CaptureBrowserMonitoringAttributes;
-                JavaScriptAgentIncludes = _configuration.CaptureBrowserMonitoringAttributesIncludes;
-                JavaScriptAgentExcludes = _configuration.CaptureBrowserMonitoringAttributesExcludes;
-
-                TransactionEventEnabled = _configuration.TransactionEventsAttributesEnabled;
-                TransactionEventIncludes = _configuration.TransactionEventsAttributesInclude;
-                TransactionEventExcludes = _configuration.TransactionEventsAttributesExclude;
-
-                TransactionTraceEnabled = _configuration.CaptureTransactionTraceAttributes;
-                TransactionTraceIncludes = _configuration.CaptureTransactionTraceAttributesIncludes;
-                TransactionTraceExcludes = _configuration.CaptureTransactionTraceAttributesExcludes;
-
-                ErrorEventsEnabled = _configuration.ErrorCollectorCaptureEvents;
-                ErrorEventIncludes = _configuration.CaptureErrorCollectorAttributesIncludes;
-                ErrorEventExcludes = _configuration.CaptureErrorCollectorAttributesExcludes;
-
-                SpanEventsEnabled = _configuration.SpanEventsEnabled;
-                SpanEventIncludes = _configuration.SpanEventsAttributesInclude;
-                SpanEventExcludes = _configuration.SpanEventsAttributesExclude;
-
-                CustomEventsEnabled = _configuration.CustomEventsEnabled;
-                CustomEventIncludes = _configuration.CustomEventsAttributesInclude;
-                CustomEventExcludes = _configuration.CustomEventsAttributesExclude;
-            }
-
-            public bool AttributesEnabled = true;
-            public IEnumerable<string> Excludes = Enumerable.Empty<string>();
-            public IEnumerable<string> Includes = Enumerable.Empty<string>();
-
-            public bool JavaScriptAgentEnabled = true;
-            public IEnumerable<string> JavaScriptAgentExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> JavaScriptAgentIncludes = Enumerable.Empty<string>();
-
-            public bool ErrorTraceEnabled = true;
-            public IEnumerable<string> ErrorTraceExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> ErrorTraceIncludes = Enumerable.Empty<string>();
-
-            public bool TransactionEventEnabled = true;
-            public IEnumerable<string> TransactionEventExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> TransactionEventIncludes = Enumerable.Empty<string>();
-
-            public bool TransactionTraceEnabled = true;
-            public IEnumerable<string> TransactionTraceExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> TransactionTraceIncludes = Enumerable.Empty<string>();
-
-            public IEnumerable<string> ImplicitExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> ImplicitIncludes = Enumerable.Empty<string>();
-
-            public IEnumerable<string> ErrorEventExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> ErrorEventIncludes = Enumerable.Empty<string>();
-            public bool ErrorEventsEnabled = true;
-
-            public IEnumerable<string> SpanEventExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> SpanEventIncludes = Enumerable.Empty<string>();
-            public bool SpanEventsEnabled = true;
-
-            public IEnumerable<string> CustomEventExcludes = Enumerable.Empty<string>();
-            public IEnumerable<string> CustomEventIncludes = Enumerable.Empty<string>();
-            public bool CustomEventsEnabled = true;
-
+            case Clude.Exclude:
+                return true;
+            case Clude.Include:
+                return false;
+            case Clude.Unknown:
+                throw new Exception("Expected exclude or include but found Unknown.");
+            default:
+                throw new Exception("Expected exclude or include but found " + clude);
         }
     }
 
+    private static TrieNode<AttributeFilterNode> CreateAttributeNodeTrie(IEnumerable<AttributeFilterNode> nodes)
+    {
+        var trieBuilder = new TrieBuilder<AttributeFilterNode>(
+            rootNodeDataFactory: () => new AttributeFilterNode("*", AttributeDestinations.None, AttributeDestinations.None),
+            nodeDataMerger: MergeAttributeNodes,
+            nodeDataComparor: CompareAttributeNodes,
+            nodeDataHasher: HashAttributeNode,
+            canParentAcceptChildChecker: CanParentAcceptChild,
+            canNodeHaveChildrenChecker: CanNodeHaveChildren);
 
+        return trieBuilder.CreateTrie(nodes);
+    }
+
+    private static IEnumerable<AttributeFilterNode> CreateExplicitAttributeNodes(Settings settings)
+    {
+        var globalIncludes = CreateAttributeNodes(settings.Includes, AttributeDestinations.All, true);
+        var globalExcludes = CreateAttributeNodes(settings.Excludes, AttributeDestinations.All, false);
+        var errorTraceIncludes = CreateAttributeNodes(settings.ErrorTraceIncludes, AttributeDestinations.ErrorTrace, true);
+        var errorTraceExcludes = CreateAttributeNodes(settings.ErrorTraceExcludes, AttributeDestinations.ErrorTrace, false);
+        var javaScriptAgentIncludes = CreateAttributeNodes(settings.JavaScriptAgentIncludes, AttributeDestinations.JavaScriptAgent, true);
+        var javaScriptAgentExcludes = CreateAttributeNodes(settings.JavaScriptAgentExcludes, AttributeDestinations.JavaScriptAgent, false);
+        var transactionEventIncludes = CreateAttributeNodes(settings.TransactionEventIncludes, AttributeDestinations.TransactionEvent, true);
+        var transactionEventExcludes = CreateAttributeNodes(settings.TransactionEventExcludes, AttributeDestinations.TransactionEvent, false);
+        var transactionTraceIncludes = CreateAttributeNodes(settings.TransactionTraceIncludes, AttributeDestinations.TransactionTrace, true);
+        var transactionTraceExcludes = CreateAttributeNodes(settings.TransactionTraceExcludes, AttributeDestinations.TransactionTrace, false);
+        var eventErrorIncludes = CreateAttributeNodes(settings.ErrorEventIncludes, AttributeDestinations.ErrorEvent, true);
+        var eventErrorExcludes = CreateAttributeNodes(settings.ErrorEventExcludes, AttributeDestinations.ErrorEvent, false);
+        var spanEventIncludes = CreateAttributeNodes(settings.SpanEventIncludes, AttributeDestinations.SpanEvent, true);
+        var spanEventExcludes = CreateAttributeNodes(settings.SpanEventExcludes, AttributeDestinations.SpanEvent, false);
+
+        return globalIncludes
+            .Concat(globalExcludes)
+            .Concat(errorTraceIncludes)
+            .Concat(errorTraceExcludes)
+            .Concat(javaScriptAgentIncludes)
+            .Concat(javaScriptAgentExcludes)
+            .Concat(transactionEventIncludes)
+            .Concat(transactionEventExcludes)
+            .Concat(transactionTraceIncludes)
+            .Concat(transactionTraceExcludes)
+            .Concat(eventErrorIncludes)
+            .Concat(eventErrorExcludes)
+            .Concat(spanEventIncludes)
+            .Concat(spanEventExcludes);
+    }
+
+    private static IEnumerable<AttributeFilterNode> CreateImplicitAttributeNodes(Settings settings)
+    {
+        var globalIncludes = CreateAttributeNodes(settings.ImplicitIncludes, AttributeDestinations.All, true);
+        var globalExcludes = CreateAttributeNodes(settings.ImplicitExcludes, AttributeDestinations.All, false);
+
+        return globalIncludes.Concat(globalExcludes);
+    }
+
+    private static IEnumerable<AttributeFilterNode> CreateAttributeNodes(IEnumerable<string> keys, AttributeDestinations destinations, bool include)
+    {
+        return keys
+            .Where(key => key != null)
+            .Select(key => CreateAttributeNode(key, destinations, include));
+    }
+
+    private static AttributeFilterNode CreateAttributeNode(string key, AttributeDestinations destinations, bool include)
+    {
+        var includes = include ? destinations : AttributeDestinations.None;
+        var excludes = include ? AttributeDestinations.None : destinations;
+        return new AttributeFilterNode(key, includes, excludes);
+    }
+
+    private static AttributeFilterNode MergeAttributeNodes(IEnumerable<AttributeFilterNode> nodeBuilders)
+    {
+        var mergedNode = nodeBuilders.Aggregate(MergeAttributeNodes);
+        if (mergedNode == null)
+            throw new NullReferenceException("Attempt to merge attribute nodes yielded a null result.");
+        return mergedNode;
+    }
+
+    private static AttributeFilterNode MergeAttributeNodes(AttributeFilterNode left, AttributeFilterNode right)
+    {
+        var key = left.Wildcard ? left.Key + "*" : left.Key;
+        var includes = left.DestinationIncludes | right.DestinationIncludes;
+        var excludes = left.DestinationExcludes | right.DestinationExcludes;
+        return new AttributeFilterNode(key, includes, excludes);
+    }
+
+    private static int CompareAttributeNodes(AttributeFilterNode left, AttributeFilterNode right)
+    {
+        // keys are different, just use the key comparison result
+        if (left.Key != right.Key)
+        {
+            return string.Compare(left.Key, right.Key, StringComparison.Ordinal);
+        }
+
+        // keys match and wildcard is the same, the attribute nodes are the same (possibly different rules, will need merging)
+        if (left.Wildcard == right.Wildcard)
+        {
+            return 0;
+        }
+
+        // keys match, wildcards differ, the one with the wildcard comes first
+        return left.Wildcard ? -1 : 1;
+    }
+
+    private static int HashAttributeNode(AttributeFilterNode nodeBuilder)
+    {
+        var suffix = nodeBuilder.Wildcard ? "*" : "";
+        var stringToHash = nodeBuilder.Key + suffix;
+        return stringToHash.GetHashCode();
+    }
+
+    private static bool CanParentAcceptChild(AttributeFilterNode parent, AttributeFilterNode orphan)
+    {
+        if (!parent.Wildcard)
+        {
+            return false;
+        }
+
+        if (!orphan.Key.StartsWith(parent.Key))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool CanNodeHaveChildren(AttributeFilterNode node)
+    {
+        return node.Wildcard;
+    }
+
+    public class Settings
+    {
+        //Used for filtering intrinsic attributess (or not filtering them)
+        public Settings()
+        {
+        }
+
+        public Settings(IConfiguration _configuration)
+        {
+            AttributesEnabled = _configuration.CaptureAttributes;
+            Includes = _configuration.CaptureAttributesIncludes;
+            Excludes = _configuration.CaptureAttributesExcludes;
+
+            ErrorTraceEnabled = _configuration.CaptureErrorCollectorAttributes;
+            ErrorTraceIncludes = _configuration.CaptureErrorCollectorAttributesIncludes;
+            ErrorTraceExcludes = _configuration.CaptureErrorCollectorAttributesExcludes;
+
+            JavaScriptAgentEnabled = _configuration.CaptureBrowserMonitoringAttributes;
+            JavaScriptAgentIncludes = _configuration.CaptureBrowserMonitoringAttributesIncludes;
+            JavaScriptAgentExcludes = _configuration.CaptureBrowserMonitoringAttributesExcludes;
+
+            TransactionEventEnabled = _configuration.TransactionEventsAttributesEnabled;
+            TransactionEventIncludes = _configuration.TransactionEventsAttributesInclude;
+            TransactionEventExcludes = _configuration.TransactionEventsAttributesExclude;
+
+            TransactionTraceEnabled = _configuration.CaptureTransactionTraceAttributes;
+            TransactionTraceIncludes = _configuration.CaptureTransactionTraceAttributesIncludes;
+            TransactionTraceExcludes = _configuration.CaptureTransactionTraceAttributesExcludes;
+
+            ErrorEventsEnabled = _configuration.ErrorCollectorCaptureEvents;
+            ErrorEventIncludes = _configuration.CaptureErrorCollectorAttributesIncludes;
+            ErrorEventExcludes = _configuration.CaptureErrorCollectorAttributesExcludes;
+
+            SpanEventsEnabled = _configuration.SpanEventsEnabled;
+            SpanEventIncludes = _configuration.SpanEventsAttributesInclude;
+            SpanEventExcludes = _configuration.SpanEventsAttributesExclude;
+
+            CustomEventsEnabled = _configuration.CustomEventsEnabled;
+            CustomEventIncludes = _configuration.CustomEventsAttributesInclude;
+            CustomEventExcludes = _configuration.CustomEventsAttributesExclude;
+        }
+
+        public bool AttributesEnabled = true;
+        public IEnumerable<string> Excludes = Enumerable.Empty<string>();
+        public IEnumerable<string> Includes = Enumerable.Empty<string>();
+
+        public bool JavaScriptAgentEnabled = true;
+        public IEnumerable<string> JavaScriptAgentExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> JavaScriptAgentIncludes = Enumerable.Empty<string>();
+
+        public bool ErrorTraceEnabled = true;
+        public IEnumerable<string> ErrorTraceExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> ErrorTraceIncludes = Enumerable.Empty<string>();
+
+        public bool TransactionEventEnabled = true;
+        public IEnumerable<string> TransactionEventExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> TransactionEventIncludes = Enumerable.Empty<string>();
+
+        public bool TransactionTraceEnabled = true;
+        public IEnumerable<string> TransactionTraceExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> TransactionTraceIncludes = Enumerable.Empty<string>();
+
+        public IEnumerable<string> ImplicitExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> ImplicitIncludes = Enumerable.Empty<string>();
+
+        public IEnumerable<string> ErrorEventExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> ErrorEventIncludes = Enumerable.Empty<string>();
+        public bool ErrorEventsEnabled = true;
+
+        public IEnumerable<string> SpanEventExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> SpanEventIncludes = Enumerable.Empty<string>();
+        public bool SpanEventsEnabled = true;
+
+        public IEnumerable<string> CustomEventExcludes = Enumerable.Empty<string>();
+        public IEnumerable<string> CustomEventIncludes = Enumerable.Empty<string>();
+        public bool CustomEventsEnabled = true;
+
+    }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilterNode.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilterNode.cs
@@ -1,30 +1,29 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+internal class AttributeFilterNode
 {
-    internal class AttributeFilterNode
+    public readonly string Key;
+
+    public readonly bool Wildcard;
+
+    public readonly AttributeDestinations DestinationIncludes;
+    public readonly AttributeDestinations DestinationExcludes;
+
+    public AttributeFilterNode(string key, AttributeDestinations includes, AttributeDestinations excludes)
     {
-        public readonly string Key;
-
-        public readonly bool Wildcard;
-
-        public readonly AttributeDestinations DestinationIncludes;
-        public readonly AttributeDestinations DestinationExcludes;
-
-        public AttributeFilterNode(string key, AttributeDestinations includes, AttributeDestinations excludes)
+        if (key.EndsWith("*"))
         {
-            if (key.EndsWith("*"))
-            {
-                Wildcard = true;
-                Key = key.Substring(0, key.Length - 1);
-            }
-            else
-            {
-                Key = key;
-            }
-            DestinationIncludes = includes;
-            DestinationExcludes = excludes;
+            Wildcard = true;
+            Key = key.Substring(0, key.Length - 1);
         }
+        else
+        {
+            Key = key;
+        }
+        DestinationIncludes = includes;
+        DestinationExcludes = excludes;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValue.cs
@@ -4,69 +4,67 @@
 using System;
 using System.Diagnostics;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public interface IAttributeValue
 {
-    public interface IAttributeValue
+    AttributeDefinition AttributeDefinition { get; }
+
+    object Value { get; set; }
+
+    Lazy<object> LazyValue { get; set; }
+
+    void MakeImmutable();
+}
+
+[DebuggerDisplay("{_value ?? _lazyValue}")]
+public class AttributeValue : IAttributeValue
+{
+    public AttributeValue(AttributeDefinition attribDef)
     {
-        AttributeDefinition AttributeDefinition { get; }
-
-        object Value { get; set; }
-
-        Lazy<object> LazyValue { get; set; }
-
-        void MakeImmutable();
+        AttributeDefinition = attribDef;
     }
 
-    [DebuggerDisplay("{_value ?? _lazyValue}")]
-    public class AttributeValue : IAttributeValue
+    public AttributeDefinition AttributeDefinition { get; private set; }
+
+    private object _value;
+    public object Value
     {
-        public AttributeValue(AttributeDefinition attribDef)
+        get => _value;
+        set
         {
-            AttributeDefinition = attribDef;
-        }
-
-        public AttributeDefinition AttributeDefinition { get; private set; }
-
-        private object _value;
-        public object Value
-        {
-            get => _value;
-            set
-            {
-                if (IsImmutable) return;
-                _value = value;
-                _lazyValue = null;
-            }
-        }
-
-        private Lazy<object> _lazyValue;
-        public Lazy<object> LazyValue
-        {
-            get => _lazyValue;
-            set
-            {
-                if (IsImmutable) return;
-                _lazyValue = value;
-                _value = null;
-            }
-        }
-
-        public bool IsImmutable { get; private set; }
-
-        public void MakeImmutable()
-        {
-            if (IsImmutable)
-            {
-                return;
-            }
-
-            if (LazyValue != null && Value == null)
-            {
-                Value = LazyValue.Value;
-            }
-
-            IsImmutable = true;
+            if (IsImmutable) return;
+            _value = value;
+            _lazyValue = null;
         }
     }
 
+    private Lazy<object> _lazyValue;
+    public Lazy<object> LazyValue
+    {
+        get => _lazyValue;
+        set
+        {
+            if (IsImmutable) return;
+            _lazyValue = value;
+            _value = null;
+        }
+    }
+
+    public bool IsImmutable { get; private set; }
+
+    public void MakeImmutable()
+    {
+        if (IsImmutable)
+        {
+            return;
+        }
+
+        if (LazyValue != null && Value == null)
+        {
+            Value = LazyValue.Value;
+        }
+
+        IsImmutable = true;
+    }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValueCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeValueCollection.cs
@@ -1,502 +1,499 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System;
-using System.Collections.ObjectModel;
-using NewRelic.Agent.Extensions.Logging;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public interface IAttributeValueCollection
 {
-    public interface IAttributeValueCollection
+    /// <summary>
+    /// Even this enum is Flags, this should only be one attribute destination
+    /// </summary>
+    AttributeDestinations[] TargetModelTypes { get; }
+
+    AttributeDestinations TargetModelTypesAsFlags { get; }
+
+    int Count { get; }
+
+    bool IsImmutable { get; }
+
+    void AddRange(IAttributeValueCollection fromCollection);
+
+    void MakeImmutable();
+
+    bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, TOutput value);
+
+    bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, Lazy<object> lazyImpl);
+
+    bool TrySetValue(IAttributeValue attrib);
+
+    IEnumerable<IAttributeValue> GetAttributeValues(AttributeClassification classification);
+
+    IDictionary<string, object> GetAttributeValuesDic(AttributeClassification classification);
+
+    IDictionary<string, object> GetAllAttributeValuesDic();
+}
+
+public abstract class AttributeValueCollectionBase<TAttrib> : IAttributeValueCollection where TAttrib : IAttributeValue
+{
+    private static AttributeDestinations[] _allTargetModelTypes;
+
+    public static AttributeDestinations[] AllTargetModelTypes => _allTargetModelTypes
+                                                                 ?? (_allTargetModelTypes = Enum.GetValues(typeof(AttributeDestinations))
+                                                                     .Cast<AttributeDestinations>()
+                                                                     .Where(x => x != AttributeDestinations.All && x != AttributeDestinations.None)
+                                                                     .ToArray());
+
+    public const int MaxCountUserAttrib = 64;
+    public const int MaxCountAllAttrib = 255;
+
+    // In priority order: user < intrinsics < agent
+    protected static readonly AttributeClassification[] _allClassifications = new[] { AttributeClassification.UserAttributes, AttributeClassification.Intrinsics, AttributeClassification.AgentAttributes };
+
+    private int _intrinsicAttributeCount;
+    private int _agentAttributeCount;
+    private int _userAttributeCount;
+
+    private readonly string _transactionGuid;
+
+    public int Count => _intrinsicAttributeCount + _agentAttributeCount + _userAttributeCount;
+
+    public AttributeDestinations[] TargetModelTypes { get; private set; }
+    public AttributeDestinations TargetModelTypesAsFlags { get; private set; }
+
+    public abstract bool CollectionContainsAttribute(AttributeDefinition attrDef);
+
+    private bool ValidateCollectionLimits(AttributeDefinition attrDef)
     {
-        /// <summary>
-        /// Even this enum is Flags, this should only be one attribute destination
-        /// </summary>
-        AttributeDestinations[] TargetModelTypes { get; }
+        var attributeLimitReached = false;
+        string message = string.Empty;
 
-        AttributeDestinations TargetModelTypesAsFlags { get; }
-
-        int Count { get; }
-
-        bool IsImmutable { get; }
-
-        void AddRange(IAttributeValueCollection fromCollection);
-
-        void MakeImmutable();
-
-        bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, TOutput value);
-
-        bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, Lazy<object> lazyImpl);
-
-        bool TrySetValue(IAttributeValue attrib);
-
-        IEnumerable<IAttributeValue> GetAttributeValues(AttributeClassification classification);
-
-        IDictionary<string, object> GetAttributeValuesDic(AttributeClassification classification);
-
-        IDictionary<string, object> GetAllAttributeValuesDic();
-    }
-
-    public abstract class AttributeValueCollectionBase<TAttrib> : IAttributeValueCollection where TAttrib : IAttributeValue
-    {
-        private static AttributeDestinations[] _allTargetModelTypes;
-
-        public static AttributeDestinations[] AllTargetModelTypes => _allTargetModelTypes
-            ?? (_allTargetModelTypes = Enum.GetValues(typeof(AttributeDestinations))
-            .Cast<AttributeDestinations>()
-            .Where(x => x != AttributeDestinations.All && x != AttributeDestinations.None)
-            .ToArray());
-
-        public const int MaxCountUserAttrib = 64;
-        public const int MaxCountAllAttrib = 255;
-
-        // In priority order: user < intrinsics < agent
-        protected static readonly AttributeClassification[] _allClassifications = new[] { AttributeClassification.UserAttributes, AttributeClassification.Intrinsics, AttributeClassification.AgentAttributes };
-
-        private int _intrinsicAttributeCount;
-        private int _agentAttributeCount;
-        private int _userAttributeCount;
-
-        private readonly string _transactionGuid;
-
-        public int Count => _intrinsicAttributeCount + _agentAttributeCount + _userAttributeCount;
-
-        public AttributeDestinations[] TargetModelTypes { get; private set; }
-        public AttributeDestinations TargetModelTypesAsFlags { get; private set; }
-
-        public abstract bool CollectionContainsAttribute(AttributeDefinition attrDef);
-
-        private bool ValidateCollectionLimits(AttributeDefinition attrDef)
+        if (attrDef.Classification == AttributeClassification.UserAttributes && _userAttributeCount >= MaxCountUserAttrib)
         {
-            var attributeLimitReached = false;
-            string message = string.Empty;
-
-            if (attrDef.Classification == AttributeClassification.UserAttributes && _userAttributeCount >= MaxCountUserAttrib)
-            {
-                message = $"User Attribute '{attrDef.Name}' was not recorded - A max of {MaxCountUserAttrib} User Attributes may be supplied.";
-                attributeLimitReached = true;
-            }
-            else if (Count >= MaxCountAllAttrib)
-            {
-                message = $"{attrDef.Classification} Attribute '{attrDef.Name}' was not recorded - A max of {MaxCountAllAttrib} attributes may be supplied.";
-                attributeLimitReached = true;
-            }
-
-            // Log a message and return false if we hit an attribute limit but don't currently contain the attribute
-            if (attributeLimitReached && !CollectionContainsAttribute(attrDef))
-            {
-                LogTransactionIfFinest(message);
-                return false;
-            }
-
-            return true;
+            message = $"User Attribute '{attrDef.Name}' was not recorded - A max of {MaxCountUserAttrib} User Attributes may be supplied.";
+            attributeLimitReached = true;
+        }
+        else if (Count >= MaxCountAllAttrib)
+        {
+            message = $"{attrDef.Classification} Attribute '{attrDef.Name}' was not recorded - A max of {MaxCountAllAttrib} attributes may be supplied.";
+            attributeLimitReached = true;
         }
 
-        private AttributeValueCollectionBase() { }
-
-        protected AttributeValueCollectionBase(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes)
-            : this(targetModelTypes)
+        // Log a message and return false if we hit an attribute limit but don't currently contain the attribute
+        if (attributeLimitReached && !CollectionContainsAttribute(attrDef))
         {
-            AddRange(fromCollection);
-        }
-
-        protected AttributeValueCollectionBase(params AttributeDestinations[] targetModelTypes)
-        {
-            TargetModelTypes = targetModelTypes;
-            foreach (var targetModelType in targetModelTypes)
-            {
-                TargetModelTypesAsFlags |= targetModelType;
-            }
-        }
-
-        protected AttributeValueCollectionBase(string transactionGuid, params AttributeDestinations[] targetModelTypes)
-        {
-            TargetModelTypes = targetModelTypes;
-            foreach (var targetModelType in targetModelTypes)
-            {
-                TargetModelTypesAsFlags |= targetModelType;
-            }
-
-            _transactionGuid = transactionGuid;
-        }
-
-        public IEnumerable<IAttributeValue> GetAttributeValues(AttributeClassification classification)
-        {
-            return GetAttribValuesImpl(classification).Cast<IAttributeValue>();
-        }
-
-        public IDictionary<string, object> GetAttributeValuesDic(AttributeClassification classification)
-        {
-            var result = new Dictionary<string, object>();
-            foreach (var attribVal in GetAttribValuesImpl(classification))
-            {
-                result[attribVal.AttributeDefinition.Name] = attribVal.Value;
-            }
-
-            return result;
-        }
-
-        public IDictionary<string, object> GetAllAttributeValuesDic()
-        {
-            var result = new Dictionary<string, object>();
-            foreach (var classification in _allClassifications)
-            {
-                foreach (var attribVal in GetAttribValuesImpl(classification))
-                {
-                    // This will overwrite existing values in the order of: user < intrinsic < agent
-                    result[attribVal.AttributeDefinition.Name] = attribVal.Value;
-                }
-            }
-
-            return result;
-        }
-
-        public void AddRange(IEnumerable<IAttributeValue> attribValues)
-        {
-            foreach (var attribVal in attribValues)
-            {
-
-                if ((attribVal.AttributeDefinition.AttributeDestinations & TargetModelTypesAsFlags) == 0)
-                {
-                    continue;
-                }
-
-                TrySetValue(attribVal);
-            }
-        }
-
-        public void AddRange(IAttributeValueCollection fromCollection)
-        {
-            foreach (var classification in _allClassifications)
-            {
-                AddRange(fromCollection.GetAttributeValues(classification));
-            }
-        }
-
-        public bool IsImmutable { get; private set; } = false;
-
-        private void IncrementAttribCount(AttributeClassification classification)
-        {
-            switch (classification)
-            {
-                case AttributeClassification.Intrinsics:
-                    Interlocked.Increment(ref _intrinsicAttributeCount);
-                    break;
-
-                case AttributeClassification.AgentAttributes:
-                    Interlocked.Increment(ref _agentAttributeCount);
-                    break;
-
-                case AttributeClassification.UserAttributes:
-                    Interlocked.Increment(ref _userAttributeCount);
-                    break;
-
-            }
-        }
-
-        public bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, TOutput val)
-        {
-            if (!ValidateCollectionLimits(attribDef))
-            {
-                return false;
-            }
-
-            if (!SetValueImpl(attribDef, val))
-            {
-                return false;
-            }
-
-            IncrementAttribCount(attribDef.Classification);
-
-            return true;
-        }
-
-        public bool TrySetValue(IAttributeValue attribValue)
-        {
-            if (!ValidateCollectionLimits(attribValue.AttributeDefinition))
-            {
-                return false;
-            }
-
-            if (!SetValueImpl(attribValue))
-            {
-                return false;
-            }
-
-            IncrementAttribCount(attribValue.AttributeDefinition.Classification);
-
-            return true;
-        }
-
-        public bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, Lazy<object> lazyValueImpl)
-        {
-            if (lazyValueImpl == null || !ValidateCollectionLimits(attribDef))
-            {
-                return false;
-            }
-
-            if (!SetValueImpl(attribDef, lazyValueImpl))
-            {
-                return false;
-            }
-
-
-            IncrementAttribCount(attribDef.Classification);
-
-            return true;
-        }
-
-
-        protected abstract bool SetValueImpl(IAttributeValue attribVal);
-
-        protected abstract bool SetValueImpl(AttributeDefinition attribDef, object value);
-
-        protected abstract bool SetValueImpl(AttributeDefinition attribDef, Lazy<object> lazyValue);
-
-        protected abstract void RemoveItemsImpl(IEnumerable<TAttrib> itemsToRemove);
-
-        protected abstract IEnumerable<TAttrib> GetAttribValuesImpl(AttributeClassification classification);
-
-        public void MakeImmutable()
-        {
-            if (IsImmutable)
-            {
-                return;
-            }
-
-            foreach (var classification in _allClassifications)
-            {
-                var itemsToRemove = new List<TAttrib>();
-                foreach (var attribVal in GetAttribValuesImpl(classification))
-                {
-                    try
-                    {
-                        attribVal.MakeImmutable();
-
-                        if (attribVal.Value == null)
-                        {
-                            //Nothing to log here because the ResolveLazyValue function
-                            //records the error message
-                            itemsToRemove.Add(attribVal);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Finest(ex, "{attribVal.AttributeDefinition.Classification} Attribute '{attribVal.AttributeDefinition.Name}' was not recorded - exception occurred while resolving value (lazy)");
-                        itemsToRemove.Add(attribVal);
-                    }
-                }
-
-                if (itemsToRemove.Count > 0)
-                {
-                    RemoveItemsImpl(itemsToRemove);
-                }
-            }
-
-            IsImmutable = true;
-        }
-
-        private void LogTransactionIfFinest(string message)
-        {
-            if (Log.IsFinestEnabled && !string.IsNullOrWhiteSpace(_transactionGuid))
-            {
-                Log.Finest($"Trx {_transactionGuid}: {message}");
-            }
-            else
-            {
-                Log.Debug(message);
-            }
-        }
-    }
-
-    public class AttributeValueCollection : AttributeValueCollectionBase<AttributeValue>
-    {
-        public AttributeValueCollection(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes) : base(fromCollection, targetModelTypes)
-        {
-        }
-
-        public AttributeValueCollection(params AttributeDestinations[] targetModelTypes) : base(targetModelTypes)
-        {
-        }
-
-        public AttributeValueCollection(string transactionGuid, params AttributeDestinations[] targetModelTypes) : base(transactionGuid, targetModelTypes)
-        {
-        }
-
-        private readonly Dictionary<AttributeClassification, object> _lockObjects = new Dictionary<AttributeClassification, object>
-        {
-            { AttributeClassification.AgentAttributes, new object() },
-            { AttributeClassification.Intrinsics, new object() },
-            { AttributeClassification.UserAttributes, new object() }
-        };
-
-        private Dictionary<Guid, AttributeValue> _intrinsicAttributes;
-        private Dictionary<Guid, AttributeValue> _agentAttributes;
-        private Dictionary<Guid, AttributeValue> _userAttributes;
-
-        private Dictionary<Guid, AttributeValue> GetAttribValuesInternal(AttributeClassification classification, bool withCreate)
-        {
-            switch (classification)
-            {
-                case AttributeClassification.Intrinsics:
-                    return withCreate
-                        ? _intrinsicAttributes ??= new Dictionary<Guid, AttributeValue>()
-                        : _intrinsicAttributes;
-
-                case AttributeClassification.AgentAttributes:
-                    return withCreate
-                        ? _agentAttributes ??= new Dictionary<Guid, AttributeValue>()
-                        : _agentAttributes;
-
-                case AttributeClassification.UserAttributes:
-                    return withCreate
-                        ? _userAttributes ??= new Dictionary<Guid, AttributeValue>()
-                        : _userAttributes;
-            }
-
-            return null;
-        }
-
-        protected override IEnumerable<AttributeValue> GetAttribValuesImpl(AttributeClassification classification)
-        {
-            var dic = GetAttribValuesInternal(classification, false);
-
-            return dic?.Values ?? Enumerable.Empty<AttributeValue>();
-        }
-
-        protected override void RemoveItemsImpl(IEnumerable<AttributeValue> itemsToRemove)
-        {
-            foreach (var lockObjKvp in _lockObjects)
-            {
-                var guidsToRemove = itemsToRemove
-                    .Where(x => x.AttributeDefinition.Classification == lockObjKvp.Key)
-                    .Select(x => x.AttributeDefinition.Guid)
-                    .ToArray();
-
-                if (guidsToRemove.Length == 0)
-                {
-                    continue;
-                }
-
-                var dicForClassification = GetAttribValuesInternal(lockObjKvp.Key, false);
-                if (dicForClassification == null)
-                {
-                    continue;
-                }
-
-                lock (lockObjKvp.Value)
-                {
-                    foreach (var guidToRemove in guidsToRemove)
-                    {
-                        dicForClassification.Remove(guidToRemove);
-                    }
-                }
-            }
-        }
-
-        public override bool CollectionContainsAttribute(AttributeDefinition attrDef)
-        {
-            var lockObj = _lockObjects[attrDef.Classification];
-            lock (lockObj)
-            {
-                var dic = GetAttribValuesInternal(attrDef.Classification, false);
-                var hasItem = dic?.ContainsKey(attrDef.Guid);
-                return hasItem.HasValue && hasItem.Value;
-            }
-        }
-
-        protected override bool SetValueImpl(IAttributeValue attribVal)
-        {
-            if (IsImmutable)
-            {
-#if DEBUG
-                // try to catch attempts to add to an immutable collection during development
-                throw new Exception($"Attempted to add attribute {attribVal.AttributeDefinition.Name} to immutable collection");
-#endif
-            }
-            if (attribVal is AttributeValue attribValTyped)
-            {
-                return SetValueImplInternal(attribValTyped);
-            }
-
-            if (attribVal.Value != null)
-            {
-                return SetValueImpl(attribVal.AttributeDefinition, attribVal.Value);
-            }
-
-            if (attribVal.LazyValue != null)
-            {
-                return SetValueImpl(attribVal.AttributeDefinition, attribVal.LazyValue);
-            }
-
+            LogTransactionIfFinest(message);
             return false;
         }
 
-        protected override bool SetValueImpl(AttributeDefinition attribDef, object value)
+        return true;
+    }
+
+    private AttributeValueCollectionBase() { }
+
+    protected AttributeValueCollectionBase(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes)
+        : this(targetModelTypes)
+    {
+        AddRange(fromCollection);
+    }
+
+    protected AttributeValueCollectionBase(params AttributeDestinations[] targetModelTypes)
+    {
+        TargetModelTypes = targetModelTypes;
+        foreach (var targetModelType in targetModelTypes)
         {
-            if (IsImmutable)
-            {
-#if DEBUG
-                // try to catch attempts to add to an immutable collection during development
-                throw new Exception($"Attempted to add attribute {attribDef.Name} to immutable collection");
-#else
-                return false;
-#endif
-            }
+            TargetModelTypesAsFlags |= targetModelType;
+        }
+    }
 
-            var attribVal = new AttributeValue(attribDef)
-            {
-                Value = value
-            };
-
-            return SetValueImplInternal(attribVal);
+    protected AttributeValueCollectionBase(string transactionGuid, params AttributeDestinations[] targetModelTypes)
+    {
+        TargetModelTypes = targetModelTypes;
+        foreach (var targetModelType in targetModelTypes)
+        {
+            TargetModelTypesAsFlags |= targetModelType;
         }
 
-        protected override bool SetValueImpl(AttributeDefinition attribDef, Lazy<object> lazyValue)
+        _transactionGuid = transactionGuid;
+    }
+
+    public IEnumerable<IAttributeValue> GetAttributeValues(AttributeClassification classification)
+    {
+        return GetAttribValuesImpl(classification).Cast<IAttributeValue>();
+    }
+
+    public IDictionary<string, object> GetAttributeValuesDic(AttributeClassification classification)
+    {
+        var result = new Dictionary<string, object>();
+        foreach (var attribVal in GetAttribValuesImpl(classification))
         {
-            if (IsImmutable)
-            {
-#if DEBUG
-                // try to catch attempts to add to an immutable collection during development
-                throw new Exception($"Attempted to add attribute {attribDef.Name} to immutable collection");
-#else
-                return false;
-#endif
-            }
-
-            var attribVal = new AttributeValue(attribDef)
-            {
-                LazyValue = lazyValue
-            };
-
-            return SetValueImplInternal(attribVal);
+            result[attribVal.AttributeDefinition.Name] = attribVal.Value;
         }
 
-        private bool SetValueImplInternal(AttributeValue attribVal)
+        return result;
+    }
+
+    public IDictionary<string, object> GetAllAttributeValuesDic()
+    {
+        var result = new Dictionary<string, object>();
+        foreach (var classification in _allClassifications)
         {
-            if (IsImmutable)
+            foreach (var attribVal in GetAttribValuesImpl(classification))
             {
+                // This will overwrite existing values in the order of: user < intrinsic < agent
+                result[attribVal.AttributeDefinition.Name] = attribVal.Value;
+            }
+        }
+
+        return result;
+    }
+
+    public void AddRange(IEnumerable<IAttributeValue> attribValues)
+    {
+        foreach (var attribVal in attribValues)
+        {
+
+            if ((attribVal.AttributeDefinition.AttributeDestinations & TargetModelTypesAsFlags) == 0)
+            {
+                continue;
+            }
+
+            TrySetValue(attribVal);
+        }
+    }
+
+    public void AddRange(IAttributeValueCollection fromCollection)
+    {
+        foreach (var classification in _allClassifications)
+        {
+            AddRange(fromCollection.GetAttributeValues(classification));
+        }
+    }
+
+    public bool IsImmutable { get; private set; } = false;
+
+    private void IncrementAttribCount(AttributeClassification classification)
+    {
+        switch (classification)
+        {
+            case AttributeClassification.Intrinsics:
+                Interlocked.Increment(ref _intrinsicAttributeCount);
+                break;
+
+            case AttributeClassification.AgentAttributes:
+                Interlocked.Increment(ref _agentAttributeCount);
+                break;
+
+            case AttributeClassification.UserAttributes:
+                Interlocked.Increment(ref _userAttributeCount);
+                break;
+
+        }
+    }
+
+    public bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, TOutput val)
+    {
+        if (!ValidateCollectionLimits(attribDef))
+        {
+            return false;
+        }
+
+        if (!SetValueImpl(attribDef, val))
+        {
+            return false;
+        }
+
+        IncrementAttribCount(attribDef.Classification);
+
+        return true;
+    }
+
+    public bool TrySetValue(IAttributeValue attribValue)
+    {
+        if (!ValidateCollectionLimits(attribValue.AttributeDefinition))
+        {
+            return false;
+        }
+
+        if (!SetValueImpl(attribValue))
+        {
+            return false;
+        }
+
+        IncrementAttribCount(attribValue.AttributeDefinition.Classification);
+
+        return true;
+    }
+
+    public bool TrySetValue<TInput, TOutput>(AttributeDefinition<TInput, TOutput> attribDef, Lazy<object> lazyValueImpl)
+    {
+        if (lazyValueImpl == null || !ValidateCollectionLimits(attribDef))
+        {
+            return false;
+        }
+
+        if (!SetValueImpl(attribDef, lazyValueImpl))
+        {
+            return false;
+        }
+
+
+        IncrementAttribCount(attribDef.Classification);
+
+        return true;
+    }
+
+
+    protected abstract bool SetValueImpl(IAttributeValue attribVal);
+
+    protected abstract bool SetValueImpl(AttributeDefinition attribDef, object value);
+
+    protected abstract bool SetValueImpl(AttributeDefinition attribDef, Lazy<object> lazyValue);
+
+    protected abstract void RemoveItemsImpl(IEnumerable<TAttrib> itemsToRemove);
+
+    protected abstract IEnumerable<TAttrib> GetAttribValuesImpl(AttributeClassification classification);
+
+    public void MakeImmutable()
+    {
+        if (IsImmutable)
+        {
+            return;
+        }
+
+        foreach (var classification in _allClassifications)
+        {
+            var itemsToRemove = new List<TAttrib>();
+            foreach (var attribVal in GetAttribValuesImpl(classification))
+            {
+                try
+                {
+                    attribVal.MakeImmutable();
+
+                    if (attribVal.Value == null)
+                    {
+                        //Nothing to log here because the ResolveLazyValue function
+                        //records the error message
+                        itemsToRemove.Add(attribVal);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Finest(ex, "{attribVal.AttributeDefinition.Classification} Attribute '{attribVal.AttributeDefinition.Name}' was not recorded - exception occurred while resolving value (lazy)");
+                    itemsToRemove.Add(attribVal);
+                }
+            }
+
+            if (itemsToRemove.Count > 0)
+            {
+                RemoveItemsImpl(itemsToRemove);
+            }
+        }
+
+        IsImmutable = true;
+    }
+
+    private void LogTransactionIfFinest(string message)
+    {
+        if (Log.IsFinestEnabled && !string.IsNullOrWhiteSpace(_transactionGuid))
+        {
+            Log.Finest($"Trx {_transactionGuid}: {message}");
+        }
+        else
+        {
+            Log.Debug(message);
+        }
+    }
+}
+
+public class AttributeValueCollection : AttributeValueCollectionBase<AttributeValue>
+{
+    public AttributeValueCollection(IAttributeValueCollection fromCollection, params AttributeDestinations[] targetModelTypes) : base(fromCollection, targetModelTypes)
+    {
+    }
+
+    public AttributeValueCollection(params AttributeDestinations[] targetModelTypes) : base(targetModelTypes)
+    {
+    }
+
+    public AttributeValueCollection(string transactionGuid, params AttributeDestinations[] targetModelTypes) : base(transactionGuid, targetModelTypes)
+    {
+    }
+
+    private readonly Dictionary<AttributeClassification, object> _lockObjects = new Dictionary<AttributeClassification, object>
+    {
+        { AttributeClassification.AgentAttributes, new object() },
+        { AttributeClassification.Intrinsics, new object() },
+        { AttributeClassification.UserAttributes, new object() }
+    };
+
+    private Dictionary<Guid, AttributeValue> _intrinsicAttributes;
+    private Dictionary<Guid, AttributeValue> _agentAttributes;
+    private Dictionary<Guid, AttributeValue> _userAttributes;
+
+    private Dictionary<Guid, AttributeValue> GetAttribValuesInternal(AttributeClassification classification, bool withCreate)
+    {
+        switch (classification)
+        {
+            case AttributeClassification.Intrinsics:
+                return withCreate
+                    ? _intrinsicAttributes ??= new Dictionary<Guid, AttributeValue>()
+                    : _intrinsicAttributes;
+
+            case AttributeClassification.AgentAttributes:
+                return withCreate
+                    ? _agentAttributes ??= new Dictionary<Guid, AttributeValue>()
+                    : _agentAttributes;
+
+            case AttributeClassification.UserAttributes:
+                return withCreate
+                    ? _userAttributes ??= new Dictionary<Guid, AttributeValue>()
+                    : _userAttributes;
+        }
+
+        return null;
+    }
+
+    protected override IEnumerable<AttributeValue> GetAttribValuesImpl(AttributeClassification classification)
+    {
+        var dic = GetAttribValuesInternal(classification, false);
+
+        return dic?.Values ?? Enumerable.Empty<AttributeValue>();
+    }
+
+    protected override void RemoveItemsImpl(IEnumerable<AttributeValue> itemsToRemove)
+    {
+        foreach (var lockObjKvp in _lockObjects)
+        {
+            var guidsToRemove = itemsToRemove
+                .Where(x => x.AttributeDefinition.Classification == lockObjKvp.Key)
+                .Select(x => x.AttributeDefinition.Guid)
+                .ToArray();
+
+            if (guidsToRemove.Length == 0)
+            {
+                continue;
+            }
+
+            var dicForClassification = GetAttribValuesInternal(lockObjKvp.Key, false);
+            if (dicForClassification == null)
+            {
+                continue;
+            }
+
+            lock (lockObjKvp.Value)
+            {
+                foreach (var guidToRemove in guidsToRemove)
+                {
+                    dicForClassification.Remove(guidToRemove);
+                }
+            }
+        }
+    }
+
+    public override bool CollectionContainsAttribute(AttributeDefinition attrDef)
+    {
+        var lockObj = _lockObjects[attrDef.Classification];
+        lock (lockObj)
+        {
+            var dic = GetAttribValuesInternal(attrDef.Classification, false);
+            var hasItem = dic?.ContainsKey(attrDef.Guid);
+            return hasItem.HasValue && hasItem.Value;
+        }
+    }
+
+    protected override bool SetValueImpl(IAttributeValue attribVal)
+    {
+        if (IsImmutable)
+        {
 #if DEBUG
-                // try to catch attempts to add to an immutable collection during development
-                throw new Exception($"Attempted to add attribute {attribVal.AttributeDefinition.Name} to immutable collection");
+            // try to catch attempts to add to an immutable collection during development
+            throw new Exception($"Attempted to add attribute {attribVal.AttributeDefinition.Name} to immutable collection");
+#endif
+        }
+        if (attribVal is AttributeValue attribValTyped)
+        {
+            return SetValueImplInternal(attribValTyped);
+        }
+
+        if (attribVal.Value != null)
+        {
+            return SetValueImpl(attribVal.AttributeDefinition, attribVal.Value);
+        }
+
+        if (attribVal.LazyValue != null)
+        {
+            return SetValueImpl(attribVal.AttributeDefinition, attribVal.LazyValue);
+        }
+
+        return false;
+    }
+
+    protected override bool SetValueImpl(AttributeDefinition attribDef, object value)
+    {
+        if (IsImmutable)
+        {
+#if DEBUG
+            // try to catch attempts to add to an immutable collection during development
+            throw new Exception($"Attempted to add attribute {attribDef.Name} to immutable collection");
 #else
                 return false;
 #endif
-            }
+        }
 
-            var lockObj = _lockObjects[attribVal.AttributeDefinition.Classification];
-            lock (lockObj)
-            {
-                var dic = GetAttribValuesInternal(attribVal.AttributeDefinition.Classification, true);
-                var hasItem = dic.ContainsKey(attribVal.AttributeDefinition.Guid);
-                dic[attribVal.AttributeDefinition.Guid] = attribVal;
+        var attribVal = new AttributeValue(attribDef)
+        {
+            Value = value
+        };
 
-                return !hasItem;
-            }
+        return SetValueImplInternal(attribVal);
+    }
+
+    protected override bool SetValueImpl(AttributeDefinition attribDef, Lazy<object> lazyValue)
+    {
+        if (IsImmutable)
+        {
+#if DEBUG
+            // try to catch attempts to add to an immutable collection during development
+            throw new Exception($"Attempted to add attribute {attribDef.Name} to immutable collection");
+#else
+                return false;
+#endif
+        }
+
+        var attribVal = new AttributeValue(attribDef)
+        {
+            LazyValue = lazyValue
+        };
+
+        return SetValueImplInternal(attribVal);
+    }
+
+    private bool SetValueImplInternal(AttributeValue attribVal)
+    {
+        if (IsImmutable)
+        {
+#if DEBUG
+            // try to catch attempts to add to an immutable collection during development
+            throw new Exception($"Attempted to add attribute {attribVal.AttributeDefinition.Name} to immutable collection");
+#else
+                return false;
+#endif
+        }
+
+        var lockObj = _lockObjects[attribVal.AttributeDefinition.Classification];
+        lock (lockObj)
+        {
+            var dic = GetAttribValuesInternal(attribVal.AttributeDefinition.Classification, true);
+            var hasItem = dic.ContainsKey(attribVal.AttributeDefinition.Guid);
+            dic[attribVal.AttributeDefinition.Guid] = attribVal;
+
+            return !hasItem;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/Clude.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/Clude.cs
@@ -1,12 +1,11 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+internal enum Clude
 {
-    internal enum Clude
-    {
-        Unknown = 0,
-        Exclude,
-        Include,
-    }
+    Unknown = 0,
+    Exclude,
+    Include,
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/LogContextDataFilter.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/LogContextDataFilter.cs
@@ -10,154 +10,152 @@ using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public interface ILogContextDataFilter : IDisposable
 {
-    public interface ILogContextDataFilter : IDisposable
+    Dictionary<string, object> FilterLogContextData(Dictionary<string, object> contextData);
+}
+
+public class LogContextDataFilter : ConfigurationBasedService, ILogContextDataFilter
+{
+    private IConfigurationService _configurationService;
+    private List<LogContextDataFilterRule> _includeRuleList;
+    private List<LogContextDataFilterRule> _excludeRuleList;
+    private List<LogContextDataFilterRule> _orderedCludeRuleList;
+
+    private ConcurrentDictionary<string, bool> _clusionCache = new ConcurrentDictionary<string, bool>();
+    private const int MaxCacheSize = 1000;
+    private bool _clusionCacheSizeExceededWarningLogged = false;
+
+    public LogContextDataFilter(IConfigurationService configurationService)
     {
-        Dictionary<string, object> FilterLogContextData(Dictionary<string, object> contextData);
+        _configurationService = configurationService;
     }
 
-    public class LogContextDataFilter : ConfigurationBasedService, ILogContextDataFilter
+
+    public Dictionary<string, object> FilterLogContextData(Dictionary<string, object> unfilteredContextData)
     {
-        private IConfigurationService _configurationService;
-        private List<LogContextDataFilterRule> _includeRuleList;
-        private List<LogContextDataFilterRule> _excludeRuleList;
-        private List<LogContextDataFilterRule> _orderedCludeRuleList;
-
-        private ConcurrentDictionary<string, bool> _clusionCache = new ConcurrentDictionary<string, bool>();
-        private const int MaxCacheSize = 1000;
-        private bool _clusionCacheSizeExceededWarningLogged = false;
-
-        public LogContextDataFilter(IConfigurationService configurationService)
+        if (unfilteredContextData == null)
         {
-            _configurationService = configurationService;
+            return null;
         }
 
+        var filteredContextData = new Dictionary<string, object>();
 
-        public Dictionary<string, object> FilterLogContextData(Dictionary<string, object> unfilteredContextData)
+        // Pseudocode
+        // Include/exclude rules:
+        // 1. Exclude wins over include
+        // 2. Can have a '*' wildcard at the end of an include/exclude definition
+        // 3. "more specific" rules win over "less specific".  Example: include=AB, exclude=A*, AB would be included but not ABC or AAA
+
+        // Algorithm:
+        // Create list of rules, sorted by most specific to least specific, with excludes first and then includes within each level of specificity
+        // Specificity is just the length of the string, minus any wildcard character at the end
+        // For each context data key/value pair:
+        //   First, check the "clusion cache" to see if we already know whether or not to include or exclude this key, and if so handle it appropriately
+        //   Otherwise, go through the list of rules and see if we find a matching rule to exclude or include, cache the result, and handle it appropriately
+
+        foreach (var kvp in unfilteredContextData)
         {
-            if (unfilteredContextData == null)
+            bool clusionResult;
+            if (!_clusionCache.TryGetValue(kvp.Key, out clusionResult))
             {
-                return null;
-            }
-
-            var filteredContextData = new Dictionary<string, object>();
-
-            // Pseudocode
-            // Include/exclude rules:
-            // 1. Exclude wins over include
-            // 2. Can have a '*' wildcard at the end of an include/exclude definition
-            // 3. "more specific" rules win over "less specific".  Example: include=AB, exclude=A*, AB would be included but not ABC or AAA
-
-            // Algorithm:
-            // Create list of rules, sorted by most specific to least specific, with excludes first and then includes within each level of specificity
-            // Specificity is just the length of the string, minus any wildcard character at the end
-            // For each context data key/value pair:
-            //   First, check the "clusion cache" to see if we already know whether or not to include or exclude this key, and if so handle it appropriately
-            //   Otherwise, go through the list of rules and see if we find a matching rule to exclude or include, cache the result, and handle it appropriately
-
-            foreach (var kvp in unfilteredContextData)
-            {
-                bool clusionResult;
-                if (!_clusionCache.TryGetValue(kvp.Key, out clusionResult))
+                clusionResult = GetClusionResult(kvp.Key);
+                if (_clusionCache.Count < MaxCacheSize)
                 {
-                    clusionResult = GetClusionResult(kvp.Key);
-                    if (_clusionCache.Count < MaxCacheSize)
+                    _clusionCache[kvp.Key] = clusionResult;
+                }
+                else
+                {
+                    if (!_clusionCacheSizeExceededWarningLogged)
                     {
-                        _clusionCache[kvp.Key] = clusionResult;
-                    }
-                    else
-                    {
-                        if (!_clusionCacheSizeExceededWarningLogged)
-                        {
-                            Log.Warn($"LogContextDataFilter: max # ({MaxCacheSize}) of log context data attribute name inclusion/exclusion results reached.");
-                            _clusionCacheSizeExceededWarningLogged = true;
-                        }
+                        Log.Warn($"LogContextDataFilter: max # ({MaxCacheSize}) of log context data attribute name inclusion/exclusion results reached.");
+                        _clusionCacheSizeExceededWarningLogged = true;
                     }
                 }
-
-                if (clusionResult)
-                {
-                    filteredContextData[kvp.Key] = kvp.Value;
-                }
             }
 
-            return filteredContextData;
-        }
-
-        private bool GetClusionResult(string key)
-        {
-            var allRulesInOrder = _orderedCludeRuleList ?? (_orderedCludeRuleList = GetOrderedCludeRuleList());
-
-            bool clusionResult = _includeRuleList.Count == 0; // An empty include rule list means include everything
-            foreach (var rule in allRulesInOrder)
+            if (clusionResult)
             {
-                if (RuleMatches(rule, key))
-                {
-                    clusionResult = rule.Include;
-                    break; // Because of how the rule list is ordered, we are done checking as soon as we find a match
-                }
+                filteredContextData[kvp.Key] = kvp.Value;
             }
-            return clusionResult;
         }
 
-        private bool RuleMatches(LogContextDataFilterRule rule, string text)
-        {
-            return rule.IsWildCard ? text.StartsWith(rule.Text, StringComparison.Ordinal) : text == rule.Text;
-        }
+        return filteredContextData;
+    }
 
-        private List<LogContextDataFilterRule> GetCludeRulesFromConfig(bool isIncludeRules)
+    private bool GetClusionResult(string key)
+    {
+        var allRulesInOrder = _orderedCludeRuleList ?? (_orderedCludeRuleList = GetOrderedCludeRuleList());
+
+        bool clusionResult = _includeRuleList.Count == 0; // An empty include rule list means include everything
+        foreach (var rule in allRulesInOrder)
         {
-            List<LogContextDataFilterRule> rules = new List<LogContextDataFilterRule>();
-            var configRuleList = isIncludeRules ? _configurationService.Configuration.ContextDataInclude : _configurationService.Configuration.ContextDataExclude;
-            foreach (var configRule in configRuleList)
+            if (RuleMatches(rule, key))
             {
-                rules.Add(new LogContextDataFilterRule(configRule, isIncludeRules));
+                clusionResult = rule.Include;
+                break; // Because of how the rule list is ordered, we are done checking as soon as we find a match
             }
-            return rules;
         }
+        return clusionResult;
+    }
 
-        private List<LogContextDataFilterRule> GetOrderedCludeRuleList()
+    private bool RuleMatches(LogContextDataFilterRule rule, string text)
+    {
+        return rule.IsWildCard ? text.StartsWith(rule.Text, StringComparison.Ordinal) : text == rule.Text;
+    }
+
+    private List<LogContextDataFilterRule> GetCludeRulesFromConfig(bool isIncludeRules)
+    {
+        List<LogContextDataFilterRule> rules = new List<LogContextDataFilterRule>();
+        var configRuleList = isIncludeRules ? _configurationService.Configuration.ContextDataInclude : _configurationService.Configuration.ContextDataExclude;
+        foreach (var configRule in configRuleList)
         {
-            var includeRuleList = _includeRuleList ?? (_includeRuleList = GetCludeRulesFromConfig(true));
-            var excludeRuleList = _excludeRuleList ?? (_excludeRuleList = GetCludeRulesFromConfig(false));
+            rules.Add(new LogContextDataFilterRule(configRule, isIncludeRules));
+        }
+        return rules;
+    }
 
-            // This works because OrderBy uses a stable sort.  By sorting each list individually,
-            // concactenating them, and then sorting again, we get a list of rules ordered by length (specificity) descending,
-            // with excludes before includes for each level of specificity
-            return excludeRuleList.OrderByDescending(rule => rule.Specificity).Concat(
+    private List<LogContextDataFilterRule> GetOrderedCludeRuleList()
+    {
+        var includeRuleList = _includeRuleList ?? (_includeRuleList = GetCludeRulesFromConfig(true));
+        var excludeRuleList = _excludeRuleList ?? (_excludeRuleList = GetCludeRulesFromConfig(false));
+
+        // This works because OrderBy uses a stable sort.  By sorting each list individually,
+        // concactenating them, and then sorting again, we get a list of rules ordered by length (specificity) descending,
+        // with excludes before includes for each level of specificity
+        return excludeRuleList.OrderByDescending(rule => rule.Specificity).Concat(
                 includeRuleList.OrderByDescending(rule => rule.Specificity))
-                .OrderByDescending(rule => rule.Specificity).ToList();
-        }
-
-        protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            _includeRuleList = null;
-            _excludeRuleList = null;
-            _orderedCludeRuleList = null;
-            _clusionCache = new ConcurrentDictionary<string, bool>();
-            _clusionCacheSizeExceededWarningLogged = false;
-        }
+            .OrderByDescending(rule => rule.Specificity).ToList();
     }
-    public class LogContextDataFilterRule
+
+    protected override void OnConfigurationUpdated(ConfigurationUpdateSource configurationUpdateSource)
     {
-        string _text;
-        bool _include;
-        int _specificity; // just the length, except ignore a trailing wildcard.  I.e. AB is more specific than A*
-        bool _isWildCard;
+        _includeRuleList = null;
+        _excludeRuleList = null;
+        _orderedCludeRuleList = null;
+        _clusionCache = new ConcurrentDictionary<string, bool>();
+        _clusionCacheSizeExceededWarningLogged = false;
+    }
+}
+public class LogContextDataFilterRule
+{
+    string _text;
+    bool _include;
+    int _specificity; // just the length, except ignore a trailing wildcard.  I.e. AB is more specific than A*
+    bool _isWildCard;
 
-        public LogContextDataFilterRule(string text, bool include)
-        {
-            _isWildCard = text.EndsWith("*");
-            _text = text.TrimEnd('*');
-            _include = include;
-            _specificity = _text.Length;
-        }
-
-        public string Text => _text;
-        public bool Include => _include;
-        public int Specificity => _specificity;
-        public bool IsWildCard => _isWildCard;
+    public LogContextDataFilterRule(string text, bool include)
+    {
+        _isWildCard = text.EndsWith("*");
+        _text = text.TrimEnd('*');
+        _include = include;
+        _specificity = _text.Length;
     }
 
+    public string Text => _text;
+    public bool Include => _include;
+    public int Specificity => _specificity;
+    public bool IsWildCard => _isWildCard;
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/TrieBuilder.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/TrieBuilder.cs
@@ -5,95 +5,94 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public class TrieBuilder<T>
 {
-    public class TrieBuilder<T>
+    private readonly Func<T> _rootNodeMetaDataFactory;
+
+    private readonly Func<IEnumerable<T>, T> _nodeMerger;
+
+    private readonly Func<T, bool> _canNodeHaveChildrenChecker;
+
+    private readonly TrieNodeComparor<T> _nodeComparor;
+
+    public TrieBuilder(
+        Func<T> rootNodeDataFactory,
+        Func<IEnumerable<T>, T> nodeDataMerger,
+        Func<T, T, int> nodeDataComparor,
+        Func<T, int> nodeDataHasher,
+        Func<T, T, bool> canParentAcceptChildChecker,
+        Func<T, bool> canNodeHaveChildrenChecker)
     {
-        private readonly Func<T> _rootNodeMetaDataFactory;
+        _rootNodeMetaDataFactory = rootNodeDataFactory;
+        _nodeMerger = nodeDataMerger;
+        _canNodeHaveChildrenChecker = canNodeHaveChildrenChecker;
+        _nodeComparor = new TrieNodeComparor<T>(nodeDataComparor, nodeDataHasher, canParentAcceptChildChecker);
+    }
 
-        private readonly Func<IEnumerable<T>, T> _nodeMerger;
+    public TrieNode<T> CreateTrie(IEnumerable<T> nodeMetaDatas)
+    {
+        var rootNodeMetaData = _rootNodeMetaDataFactory();
+        if (rootNodeMetaData == null)
+            throw new NullReferenceException("Root node factory cannot return a null root node.");
+        if (!_canNodeHaveChildrenChecker(rootNodeMetaData))
+            throw new InvalidOperationException("Node returned by root node must be able to have children.");
 
-        private readonly Func<T, bool> _canNodeHaveChildrenChecker;
+        var rootNode = new TrieNode<T>(rootNodeMetaData);
 
-        private readonly TrieNodeComparor<T> _nodeComparor;
+        var datas = nodeMetaDatas
+            .OrderBy(nodeMetaData => nodeMetaData, _nodeComparor)
+            .GroupBy(nodeMetaData => nodeMetaData, _nodeComparor)
+            .Where(NodeDataGroupingIsNotEmpty)
+            .Select(MergeNodeDatas)
+            .Select(TrieNodeFromData);
 
-        public TrieBuilder(
-            Func<T> rootNodeDataFactory,
-            Func<IEnumerable<T>, T> nodeDataMerger,
-            Func<T, T, int> nodeDataComparor,
-            Func<T, int> nodeDataHasher,
-            Func<T, T, bool> canParentAcceptChildChecker,
-            Func<T, bool> canNodeHaveChildrenChecker)
+        foreach (var orphan in datas)
         {
-            _rootNodeMetaDataFactory = rootNodeDataFactory;
-            _nodeMerger = nodeDataMerger;
-            _canNodeHaveChildrenChecker = canNodeHaveChildrenChecker;
-            _nodeComparor = new TrieNodeComparor<T>(nodeDataComparor, nodeDataHasher, canParentAcceptChildChecker);
+            TryAddNodeAsChild(rootNode, orphan);
         }
 
-        public TrieNode<T> CreateTrie(IEnumerable<T> nodeMetaDatas)
-        {
-            var rootNodeMetaData = _rootNodeMetaDataFactory();
-            if (rootNodeMetaData == null)
-                throw new NullReferenceException("Root node factory cannot return a null root node.");
-            if (!_canNodeHaveChildrenChecker(rootNodeMetaData))
-                throw new InvalidOperationException("Node returned by root node must be able to have children.");
+        return rootNode;
+    }
 
-            var rootNode = new TrieNode<T>(rootNodeMetaData);
+    private static TrieNode<T> TrieNodeFromData(T metaData)
+    {
+        return new TrieNode<T>(metaData);
+    }
 
-            var datas = nodeMetaDatas
-                .OrderBy(nodeMetaData => nodeMetaData, _nodeComparor)
-                .GroupBy(nodeMetaData => nodeMetaData, _nodeComparor)
-                .Where(NodeDataGroupingIsNotEmpty)
-                .Select(MergeNodeDatas)
-                .Select(TrieNodeFromData);
+    private static bool NodeDataGroupingIsNotEmpty(IGrouping<T, T> nodes)
+    {
+        if (nodes == null)
+            return false;
 
-            foreach (var orphan in datas)
-            {
-                TryAddNodeAsChild(rootNode, orphan);
-            }
+        return nodes.Any();
+    }
 
-            return rootNode;
-        }
+    private T MergeNodeDatas(IGrouping<T, T> nodes)
+    {
+        var mergedNode = _nodeMerger(nodes);
+        if (mergedNode == null)
+            throw new NullReferenceException("The node data merger method must return a non-null object.");
+        return mergedNode;
+    }
 
-        private static TrieNode<T> TrieNodeFromData(T metaData)
-        {
-            return new TrieNode<T>(metaData);
-        }
+    private bool TryAddNodeAsChild(TrieNode<T> parent, TrieNode<T> orphan)
+    {
+        if (!_nodeComparor.PotentialChild(parent.Data, orphan.Data))
+            return false;
 
-        private static bool NodeDataGroupingIsNotEmpty(IGrouping<T, T> nodes)
-        {
-            if (nodes == null)
-                return false;
+        if (!_canNodeHaveChildrenChecker(parent.Data))
+            return false;
 
-            return nodes.Any();
-        }
-
-        private T MergeNodeDatas(IGrouping<T, T> nodes)
-        {
-            var mergedNode = _nodeMerger(nodes);
-            if (mergedNode == null)
-                throw new NullReferenceException("The node data merger method must return a non-null object.");
-            return mergedNode;
-        }
-
-        private bool TryAddNodeAsChild(TrieNode<T> parent, TrieNode<T> orphan)
-        {
-            if (!_nodeComparor.PotentialChild(parent.Data, orphan.Data))
-                return false;
-
-            if (!_canNodeHaveChildrenChecker(parent.Data))
-                return false;
-
-            var addedToChild = parent.Children
-                .Where(child => child != null)
-                .Where(child => TryAddNodeAsChild(child, orphan))
-                .Any();
-            if (addedToChild)
-                return true;
-
-            parent.Children.Add(orphan);
+        var addedToChild = parent.Children
+            .Where(child => child != null)
+            .Where(child => TryAddNodeAsChild(child, orphan))
+            .Any();
+        if (addedToChild)
             return true;
-        }
+
+        parent.Children.Add(orphan);
+        return true;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/TrieNode.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/TrieNode.cs
@@ -3,17 +3,16 @@
 
 using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public class TrieNode<T>
 {
-    public class TrieNode<T>
+    public readonly T Data;
+
+    public readonly ICollection<TrieNode<T>> Children = new List<TrieNode<T>>();
+
+    public TrieNode(T metaData)
     {
-        public readonly T Data;
-
-        public readonly ICollection<TrieNode<T>> Children = new List<TrieNode<T>>();
-
-        public TrieNode(T metaData)
-        {
-            Data = metaData;
-        }
+        Data = metaData;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/TrieNodeComparor.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/TrieNodeComparor.cs
@@ -4,50 +4,49 @@
 using System;
 using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+internal class TrieNodeComparor<T> : IComparer<T>, IEqualityComparer<T>
 {
-    internal class TrieNodeComparor<T> : IComparer<T>, IEqualityComparer<T>
+    private readonly Func<T, T, int> _nodeComparor;
+
+    private readonly Func<T, int> _nodeHasher;
+
+    private readonly Func<T, T, bool> _potentialChildChecker;
+
+    public int Compare(T left, T right)
     {
-        private readonly Func<T, T, int> _nodeComparor;
+        if (left == null && right == null)
+            return 0;
 
-        private readonly Func<T, int> _nodeHasher;
+        if (left == null)
+            return -1;
 
-        private readonly Func<T, T, bool> _potentialChildChecker;
+        if (right == null)
+            return 1;
 
-        public int Compare(T left, T right)
-        {
-            if (left == null && right == null)
-                return 0;
+        return _nodeComparor(left, right);
+    }
 
-            if (left == null)
-                return -1;
+    public TrieNodeComparor(Func<T, T, int> nodeComparor, Func<T, int> nodeHasher, Func<T, T, bool> potentialChildChecker)
+    {
+        _nodeComparor = nodeComparor;
+        _nodeHasher = nodeHasher;
+        _potentialChildChecker = potentialChildChecker;
+    }
 
-            if (right == null)
-                return 1;
+    public bool Equals(T left, T right)
+    {
+        return Compare(left, right) == 0;
+    }
 
-            return _nodeComparor(left, right);
-        }
+    public int GetHashCode(T node)
+    {
+        return _nodeHasher(node);
+    }
 
-        public TrieNodeComparor(Func<T, T, int> nodeComparor, Func<T, int> nodeHasher, Func<T, T, bool> potentialChildChecker)
-        {
-            _nodeComparor = nodeComparor;
-            _nodeHasher = nodeHasher;
-            _potentialChildChecker = potentialChildChecker;
-        }
-
-        public bool Equals(T left, T right)
-        {
-            return Compare(left, right) == 0;
-        }
-
-        public int GetHashCode(T node)
-        {
-            return _nodeHasher(node);
-        }
-
-        public bool PotentialChild(T parent, T child)
-        {
-            return _potentialChildChecker(parent, child);
-        }
+    public bool PotentialChild(T parent, T child)
+    {
+        return _potentialChildChecker(parent, child);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Attributes/TypeAttributeValue.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/TypeAttributeValue.cs
@@ -1,14 +1,13 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+public enum TypeAttributeValue
 {
-    public enum TypeAttributeValue
-    {
-        Transaction = 1,
-        TransactionError = 2,
-        Span = 3,
-        SpanLink = 4,
-        SpanEvent = 5
-    }
+    Transaction = 1,
+    TransactionError = 2,
+    Span = 3,
+    SpanLink = 4,
+    SpanEvent = 5
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringConfigurationData.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringConfigurationData.cs
@@ -4,78 +4,76 @@
 using System;
 using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+//NREUM.info={
+//  "beacon":"staging-beacon-1.newrelic.com",
+//  "errorBeacon":"staging-jserror.newrelic.com",
+//  "licenseKey":"3ed9cebafb",
+//  "applicationID":"45526",
+//  "transactionName":"J1lZFRQMVF9VFk4AWwtRRE4PDVxWSA==",
+//  "queueTime":0,
+//  "applicationTime":116,
+//  "agent":"js-agent.newrelic.com/nr-213.min.js",
+//  "userAttributes":"SxNHQFFHFA0aSl9cV1JeVkoWGRRUTUpEXl9vWFYRDgEESg=="
+//   "sslForHttp":"true"
+//}
+
+public class BrowserMonitoringConfigurationData
 {
+    private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
-    //NREUM.info={
-    //  "beacon":"staging-beacon-1.newrelic.com",
-    //  "errorBeacon":"staging-jserror.newrelic.com",
-    //  "licenseKey":"3ed9cebafb",
-    //  "applicationID":"45526",
-    //  "transactionName":"J1lZFRQMVF9VFk4AWwtRRE4PDVxWSA==",
-    //  "queueTime":0,
-    //  "applicationTime":116,
-    //  "agent":"js-agent.newrelic.com/nr-213.min.js",
-    //  "userAttributes":"SxNHQFFHFA0aSl9cV1JeVkoWGRRUTUpEXl9vWFYRDgEESg=="
-    //   "sslForHttp":"true"
-    //}
+    [JsonProperty("beacon")]
+    public string Beacon { get; }
 
-    public class BrowserMonitoringConfigurationData
+    [JsonProperty("errorBeacon")]
+    public string ErrorBeacon { get; }
+
+    [JsonProperty("licenseKey")]
+    public string BrowserLicenseKey { get; }
+
+    [JsonProperty("applicationID")]
+    public string ApplicationId { get; }
+
+    [JsonProperty("transactionName")]
+    public string ObfuscatedTransactionName { get; }
+
+    [JsonProperty("queueTime")]
+    public int QueueTimeMilliseconds => (int)_queueTime.TotalMilliseconds;
+    private readonly TimeSpan _queueTime;
+
+    [JsonProperty("applicationTime")]
+    public int ApplicationTimeMilliseconds => (int)_applicationTime.TotalMilliseconds;
+    private readonly TimeSpan _applicationTime;
+
+    [JsonProperty("agent")]
+    public string Agent { get; }
+
+    [JsonProperty("atts")]
+    public string ObfuscatedUserAttributes { get; }
+
+    [JsonProperty("sslForHttp", NullValueHandling = NullValueHandling.Ignore)]
+    public string SslForHttp => _sslForHttp ? "true" : null;
+    private readonly bool _sslForHttp;
+
+    public BrowserMonitoringConfigurationData(string licenseKey, string beacon, string errorBeacon, string browserMonitoringKey, string applicationId, string obfuscatedTransactionName, TimeSpan queueTime, TimeSpan applicationTime, string jsAgentPayloadFile, string obfuscatedFormattedAttributes, bool sslForHttp)
     {
-        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
-
-        [JsonProperty("beacon")]
-        public string Beacon { get; }
-
-        [JsonProperty("errorBeacon")]
-        public string ErrorBeacon { get; }
-
-        [JsonProperty("licenseKey")]
-        public string BrowserLicenseKey { get; }
-
-        [JsonProperty("applicationID")]
-        public string ApplicationId { get; }
-
-        [JsonProperty("transactionName")]
-        public string ObfuscatedTransactionName { get; }
-
-        [JsonProperty("queueTime")]
-        public int QueueTimeMilliseconds => (int)_queueTime.TotalMilliseconds;
-        private readonly TimeSpan _queueTime;
-
-        [JsonProperty("applicationTime")]
-        public int ApplicationTimeMilliseconds => (int)_applicationTime.TotalMilliseconds;
-        private readonly TimeSpan _applicationTime;
-
-        [JsonProperty("agent")]
-        public string Agent { get; }
-
-        [JsonProperty("atts")]
-        public string ObfuscatedUserAttributes { get; }
-
-        [JsonProperty("sslForHttp", NullValueHandling = NullValueHandling.Ignore)]
-        public string SslForHttp => _sslForHttp ? "true" : null;
-        private readonly bool _sslForHttp;
-
-        public BrowserMonitoringConfigurationData(string licenseKey, string beacon, string errorBeacon, string browserMonitoringKey, string applicationId, string obfuscatedTransactionName, TimeSpan queueTime, TimeSpan applicationTime, string jsAgentPayloadFile, string obfuscatedFormattedAttributes, bool sslForHttp)
-        {
-            Beacon = beacon;
-            ErrorBeacon = errorBeacon;
-            BrowserLicenseKey = browserMonitoringKey;
-            ApplicationId = applicationId;
-            ObfuscatedTransactionName = obfuscatedTransactionName;
-            _queueTime = queueTime;
-            _applicationTime = applicationTime;
-            Agent = jsAgentPayloadFile;
-            ObfuscatedUserAttributes = obfuscatedFormattedAttributes ?? string.Empty;
-            _sslForHttp = sslForHttp;
-        }
-
-        public string ToJsonString()
-        {
-
-            return JsonConvert.SerializeObject(this, Formatting.None, _jsonSettings);
-        }
-
+        Beacon = beacon;
+        ErrorBeacon = errorBeacon;
+        BrowserLicenseKey = browserMonitoringKey;
+        ApplicationId = applicationId;
+        ObfuscatedTransactionName = obfuscatedTransactionName;
+        _queueTime = queueTime;
+        _applicationTime = applicationTime;
+        Agent = jsAgentPayloadFile;
+        ObfuscatedUserAttributes = obfuscatedFormattedAttributes ?? string.Empty;
+        _sslForHttp = sslForHttp;
     }
+
+    public string ToJsonString()
+    {
+
+        return JsonConvert.SerializeObject(this, Formatting.None, _jsonSettings);
+    }
+
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringPrereqChecker.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringPrereqChecker.cs
@@ -10,133 +10,132 @@ using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Transactions;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
-{
-    public interface IBrowserMonitoringPrereqChecker
-    {
-        /// <summary>
-        /// Returns true if RUM should be injected. Use if requestPath and contentType are not known.
-        /// </summary>
-        bool ShouldManuallyInject(IInternalTransaction transaction);
+namespace NewRelic.Agent.Core.BrowserMonitoring;
 
-        /// <summary>
-        /// Returns true if RUM should be injected. Use if requestPath and contentType are known.
-        /// </summary>
-        bool ShouldAutomaticallyInject(IInternalTransaction transaction, string requestPath, string contentType);
+public interface IBrowserMonitoringPrereqChecker
+{
+    /// <summary>
+    /// Returns true if RUM should be injected. Use if requestPath and contentType are not known.
+    /// </summary>
+    bool ShouldManuallyInject(IInternalTransaction transaction);
+
+    /// <summary>
+    /// Returns true if RUM should be injected. Use if requestPath and contentType are known.
+    /// </summary>
+    bool ShouldAutomaticallyInject(IInternalTransaction transaction, string requestPath, string contentType);
+}
+
+public class BrowserMonitoringPrereqChecker : IBrowserMonitoringPrereqChecker
+{
+    private readonly IConfigurationService _configurationService;
+
+    public BrowserMonitoringPrereqChecker(IConfigurationService configurationService)
+    {
+        _configurationService = configurationService;
     }
 
-    public class BrowserMonitoringPrereqChecker : IBrowserMonitoringPrereqChecker
+    public bool ShouldManuallyInject(IInternalTransaction transaction)
     {
-        private readonly IConfigurationService _configurationService;
+        if (!IsValidBrowserMonitoringJavaScriptAgentLoaderType())
+            return false;
 
-        public BrowserMonitoringPrereqChecker(IConfigurationService configurationService)
+        return !transaction.IgnoreAllBrowserMonitoring;
+    }
+
+    public bool ShouldAutomaticallyInject(IInternalTransaction transaction, string requestPath, string contentType)
+    {
+        if (!IsValidBrowserMonitoringJavaScriptAgentLoaderType())
+            return false;
+
+        if (!_configurationService.Configuration.BrowserMonitoringAutoInstrument)
+            return false;
+
+        if (transaction.IgnoreAutoBrowserMonitoring || transaction.IgnoreAllBrowserMonitoring)
+            return false;
+
+        if (!IsHtmlContent(contentType))
+            return false;
+
+        // Perform this check last due to its potentially large cost
+        if (!BrowserInstrumentationAllowedForUrlPath(requestPath, _configurationService.Configuration.RequestPathExclusionList))
+            return false;
+
+        return true;
+    }
+
+    private bool IsValidBrowserMonitoringJavaScriptAgentLoaderType()
+    {
+        var loaderType = _configurationService.Configuration.BrowserMonitoringJavaScriptAgentLoaderType;
+        var isValid = !loaderType.Equals("none", StringComparison.InvariantCultureIgnoreCase);
+
+        return isValid;
+    }
+
+    private static bool IsHtmlContent(string contentType)
+    {
+        if (string.IsNullOrEmpty(contentType))
+            return false;
+
+        try
         {
-            _configurationService = configurationService;
+            return new ContentType(contentType).MediaType == "text/html";
         }
-
-        public bool ShouldManuallyInject(IInternalTransaction transaction)
+        catch (Exception ex)
         {
-            if (!IsValidBrowserMonitoringJavaScriptAgentLoaderType())
-                return false;
-
-            return !transaction.IgnoreAllBrowserMonitoring;
+            Log.Debug(ex, "Unable to parse content type");
+            return false;
         }
+    }
 
-        public bool ShouldAutomaticallyInject(IInternalTransaction transaction, string requestPath, string contentType)
-        {
-            if (!IsValidBrowserMonitoringJavaScriptAgentLoaderType())
-                return false;
-
-            if (!_configurationService.Configuration.BrowserMonitoringAutoInstrument)
-                return false;
-
-            if (transaction.IgnoreAutoBrowserMonitoring || transaction.IgnoreAllBrowserMonitoring)
-                return false;
-
-            if (!IsHtmlContent(contentType))
-                return false;
-
-            // Perform this check last due to its potentially large cost
-            if (!BrowserInstrumentationAllowedForUrlPath(requestPath, _configurationService.Configuration.RequestPathExclusionList))
-                return false;
-
+    /// <summary>
+    /// Determines whether the agent's Javascript Instrumentation should be injected for
+    /// a page request whose <see cref="System.Web.HttpRequest.Path" /> is <paramref name="requestPath"/>.
+    /// </summary>
+    /// <remarks>
+    /// Since we're building against .NET 2.0/3.5, we cannot take advantage of a .NET 4.5 addition 
+    /// to System.Text.RegularExpressions.Regex which allows you to pass a TimeSpan as a timeout.
+    /// This requires a little explanation: Regular expression evaluation can take a long time 
+    /// (multiple seconds even!) depending on the complexity of the expression. Prior to .NET 4.5,
+    /// a Regex either would never time out, or, if an application domain-specific timeout existed
+    /// in the current application domain, it would timeout based on that timeout setting. Upon
+    /// timing out, the Regex evaluation statement (e.g., IsMatch) would throw a 
+    /// <see cref="System.Text.RegularExpressions.RegexMatchTimeoutException" />.
+    /// 
+    /// In our case, we cannot set a regular expression-specific timeout since we're not building 
+    /// against .NET 4.5. Since we are running in another application's process, it is not advisable
+    /// for us to set the application domain's regular expression timeout. So, we have to simply catch
+    /// that timeout-based exception to be safe. For simplicity, this method catches all exceptions although
+    /// it is unlikely anything but a timeout exception would occur.
+    /// 
+    /// For further reference, see http://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex(v=vs.110).aspx
+    /// and http://softwareninjaneer.com/posts/regex-engine-updated-to-allow-timeouts-in-net-4-5/
+    /// </remarks>
+    /// <param name="requestPath">The requestPath to be evaluated for blacklisting.</param>
+    /// <param name="requestPathExclusionList">A list of Regex's. </param>
+    /// <returns>True if browser instrumentation should occur for the page request.</returns>
+    private static bool BrowserInstrumentationAllowedForUrlPath(string requestPath, IEnumerable<Regex> requestPathExclusionList)
+    {
+        if (string.IsNullOrEmpty(requestPath))
             return true;
-        }
 
-        private bool IsValidBrowserMonitoringJavaScriptAgentLoaderType()
+        return requestPathExclusionList
+            .Where(regex => regex != null)
+            .All(regex => !IsMatch(requestPath, regex));
+    }
+
+    private static bool IsMatch(string path, Regex regex)
+    {
+        try
         {
-            var loaderType = _configurationService.Configuration.BrowserMonitoringJavaScriptAgentLoaderType;
-            var isValid = !loaderType.Equals("none", StringComparison.InvariantCultureIgnoreCase);
-
-            return isValid;
-        }
-
-        private static bool IsHtmlContent(string contentType)
-        {
-            if (string.IsNullOrEmpty(contentType))
-                return false;
-
-            try
-            {
-                return new ContentType(contentType).MediaType == "text/html";
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "Unable to parse content type");
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Determines whether the agent's Javascript Instrumentation should be injected for
-        /// a page request whose <see cref="System.Web.HttpRequest.Path" /> is <paramref name="requestPath"/>.
-        /// </summary>
-        /// <remarks>
-        /// Since we're building against .NET 2.0/3.5, we cannot take advantage of a .NET 4.5 addition 
-        /// to System.Text.RegularExpressions.Regex which allows you to pass a TimeSpan as a timeout.
-        /// This requires a little explanation: Regular expression evaluation can take a long time 
-        /// (multiple seconds even!) depending on the complexity of the expression. Prior to .NET 4.5,
-        /// a Regex either would never time out, or, if an application domain-specific timeout existed
-        /// in the current application domain, it would timeout based on that timeout setting. Upon
-        /// timing out, the Regex evaluation statement (e.g., IsMatch) would throw a 
-        /// <see cref="System.Text.RegularExpressions.RegexMatchTimeoutException" />.
-        /// 
-        /// In our case, we cannot set a regular expression-specific timeout since we're not building 
-        /// against .NET 4.5. Since we are running in another application's process, it is not advisable
-        /// for us to set the application domain's regular expression timeout. So, we have to simply catch
-        /// that timeout-based exception to be safe. For simplicity, this method catches all exceptions although
-        /// it is unlikely anything but a timeout exception would occur.
-        /// 
-        /// For further reference, see http://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex(v=vs.110).aspx
-        /// and http://softwareninjaneer.com/posts/regex-engine-updated-to-allow-timeouts-in-net-4-5/
-        /// </remarks>
-        /// <param name="requestPath">The requestPath to be evaluated for blacklisting.</param>
-        /// <param name="requestPathExclusionList">A list of Regex's. </param>
-        /// <returns>True if browser instrumentation should occur for the page request.</returns>
-        private static bool BrowserInstrumentationAllowedForUrlPath(string requestPath, IEnumerable<Regex> requestPathExclusionList)
-        {
-            if (string.IsNullOrEmpty(requestPath))
+            if (regex.IsMatch(path))
                 return true;
 
-            return requestPathExclusionList
-                .Where(regex => regex != null)
-                .All(regex => !IsMatch(requestPath, regex));
+            return false;
         }
-
-        private static bool IsMatch(string path, Regex regex)
+        catch (Exception e)
         {
-            try
-            {
-                if (regex.IsMatch(path))
-                    return true;
-
-                return false;
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Exception attempting to validate request path for Browser Instrumentation blacklisting");
-                return false;
-            }
+            Log.Error(e, "Exception attempting to validate request path for Browser Instrumentation blacklisting");
+            return false;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringScriptMaker.cs
@@ -1,6 +1,8 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Web;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Attributes;
 using NewRelic.Agent.Core.JsonConverters;
@@ -9,146 +11,143 @@ using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 using Newtonsoft.Json;
-using System;
-using System.Web;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+public interface IBrowserMonitoringScriptMaker
 {
-    public interface IBrowserMonitoringScriptMaker
+    string GetScript(IInternalTransaction transaction, string nonce);
+}
+
+public class BrowserMonitoringScriptMaker : IBrowserMonitoringScriptMaker
+{
+    private readonly BrowserEventWireModelSerializer _jsonConverter = new BrowserEventWireModelSerializer();
+
+    private readonly IConfigurationService _configurationService;
+
+    private readonly ITransactionMetricNameMaker _transactionMetricNameMaker;
+
+    private readonly ITransactionAttributeMaker _transactionAttributeMaker;
+
+    private readonly IAttributeDefinitionService _attribDefSvc;
+
+    private static readonly TimeSpan _zeroTimespan = TimeSpan.FromSeconds(0);
+
+    public BrowserMonitoringScriptMaker(IConfigurationService configurationService, ITransactionMetricNameMaker transactionMetricNameMaker, ITransactionAttributeMaker transactionAttributeMaker, IAttributeDefinitionService attribDefSvc)
     {
-        string GetScript(IInternalTransaction transaction, string nonce);
+        _configurationService = configurationService;
+        _transactionMetricNameMaker = transactionMetricNameMaker;
+        _transactionAttributeMaker = transactionAttributeMaker;
+        _attribDefSvc = attribDefSvc;
     }
 
-    public class BrowserMonitoringScriptMaker : IBrowserMonitoringScriptMaker
+    public string GetScript(IInternalTransaction transaction, string nonce)
     {
-        private readonly BrowserEventWireModelSerializer _jsonConverter = new BrowserEventWireModelSerializer();
-
-        private readonly IConfigurationService _configurationService;
-
-        private readonly ITransactionMetricNameMaker _transactionMetricNameMaker;
-
-        private readonly ITransactionAttributeMaker _transactionAttributeMaker;
-
-        private readonly IAttributeDefinitionService _attribDefSvc;
-
-        private static readonly TimeSpan _zeroTimespan = TimeSpan.FromSeconds(0);
-
-        public BrowserMonitoringScriptMaker(IConfigurationService configurationService, ITransactionMetricNameMaker transactionMetricNameMaker, ITransactionAttributeMaker transactionAttributeMaker, IAttributeDefinitionService attribDefSvc)
+        if (string.IsNullOrEmpty(_configurationService.Configuration.BrowserMonitoringJavaScriptAgent))
         {
-            _configurationService = configurationService;
-            _transactionMetricNameMaker = transactionMetricNameMaker;
-            _transactionAttributeMaker = transactionAttributeMaker;
-            _attribDefSvc = attribDefSvc;
+            Log.Debug("Skipping RUM injection because \"js_agent_loader\" config is missing or empty");
+            return null;
         }
 
-        public string GetScript(IInternalTransaction transaction, string nonce)
+        if (_configurationService.Configuration.BrowserMonitoringJavaScriptAgentLoaderType.Equals("none",
+                StringComparison.InvariantCultureIgnoreCase))
         {
-            if (string.IsNullOrEmpty(_configurationService.Configuration.BrowserMonitoringJavaScriptAgent))
-            {
-                Log.Debug("Skipping RUM injection because \"js_agent_loader\" config is missing or empty");
-                return null;
-            }
-
-            if (_configurationService.Configuration.BrowserMonitoringJavaScriptAgentLoaderType.Equals("none",
-                    StringComparison.InvariantCultureIgnoreCase))
-            {
-                Log.Debug("Skipping RUM injection because \"browser_monitoring.loader\" config is \"none\"");
-                return null;
-            }
-
-            if (transaction.Ignored)
-            {
-                Log.Debug("Skipping RUM injection because transaction is ignored");
-                return null;
-            }
-
-            var transactionMetricName = _transactionMetricNameMaker.GetTransactionMetricName(transaction.CandidateTransactionName.CurrentTransactionName);
-            if (transactionMetricName.ShouldIgnore)
-            {
-                Log.Debug("Skipping RUM injection because transaction name is ignored");
-                return null;
-            }
-
-            var licenseKey = _configurationService.Configuration.AgentLicenseKey;
-            // serverless mode doesn't require a license key, so this check can fail.
-            if (string.IsNullOrEmpty(licenseKey) || "REPLACE_WITH_LICENSE_KEY".Equals(licenseKey))
-            {
-                Log.Debug("Skipping RUM injection because license key is not set.");
-                return null;
-            }
-
-            var browserConfigurationData = GetBrowserConfigurationData(transaction, transactionMetricName, licenseKey);
-
-            // getting a stack trace is expensive, so only do it if we are going to log
-            if (Log.IsFinestEnabled)
-                transaction.LogFinest("RUM: TryGetBrowserTimingHeader success.");
-
-            var scriptNonce = String.IsNullOrEmpty(nonce) ? String.Empty : $@" nonce=""{HttpUtility.HtmlAttributeEncode(nonce)}""";
-
-            // The JavaScript variable NREUMQ stands for New Relic End User Metric "Q". This was the name before marketing renamed "EUM" to "RUM".
-            // We can't change the name of the variable since: (a) we have to be consistent across agents, and (b) it has to be in sync with the rum.js file which is downloaded from NR servers.
-            var javascriptAgentConfiguration = $"window.NREUM||(NREUM={{}});NREUM.info = {browserConfigurationData.ToJsonString()}";
-            var javascriptAgent = _configurationService.Configuration.BrowserMonitoringJavaScriptAgent;
-            return $"<script type=\"text/javascript\"{scriptNonce}>{javascriptAgentConfiguration}</script><script type=\"text/javascript\"{scriptNonce}>{javascriptAgent}</script>";
+            Log.Debug("Skipping RUM injection because \"browser_monitoring.loader\" config is \"none\"");
+            return null;
         }
 
-        private BrowserMonitoringConfigurationData GetBrowserConfigurationData(IInternalTransaction transaction, TransactionMetricName transactionMetricName, string licenseKey)
+        if (transaction.Ignored)
         {
-            var configuration = _configurationService.Configuration;
-
-            var beacon = configuration.BrowserMonitoringBeaconAddress;
-            if (beacon == null)
-                throw new NullReferenceException(nameof(beacon));
-
-            var errorBeacon = configuration.BrowserMonitoringErrorBeaconAddress;
-            if (errorBeacon == null)
-                throw new NullReferenceException(nameof(errorBeacon));
-
-            var browserMonitoringKey = configuration.BrowserMonitoringKey;
-            if (browserMonitoringKey == null)
-                throw new NullReferenceException(nameof(browserMonitoringKey));
-
-            var applicationId = configuration.BrowserMonitoringApplicationId;
-            if (applicationId == null)
-                throw new NullReferenceException(nameof(applicationId));
-
-            var jsAgentPayloadFile = configuration.BrowserMonitoringJavaScriptAgentFile;
-            if (jsAgentPayloadFile == null)
-                throw new NullReferenceException(nameof(jsAgentPayloadFile));
-
-            var obfuscatedTransactionName = Strings.ObfuscateStringWithKey(transactionMetricName.PrefixedName, licenseKey);
-            var queueTime = transaction.TransactionMetadata.QueueTime ?? _zeroTimespan;
-            var applicationTime = transaction.GetDurationUntilNow();
-
-            var attributes = new AttributeValueCollection(AttributeDestinations.JavaScriptAgent);
-            _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, transaction.TransactionMetadata);
-
-            // for now, treat tripId as an agent attribute when passing to browser.  Eventually this will be an intrinsic but need changes to browser code first.
-            // if CrossApplicationReferrerTripId is null then this transaction started the first external request, so use its guid
-            _attribDefSvc.AttributeDefs.BrowserTripId.TrySetValue(attributes, transaction.TransactionMetadata.CrossApplicationReferrerTripId ?? transaction.Guid);
-
-            //This will resolve any Lazy values and remove null values from the collection.
-            //Browser monitoring should not render JSON for attributes if there are none
-            attributes.MakeImmutable();
-
-            var obfuscatedFormattedAttributes = GetObfuscatedFormattedAttributes(attributes, licenseKey);
-            var sslForHttp = configuration.BrowserMonitoringUseSsl;
-
-            return new BrowserMonitoringConfigurationData(licenseKey, beacon, errorBeacon, browserMonitoringKey, applicationId, obfuscatedTransactionName, queueTime, applicationTime, jsAgentPayloadFile, obfuscatedFormattedAttributes, sslForHttp);
+            Log.Debug("Skipping RUM injection because transaction is ignored");
+            return null;
         }
 
-        private string GetObfuscatedFormattedAttributes(AttributeValueCollection attribValues, string licenseKey)
+        var transactionMetricName = _transactionMetricNameMaker.GetTransactionMetricName(transaction.CandidateTransactionName.CurrentTransactionName);
+        if (transactionMetricName.ShouldIgnore)
         {
-            if (attribValues == null)
-            {
-                return null;
-            }
-
-            var json = JsonConvert.SerializeObject(attribValues, _jsonConverter);
-
-            return string.IsNullOrWhiteSpace(json)
-                ? null
-                : Strings.ObfuscateStringWithKey(json, licenseKey);
+            Log.Debug("Skipping RUM injection because transaction name is ignored");
+            return null;
         }
+
+        var licenseKey = _configurationService.Configuration.AgentLicenseKey;
+        // serverless mode doesn't require a license key, so this check can fail.
+        if (string.IsNullOrEmpty(licenseKey) || "REPLACE_WITH_LICENSE_KEY".Equals(licenseKey))
+        {
+            Log.Debug("Skipping RUM injection because license key is not set.");
+            return null;
+        }
+
+        var browserConfigurationData = GetBrowserConfigurationData(transaction, transactionMetricName, licenseKey);
+
+        // getting a stack trace is expensive, so only do it if we are going to log
+        if (Log.IsFinestEnabled)
+            transaction.LogFinest("RUM: TryGetBrowserTimingHeader success.");
+
+        var scriptNonce = String.IsNullOrEmpty(nonce) ? String.Empty : $@" nonce=""{HttpUtility.HtmlAttributeEncode(nonce)}""";
+
+        // The JavaScript variable NREUMQ stands for New Relic End User Metric "Q". This was the name before marketing renamed "EUM" to "RUM".
+        // We can't change the name of the variable since: (a) we have to be consistent across agents, and (b) it has to be in sync with the rum.js file which is downloaded from NR servers.
+        var javascriptAgentConfiguration = $"window.NREUM||(NREUM={{}});NREUM.info = {browserConfigurationData.ToJsonString()}";
+        var javascriptAgent = _configurationService.Configuration.BrowserMonitoringJavaScriptAgent;
+        return $"<script type=\"text/javascript\"{scriptNonce}>{javascriptAgentConfiguration}</script><script type=\"text/javascript\"{scriptNonce}>{javascriptAgent}</script>";
+    }
+
+    private BrowserMonitoringConfigurationData GetBrowserConfigurationData(IInternalTransaction transaction, TransactionMetricName transactionMetricName, string licenseKey)
+    {
+        var configuration = _configurationService.Configuration;
+
+        var beacon = configuration.BrowserMonitoringBeaconAddress;
+        if (beacon == null)
+            throw new NullReferenceException(nameof(beacon));
+
+        var errorBeacon = configuration.BrowserMonitoringErrorBeaconAddress;
+        if (errorBeacon == null)
+            throw new NullReferenceException(nameof(errorBeacon));
+
+        var browserMonitoringKey = configuration.BrowserMonitoringKey;
+        if (browserMonitoringKey == null)
+            throw new NullReferenceException(nameof(browserMonitoringKey));
+
+        var applicationId = configuration.BrowserMonitoringApplicationId;
+        if (applicationId == null)
+            throw new NullReferenceException(nameof(applicationId));
+
+        var jsAgentPayloadFile = configuration.BrowserMonitoringJavaScriptAgentFile;
+        if (jsAgentPayloadFile == null)
+            throw new NullReferenceException(nameof(jsAgentPayloadFile));
+
+        var obfuscatedTransactionName = Strings.ObfuscateStringWithKey(transactionMetricName.PrefixedName, licenseKey);
+        var queueTime = transaction.TransactionMetadata.QueueTime ?? _zeroTimespan;
+        var applicationTime = transaction.GetDurationUntilNow();
+
+        var attributes = new AttributeValueCollection(AttributeDestinations.JavaScriptAgent);
+        _transactionAttributeMaker.SetUserAndAgentAttributes(attributes, transaction.TransactionMetadata);
+
+        // for now, treat tripId as an agent attribute when passing to browser.  Eventually this will be an intrinsic but need changes to browser code first.
+        // if CrossApplicationReferrerTripId is null then this transaction started the first external request, so use its guid
+        _attribDefSvc.AttributeDefs.BrowserTripId.TrySetValue(attributes, transaction.TransactionMetadata.CrossApplicationReferrerTripId ?? transaction.Guid);
+
+        //This will resolve any Lazy values and remove null values from the collection.
+        //Browser monitoring should not render JSON for attributes if there are none
+        attributes.MakeImmutable();
+
+        var obfuscatedFormattedAttributes = GetObfuscatedFormattedAttributes(attributes, licenseKey);
+        var sslForHttp = configuration.BrowserMonitoringUseSsl;
+
+        return new BrowserMonitoringConfigurationData(licenseKey, beacon, errorBeacon, browserMonitoringKey, applicationId, obfuscatedTransactionName, queueTime, applicationTime, jsAgentPayloadFile, obfuscatedFormattedAttributes, sslForHttp);
+    }
+
+    private string GetObfuscatedFormattedAttributes(AttributeValueCollection attribValues, string licenseKey)
+    {
+        if (attribValues == null)
+        {
+            return null;
+        }
+
+        var json = JsonConvert.SerializeObject(attribValues, _jsonConverter);
+
+        return string.IsNullOrWhiteSpace(json)
+            ? null
+            : Strings.ObfuscateStringWithKey(json, licenseKey);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringStreamInjector.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringStreamInjector.cs
@@ -1,151 +1,150 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Extensions.Logging;
 using System;
 using System.IO;
 using System.Text;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+public class BrowserMonitoringStreamInjector : Stream
 {
-    public class BrowserMonitoringStreamInjector : Stream
+    private readonly BrowserMonitoringWriter _jsWriter;
+
+    private readonly Encoding _contentEncoding;
+
+    private Action<byte[], int, int> _streamWriter;
+
+    public BrowserMonitoringStreamInjector(Func<string> getJavascriptAgentScript, Stream output, Encoding contentEncoding, BrowserMonitoringWriter browserMonitoringWriter = null)
     {
-        private readonly BrowserMonitoringWriter _jsWriter;
+        _jsWriter = browserMonitoringWriter ?? new BrowserMonitoringWriter(getJavascriptAgentScript);
+        OutputStream = output;
+        _contentEncoding = contentEncoding;
+    }
 
-        private readonly Encoding _contentEncoding;
+    public override bool CanRead => OutputStream.CanRead;
+    public override bool CanSeek => OutputStream.CanSeek;
+    public override bool CanWrite => OutputStream.CanWrite;
+    public override long Length => OutputStream.Length;
 
-        private Action<byte[], int, int> _streamWriter;
+    public override long Position
+    {
+        get { return OutputStream.Position; }
+        set { OutputStream.Position = value; }
+    }
 
-        public BrowserMonitoringStreamInjector(Func<string> getJavascriptAgentScript, Stream output, Encoding contentEncoding, BrowserMonitoringWriter browserMonitoringWriter = null)
+    public override void Close()
+    {
+        OutputStream.Close();
+        base.Close();
+    }
+
+    private Stream OutputStream { get; }
+
+    public override void Flush()
+    {
+        OutputStream.Flush();
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        return OutputStream.Seek(offset, origin);
+    }
+
+    public override void SetLength(long value)
+    {
+        OutputStream.SetLength(value);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        return OutputStream.Read(buffer, offset, count);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        // BEWARE: There is no try/catch between this method and the users application!  Anything that can throw *must* be wrapped in a try/catch block!  We cannot wrap this in a try/catch block because we should not catch exceptions thrown by the underlying stream.
+
+        // the first time Write is called, get the function that we will use to write
+        _streamWriter ??= GetInjectingStreamWriter(_contentEncoding);
+
+        _streamWriter(buffer, offset, count);
+    }
+
+    private void PassThroughStreamWriter(byte[] buffer, int offset, int count)
+    {
+        OutputStream.Write(buffer, offset, count);
+    }
+
+    private Action<byte[], int, int> GetInjectingStreamWriter(Encoding contentEncoding)
+    {
+        return (buffer, offset, count) =>
         {
-            _jsWriter = browserMonitoringWriter ?? new BrowserMonitoringWriter(getJavascriptAgentScript);
-            OutputStream = output;
-            _contentEncoding = contentEncoding;
-        }
+            var scriptInjected = false;
+            var originalBuffer = buffer;
+            var originalOffset = offset;
+            var originalCount = count;
+            var trimmedBuffer = new TrimmedEncodedBuffer(contentEncoding, buffer, offset, count);
 
-        public override bool CanRead => OutputStream.CanRead;
-        public override bool CanSeek => OutputStream.CanSeek;
-        public override bool CanWrite => OutputStream.CanWrite;
-        public override long Length => OutputStream.Length;
-
-        public override long Position
-        {
-            get { return OutputStream.Position; }
-            set { OutputStream.Position = value; }
-        }
-
-        public override void Close()
-        {
-            OutputStream.Close();
-            base.Close();
-        }
-
-        private Stream OutputStream { get; }
-
-        public override void Flush()
-        {
-            OutputStream.Flush();
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return OutputStream.Seek(offset, origin);
-        }
-
-        public override void SetLength(long value)
-        {
-            OutputStream.SetLength(value);
-        }
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return OutputStream.Read(buffer, offset, count);
-        }
-
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            // BEWARE: There is no try/catch between this method and the users application!  Anything that can throw *must* be wrapped in a try/catch block!  We cannot wrap this in a try/catch block because we should not catch exceptions thrown by the underlying stream.
-
-            // the first time Write is called, get the function that we will use to write
-            _streamWriter ??= GetInjectingStreamWriter(_contentEncoding);
-
-            _streamWriter(buffer, offset, count);
-        }
-
-        private void PassThroughStreamWriter(byte[] buffer, int offset, int count)
-        {
-            OutputStream.Write(buffer, offset, count);
-        }
-
-        private Action<byte[], int, int> GetInjectingStreamWriter(Encoding contentEncoding)
-        {
-            return (buffer, offset, count) =>
+            try
             {
-                var scriptInjected = false;
-                var originalBuffer = buffer;
-                var originalOffset = offset;
-                var originalCount = count;
-                var trimmedBuffer = new TrimmedEncodedBuffer(contentEncoding, buffer, offset, count);
+                var injectedStreamBytes = TryGetInjectedBytes(contentEncoding, trimmedBuffer.Buffer, trimmedBuffer.Offset, trimmedBuffer.Length);
+                if (injectedStreamBytes == null)
+                    return;
 
-                try
-                {
-                    var injectedStreamBytes = TryGetInjectedBytes(contentEncoding, trimmedBuffer.Buffer, trimmedBuffer.Offset, trimmedBuffer.Length);
-                    if (injectedStreamBytes == null)
-                        return;
+                scriptInjected = true;
+                buffer = injectedStreamBytes;
+                offset = 0;
+                count = injectedStreamBytes.Length;
 
-                    scriptInjected = true;
-                    buffer = injectedStreamBytes;
-                    offset = 0;
-                    count = injectedStreamBytes.Length;
-
-                    // once we have written the JavaScript agent, switch over to the passthrough writer for the rest of the stream
-                    _streamWriter = PassThroughStreamWriter;
-                }
-                catch (Exception exception)
-                {
-                    Log.Error(exception, "Failed to inject JavaScript agent into response stream");
-                    scriptInjected = false;
-                    buffer = originalBuffer;
-                    offset = originalOffset;
-                    count = originalCount;
-                    _streamWriter = PassThroughStreamWriter;
-                }
-                finally
-                {
-                    // this needs to remain outside of the try block since we do not want to incorrectly catch exceptions thrown from the underlying filter
-                    if (scriptInjected && trimmedBuffer.HasLeadingExtraBytes)
-                        OutputStream.Write(trimmedBuffer.Buffer, trimmedBuffer.LeadingExtraBytesOffset, trimmedBuffer.LeadingExtraBytesCount);
-
-                    OutputStream.Write(buffer, offset, count);
-
-                    if (scriptInjected && trimmedBuffer.HasTrailingExtraBytes)
-                        OutputStream.Write(trimmedBuffer.Buffer, trimmedBuffer.TrailingExtraBytesOffset, trimmedBuffer.TrailingExtraBytesCount);
-                }
-            };
-        }
-
-        private byte[] TryGetInjectedBytes(Encoding contentEncoding, byte[] buffer, int offset, int count)
-        {
-            var decoder = _contentEncoding.GetDecoder();
-            var decodedBuffer = Strings.GetStringBufferFromBytes(decoder, buffer, offset, count);
-            if (string.IsNullOrEmpty(decodedBuffer))
-                return null;
-
-            return TryGetBrowserMonitoringHeaders(contentEncoding, decodedBuffer);
-        }
-
-        private byte[] TryGetBrowserMonitoringHeaders(Encoding contentEncoding, string content)
-        {
-            var contentWithBrowserMonitoringHeaders = _jsWriter.WriteScriptHeaders(content);
-            if (string.IsNullOrEmpty(contentWithBrowserMonitoringHeaders))
-            {
-                Log.Finest("RUM: Could not find a place to inject JS Agent.");
-                return null;
+                // once we have written the JavaScript agent, switch over to the passthrough writer for the rest of the stream
+                _streamWriter = PassThroughStreamWriter;
             }
+            catch (Exception exception)
+            {
+                Log.Error(exception, "Failed to inject JavaScript agent into response stream");
+                scriptInjected = false;
+                buffer = originalBuffer;
+                offset = originalOffset;
+                count = originalCount;
+                _streamWriter = PassThroughStreamWriter;
+            }
+            finally
+            {
+                // this needs to remain outside of the try block since we do not want to incorrectly catch exceptions thrown from the underlying filter
+                if (scriptInjected && trimmedBuffer.HasLeadingExtraBytes)
+                    OutputStream.Write(trimmedBuffer.Buffer, trimmedBuffer.LeadingExtraBytesOffset, trimmedBuffer.LeadingExtraBytesCount);
 
-            Log.Finest("RUM: Injected JS Agent.");
-            return contentEncoding.GetBytes(contentWithBrowserMonitoringHeaders);
+                OutputStream.Write(buffer, offset, count);
+
+                if (scriptInjected && trimmedBuffer.HasTrailingExtraBytes)
+                    OutputStream.Write(trimmedBuffer.Buffer, trimmedBuffer.TrailingExtraBytesOffset, trimmedBuffer.TrailingExtraBytesCount);
+            }
+        };
+    }
+
+    private byte[] TryGetInjectedBytes(Encoding contentEncoding, byte[] buffer, int offset, int count)
+    {
+        var decoder = _contentEncoding.GetDecoder();
+        var decodedBuffer = Strings.GetStringBufferFromBytes(decoder, buffer, offset, count);
+        if (string.IsNullOrEmpty(decodedBuffer))
+            return null;
+
+        return TryGetBrowserMonitoringHeaders(contentEncoding, decodedBuffer);
+    }
+
+    private byte[] TryGetBrowserMonitoringHeaders(Encoding contentEncoding, string content)
+    {
+        var contentWithBrowserMonitoringHeaders = _jsWriter.WriteScriptHeaders(content);
+        if (string.IsNullOrEmpty(contentWithBrowserMonitoringHeaders))
+        {
+            Log.Finest("RUM: Could not find a place to inject JS Agent.");
+            return null;
         }
+
+        Log.Finest("RUM: Injected JS Agent.");
+        return contentEncoding.GetBytes(contentWithBrowserMonitoringHeaders);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserMonitoringWriter.cs
@@ -1,99 +1,98 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.Utilities;
 using System;
 using System.Text.RegularExpressions;
+using NewRelic.Agent.Core.Utilities;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+public class BrowserMonitoringWriter
 {
-    public class BrowserMonitoringWriter
+    private readonly Func<string> _getJsScript;
+
+    private static readonly Regex XUaCompatibleFilter = new Regex(@"(<\s*meta[^>]+http-equiv[\s]*=[\s]*['""]x-ua-compatible['""][^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+    private static readonly Regex CharsetFilter = new Regex(@"(<\s*meta[^>]+charset\s*=[^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+    public BrowserMonitoringWriter(Func<string> getJsScript)
     {
-        private readonly Func<string> _getJsScript;
-
-        private static readonly Regex XUaCompatibleFilter = new Regex(@"(<\s*meta[^>]+http-equiv[\s]*=[\s]*['""]x-ua-compatible['""][^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-        private static readonly Regex CharsetFilter = new Regex(@"(<\s*meta[^>]+charset\s*=[^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-
-        public BrowserMonitoringWriter(Func<string> getJsScript)
-        {
-            _getJsScript = getJsScript;
-        }
-
-        private int? FindFirstOpeningHeadTag(string content)
-        {
-            int? indexOpeningHead = null;
-
-            var indexTemp = content.IndexOf("<head", StringComparison.InvariantCultureIgnoreCase);
-            if (indexTemp < 0)
-                return null;
-
-            if (content[indexTemp + 5] == '>' || content[indexTemp + 5] == ' ')
-            {
-                indexOpeningHead = indexTemp;
-            }
-
-            return indexOpeningHead;
-        }
-
-        private string AttemptInsertionPriorToBodyTag(string content)
-        {
-            var bodyWithJsHeader = string.Empty;
-
-            var indexOfBodyTag = content.IndexOf("<body", StringComparison.InvariantCultureIgnoreCase);
-            if (indexOfBodyTag < 0)
-                return bodyWithJsHeader;
-
-            var jsScriptWithBodyPrefix = string.Format("{0}<body", _getJsScript());
-            bodyWithJsHeader = content.Replace("<body", jsScriptWithBodyPrefix, StringComparison.InvariantCultureIgnoreCase, 1);
-
-            return bodyWithJsHeader;
-        }
-
-        // Specification for Javascript insertion: https://newrelic.atlassian.net/wiki/spaces/eng/pages/50299103/BAM+Agent+Auto-Instrumentation
-        public virtual string WriteScriptHeaders(string content)
-        {
-            var openingHeadTagIndex = FindFirstOpeningHeadTag(content);
-
-            // No <HEAD> tag. Attempt to insert before <BODY> tag (not a great fallback option).
-            if (!openingHeadTagIndex.HasValue)
-                return AttemptInsertionPriorToBodyTag(content);
-
-            // Since we have a head tag (top of 'page'), search for <X_UA_COMPATIBLE> and for <CHARSET> tags in Head section
-            var xUaCompatibleFilterMatch = XUaCompatibleFilter.Match(content, openingHeadTagIndex.Value);
-            var charsetFilterMatch = CharsetFilter.Match(content, openingHeadTagIndex.Value);
-
-            // We have a <HEAD> tag, but didn't find the other tags we wanted. Find </HEAD> tag.  It's okay if we don't find it!
-            var closingHeadTagIndex = content.IndexOf("</head>", StringComparison.InvariantCultureIgnoreCase);
-
-            // Check if we found the tags and based on which comes last AND that this happens INSIDE the HEAD tag - do a replace on that.
-            if ((xUaCompatibleFilterMatch.Success || charsetFilterMatch.Success) && (xUaCompatibleFilterMatch.Index < closingHeadTagIndex || charsetFilterMatch.Index > closingHeadTagIndex))
-            {
-                var match = charsetFilterMatch;
-                if(xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index)
-                {
-                    match = xUaCompatibleFilterMatch;
-                }
-
-                var contentSubString = content.Substring(match.Index, match.Length);
-                var jsScriptWithContentSubString = string.Format("{0}{1}", contentSubString, _getJsScript());
-
-                return content.Remove(match.Index, match.Length).Insert(match.Index, jsScriptWithContentSubString);
-            }
-
-            // Found both HEAD tags, no  meta tags, get index immediately after the <HEAD>. Find first '>' which will be end of head opening tag.
-            var indexOfEndHeadOpeningTag = content.IndexOf('>', openingHeadTagIndex.Value);
-
-            // The <HEAD> tag may be malformed or simply be another type of tag, if so do not use it
-            if (!(indexOfEndHeadOpeningTag > openingHeadTagIndex))
-                return string.Empty;
-
-            // Get the whole open HEAD tag string
-            var headOpeningTag = content.Substring(openingHeadTagIndex.Value, (indexOfEndHeadOpeningTag - openingHeadTagIndex.Value) + 1);
-
-            // Insert immediately after the <HEAD> tag. 
-            var jsScriptWithHeadPrefix = string.Format("{0}{1}", headOpeningTag, _getJsScript());
-            return content.Replace(headOpeningTag, jsScriptWithHeadPrefix, StringComparison.InvariantCultureIgnoreCase, 1);
-        }
-
+        _getJsScript = getJsScript;
     }
+
+    private int? FindFirstOpeningHeadTag(string content)
+    {
+        int? indexOpeningHead = null;
+
+        var indexTemp = content.IndexOf("<head", StringComparison.InvariantCultureIgnoreCase);
+        if (indexTemp < 0)
+            return null;
+
+        if (content[indexTemp + 5] == '>' || content[indexTemp + 5] == ' ')
+        {
+            indexOpeningHead = indexTemp;
+        }
+
+        return indexOpeningHead;
+    }
+
+    private string AttemptInsertionPriorToBodyTag(string content)
+    {
+        var bodyWithJsHeader = string.Empty;
+
+        var indexOfBodyTag = content.IndexOf("<body", StringComparison.InvariantCultureIgnoreCase);
+        if (indexOfBodyTag < 0)
+            return bodyWithJsHeader;
+
+        var jsScriptWithBodyPrefix = string.Format("{0}<body", _getJsScript());
+        bodyWithJsHeader = content.Replace("<body", jsScriptWithBodyPrefix, StringComparison.InvariantCultureIgnoreCase, 1);
+
+        return bodyWithJsHeader;
+    }
+
+    // Specification for Javascript insertion: https://newrelic.atlassian.net/wiki/spaces/eng/pages/50299103/BAM+Agent+Auto-Instrumentation
+    public virtual string WriteScriptHeaders(string content)
+    {
+        var openingHeadTagIndex = FindFirstOpeningHeadTag(content);
+
+        // No <HEAD> tag. Attempt to insert before <BODY> tag (not a great fallback option).
+        if (!openingHeadTagIndex.HasValue)
+            return AttemptInsertionPriorToBodyTag(content);
+
+        // Since we have a head tag (top of 'page'), search for <X_UA_COMPATIBLE> and for <CHARSET> tags in Head section
+        var xUaCompatibleFilterMatch = XUaCompatibleFilter.Match(content, openingHeadTagIndex.Value);
+        var charsetFilterMatch = CharsetFilter.Match(content, openingHeadTagIndex.Value);
+
+        // We have a <HEAD> tag, but didn't find the other tags we wanted. Find </HEAD> tag.  It's okay if we don't find it!
+        var closingHeadTagIndex = content.IndexOf("</head>", StringComparison.InvariantCultureIgnoreCase);
+
+        // Check if we found the tags and based on which comes last AND that this happens INSIDE the HEAD tag - do a replace on that.
+        if ((xUaCompatibleFilterMatch.Success || charsetFilterMatch.Success) && (xUaCompatibleFilterMatch.Index < closingHeadTagIndex || charsetFilterMatch.Index > closingHeadTagIndex))
+        {
+            var match = charsetFilterMatch;
+            if(xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index)
+            {
+                match = xUaCompatibleFilterMatch;
+            }
+
+            var contentSubString = content.Substring(match.Index, match.Length);
+            var jsScriptWithContentSubString = string.Format("{0}{1}", contentSubString, _getJsScript());
+
+            return content.Remove(match.Index, match.Length).Insert(match.Index, jsScriptWithContentSubString);
+        }
+
+        // Found both HEAD tags, no  meta tags, get index immediately after the <HEAD>. Find first '>' which will be end of head opening tag.
+        var indexOfEndHeadOpeningTag = content.IndexOf('>', openingHeadTagIndex.Value);
+
+        // The <HEAD> tag may be malformed or simply be another type of tag, if so do not use it
+        if (!(indexOfEndHeadOpeningTag > openingHeadTagIndex))
+            return string.Empty;
+
+        // Get the whole open HEAD tag string
+        var headOpeningTag = content.Substring(openingHeadTagIndex.Value, (indexOfEndHeadOpeningTag - openingHeadTagIndex.Value) + 1);
+
+        // Insert immediately after the <HEAD> tag. 
+        var jsScriptWithHeadPrefix = string.Format("{0}{1}", headOpeningTag, _getJsScript());
+        return content.Replace(headOpeningTag, jsScriptWithHeadPrefix, StringComparison.InvariantCultureIgnoreCase, 1);
+    }
+
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionHelper.cs
@@ -6,54 +6,53 @@ using System.IO;
 using System.Threading.Tasks;
 using NewRelic.Agent.Api;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+public static class BrowserScriptInjectionHelper
 {
-    public static class BrowserScriptInjectionHelper
+    /// <summary>
+    /// Determine where to inject the RUM script and write the buffer to the base stream.
+    /// </summary>
+    /// <param name="buffer">UTF-8 encoded buffer representing the current page</param>
+    /// <param name="baseStream"></param>
+    /// <param name="rumBytes"></param>
+    /// <param name="transaction"></param>
+    /// <returns></returns>
+    public static async Task InjectBrowserScriptAsync(byte[] buffer, Stream baseStream, byte[] rumBytes, ITransaction transaction)
     {
-        /// <summary>
-        /// Determine where to inject the RUM script and write the buffer to the base stream.
-        /// </summary>
-        /// <param name="buffer">UTF-8 encoded buffer representing the current page</param>
-        /// <param name="baseStream"></param>
-        /// <param name="rumBytes"></param>
-        /// <param name="transaction"></param>
-        /// <returns></returns>
-        public static async Task InjectBrowserScriptAsync(byte[] buffer, Stream baseStream, byte[] rumBytes, ITransaction transaction)
+        var index = BrowserScriptInjectionIndexHelper.TryFindInjectionIndex(buffer);
+        if (index == -1)
         {
-            var index = BrowserScriptInjectionIndexHelper.TryFindInjectionIndex(buffer);
-            if (index == -1)
-            {
-                // not found, can't inject anything
-                transaction?.LogFinest("Skipping RUM Injection: No suitable location found to inject script.");
-                await TryWriteStreamAsync(baseStream, buffer, 0, buffer.Length, transaction);
-                return;
-            }
-
-            transaction?.LogFinest($"Injecting RUM script at byte index {index}.");
-
-            if (index < buffer.Length) // validate index is less than buffer length
-            {
-                // Write everything up to the insertion index
-                await TryWriteStreamAsync(baseStream, buffer, 0, index, transaction);
-                // Write the RUM script
-                await TryWriteStreamAsync(baseStream, rumBytes, 0, rumBytes.Length, transaction);
-                // Write the rest of the doc, starting after the insertion index
-                await TryWriteStreamAsync(baseStream, buffer, index, buffer.Length - index, transaction);
-            }
-            else
-                transaction?.LogFinest($"Skipping RUM Injection: Insertion index was invalid.");
+            // not found, can't inject anything
+            transaction?.LogFinest("Skipping RUM Injection: No suitable location found to inject script.");
+            await TryWriteStreamAsync(baseStream, buffer, 0, buffer.Length, transaction);
+            return;
         }
 
-        private static async Task TryWriteStreamAsync(Stream stream, byte[] buffer, int offset, int count, ITransaction transaction)
+        transaction?.LogFinest($"Injecting RUM script at byte index {index}.");
+
+        if (index < buffer.Length) // validate index is less than buffer length
         {
-            try
-            {
-                await stream.WriteAsync(buffer, offset, count);
-            }
-            catch (ObjectDisposedException)
-            {
-                transaction?.LogFinest("RUM Injection aborted: Stream was disposed.");
-            }
+            // Write everything up to the insertion index
+            await TryWriteStreamAsync(baseStream, buffer, 0, index, transaction);
+            // Write the RUM script
+            await TryWriteStreamAsync(baseStream, rumBytes, 0, rumBytes.Length, transaction);
+            // Write the rest of the doc, starting after the insertion index
+            await TryWriteStreamAsync(baseStream, buffer, index, buffer.Length - index, transaction);
+        }
+        else
+            transaction?.LogFinest($"Skipping RUM Injection: Insertion index was invalid.");
+    }
+
+    private static async Task TryWriteStreamAsync(Stream stream, byte[] buffer, int offset, int count, ITransaction transaction)
+    {
+        try
+        {
+            await stream.WriteAsync(buffer, offset, count);
+        }
+        catch (ObjectDisposedException)
+        {
+            transaction?.LogFinest("RUM Injection aborted: Stream was disposed.");
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionIndexHelper.cs
+++ b/src/Agent/NewRelic/Agent/Core/BrowserMonitoring/BrowserScriptInjectionIndexHelper.cs
@@ -6,132 +6,131 @@ using System.Text;
 using System.Text.RegularExpressions;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.BrowserMonitoring
+namespace NewRelic.Agent.Core.BrowserMonitoring;
+
+internal static class BrowserScriptInjectionIndexHelper
 {
-    internal static class BrowserScriptInjectionIndexHelper
+
+    private static readonly Regex XUaCompatibleFilter = new Regex(@"(<\s*meta[^>]+http-equiv[\s]*=[\s]*['""]x-ua-compatible['""][^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+    private static readonly Regex CharsetFilter = new Regex(@"(<\s*meta[^>]+charset\s*=[^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Returns the index into the (UTF-8 encoded) buffer where the RUM script should be injected, or -1 if no suitable location is found
+    /// </summary>
+    /// <param name="content"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Specification for Javascript insertion: https://newrelic.atlassian.net/wiki/spaces/eng/pages/50299103/BAM+Agent+Auto-Instrumentation
+    /// </remarks>
+    public static int TryFindInjectionIndex(byte[] content)
     {
-
-        private static readonly Regex XUaCompatibleFilter = new Regex(@"(<\s*meta[^>]+http-equiv[\s]*=[\s]*['""]x-ua-compatible['""][^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-        private static readonly Regex CharsetFilter = new Regex(@"(<\s*meta[^>]+charset\s*=[^>]*>)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
-
-        /// <summary>
-        /// Returns the index into the (UTF-8 encoded) buffer where the RUM script should be injected, or -1 if no suitable location is found
-        /// </summary>
-        /// <param name="content"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// Specification for Javascript insertion: https://newrelic.atlassian.net/wiki/spaces/eng/pages/50299103/BAM+Agent+Auto-Instrumentation
-        /// </remarks>
-        public static int TryFindInjectionIndex(byte[] content)
+        try
         {
-            try
+            var contentAsString = Encoding.UTF8.GetString(content);
+
+            var openingHeadTagIndex = FindFirstOpeningHeadTag(contentAsString);
+
+            // No <HEAD> tag. Attempt to insert before <BODY> tag (not a great fallback option).
+            if (openingHeadTagIndex == -1)
             {
-                var contentAsString = Encoding.UTF8.GetString(content);
+                return FindIndexBeforeBodyTag(content, contentAsString);
+            }
 
-                var openingHeadTagIndex = FindFirstOpeningHeadTag(contentAsString);
+            // Since we have a head tag (top of 'page'), search for <X_UA_COMPATIBLE> and for <CHARSET> tags in Head section
+            var xUaCompatibleFilterMatch = XUaCompatibleFilter.Match(contentAsString, openingHeadTagIndex);
+            var charsetFilterMatch = CharsetFilter.Match(contentAsString, openingHeadTagIndex);
 
-                // No <HEAD> tag. Attempt to insert before <BODY> tag (not a great fallback option).
-                if (openingHeadTagIndex == -1)
+            // Try to find </HEAD> tag. (It's okay if we don't find it!)
+            var closingHeadTagIndex = contentAsString.IndexOf("</head>", StringComparison.InvariantCultureIgnoreCase);
+
+            // Find which of the two tags occurs latest (if at all) and ensure that at least
+            // one of the matches occurs prior to the closing head tag
+            if ((xUaCompatibleFilterMatch.Success || charsetFilterMatch.Success) &&
+                (xUaCompatibleFilterMatch.Index < closingHeadTagIndex || charsetFilterMatch.Index < closingHeadTagIndex))
+            {
+                var match = charsetFilterMatch;
+                if (xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index)
                 {
-                    return FindIndexBeforeBodyTag(content, contentAsString);
+                    match = xUaCompatibleFilterMatch;
                 }
 
-                // Since we have a head tag (top of 'page'), search for <X_UA_COMPATIBLE> and for <CHARSET> tags in Head section
-                var xUaCompatibleFilterMatch = XUaCompatibleFilter.Match(contentAsString, openingHeadTagIndex);
-                var charsetFilterMatch = CharsetFilter.Match(contentAsString, openingHeadTagIndex);
+                // find the index just after the end of the regex match in the UTF-8 buffer
+                var contentSubString = contentAsString.Substring(match.Index, match.Length);
+                var utf8HeadMatchIndex = IndexOfByteArray(content, contentSubString, out var substringBytesLength);
 
-                // Try to find </HEAD> tag. (It's okay if we don't find it!)
-                var closingHeadTagIndex = contentAsString.IndexOf("</head>", StringComparison.InvariantCultureIgnoreCase);
-
-                // Find which of the two tags occurs latest (if at all) and ensure that at least
-                // one of the matches occurs prior to the closing head tag
-                if ((xUaCompatibleFilterMatch.Success || charsetFilterMatch.Success) &&
-                    (xUaCompatibleFilterMatch.Index < closingHeadTagIndex || charsetFilterMatch.Index < closingHeadTagIndex))
-                {
-                    var match = charsetFilterMatch;
-                    if (xUaCompatibleFilterMatch.Index > charsetFilterMatch.Index)
-                    {
-                        match = xUaCompatibleFilterMatch;
-                    }
-
-                    // find the index just after the end of the regex match in the UTF-8 buffer
-                    var contentSubString = contentAsString.Substring(match.Index, match.Length);
-                    var utf8HeadMatchIndex = IndexOfByteArray(content, contentSubString, out var substringBytesLength);
-
-                    return utf8HeadMatchIndex + substringBytesLength;
-                }
-
-                // found opening head tag but no meta tags, insert immediately after the opening head tag
-                // Find first '>' after the opening head tag, which will be end of head opening tag.
-                var indexOfEndHeadOpeningTag = contentAsString.IndexOf('>', openingHeadTagIndex);
-
-                // The <HEAD> tag may be malformed or simply be another type of tag, if so do not use it
-                if (!(indexOfEndHeadOpeningTag > openingHeadTagIndex))
-                    return -1;
-
-                // Get the whole open HEAD tag string
-                var headOpeningTag = contentAsString.Substring(openingHeadTagIndex, (indexOfEndHeadOpeningTag - openingHeadTagIndex) + 1);
-                var utf8HeadOpeningTagIndex = IndexOfByteArray(content, headOpeningTag, out var headOpeningTagBytesLength);
-                return utf8HeadOpeningTagIndex + headOpeningTagBytesLength;
-            }
-            catch (Exception e)
-            {
-                Log.LogMessage(LogLevel.Error, e, "Unexpected exception in TryFindInjectionIndex().");
-                return -1;
-            }
-        }
-
-        private static int FindIndexBeforeBodyTag(byte[] content, string contentAsString)
-        {
-            const string bodyOpenTag = "<body";
-
-            var indexOfBodyTag = contentAsString.IndexOf(bodyOpenTag, StringComparison.InvariantCultureIgnoreCase);
-            if (indexOfBodyTag < 0)
-                return -1;
-
-            // find the body tag start index in the UTF-8 buffer
-            var bodyFromContent = contentAsString.Substring(indexOfBodyTag, bodyOpenTag.Length);
-            var utf8BodyTagIndex = IndexOfByteArray(content, bodyFromContent, out _);
-            return utf8BodyTagIndex;
-        }
-
-        private static int FindFirstOpeningHeadTag(string content)
-        {
-            int indexOpeningHead = -1;
-
-            var indexTemp = content.IndexOf("<head", StringComparison.InvariantCultureIgnoreCase);
-            if (indexTemp < 0)
-                return -1;
-
-            if (content[indexTemp + 5] == '>' || content[indexTemp + 5] == ' ')
-            {
-                indexOpeningHead = indexTemp;
+                return utf8HeadMatchIndex + substringBytesLength;
             }
 
-            return indexOpeningHead;
-        }
+            // found opening head tag but no meta tags, insert immediately after the opening head tag
+            // Find first '>' after the opening head tag, which will be end of head opening tag.
+            var indexOfEndHeadOpeningTag = contentAsString.IndexOf('>', openingHeadTagIndex);
 
-        /// <summary>
-        /// Returns an index into a byte array to find a string in the byte array.
-        /// Exact match using the encoding provided or UTF-8 by default.
-        /// </summary>
-        /// <param name="buffer"></param>
-        /// <param name="stringToFind"></param>
-        /// <param name="stringToFindBytesLength"></param>
-        /// <param name="encoding"></param>
-        /// <returns></returns>
-        private static int IndexOfByteArray(byte[] buffer, string stringToFind, out int stringToFindBytesLength, Encoding encoding = null)
-        {
-            stringToFindBytesLength = 0;
-            encoding ??= Encoding.UTF8;
-
-            if (buffer.Length == 0 || string.IsNullOrEmpty(stringToFind))
+            // The <HEAD> tag may be malformed or simply be another type of tag, if so do not use it
+            if (!(indexOfEndHeadOpeningTag > openingHeadTagIndex))
                 return -1;
 
-            var stringToFindBytes = encoding.GetBytes(stringToFind);
-            stringToFindBytesLength = stringToFindBytes.Length;
-
-            return buffer.AsSpan().IndexOf(stringToFindBytes);
+            // Get the whole open HEAD tag string
+            var headOpeningTag = contentAsString.Substring(openingHeadTagIndex, (indexOfEndHeadOpeningTag - openingHeadTagIndex) + 1);
+            var utf8HeadOpeningTagIndex = IndexOfByteArray(content, headOpeningTag, out var headOpeningTagBytesLength);
+            return utf8HeadOpeningTagIndex + headOpeningTagBytesLength;
         }
+        catch (Exception e)
+        {
+            Log.LogMessage(LogLevel.Error, e, "Unexpected exception in TryFindInjectionIndex().");
+            return -1;
+        }
+    }
+
+    private static int FindIndexBeforeBodyTag(byte[] content, string contentAsString)
+    {
+        const string bodyOpenTag = "<body";
+
+        var indexOfBodyTag = contentAsString.IndexOf(bodyOpenTag, StringComparison.InvariantCultureIgnoreCase);
+        if (indexOfBodyTag < 0)
+            return -1;
+
+        // find the body tag start index in the UTF-8 buffer
+        var bodyFromContent = contentAsString.Substring(indexOfBodyTag, bodyOpenTag.Length);
+        var utf8BodyTagIndex = IndexOfByteArray(content, bodyFromContent, out _);
+        return utf8BodyTagIndex;
+    }
+
+    private static int FindFirstOpeningHeadTag(string content)
+    {
+        int indexOpeningHead = -1;
+
+        var indexTemp = content.IndexOf("<head", StringComparison.InvariantCultureIgnoreCase);
+        if (indexTemp < 0)
+            return -1;
+
+        if (content[indexTemp + 5] == '>' || content[indexTemp + 5] == ' ')
+        {
+            indexOpeningHead = indexTemp;
+        }
+
+        return indexOpeningHead;
+    }
+
+    /// <summary>
+    /// Returns an index into a byte array to find a string in the byte array.
+    /// Exact match using the encoding provided or UTF-8 by default.
+    /// </summary>
+    /// <param name="buffer"></param>
+    /// <param name="stringToFind"></param>
+    /// <param name="stringToFindBytesLength"></param>
+    /// <param name="encoding"></param>
+    /// <returns></returns>
+    private static int IndexOfByteArray(byte[] buffer, string stringToFind, out int stringToFindBytesLength, Encoding encoding = null)
+    {
+        stringToFindBytesLength = 0;
+        encoding ??= Encoding.UTF8;
+
+        if (buffer.Length == 0 || string.IsNullOrEmpty(stringToFind))
+            return -1;
+
+        var stringToFindBytes = encoding.GetBytes(stringToFind);
+        stringToFindBytesLength = stringToFindBytes.Length;
+
+        return buffer.AsSpan().IndexOf(stringToFindBytes);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/CallStack/CallStackManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/CallStack/CallStackManager.cs
@@ -7,244 +7,243 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.Configuration;
 
-namespace NewRelic.Agent.Core.CallStack
+namespace NewRelic.Agent.Core.CallStack;
+
+public interface ICallStackManager
 {
-    public interface ICallStackManager
-    {
-        /// <summary>
-        /// Adds a new object to the top of the callstack.
-        /// </summary>
-        void Push(int uniqueId);
-
-        /// <summary>
-        /// Removes the given object from top of the callstack. Does nothing if the stack is callstack empty. Will throw if the callstack is not empty and the given object is not on top.
-        /// </summary>
-        void TryPop(int uniqueId, int? parentId);
-
-        /// <summary>
-        /// Returns the object on top of the callstack, or null if callstack is empty.
-        /// </summary>
-        /// <returns>The object on top of the callstack, or null if callstack is empty.</returns>
-        int? TryPeek();
-
-        /// <summary>
-        /// Clears the callstack.
-        /// </summary>
-        void Clear();
-
-        /// <summary>
-        /// Switches from synchronous to asynchronous storage.
-        /// </summary>
-        /// <returns>Returns true if the storage mechanism was switched.</returns>
-        bool AttachToAsync();
-    }
-
-    public delegate void CallStackPop(object uniqueObject, object uniqueParent);
-
-    public interface ICallStackManagerFactory
-    {
-        ICallStackManager CreateCallStackManager();
-    }
-
-    public class ResolvedCallStackManagerFactory : ICallStackManagerFactory
-    {
-        private readonly ICallStackManagerFactory _callStackManagerFactory;
-        private readonly IConfiguration _configuration;
-
-        public ResolvedCallStackManagerFactory(IEnumerable<IContextStorageFactory> storageFactories, IConfigurationService configurationService)    
-        {
-            _configuration = configurationService.Configuration;
-            _callStackManagerFactory = CreateFactory(storageFactories);
-        }
-
-        private ICallStackManagerFactory CreateFactory(IEnumerable<IContextStorageFactory> storageFactories)
-        {
-            var listOfFactories = storageFactories.ToList();
-
-            // if hybrid http context storage is enabled, use it instead of asynclocal but fallback to asynclocal if it's not available
-            var asyncLocalFactory = 
-                listOfFactories.FirstOrDefault(f => _configuration.HybridHttpContextStorageEnabled  && f.IsHybridStorage)
-                ??
-                listOfFactories.FirstOrDefault(f => f.Type == ContextStorageType.AsyncLocal);
-
-            if (asyncLocalFactory != null)
-            {
-                Log.Debug("Using async storage {0} for call stack with AsyncCallStackManagerFactory", asyncLocalFactory.GetType().FullName);
-                return new AsyncCallStackManagerFactory(asyncLocalFactory);
-            }
-
-            var callContextLogicalDataFactory = listOfFactories.FirstOrDefault(f => f.Type == ContextStorageType.CallContextLogicalData);
-            if (callContextLogicalDataFactory != null)
-            {
-                Log.Debug("Using async storage {0} for call stack with AsyncCallStackManagerFactory", callContextLogicalDataFactory.GetType().FullName);
-                return new AsyncCallStackManagerFactory(callContextLogicalDataFactory);
-            }
-
-            listOfFactories.Add(GetThreadLocalContextStorageFactory());
-
-            Log.Debug("No specialized async storage found. Using standard factories with CallStackManagerFactory.");
-            return new CallStackManagerFactory(listOfFactories);
-        }
-
-        public ICallStackManager CreateCallStackManager()
-        {
-            return _callStackManagerFactory.CreateCallStackManager();
-        }
-
-        private static IContextStorageFactory GetThreadLocalContextStorageFactory()
-        {
-            return new ThreadLocalContextStorageFactory();
-        }
-    }
-
-    public class CallStackManagerFactory : ICallStackManagerFactory
-    {
-        private readonly IEnumerable<IContextStorageFactory> _storageFactories;
-
-        public CallStackManagerFactory(IEnumerable<IContextStorageFactory> storageFactories)
-        {
-            this._storageFactories = storageFactories;
-        }
-
-        public ICallStackManager CreateCallStackManager()
-        {
-            // we don't know yet which of these CanProvide, but we know which can load their assemblies.
-            // defer final decision on which one to use to the CallStackTracker
-            var parentTrackers = _storageFactories
-                    .Select(factory => factory.CreateContext<int?>("NewRelic.ParentObject"))
-                    .Where(tracker => tracker != null)
-                    .OrderByDescending(context => context.Priority)
-                    .ToList();
-
-            // even though the ASP and WCF contexts can't provide at this point, the Default context can.
-            // Want to make sure it is there (.dll could have been deleted from \Extensions), else fall back.
-            return new CallStackManager(parentTrackers);
-        }
-    }
-
-    public class AsyncCallStackManagerFactory : ICallStackManagerFactory
-    {
-        private readonly IContextStorage<int?> _storageContext;
-
-        public AsyncCallStackManagerFactory(IContextStorageFactory factory)
-        {
-            this._storageContext = factory.CreateContext<int?>("NewRelic.ParentObject");
-        }
-
-        public ICallStackManager CreateCallStackManager()
-        {
-            // our async contexts can exhibit undesirable sticky behavior if they're first accessed in
-            // a synchronous context.  This clears out anything stuck on the context.
-            _storageContext.Clear();
-            return new SyncToAsyncCallStackManager(_storageContext);
-        }
-    }
+    /// <summary>
+    /// Adds a new object to the top of the callstack.
+    /// </summary>
+    void Push(int uniqueId);
 
     /// <summary>
-    /// A call stack manager that starts synchronous and switches to async storage when AttachToAsync
-    /// is called.
+    /// Removes the given object from top of the callstack. Does nothing if the stack is callstack empty. Will throw if the callstack is not empty and the given object is not on top.
     /// </summary>
-    public class SyncToAsyncCallStackManager : BaseCallStackManager
+    void TryPop(int uniqueId, int? parentId);
+
+    /// <summary>
+    /// Returns the object on top of the callstack, or null if callstack is empty.
+    /// </summary>
+    /// <returns>The object on top of the callstack, or null if callstack is empty.</returns>
+    int? TryPeek();
+
+    /// <summary>
+    /// Clears the callstack.
+    /// </summary>
+    void Clear();
+
+    /// <summary>
+    /// Switches from synchronous to asynchronous storage.
+    /// </summary>
+    /// <returns>Returns true if the storage mechanism was switched.</returns>
+    bool AttachToAsync();
+}
+
+public delegate void CallStackPop(object uniqueObject, object uniqueParent);
+
+public interface ICallStackManagerFactory
+{
+    ICallStackManager CreateCallStackManager();
+}
+
+public class ResolvedCallStackManagerFactory : ICallStackManagerFactory
+{
+    private readonly ICallStackManagerFactory _callStackManagerFactory;
+    private readonly IConfiguration _configuration;
+
+    public ResolvedCallStackManagerFactory(IEnumerable<IContextStorageFactory> storageFactories, IConfigurationService configurationService)    
     {
-        private readonly IContextStorage<int?> _asyncContextStorage;
-        private volatile IContextStorage<int?> _currentContextStorage;
-
-        public SyncToAsyncCallStackManager(IContextStorage<int?> asyncContextStorage)
-        {
-            _asyncContextStorage = asyncContextStorage;
-            _currentContextStorage = new SynchronousContextStorage();
-        }
-        public override bool AttachToAsync()
-        {
-            var currentValue = _currentContextStorage.GetData();
-            _currentContextStorage = _asyncContextStorage;
-            _currentContextStorage.SetData(currentValue);
-            return true;
-        }
-
-        protected override IContextStorage<int?> CurrentStorage => _currentContextStorage;
-
-        private sealed class SynchronousContextStorage : IContextStorage<int?>
-        {
-            private int? _id;
-            public byte Priority => 0;
-
-            public bool CanProvide => true;
-
-            public void Clear()
-            {
-                _id = null;
-            }
-
-            public int? GetData()
-            {
-                return _id;
-            }
-
-            public void SetData(int? id)
-            {
-                _id = id;
-            }
-        }
+        _configuration = configurationService.Configuration;
+        _callStackManagerFactory = CreateFactory(storageFactories);
     }
 
-    public class CallStackManager : BaseCallStackManager
+    private ICallStackManagerFactory CreateFactory(IEnumerable<IContextStorageFactory> storageFactories)
     {
-        private readonly IEnumerable<IContextStorage<int?>> _parentTrackers;
+        var listOfFactories = storageFactories.ToList();
 
-        public CallStackManager(List<IContextStorage<int?>> parentTrackers)
+        // if hybrid http context storage is enabled, use it instead of asynclocal but fallback to asynclocal if it's not available
+        var asyncLocalFactory = 
+            listOfFactories.FirstOrDefault(f => _configuration.HybridHttpContextStorageEnabled  && f.IsHybridStorage)
+            ??
+            listOfFactories.FirstOrDefault(f => f.Type == ContextStorageType.AsyncLocal);
+
+        if (asyncLocalFactory != null)
         {
-            this._parentTrackers = parentTrackers;
+            Log.Debug("Using async storage {0} for call stack with AsyncCallStackManagerFactory", asyncLocalFactory.GetType().FullName);
+            return new AsyncCallStackManagerFactory(asyncLocalFactory);
         }
 
-        protected override IContextStorage<int?> CurrentStorage
+        var callContextLogicalDataFactory = listOfFactories.FirstOrDefault(f => f.Type == ContextStorageType.CallContextLogicalData);
+        if (callContextLogicalDataFactory != null)
         {
-            get
-            {
-                foreach (var storage in _parentTrackers)
-                {
-                    if (storage.CanProvide)
-                    {
-                        return storage;
-                    }
-                }
-                return null;
-            }
+            Log.Debug("Using async storage {0} for call stack with AsyncCallStackManagerFactory", callContextLogicalDataFactory.GetType().FullName);
+            return new AsyncCallStackManagerFactory(callContextLogicalDataFactory);
         }
+
+        listOfFactories.Add(GetThreadLocalContextStorageFactory());
+
+        Log.Debug("No specialized async storage found. Using standard factories with CallStackManagerFactory.");
+        return new CallStackManagerFactory(listOfFactories);
     }
 
-    public abstract class BaseCallStackManager : ICallStackManager
+    public ICallStackManager CreateCallStackManager()
     {
-        protected abstract IContextStorage<int?> CurrentStorage { get; }
+        return _callStackManagerFactory.CreateCallStackManager();
+    }
 
-        public void Push(int id)
-        {
-            CurrentStorage?.SetData(id);
-        }
+    private static IContextStorageFactory GetThreadLocalContextStorageFactory()
+    {
+        return new ThreadLocalContextStorageFactory();
+    }
+}
 
-        public void TryPop(int uniqueId, int? parentId)
-        {
-            var storage = CurrentStorage;
-            // It is OK to ignore pops when the intended object is not on top of call stack. There are several non-exceptional scenarios where this occurs, particularly for async code.
-            if (storage?.GetData() != uniqueId)
-                return;
+public class CallStackManagerFactory : ICallStackManagerFactory
+{
+    private readonly IEnumerable<IContextStorageFactory> _storageFactories;
 
-            storage?.SetData(parentId);
-        }
+    public CallStackManagerFactory(IEnumerable<IContextStorageFactory> storageFactories)
+    {
+        this._storageFactories = storageFactories;
+    }
 
-        public int? TryPeek()
-        {
-            return CurrentStorage?.GetData();
-        }
+    public ICallStackManager CreateCallStackManager()
+    {
+        // we don't know yet which of these CanProvide, but we know which can load their assemblies.
+        // defer final decision on which one to use to the CallStackTracker
+        var parentTrackers = _storageFactories
+            .Select(factory => factory.CreateContext<int?>("NewRelic.ParentObject"))
+            .Where(tracker => tracker != null)
+            .OrderByDescending(context => context.Priority)
+            .ToList();
+
+        // even though the ASP and WCF contexts can't provide at this point, the Default context can.
+        // Want to make sure it is there (.dll could have been deleted from \Extensions), else fall back.
+        return new CallStackManager(parentTrackers);
+    }
+}
+
+public class AsyncCallStackManagerFactory : ICallStackManagerFactory
+{
+    private readonly IContextStorage<int?> _storageContext;
+
+    public AsyncCallStackManagerFactory(IContextStorageFactory factory)
+    {
+        this._storageContext = factory.CreateContext<int?>("NewRelic.ParentObject");
+    }
+
+    public ICallStackManager CreateCallStackManager()
+    {
+        // our async contexts can exhibit undesirable sticky behavior if they're first accessed in
+        // a synchronous context.  This clears out anything stuck on the context.
+        _storageContext.Clear();
+        return new SyncToAsyncCallStackManager(_storageContext);
+    }
+}
+
+/// <summary>
+/// A call stack manager that starts synchronous and switches to async storage when AttachToAsync
+/// is called.
+/// </summary>
+public class SyncToAsyncCallStackManager : BaseCallStackManager
+{
+    private readonly IContextStorage<int?> _asyncContextStorage;
+    private volatile IContextStorage<int?> _currentContextStorage;
+
+    public SyncToAsyncCallStackManager(IContextStorage<int?> asyncContextStorage)
+    {
+        _asyncContextStorage = asyncContextStorage;
+        _currentContextStorage = new SynchronousContextStorage();
+    }
+    public override bool AttachToAsync()
+    {
+        var currentValue = _currentContextStorage.GetData();
+        _currentContextStorage = _asyncContextStorage;
+        _currentContextStorage.SetData(currentValue);
+        return true;
+    }
+
+    protected override IContextStorage<int?> CurrentStorage => _currentContextStorage;
+
+    private sealed class SynchronousContextStorage : IContextStorage<int?>
+    {
+        private int? _id;
+        public byte Priority => 0;
+
+        public bool CanProvide => true;
 
         public void Clear()
         {
-            CurrentStorage?.SetData(null);
+            _id = null;
         }
 
-        public virtual bool AttachToAsync()
+        public int? GetData()
         {
-            return false;
+            return _id;
         }
+
+        public void SetData(int? id)
+        {
+            _id = id;
+        }
+    }
+}
+
+public class CallStackManager : BaseCallStackManager
+{
+    private readonly IEnumerable<IContextStorage<int?>> _parentTrackers;
+
+    public CallStackManager(List<IContextStorage<int?>> parentTrackers)
+    {
+        this._parentTrackers = parentTrackers;
+    }
+
+    protected override IContextStorage<int?> CurrentStorage
+    {
+        get
+        {
+            foreach (var storage in _parentTrackers)
+            {
+                if (storage.CanProvide)
+                {
+                    return storage;
+                }
+            }
+            return null;
+        }
+    }
+}
+
+public abstract class BaseCallStackManager : ICallStackManager
+{
+    protected abstract IContextStorage<int?> CurrentStorage { get; }
+
+    public void Push(int id)
+    {
+        CurrentStorage?.SetData(id);
+    }
+
+    public void TryPop(int uniqueId, int? parentId)
+    {
+        var storage = CurrentStorage;
+        // It is OK to ignore pops when the intended object is not on top of call stack. There are several non-exceptional scenarios where this occurs, particularly for async code.
+        if (storage?.GetData() != uniqueId)
+            return;
+
+        storage?.SetData(parentId);
+    }
+
+    public int? TryPeek()
+    {
+        return CurrentStorage?.GetData();
+    }
+
+    public void Clear()
+    {
+        CurrentStorage?.SetData(null);
+    }
+
+    public virtual bool AttachToAsync()
+    {
+        return false;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/AbstractCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/AbstractCommand.cs
@@ -3,12 +3,11 @@
 
 using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Commands
-{
-    public abstract class AbstractCommand : ICommand
-    {
-        public string Name { get; protected set; }
+namespace NewRelic.Agent.Core.Commands;
 
-        public abstract object Process(IDictionary<string, object> arguments);
-    }
+public abstract class AbstractCommand : ICommand
+{
+    public string Name { get; protected set; }
+
+    public abstract object Process(IDictionary<string, object> arguments);
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/CommandModel.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/CommandModel.cs
@@ -5,36 +5,35 @@ using System.Collections.Generic;
 using NewRelic.Agent.Core.JsonConverters;
 using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+[JsonConverter(typeof(JsonArrayConverter))]
+public class CommandModel
 {
-    [JsonConverter(typeof(JsonArrayConverter))]
-    public class CommandModel
+    [JsonArrayIndex(Index = 0)]
+    public readonly int CommandId;
+
+    [JsonArrayIndex(Index = 1)]
+    public readonly CommandDetails Details;
+
+    public CommandModel(int commandId, CommandDetails details)
     {
-        [JsonArrayIndex(Index = 0)]
-        public readonly int CommandId;
-
-        [JsonArrayIndex(Index = 1)]
-        public readonly CommandDetails Details;
-
-        public CommandModel(int commandId, CommandDetails details)
-        {
-            CommandId = commandId;
-            Details = details;
-        }
+        CommandId = commandId;
+        Details = details;
     }
+}
 
-    public class CommandDetails
+public class CommandDetails
+{
+    [JsonProperty("name")]
+    public readonly string Name;
+
+    [JsonProperty("arguments")]
+    public readonly IDictionary<string, object> Arguments;
+
+    public CommandDetails(string name, IDictionary<string, object> arguments)
     {
-        [JsonProperty("name")]
-        public readonly string Name;
-
-        [JsonProperty("arguments")]
-        public readonly IDictionary<string, object> Arguments;
-
-        public CommandDetails(string name, IDictionary<string, object> arguments)
-        {
-            Name = name;
-            Arguments = arguments;
-        }
+        Name = name;
+        Arguments = arguments;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/CommandService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/CommandService.cs
@@ -1,105 +1,104 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
+using System.Globalization;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
-using System.Collections.Generic;
-using System.Globalization;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+public class CommandService : DisposableService
 {
-    public class CommandService : DisposableService
+    private readonly IDictionary<string, ICommand> _knownCommands = new Dictionary<string, ICommand>();
+
+    private readonly IDataTransportService _dataTransportService;
+
+    private readonly IScheduler _scheduler;
+
+    private readonly IConfigurationService _configurationService;
+
+    public CommandService(IDataTransportService dataTransportService, IScheduler scheduler, IConfigurationService configurationService)
     {
-        private readonly IDictionary<string, ICommand> _knownCommands = new Dictionary<string, ICommand>();
+        _dataTransportService = dataTransportService;
+        _configurationService = configurationService;
+        _scheduler = scheduler;
 
-        private readonly IDataTransportService _dataTransportService;
+        _scheduler.ExecuteEvery(GetAndExecuteAgentCommands, _configurationService.Configuration.GetAgentCommandsCycle);
+    }
 
-        private readonly IScheduler _scheduler;
+    public override void Dispose()
+    {
+        _scheduler.StopExecuting(GetAndExecuteAgentCommands);
+    }
 
-        private readonly IConfigurationService _configurationService;
-
-        public CommandService(IDataTransportService dataTransportService, IScheduler scheduler, IConfigurationService configurationService)
+    public void AddCommands(params ICommand[] commands)
+    {
+        foreach (var command in commands)
         {
-            _dataTransportService = dataTransportService;
-            _configurationService = configurationService;
-            _scheduler = scheduler;
-
-            _scheduler.ExecuteEvery(GetAndExecuteAgentCommands, _configurationService.Configuration.GetAgentCommandsCycle);
-        }
-
-        public override void Dispose()
-        {
-            _scheduler.StopExecuting(GetAndExecuteAgentCommands);
-        }
-
-        public void AddCommands(params ICommand[] commands)
-        {
-            foreach (var command in commands)
+            if (command != null)
             {
-                if (command != null)
-                {
-                    _knownCommands.Add(command.Name, command);
-                }
+                _knownCommands.Add(command.Name, command);
             }
         }
+    }
 
-        private void GetAndExecuteAgentCommands()
-        {
-            var commands = _dataTransportService.GetAgentCommands();
-            var commandResults = ProcessCommands(commands);
-            if (commandResults.Count < 1)
-                return;
+    private void GetAndExecuteAgentCommands()
+    {
+        var commands = _dataTransportService.GetAgentCommands();
+        var commandResults = ProcessCommands(commands);
+        if (commandResults.Count < 1)
+            return;
 
-            _dataTransportService.SendCommandResults(commandResults);
-        }
+        _dataTransportService.SendCommandResults(commandResults);
+    }
 
-        public IDictionary<string, object> ProcessCommands(IEnumerable<CommandModel> commandModels)
-        {
-            var results = new Dictionary<string, object>();
+    public IDictionary<string, object> ProcessCommands(IEnumerable<CommandModel> commandModels)
+    {
+        var results = new Dictionary<string, object>();
 
-            if (commandModels == null)
-                return results;
-
-            foreach (var commandModel in commandModels)
-            {
-                if (commandModel == null)
-                    continue;
-                if (commandModel.Details == null)
-                    continue;
-
-                var id = commandModel.CommandId;
-                var name = commandModel.Details.Name;
-                var arguments = commandModel.Details.Arguments;
-
-                if (name == null)
-                    continue;
-                if (arguments == null)
-                    continue;
-
-                object returnValue;
-                var command = _knownCommands.GetValueOrDefault(name);
-                if (command == null)
-                {
-                    var msg = $"Ignoring command named '{name}' that the agent doesn't know how to execute";
-                    Log.Debug(msg);
-                    returnValue = new Dictionary<string, object>
-                    {
-                        { "errors", msg },
-                        { "error", msg }
-                    };
-                }
-                else
-                {
-                    returnValue = command.Process(arguments);
-                }
-
-                results.Add(id.ToString(CultureInfo.InvariantCulture), returnValue);
-            }
+        if (commandModels == null)
             return results;
+
+        foreach (var commandModel in commandModels)
+        {
+            if (commandModel == null)
+                continue;
+            if (commandModel.Details == null)
+                continue;
+
+            var id = commandModel.CommandId;
+            var name = commandModel.Details.Name;
+            var arguments = commandModel.Details.Arguments;
+
+            if (name == null)
+                continue;
+            if (arguments == null)
+                continue;
+
+            object returnValue;
+            var command = _knownCommands.GetValueOrDefault(name);
+            if (command == null)
+            {
+                var msg = $"Ignoring command named '{name}' that the agent doesn't know how to execute";
+                Log.Debug(msg);
+                returnValue = new Dictionary<string, object>
+                {
+                    { "errors", msg },
+                    { "error", msg }
+                };
+            }
+            else
+            {
+                returnValue = command.Process(arguments);
+            }
+
+            results.Add(id.ToString(CultureInfo.InvariantCulture), returnValue);
         }
+        return results;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/ICommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/ICommand.cs
@@ -3,24 +3,23 @@
 
 using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+/// <summary>
+/// Commands are downloaded from the RPM service and executed. 
+/// </summary>
+public interface ICommand
 {
     /// <summary>
-    /// Commands are downloaded from the RPM service and executed. 
+    /// The name of this command.
     /// </summary>
-    public interface ICommand
-    {
-        /// <summary>
-        /// The name of this command.
-        /// </summary>
-        string Name { get; }
+    string Name { get; }
 
-        /// <summary>
-        /// Executes this command.  This is called from the CommandService
-        /// if it receives a command from the rpm service that matches this command.
-        /// </summary>
-        /// <param name="arguments"></param>
-        /// <returns></returns>
-        object Process(IDictionary<string, object> arguments); // throws CommandException;
-    }
+    /// <summary>
+    /// Executes this command.  This is called from the CommandService
+    /// if it receives a command from the rpm service that matches this command.
+    /// </summary>
+    /// <param name="arguments"></param>
+    /// <returns></returns>
+    object Process(IDictionary<string, object> arguments); // throws CommandException;
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/InstrumentationUpdateCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/InstrumentationUpdateCommand.cs
@@ -8,66 +8,65 @@ using NewRelic.Agent.Core.Instrumentation;
 using NewRelic.Agent.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+public class InstrumentationUpdateCommand : AbstractCommand
 {
-    public class InstrumentationUpdateCommand : AbstractCommand
+    private readonly IInstrumentationService _instrumentationService;
+
+    public InstrumentationUpdateCommand(IInstrumentationService instrumentationService)
     {
-        private readonly IInstrumentationService _instrumentationService;
+        Name = "instrumentation_update";
+        _instrumentationService = instrumentationService;
+    }
 
-        public InstrumentationUpdateCommand(IInstrumentationService instrumentationService)
+    public override object Process(IDictionary<string, object> arguments)
+    {
+        var errorMessage = InstrumentationUpdate(arguments);
+        if (errorMessage == null)
         {
-            Name = "instrumentation_update";
-            _instrumentationService = instrumentationService;
+            return new Dictionary<string, object>();
         }
 
-        public override object Process(IDictionary<string, object> arguments)
+        Log.Error(errorMessage);
+
+        // Other commands send errors under the error key, but I've verified the UI uses `errors`
+        // Originally noticed this in the java agent code: https://source.datanerd.us/java-agent/java_agent/blob/master/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/ReinstrumentResult.java
+        return new Dictionary<string, object>
         {
-            var errorMessage = InstrumentationUpdate(arguments);
-            if (errorMessage == null)
-            {
-                return new Dictionary<string, object>();
-            }
+            {"errors", errorMessage}
+        };
+    }
 
-            Log.Error(errorMessage);
-
-            // Other commands send errors under the error key, but I've verified the UI uses `errors`
-            // Originally noticed this in the java agent code: https://source.datanerd.us/java-agent/java_agent/blob/master/newrelic-agent/src/main/java/com/newrelic/agent/reinstrument/ReinstrumentResult.java
-            return new Dictionary<string, object>
-            {
-                {"errors", errorMessage}
-            };
-        }
-
-        private string InstrumentationUpdate(IDictionary<string, object> arguments)
+    private string InstrumentationUpdate(IDictionary<string, object> arguments)
+    {
+        if (arguments.TryGetValue("instrumentation", out var instrumentationSetObject))
         {
-            if (arguments.TryGetValue("instrumentation", out var instrumentationSetObject))
+            if (instrumentationSetObject is JObject instrumentationSet)
             {
-                if (instrumentationSetObject is JObject instrumentationSet)
+                try
                 {
-                    try
-                    {
-                        var instrumentationConfig = instrumentationSet.ToObject<ServerConfiguration.InstrumentationConfig>();
-                        _instrumentationService.AddOrUpdateLiveInstrumentation(instrumentationConfig.Name, instrumentationConfig.Config);
-                        _instrumentationService.ApplyInstrumentation();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(e, "The instrumentation update was malformed");
-                        return "The instrumentation update was malformed";
-                    }
+                    var instrumentationConfig = instrumentationSet.ToObject<ServerConfiguration.InstrumentationConfig>();
+                    _instrumentationService.AddOrUpdateLiveInstrumentation(instrumentationConfig.Name, instrumentationConfig.Config);
+                    _instrumentationService.ApplyInstrumentation();
                 }
-                else
+                catch (Exception e)
                 {
-                    return "The instrumentation update instrumentation set was empty";
+                    Log.Error(e, "The instrumentation update was malformed");
+                    return "The instrumentation update was malformed";
                 }
             }
             else
             {
-                return "The instrumentation key was missing";
+                return "The instrumentation update instrumentation set was empty";
             }
-
-            Log.Debug($"{Name} command complete.");
-            return null;
         }
+        else
+        {
+            return "The instrumentation key was missing";
+        }
+
+        Log.Debug($"{Name} command complete.");
+        return null;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/RestartCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/RestartCommand.cs
@@ -5,22 +5,21 @@ using System.Collections.Generic;
 using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Utilities;
 
-namespace NewRelic.Agent.Core.Commands
-{
-    /// <summary>
-    /// A command that restarts the agent. 
-    /// </summary>
-    public class RestartCommand : AbstractCommand
-    {
-        public RestartCommand()
-        {
-            Name = "restart";
-        }
+namespace NewRelic.Agent.Core.Commands;
 
-        public override object Process(IDictionary<string, object> arguments)
-        {
-            EventBus<RestartAgentEvent>.Publish(new RestartAgentEvent());
-            return null;
-        }
+/// <summary>
+/// A command that restarts the agent. 
+/// </summary>
+public class RestartCommand : AbstractCommand
+{
+    public RestartCommand()
+    {
+        Name = "restart";
+    }
+
+    public override object Process(IDictionary<string, object> arguments)
+    {
+        EventBus<RestartAgentEvent>.Publish(new RestartAgentEvent());
+        return null;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/ShutdownCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/ShutdownCommand.cs
@@ -5,22 +5,21 @@ using System.Collections.Generic;
 using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Utilities;
 
-namespace NewRelic.Agent.Core.Commands
-{
-    /// <summary>
-    /// A command that shuts down the agent. 
-    /// </summary>
-    public class ShutdownCommand : AbstractCommand
-    {
-        public ShutdownCommand()
-        {
-            Name = "shutdown";
-        }
+namespace NewRelic.Agent.Core.Commands;
 
-        public override object Process(IDictionary<string, object> arguments)
-        {
-            EventBus<KillAgentEvent>.Publish(new KillAgentEvent());
-            return null;
-        }
+/// <summary>
+/// A command that shuts down the agent. 
+/// </summary>
+public class ShutdownCommand : AbstractCommand
+{
+    public ShutdownCommand()
+    {
+        Name = "shutdown";
+    }
+
+    public override object Process(IDictionary<string, object> arguments)
+    {
+        EventBus<KillAgentEvent>.Publish(new KillAgentEvent());
+        return null;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/StartThreadProfilerCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/StartThreadProfilerCommand.cs
@@ -1,56 +1,55 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Collections.Generic;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.ThreadProfiling;
 using NewRelic.Agent.Extensions.Logging;
-using System.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+public class StartThreadProfilerCommand : AbstractCommand
 {
-    public class StartThreadProfilerCommand : AbstractCommand
+    public IThreadProfilingSessionControl ThreadProfilingService { get; set; }
+
+    public StartThreadProfilerCommand(IThreadProfilingSessionControl threadProfilingService)
     {
-        public IThreadProfilingSessionControl ThreadProfilingService { get; set; }
+        Name = "start_profiler";
+        ThreadProfilingService = threadProfilingService;
+    }
 
-        public StartThreadProfilerCommand(IThreadProfilingSessionControl threadProfilingService)
+    public override object Process(IDictionary<string, object> arguments)
+    {
+        var errorMessage = StartThreadProfilingSessions(arguments);
+        if (errorMessage == null)
+            return new Dictionary<string, object>();
+
+        return new Dictionary<string, object>
         {
-            Name = "start_profiler";
-            ThreadProfilingService = threadProfilingService;
+            {"error", errorMessage}
+        };
+    }
+
+    private string StartThreadProfilingSessions(IDictionary<string, object> arguments)
+    {
+        if (arguments == null)
+            return "No arguments sent with start_profiler command.";
+
+        if (!AgentInstallConfiguration.IsWindows && !AgentInstallConfiguration.IsNetCore30OrAbove)
+        {
+            const string netCore30RequiredForLinuxThreadProfiling = "Cannot start a thread profiling session. Thread profiling support on Linux was introduced in .NET Core 3.0.";
+            Log.Info(netCore30RequiredForLinuxThreadProfiling);
+            return netCore30RequiredForLinuxThreadProfiling;
         }
 
-        public override object Process(IDictionary<string, object> arguments)
-        {
-            var errorMessage = StartThreadProfilingSessions(arguments);
-            if (errorMessage == null)
-                return new Dictionary<string, object>();
+        var startArgs = new ThreadProfilerCommandArgs(arguments, ThreadProfilingService.IgnoreMinMinimumSamplingDuration);
+        if (startArgs.ProfileId == 0)
+            return "A valid profile_id must be supplied to start a thread profiling session.";
 
-            return new Dictionary<string, object>
-            {
-                {"error", errorMessage}
-            };
-        }
+        var startedNewSession = ThreadProfilingService.StartThreadProfilingSession(startArgs.ProfileId, startArgs.Frequency, startArgs.Duration);
+        if (!startedNewSession)
+            return "Cannot start a thread profiling session. Another session may already be in process.";
 
-        private string StartThreadProfilingSessions(IDictionary<string, object> arguments)
-        {
-            if (arguments == null)
-                return "No arguments sent with start_profiler command.";
-
-            if (!AgentInstallConfiguration.IsWindows && !AgentInstallConfiguration.IsNetCore30OrAbove)
-            {
-                const string netCore30RequiredForLinuxThreadProfiling = "Cannot start a thread profiling session. Thread profiling support on Linux was introduced in .NET Core 3.0.";
-                Log.Info(netCore30RequiredForLinuxThreadProfiling);
-                return netCore30RequiredForLinuxThreadProfiling;
-            }
-
-            var startArgs = new ThreadProfilerCommandArgs(arguments, ThreadProfilingService.IgnoreMinMinimumSamplingDuration);
-            if (startArgs.ProfileId == 0)
-                return "A valid profile_id must be supplied to start a thread profiling session.";
-
-            var startedNewSession = ThreadProfilingService.StartThreadProfilingSession(startArgs.ProfileId, startArgs.Frequency, startArgs.Duration);
-            if (!startedNewSession)
-                return "Cannot start a thread profiling session. Another session may already be in process.";
-
-            return null;
-        }
+        return null;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Commands/ThreadProfilerCommandArgs.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/ThreadProfilerCommandArgs.cs
@@ -6,80 +6,79 @@ using System.Collections.Generic;
 using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Commands
+namespace NewRelic.Agent.Core.Commands;
+
+public class ThreadProfilerCommandArgs
 {
-    public class ThreadProfilerCommandArgs
+    private bool _ignoreMinMinimumSamplingDuration;
+
+    public const float MinimumSamplingFrequencySeconds = 0.1F;   // 1/10 of a second
+    public const float MinimumSamplingDurationSeconds = 120;       // 2 minutes
+
+    public const float MaximumSamplingFrequencySeconds = 60;       // 1 minute
+    public const float MaximumSamplingDurationSeconds = 86400;     // 24 hours
+
+    public const float DefaultSamplingFrequencySeconds = MinimumSamplingDurationSeconds;
+    public const float DefaultSamplingDurationSeconds = MinimumSamplingDurationSeconds;     // 2 minutes
+
+    public readonly int ProfileId;
+    public readonly uint Frequency;
+    public readonly uint Duration;
+    public readonly bool ReportData;
+
+    public ThreadProfilerCommandArgs(IDictionary<string, object> arguments, bool ignoreMinMinimumSamplingDuration)
     {
-        private bool _ignoreMinMinimumSamplingDuration;
+        _ignoreMinMinimumSamplingDuration = ignoreMinMinimumSamplingDuration;
 
-        public const float MinimumSamplingFrequencySeconds = 0.1F;   // 1/10 of a second
-        public const float MinimumSamplingDurationSeconds = 120;       // 2 minutes
+        var profileId = arguments.GetValueOrDefault("profile_id");
+        if (profileId != null)
+            int.TryParse(profileId.ToString(), out ProfileId);
 
-        public const float MaximumSamplingFrequencySeconds = 60;       // 1 minute
-        public const float MaximumSamplingDurationSeconds = 86400;     // 24 hours
+        Frequency = ParseFloatArgument(arguments, "sample_period", DefaultSamplingFrequencySeconds, MinimumSamplingFrequencySeconds, MaximumSamplingFrequencySeconds);
 
-        public const float DefaultSamplingFrequencySeconds = MinimumSamplingDurationSeconds;
-        public const float DefaultSamplingDurationSeconds = MinimumSamplingDurationSeconds;     // 2 minutes
+        Duration = ParseFloatArgument(arguments, "duration", DefaultSamplingDurationSeconds, ignoreMinMinimumSamplingDuration ? 0 : MinimumSamplingDurationSeconds, MaximumSamplingDurationSeconds);
 
-        public readonly int ProfileId;
-        public readonly uint Frequency;
-        public readonly uint Duration;
-        public readonly bool ReportData;
+        ReportData = ParseBooleanArgument(arguments, "report_data", true);
+    }
 
-        public ThreadProfilerCommandArgs(IDictionary<string, object> arguments, bool ignoreMinMinimumSamplingDuration)
+    private uint ParseFloatArgument(IDictionary<string, object> arguments, string argumentName, float defaultValue, float minValue, float maxValue)
+    {
+        object value;
+        if (!arguments.TryGetValue(argumentName, out value) || value == null)
+            return (uint)defaultValue * 1000;
+
+        float parsedValue;
+        if (!float.TryParse(value.ToString(), out parsedValue))
+            return (uint)defaultValue * 1000;
+
+        try
         {
-            _ignoreMinMinimumSamplingDuration = ignoreMinMinimumSamplingDuration;
+            if (parsedValue == 0)
+                parsedValue = defaultValue;
+            else if (parsedValue < minValue)
+                parsedValue = minValue;
+            else if (parsedValue > maxValue)
+                parsedValue = maxValue;
 
-            var profileId = arguments.GetValueOrDefault("profile_id");
-            if (profileId != null)
-                int.TryParse(profileId.ToString(), out ProfileId);
-
-            Frequency = ParseFloatArgument(arguments, "sample_period", DefaultSamplingFrequencySeconds, MinimumSamplingFrequencySeconds, MaximumSamplingFrequencySeconds);
-
-            Duration = ParseFloatArgument(arguments, "duration", DefaultSamplingDurationSeconds, ignoreMinMinimumSamplingDuration ? 0 : MinimumSamplingDurationSeconds, MaximumSamplingDurationSeconds);
-
-            ReportData = ParseBooleanArgument(arguments, "report_data", true);
+            return (uint)(parsedValue * 1000);
         }
-
-        private uint ParseFloatArgument(IDictionary<string, object> arguments, string argumentName, float defaultValue, float minValue, float maxValue)
+        catch (OverflowException)
         {
-            object value;
-            if (!arguments.TryGetValue(argumentName, out value) || value == null)
-                return (uint)defaultValue * 1000;
-
-            float parsedValue;
-            if (!float.TryParse(value.ToString(), out parsedValue))
-                return (uint)defaultValue * 1000;
-
-            try
-            {
-                if (parsedValue == 0)
-                    parsedValue = defaultValue;
-                else if (parsedValue < minValue)
-                    parsedValue = minValue;
-                else if (parsedValue > maxValue)
-                    parsedValue = maxValue;
-
-                return (uint)(parsedValue * 1000);
-            }
-            catch (OverflowException)
-            {
-                Log.Debug("Received a sample_period value with start_profiler command that caused an overflow converting to milliseconds. value = {0}", parsedValue);
-                return (uint)maxValue * 1000;
-            }
+            Log.Debug("Received a sample_period value with start_profiler command that caused an overflow converting to milliseconds. value = {0}", parsedValue);
+            return (uint)maxValue * 1000;
         }
+    }
 
-        private bool ParseBooleanArgument(IDictionary<string, object> arguments, string argumentName, bool defaultValue)
-        {
-            var value = arguments.GetValueOrDefault(argumentName);
-            if (value == null)
-                return defaultValue;
+    private bool ParseBooleanArgument(IDictionary<string, object> arguments, string argumentName, bool defaultValue)
+    {
+        var value = arguments.GetValueOrDefault(argumentName);
+        if (value == null)
+            return defaultValue;
 
-            bool result;
-            if (!bool.TryParse(value.ToString(), out result))
-                return defaultValue;
+        bool result;
+        if (!bool.TryParse(value.ToString(), out result))
+            return defaultValue;
 
-            return result;
-        }
+        return result;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/BootstrapConfiguration.cs
@@ -6,354 +6,354 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NewRelic.Agent.Core.Configuration;
+using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
 
-namespace NewRelic.Agent.Core.Config
-{
-    public interface IBootstrapConfiguration
-    {
-        bool ServerlessModeEnabled { get; }
-        int DebugStartupDelaySeconds { get; }
-        string ConfigurationFileName { get; }
-        bool AgentEnabled { get; }
-        string AgentEnabledAt { get; }
-        ILogConfig LogConfig { get; }
-        string ServerlessFunctionName { get; }
-        string ServerlessFunctionVersion { get; }
-        bool AzureFunctionModeDetected { get; }
-        bool GCSamplerV2Enabled { get; }
+namespace NewRelic.Agent.Core.Config;
 
-        bool AgentControlEnabled { get; }
-        string HealthDeliveryLocation { get; }
-        int HealthFrequency { get; }
+public interface IBootstrapConfiguration
+{
+    bool ServerlessModeEnabled { get; }
+    int DebugStartupDelaySeconds { get; }
+    string ConfigurationFileName { get; }
+    bool AgentEnabled { get; }
+    string AgentEnabledAt { get; }
+    ILogConfig LogConfig { get; }
+    string ServerlessFunctionName { get; }
+    string ServerlessFunctionVersion { get; }
+    bool AzureFunctionModeDetected { get; }
+    bool GCSamplerV2Enabled { get; }
+
+    bool AgentControlEnabled { get; }
+    string HealthDeliveryLocation { get; }
+    int HealthFrequency { get; }
+}
+
+/// <summary>
+/// This configuration class is used during the bootstrapping process before the configuration service is available.
+/// This configuration is made available to the configuration service through a static property on the ConfigurationLoader
+/// which is using during the bootstrapping process. The configuration in this class should not change at runtime and is
+/// mostly meant for things that must be configured before the configuration service is available and cannot be changed
+/// at a later point in time.
+/// </summary>
+public class BootstrapConfiguration : IBootstrapConfiguration
+{
+    IConfigurationManagerStatic _configurationManagerStatic;
+    Func<string, ValueWithProvenance<string>> _getWebConfigSettingWithProvenance;
+    ValueWithProvenance<bool> _agentEnabledWithProvenance;
+    bool _agentEnabledValueFromLocalConfig;
+
+    /// <summary>
+    /// This constructor is used to create a default instance of bootstrap configuration with reasonable default values.
+    /// </summary>
+    private BootstrapConfiguration()
+    {
+        _agentEnabledWithProvenance = new ValueWithProvenance<bool>(true, "Default value");
+        LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), Directory.Exists, Path.GetFullPath);
     }
 
     /// <summary>
-    /// This configuration class is used during the bootstrapping process before the configuration service is available.
-    /// This configuration is made available to the configuration service through a static property on the ConfigurationLoader
-    /// which is using during the bootstrapping process. The configuration in this class should not change at runtime and is
-    /// mostly meant for things that must be configured before the configuration service is available and cannot be changed
-    /// at a later point in time.
+    /// This is the constructor that should be used to create an instance of the bootstrap configuration.
     /// </summary>
-    public class BootstrapConfiguration : IBootstrapConfiguration
+    /// <param name="localConfiguration">The local configuration object to use.</param>
+    /// <param name="configurationFileName">The name and path of the local configuration file.</param>
+    public BootstrapConfiguration(configuration localConfiguration, string configurationFileName)
+        : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), Directory.Exists, Path.GetFullPath)
+    { }
+
+    /// <summary>
+    /// This construction should only be used by the unit tests and allows the tests to mock some dependencies.
+    /// </summary>
+    /// <param name="localConfiguration"></param>
+    /// <param name="configurationFileName"></param>
+    /// <param name="getAppSettingWithProvenance"></param>
+    public BootstrapConfiguration(configuration localConfiguration, string configurationFileName, Func<string, ValueWithProvenance<string>> getWebConfigSettingWithProvenance, IConfigurationManagerStatic configurationManagerStatic, IProcessStatic processStatic, Predicate<string> checkDirectoryExists, Func<string, string> getFullPath)
     {
-        IConfigurationManagerStatic _configurationManagerStatic;
-        Func<string, ValueWithProvenance<string>> _getWebConfigSettingWithProvenance;
-        ValueWithProvenance<bool> _agentEnabledWithProvenance;
-        bool _agentEnabledValueFromLocalConfig;
+        ServerlessModeEnabled = CheckServerlessModeEnabled(localConfiguration);
+        GCSamplerV2Enabled = CheckGCSamplerV2Enabled(TryGetAppSettingAsBoolWithDefault(localConfiguration, "GCSamplerV2Enabled", false));
+        DebugStartupDelaySeconds = localConfiguration.debugStartupDelaySeconds;
+        ConfigurationFileName = configurationFileName;
+        LogConfig = new BootstrapLogConfig(localConfiguration.log, processStatic, checkDirectoryExists, getFullPath);
 
-        /// <summary>
-        /// This constructor is used to create a default instance of bootstrap configuration with reasonable default values.
-        /// </summary>
-        private BootstrapConfiguration()
+        // The AgentEnabled properties are lazy loaded so that logging will be available before they are initialized and we can capture the errors.
+        _configurationManagerStatic = configurationManagerStatic;
+        _getWebConfigSettingWithProvenance = getWebConfigSettingWithProvenance;
+        // Reading the value from local config now so that the bootstrap config does not need to keep a reference to the original local config object.
+        _agentEnabledValueFromLocalConfig = localConfiguration.agentEnabled;
+        _agentEnabledWithProvenance = null;
+    }
+
+    /// <summary>
+    /// This helper method is meant to define a set of default values useful for the unit tests, and a fallback in case
+    /// something changes in the agent and the ConfigurationLoader.BootstrapConfig property is not set.
+    /// </summary>
+    /// <returns>A bootstrap configuration instance with reasonable default values.</returns>
+    public static IBootstrapConfiguration GetDefault()
+    {
+        return new BootstrapConfiguration();
+    }
+
+    /// <summary>
+    /// Gets whether or not serverless mode is enabled.
+    /// </summary>
+    public bool ServerlessModeEnabled { get; private set; }
+
+    public string ServerlessFunctionName { get; private set; }
+
+    public string ServerlessFunctionVersion { get; private set; }
+
+    /// <summary>
+    /// Gets the debug startup delay in seconds. This is used primarily for debugging of AWS Lambda functions.
+    /// </summary>
+    public int DebugStartupDelaySeconds { get; private set; }
+
+    /// <summary>
+    /// Gets the name of the configuration file that was used to load this configuration.
+    /// </summary>
+    public string ConfigurationFileName { get; private set; }
+
+    public bool AgentEnabled
+    {
+        get
         {
-            _agentEnabledWithProvenance = new ValueWithProvenance<bool>(true, "Default value");
-            LogConfig = new BootstrapLogConfig(new configurationLog(), new ProcessStatic(), Directory.Exists, Path.GetFullPath);
+            if (_agentEnabledWithProvenance == null)
+            {
+                SetAgentEnabledValues();
+            }
+            return _agentEnabledWithProvenance.Value;
+        }
+    }
+
+    public string AgentEnabledAt
+    {
+        get
+        {
+            if (_agentEnabledWithProvenance == null)
+            {
+                SetAgentEnabledValues();
+            }
+            return _agentEnabledWithProvenance.Provenance;
+        }
+    }
+
+    public ILogConfig LogConfig { get; private set; }
+
+    public bool AzureFunctionModeDetected => ConfigLoaderHelpers.GetEnvironmentVar("FUNCTIONS_WORKER_RUNTIME") != null;
+
+    public bool GCSamplerV2Enabled { get; private set;}
+    public bool AgentControlEnabled => ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_ENABLED").TryToBoolean(out var enabled) && enabled;
+    public string HealthDeliveryLocation => ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_HEALTH_DELIVERY_LOCATION");
+
+    public int HealthFrequency
+    {
+        get
+        {
+            var healthFrequencyString = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_HEALTH_FREQUENCY");
+            return int.TryParse(healthFrequencyString, out var healthFrequency) ? healthFrequency : 5;
+        }
+    }
+
+    private bool CheckServerlessModeEnabled(configuration localConfiguration)
+    {
+        // We may need these later even if we don't use it now.
+        ServerlessFunctionName = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
+        ServerlessFunctionVersion = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_VERSION");
+
+        // according to the spec, environment variable takes precedence over config file
+        var serverlessModeEnvVariable = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");
+        if (serverlessModeEnvVariable.TryToBoolean(out var enabledViaEnvVariable))
+        {
+            return enabledViaEnvVariable;
         }
 
-        /// <summary>
-        /// This is the constructor that should be used to create an instance of the bootstrap configuration.
-        /// </summary>
-        /// <param name="localConfiguration">The local configuration object to use.</param>
-        /// <param name="configurationFileName">The name and path of the local configuration file.</param>
-        public BootstrapConfiguration(configuration localConfiguration, string configurationFileName)
-            : this(localConfiguration, configurationFileName, ConfigurationLoader.GetWebConfigAppSetting, new ConfigurationManagerStatic(), new ProcessStatic(), Directory.Exists, Path.GetFullPath)
-        { }
+        // env variable is not set, check for function name
+        if (!string.IsNullOrEmpty(ServerlessFunctionName))
+            return true;
 
-        /// <summary>
-        /// This construction should only be used by the unit tests and allows the tests to mock some dependencies.
-        /// </summary>
-        /// <param name="localConfiguration"></param>
-        /// <param name="configurationFileName"></param>
-        /// <param name="getAppSettingWithProvenance"></param>
-        public BootstrapConfiguration(configuration localConfiguration, string configurationFileName, Func<string, ValueWithProvenance<string>> getWebConfigSettingWithProvenance, IConfigurationManagerStatic configurationManagerStatic, IProcessStatic processStatic, Predicate<string> checkDirectoryExists, Func<string, string> getFullPath)
+        // fall back to config file
+        return localConfiguration.serverlessModeEnabled;
+    }
+
+    private bool CheckGCSamplerV2Enabled(bool localConfigurationGcSamplerV2Enabled)
+    {
+        return localConfigurationGcSamplerV2Enabled || (ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_GC_SAMPLER_V2_ENABLED").TryToBoolean(out var enabledViaEnvVariable) && enabledViaEnvVariable);
+    }
+
+    private void SetAgentEnabledValues()
+    {
+        _agentEnabledWithProvenance = TryGetAgentEnabledFromWebConfig();
+        if (_agentEnabledWithProvenance != null)
         {
-            ServerlessModeEnabled = CheckServerlessModeEnabled(localConfiguration);
-            GCSamplerV2Enabled = CheckGCSamplerV2Enabled(TryGetAppSettingAsBoolWithDefault(localConfiguration, "GCSamplerV2Enabled", false));
-            DebugStartupDelaySeconds = localConfiguration.debugStartupDelaySeconds;
-            ConfigurationFileName = configurationFileName;
-            LogConfig = new BootstrapLogConfig(localConfiguration.log, processStatic, checkDirectoryExists, getFullPath);
-
-            // The AgentEnabled properties are lazy loaded so that logging will be available before they are initialized and we can capture the errors.
-            _configurationManagerStatic = configurationManagerStatic;
-            _getWebConfigSettingWithProvenance = getWebConfigSettingWithProvenance;
-            // Reading the value from local config now so that the bootstrap config does not need to keep a reference to the original local config object.
-            _agentEnabledValueFromLocalConfig = localConfiguration.agentEnabled;
-            _agentEnabledWithProvenance = null;
+            return;
         }
 
-        /// <summary>
-        /// This helper method is meant to define a set of default values useful for the unit tests, and a fallback in case
-        /// something changes in the agent and the ConfigurationLoader.BootstrapConfig property is not set.
-        /// </summary>
-        /// <returns>A bootstrap configuration instance with reasonable default values.</returns>
-        public static IBootstrapConfiguration GetDefault()
+        _agentEnabledWithProvenance = TryGetAgentEnabledFromAppSettings();
+        if (_agentEnabledWithProvenance != null)
         {
-            return new BootstrapConfiguration();
+            return;
         }
 
-        /// <summary>
-        /// Gets whether or not serverless mode is enabled.
-        /// </summary>
-        public bool ServerlessModeEnabled { get; private set; }
+        _agentEnabledWithProvenance = new ValueWithProvenance<bool>(_agentEnabledValueFromLocalConfig, ConfigurationFileName);
+    }
 
-        public string ServerlessFunctionName { get; private set; }
+    private ValueWithProvenance<bool> TryGetAgentEnabledFromWebConfig()
+    {
+        return TryGetAgentEnabledSetting(_getWebConfigSettingWithProvenance);
+    }
 
-        public string ServerlessFunctionVersion { get; private set; }
+    private ValueWithProvenance<bool> TryGetAgentEnabledFromAppSettings()
+    {
+        return TryGetAgentEnabledSetting(getStringValueWithProvenance);
 
-        /// <summary>
-        /// Gets the debug startup delay in seconds. This is used primarily for debugging of AWS Lambda functions.
-        /// </summary>
-        public int DebugStartupDelaySeconds { get; private set; }
+        ValueWithProvenance<string> getStringValueWithProvenance(string key)
+        {
+            return new ValueWithProvenance<string>(_configurationManagerStatic.GetAppSetting(key), _configurationManagerStatic.AppSettingsFilePath);
+        }
+    }
 
-        /// <summary>
-        /// Gets the name of the configuration file that was used to load this configuration.
-        /// </summary>
-        public string ConfigurationFileName { get; private set; }
+    private ValueWithProvenance<bool> TryGetAgentEnabledSetting(Func<string, ValueWithProvenance<string>> getStringValueWithProvenance)
+    {
+        try
+        {
+            var stringValueWithProvenance = getStringValueWithProvenance(Constants.AppSettingsAgentEnabled);
+            if (stringValueWithProvenance != null && stringValueWithProvenance.Value != null && bool.TryParse(stringValueWithProvenance.Value, out var value))
+            {
+                return new ValueWithProvenance<bool>(value, stringValueWithProvenance.Provenance);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to read {Constants.AppSettingsAgentEnabled} from local config.");
+        }
 
-        public bool AgentEnabled
+        return null;
+    }
+
+    private Dictionary<string, string> TransformAppSettings(configuration localConfiguration)
+    {
+        if (localConfiguration.appSettings == null)
+            return new Dictionary<string, string>();
+
+        return localConfiguration.appSettings
+            .Where(setting => setting != null)
+            .Select(setting => new KeyValuePair<string, string>(setting.key, setting.value))
+            .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+    }
+
+    private bool TryGetAppSettingAsBoolWithDefault(configuration localConfiguration, string key, bool defaultValue)
+    {
+        var value = TransformAppSettings(localConfiguration).GetValueOrDefault(key);
+
+        bool parsedBool;
+        var parsedSuccessfully = bool.TryParse(value, out parsedBool);
+        if (!parsedSuccessfully)
+            return defaultValue;
+
+        return parsedBool;
+    }
+
+
+    private class BootstrapLogConfig : ILogConfig
+    {
+        private readonly string _directoryFromLocalConfig;
+        private readonly string _fileNameFromLocalConfig;
+        private readonly string _logRollingStrategyFromLocalConfig;
+        private readonly IProcessStatic _processStatic;
+        private readonly Predicate<string> _checkDirectoryExists;
+        private readonly Func<string, string> _getFullPath;
+
+        public BootstrapLogConfig(configurationLog localLogConfiguration, IProcessStatic processStatic, Predicate<string> checkDirectoryExists, Func<string, string> getFullPath)
+        {
+            _processStatic = processStatic;
+            _checkDirectoryExists = checkDirectoryExists;
+            _getFullPath = getFullPath;
+
+            _directoryFromLocalConfig = localLogConfiguration.directory;
+            _fileNameFromLocalConfig = localLogConfiguration.fileName;
+            _logRollingStrategyFromLocalConfig = localLogConfiguration.logRollingStrategy.ToString();
+
+            Enabled = ConfigLoaderHelpers.GetLoggingEnabledValue(localLogConfiguration);
+            Console = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_CONSOLE", localLogConfiguration.console);
+            IsAuditLogEnabled = localLogConfiguration.auditLog;
+            MaxLogFileSizeMB = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_MAX_FILE_SIZE_MB", localLogConfiguration.maxLogFileSizeMB);
+            MaxLogFiles = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_MAX_FILES", localLogConfiguration.maxLogFiles);
+
+            // The log level needs to be initialized after the Enabled property is initialized because it depends on that value
+            LogLevel = ConfigLoaderHelpers.GetLoggingLevelValue(localLogConfiguration, Enabled);
+
+            _checkDirectoryExists = checkDirectoryExists;
+            _getFullPath = getFullPath;
+        }
+
+        public bool Enabled { get; }
+
+        public string LogLevel { get; }
+
+        public bool Console { get; }
+
+        public bool IsAuditLogEnabled { get; }
+
+        public int MaxLogFileSizeMB { get; }
+
+        public int MaxLogFiles { get; }
+
+        private LogRollingStrategy? _logRollingStrategy;
+        public LogRollingStrategy LogRollingStrategy
         {
             get
             {
-                if (_agentEnabledWithProvenance == null)
+                return _logRollingStrategy ?? (_logRollingStrategy = GetLogRollingStrategy()).Value;
+            }
+        }
+
+        public string GetFullLogFileName()
+        {
+            var fileName = new System.Text.StringBuilder();
+
+            // Environment variable or log.directory from config...
+            var logDirectory = GetNewRelicLogDirectory() ?? _directoryFromLocalConfig;
+
+            if (logDirectory == null)
+            {
+                var newRelicHome = ConfigurationLoader.GetNewRelicHome();
+                if (newRelicHome != null)
                 {
-                    SetAgentEnabledValues();
+                    logDirectory = Path.Combine(newRelicHome, "logs");
                 }
-                return _agentEnabledWithProvenance.Value;
-            }
-        }
-
-        public string AgentEnabledAt
-        {
-            get
-            {
-                if (_agentEnabledWithProvenance == null)
+                else
                 {
-                    SetAgentEnabledValues();
-                }
-                return _agentEnabledWithProvenance.Provenance;
-            }
-        }
-
-        public ILogConfig LogConfig { get; private set; }
-
-        public bool AzureFunctionModeDetected => ConfigLoaderHelpers.GetEnvironmentVar("FUNCTIONS_WORKER_RUNTIME") != null;
-
-        public bool GCSamplerV2Enabled { get; private set;}
-        public bool AgentControlEnabled => ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_ENABLED").TryToBoolean(out var enabled) && enabled;
-        public string HealthDeliveryLocation => ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_HEALTH_DELIVERY_LOCATION");
-
-        public int HealthFrequency
-        {
-            get
-            {
-                var healthFrequencyString = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_AGENT_CONTROL_HEALTH_FREQUENCY");
-                return int.TryParse(healthFrequencyString, out var healthFrequency) ? healthFrequency : 5;
-            }
-        }
-
-        private bool CheckServerlessModeEnabled(configuration localConfiguration)
-        {
-            // We may need these later even if we don't use it now.
-            ServerlessFunctionName = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_NAME");
-            ServerlessFunctionVersion = ConfigLoaderHelpers.GetEnvironmentVar("AWS_LAMBDA_FUNCTION_VERSION");
-
-            // according to the spec, environment variable takes precedence over config file
-            var serverlessModeEnvVariable = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_SERVERLESS_MODE_ENABLED");
-            if (serverlessModeEnvVariable.TryToBoolean(out var enabledViaEnvVariable))
-            {
-                return enabledViaEnvVariable;
-            }
-
-            // env variable is not set, check for function name
-            if (!string.IsNullOrEmpty(ServerlessFunctionName))
-                return true;
-
-            // fall back to config file
-            return localConfiguration.serverlessModeEnabled;
-        }
-
-        private bool CheckGCSamplerV2Enabled(bool localConfigurationGcSamplerV2Enabled)
-        {
-            return localConfigurationGcSamplerV2Enabled || (ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_GC_SAMPLER_V2_ENABLED").TryToBoolean(out var enabledViaEnvVariable) && enabledViaEnvVariable);
-        }
-
-        private void SetAgentEnabledValues()
-        {
-            _agentEnabledWithProvenance = TryGetAgentEnabledFromWebConfig();
-            if (_agentEnabledWithProvenance != null)
-            {
-                return;
-            }
-
-            _agentEnabledWithProvenance = TryGetAgentEnabledFromAppSettings();
-            if (_agentEnabledWithProvenance != null)
-            {
-                return;
-            }
-
-            _agentEnabledWithProvenance = new ValueWithProvenance<bool>(_agentEnabledValueFromLocalConfig, ConfigurationFileName);
-        }
-
-        private ValueWithProvenance<bool> TryGetAgentEnabledFromWebConfig()
-        {
-            return TryGetAgentEnabledSetting(_getWebConfigSettingWithProvenance);
-        }
-
-        private ValueWithProvenance<bool> TryGetAgentEnabledFromAppSettings()
-        {
-            return TryGetAgentEnabledSetting(getStringValueWithProvenance);
-
-            ValueWithProvenance<string> getStringValueWithProvenance(string key)
-            {
-                return new ValueWithProvenance<string>(_configurationManagerStatic.GetAppSetting(key), _configurationManagerStatic.AppSettingsFilePath);
-            }
-        }
-
-        private ValueWithProvenance<bool> TryGetAgentEnabledSetting(Func<string, ValueWithProvenance<string>> getStringValueWithProvenance)
-        {
-            try
-            {
-                var stringValueWithProvenance = getStringValueWithProvenance(Constants.AppSettingsAgentEnabled);
-                if (stringValueWithProvenance != null && stringValueWithProvenance.Value != null && bool.TryParse(stringValueWithProvenance.Value, out var value))
-                {
-                    return new ValueWithProvenance<bool>(value, stringValueWithProvenance.Provenance);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Failed to read {Constants.AppSettingsAgentEnabled} from local config.");
-            }
-
-            return null;
-        }
-
-        private Dictionary<string, string> TransformAppSettings(configuration localConfiguration)
-        {
-            if (localConfiguration.appSettings == null)
-                return new Dictionary<string, string>();
-
-            return localConfiguration.appSettings
-                .Where(setting => setting != null)
-                .Select(setting => new KeyValuePair<string, string>(setting.key, setting.value))
-                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
-        }
-
-        private bool TryGetAppSettingAsBoolWithDefault(configuration localConfiguration, string key, bool defaultValue)
-        {
-            var value = TransformAppSettings(localConfiguration).GetValueOrDefault(key);
-
-            bool parsedBool;
-            var parsedSuccessfully = bool.TryParse(value, out parsedBool);
-            if (!parsedSuccessfully)
-                return defaultValue;
-
-            return parsedBool;
-        }
-
-
-        private class BootstrapLogConfig : ILogConfig
-        {
-            private readonly string _directoryFromLocalConfig;
-            private readonly string _fileNameFromLocalConfig;
-            private readonly string _logRollingStrategyFromLocalConfig;
-            private readonly IProcessStatic _processStatic;
-            private readonly Predicate<string> _checkDirectoryExists;
-            private readonly Func<string, string> _getFullPath;
-
-            public BootstrapLogConfig(configurationLog localLogConfiguration, IProcessStatic processStatic, Predicate<string> checkDirectoryExists, Func<string, string> getFullPath)
-            {
-                _processStatic = processStatic;
-                _checkDirectoryExists = checkDirectoryExists;
-                _getFullPath = getFullPath;
-
-                _directoryFromLocalConfig = localLogConfiguration.directory;
-                _fileNameFromLocalConfig = localLogConfiguration.fileName;
-                _logRollingStrategyFromLocalConfig = localLogConfiguration.logRollingStrategy.ToString();
-
-                Enabled = ConfigLoaderHelpers.GetLoggingEnabledValue(localLogConfiguration);
-                Console = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_CONSOLE", localLogConfiguration.console);
-                IsAuditLogEnabled = localLogConfiguration.auditLog;
-                MaxLogFileSizeMB = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_MAX_FILE_SIZE_MB", localLogConfiguration.maxLogFileSizeMB);
-                MaxLogFiles = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_MAX_FILES", localLogConfiguration.maxLogFiles);
-
-                // The log level needs to be initialized after the Enabled property is initialized because it depends on that value
-                LogLevel = ConfigLoaderHelpers.GetLoggingLevelValue(localLogConfiguration, Enabled);
-
-                _checkDirectoryExists = checkDirectoryExists;
-                _getFullPath = getFullPath;
-            }
-
-            public bool Enabled { get; }
-
-            public string LogLevel { get; }
-
-            public bool Console { get; }
-
-            public bool IsAuditLogEnabled { get; }
-
-            public int MaxLogFileSizeMB { get; }
-
-            public int MaxLogFiles { get; }
-
-            private LogRollingStrategy? _logRollingStrategy;
-            public LogRollingStrategy LogRollingStrategy
-            {
-                get
-                {
-                    return _logRollingStrategy ?? (_logRollingStrategy = GetLogRollingStrategy()).Value;
+                    // This case should not be possible within the agent but it is here to simplify some of the tests
+                    // and code scanners.
+                    logDirectory = string.Empty;
                 }
             }
 
-            public string GetFullLogFileName()
+            return Path.Combine(logDirectory, GetLogFileName());
+        }
+
+        private string GetNewRelicLogDirectory()
+        {
+            var newRelicLogDirectory = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_LOG_DIRECTORY", "NEWRELIC_LOG_DIRECTORY");
+            if (newRelicLogDirectory != null && _checkDirectoryExists(newRelicLogDirectory)) return _getFullPath(newRelicLogDirectory);
+
+            return newRelicLogDirectory;
+        }
+
+        private string GetLogFileName()
+        {
+            string name = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_LOG");
+            if (name != null)
             {
-                var fileName = new System.Text.StringBuilder();
-
-                // Environment variable or log.directory from config...
-                var logDirectory = GetNewRelicLogDirectory() ?? _directoryFromLocalConfig;
-
-                if (logDirectory == null)
-                {
-                    var newRelicHome = ConfigurationLoader.GetNewRelicHome();
-                    if (newRelicHome != null)
-                    {
-                        logDirectory = Path.Combine(newRelicHome, "logs");
-                    }
-                    else
-                    {
-                        // This case should not be possible within the agent but it is here to simplify some of the tests
-                        // and code scanners.
-                        logDirectory = string.Empty;
-                    }
-                }
-
-                return Path.Combine(logDirectory, GetLogFileName());
+                return Strings.SafeFileName(name);
             }
 
-            private string GetNewRelicLogDirectory()
+            name = _fileNameFromLocalConfig;
+            if (name != null)
             {
-                var newRelicLogDirectory = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_LOG_DIRECTORY", "NEWRELIC_LOG_DIRECTORY");
-                if (newRelicLogDirectory != null && _checkDirectoryExists(newRelicLogDirectory)) return _getFullPath(newRelicLogDirectory);
-
-                return newRelicLogDirectory;
+                return Strings.SafeFileName(name);
             }
-
-            private string GetLogFileName()
-            {
-                string name = ConfigLoaderHelpers.GetEnvironmentVar("NEW_RELIC_LOG");
-                if (name != null)
-                {
-                    return Strings.SafeFileName(name);
-                }
-
-                name = _fileNameFromLocalConfig;
-                if (name != null)
-                {
-                    return Strings.SafeFileName(name);
-                }
 
 #if NETSTANDARD2_0
                 try
@@ -365,30 +365,29 @@ namespace NewRelic.Agent.Core.Config
                     name = _processStatic.GetCurrentProcess().ProcessName;
                 }
 #else
-                var appDomainAppId = ConfigurationLoader.GetAppDomainAppId();
-                if (appDomainAppId != null)
-                {
-                    name = appDomainAppId;
-                }
-                else
-                {
-                    name = _processStatic.GetCurrentProcess().ProcessName;
-                }
+            var appDomainAppId = ConfigurationLoader.GetAppDomainAppId();
+            if (appDomainAppId != null)
+            {
+                name = appDomainAppId;
+            }
+            else
+            {
+                name = _processStatic.GetCurrentProcess().ProcessName;
+            }
 #endif
 
-                return "newrelic_agent_" + Strings.SafeFileName(name) + ".log";
-            }
+            return "newrelic_agent_" + Strings.SafeFileName(name) + ".log";
+        }
 
-            private LogRollingStrategy GetLogRollingStrategy()
+        private LogRollingStrategy GetLogRollingStrategy()
+        {
+            var strategy = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_ROLLING_STRATEGY", _logRollingStrategyFromLocalConfig);
+            if (Enum.TryParse(strategy, true, out LogRollingStrategy result))
             {
-                var strategy = ConfigLoaderHelpers.GetOverride("NEW_RELIC_LOG_ROLLING_STRATEGY", _logRollingStrategyFromLocalConfig);
-                if (Enum.TryParse(strategy, true, out LogRollingStrategy result))
-                {
-                    return result;
-                }
-
-                throw new ConfigurationLoaderException($"Invalid value for logRollingStrategy or NEW_RELIC_LOG_ROLLING_STRATEGY: {strategy}");
+                return result;
             }
+
+            throw new ConfigurationLoaderException($"Invalid value for logRollingStrategy or NEW_RELIC_LOG_ROLLING_STRATEGY: {strategy}");
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/Configuration.cs
@@ -10,12 +10,12 @@
 namespace NewRelic.Agent.Core.Config
 {
     using System;
-    using System.Diagnostics;
-    using System.Xml.Serialization;
     using System.Collections;
-    using System.Xml.Schema;
-    using System.ComponentModel;
     using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Xml.Schema;
+    using System.Xml.Serialization;
     
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Xsd2Code", "3.6.0.20097")]

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationAttribute.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationAttribute.cs
@@ -3,45 +3,44 @@
 
 using System;
 
-namespace NewRelic.Agent.Core.Config
+namespace NewRelic.Agent.Core.Config;
+
+/// <summary>
+/// Configuration objects use this attribute on properties to map them to settings returned from the server.
+/// This attribute is also used when reporting the agent's settings back to the server.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class ConfigurationAttribute : Attribute
 {
+    private readonly string key;
+    private readonly bool convertToString;
+
     /// <summary>
-    /// Configuration objects use this attribute on properties to map them to settings returned from the server.
-    /// This attribute is also used when reporting the agent's settings back to the server.
+    /// 
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
-    public sealed class ConfigurationAttribute : Attribute
+    /// <param name="key"></param>
+    /// <param name="convertToString">If true, the ConfigurationParser.GetSettings method will calll ToString() on the property
+    /// before reporting it to the New Relic service.</param>
+    public ConfigurationAttribute(string key, bool convertToString = false)
     {
-        private readonly string key;
-        private readonly bool convertToString;
+        this.key = key;
+        this.convertToString = convertToString;
+    }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="convertToString">If true, the ConfigurationParser.GetSettings method will calll ToString() on the property
-        /// before reporting it to the New Relic service.</param>
-        public ConfigurationAttribute(string key, bool convertToString = false)
-        {
-            this.key = key;
-            this.convertToString = convertToString;
-        }
+    /// <summary>
+    /// The server key to which the annotated property should be mapped.
+    /// </summary>
+    public string Key
+    {
+        get { return key; }
+    }
 
-        /// <summary>
-        /// The server key to which the annotated property should be mapped.
-        /// </summary>
-        public string Key
-        {
-            get { return key; }
-        }
-
-        /// <summary>
-        /// If true, the ConfigurationParser.GetSettings method will calll ToString() on the property
-        /// before reporting it to the New Relic service.
-        /// </summary>
-        public bool ConvertToString
-        {
-            get { return convertToString; }
-        }
+    /// <summary>
+    /// If true, the ConfigurationParser.GetSettings method will calll ToString() on the property
+    /// before reporting it to the New Relic service.
+    /// </summary>
+    public bool ConvertToString
+    {
+        get { return convertToString; }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationLoader.cs
@@ -1,17 +1,17 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.Events;
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Core.Configuration;
-using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
 using System;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using NewRelic.Agent.Core.Configuration;
+using NewRelic.Agent.Core.Events;
+using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 #if NETSTANDARD2_0
 using System.Reflection;
 #else
@@ -19,43 +19,42 @@ using System.Configuration;
 using System.Web;
 #endif
 
-namespace NewRelic.Agent.Core.Config
+namespace NewRelic.Agent.Core.Config;
+
+/// <summary>
+/// Reads configuration data
+/// </summary>
+public static class ConfigurationLoader
 {
+    private const string NewRelicConfigFileName = "newrelic.config";
+    private static readonly ProcessStatic _processStatic = new ProcessStatic();
 
-    /// <summary>
-    /// Reads configuration data
-    /// </summary>
-    public static class ConfigurationLoader
-    {
-        private const string NewRelicConfigFileName = "newrelic.config";
-        private static readonly ProcessStatic _processStatic = new ProcessStatic();
+    #region Unit test helpers
 
-        #region Unit test helpers
-
-        // These fields and methods exists and is public so that the test projects can replace the functionality
-        // without requiring a redesign of this static class.
+    // These fields and methods exists and is public so that the test projects can replace the functionality
+    // without requiring a redesign of this static class.
 
 #if NETFRAMEWORK
 
-        private static string InternalGetAppDomainAppId()
-        {
-            return HttpRuntime.AppDomainAppId;
-        }
-        public static Func<string> GetAppDomainAppId = InternalGetAppDomainAppId;
+    private static string InternalGetAppDomainAppId()
+    {
+        return HttpRuntime.AppDomainAppId;
+    }
+    public static Func<string> GetAppDomainAppId = InternalGetAppDomainAppId;
 
-        private static string InternalGetAppDomainAppVirtualPath()
-        {
-            return HttpRuntime.AppDomainAppVirtualPath;
-        }
-        public static Func<string> GetAppDomainAppVirtualPath = InternalGetAppDomainAppVirtualPath;
+    private static string InternalGetAppDomainAppVirtualPath()
+    {
+        return HttpRuntime.AppDomainAppVirtualPath;
+    }
+    public static Func<string> GetAppDomainAppVirtualPath = InternalGetAppDomainAppVirtualPath;
 
-        private static string InternalGetAppDomainAppPath()
-        {
-            return HttpRuntime.AppDomainAppPath;
-        }
-        public static Func<string> GetAppDomainAppPath = InternalGetAppDomainAppPath;
+    private static string InternalGetAppDomainAppPath()
+    {
+        return HttpRuntime.AppDomainAppPath;
+    }
+    public static Func<string> GetAppDomainAppPath = InternalGetAppDomainAppPath;
 
-        public static Func<string, System.Configuration.Configuration> OpenWebConfiguration = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration;
+    public static Func<string, System.Configuration.Configuration> OpenWebConfiguration = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration;
 #else
         private static string InternalGetAppDomainName()
         {
@@ -64,70 +63,70 @@ namespace NewRelic.Agent.Core.Config
         public static Func<string> GetAppDomainName = InternalGetAppDomainName;
 #endif
 
-        public static Func<string, bool> FileExists = File.Exists;
-        public static Func<string, string> FileReadAllText = File.ReadAllText;
+    public static Func<string, bool> FileExists = File.Exists;
+    public static Func<string, string> FileReadAllText = File.ReadAllText;
 
-        public static Func<string, string> PathGetDirectoryName = Path.GetDirectoryName;
-        public static Func<string, string> GetEnvironmentVar = System.Environment.GetEnvironmentVariable;
+    public static Func<string, string> PathGetDirectoryName = Path.GetDirectoryName;
+    public static Func<string, string> GetEnvironmentVar = System.Environment.GetEnvironmentVariable;
 
-        private static string InternalGetNewRelicHome()
-        {
-            return AgentInstallConfiguration.NewRelicHome;
-        }
-        public static Func<string> GetNewRelicHome = InternalGetNewRelicHome;
+    private static string InternalGetNewRelicHome()
+    {
+        return AgentInstallConfiguration.NewRelicHome;
+    }
+    public static Func<string> GetNewRelicHome = InternalGetNewRelicHome;
 
-        #endregion Unit test helpers
+    #endregion Unit test helpers
 
-        /// <summary>
-        /// Gets the bootstrap configuration for the agent. The settings in this config does not change over time, and
-        /// it is only available after the ConfigurationLoader.Initialize method has been called. If this property is
-        /// accessed before the Initialize method has been called, it will return a default bootstrap configuration.
-        /// </summary>
-        public static IBootstrapConfiguration BootstrapConfig { get; private set; } = BootstrapConfiguration.GetDefault();
+    /// <summary>
+    /// Gets the bootstrap configuration for the agent. The settings in this config does not change over time, and
+    /// it is only available after the ConfigurationLoader.Initialize method has been called. If this property is
+    /// accessed before the Initialize method has been called, it will return a default bootstrap configuration.
+    /// </summary>
+    public static IBootstrapConfiguration BootstrapConfig { get; private set; } = BootstrapConfiguration.GetDefault();
 
-        /// <summary>
-        /// Reads an application setting from the web configuration associated with the current virtual path,
-        /// or from the web site if none is found.
-        /// Typically, this will attempt to read the "web.config" or "Web.Config" file for the path.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public static ValueWithProvenance<string> GetWebConfigAppSetting(string key)
-        {
-            ValueWithProvenance<string> value = null;
+    /// <summary>
+    /// Reads an application setting from the web configuration associated with the current virtual path,
+    /// or from the web site if none is found.
+    /// Typically, this will attempt to read the "web.config" or "Web.Config" file for the path.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public static ValueWithProvenance<string> GetWebConfigAppSetting(string key)
+    {
+        ValueWithProvenance<string> value = null;
 #if NETFRAMEWORK
-            try
+        try
+        {
+            if (GetAppDomainAppId() != null)
             {
-                if (GetAppDomainAppId() != null)
+                string appVirtualPath = GetAppDomainAppVirtualPath();
+                var webConfiguration = OpenWebConfiguration(appVirtualPath);
+                var setting = webConfiguration.AppSettings.Settings[key];
+                if (setting != null)
                 {
-                    string appVirtualPath = GetAppDomainAppVirtualPath();
-                    var webConfiguration = OpenWebConfiguration(appVirtualPath);
-                    var setting = webConfiguration.AppSettings.Settings[key];
-                    if (setting != null)
-                    {
-                        return new ValueWithProvenance<string>(setting.Value, webConfiguration.FilePath);
-                    }
+                    return new ValueWithProvenance<string>(setting.Value, webConfiguration.FilePath);
                 }
             }
-            catch (Exception)
-            {
-                // Can't log anything here because the logging hasn't been initialized.  Just swallow the exception.
-            }
-            value = new ValueWithProvenance<string>(System.Web.Configuration.WebConfigurationManager.AppSettings[key],
-                "WebConfigurationManager default app settings");
-#endif
-            return value;
         }
-
-        public static ValueWithProvenance<string> GetConfigSetting(string key)
+        catch (Exception)
         {
-            ValueWithProvenance<string> value = GetWebConfigAppSetting(key);
+            // Can't log anything here because the logging hasn't been initialized.  Just swallow the exception.
+        }
+        value = new ValueWithProvenance<string>(System.Web.Configuration.WebConfigurationManager.AppSettings[key],
+            "WebConfigurationManager default app settings");
+#endif
+        return value;
+    }
+
+    public static ValueWithProvenance<string> GetConfigSetting(string key)
+    {
+        ValueWithProvenance<string> value = GetWebConfigAppSetting(key);
 #if NETFRAMEWORK
-            if (value.Value == null)
-            {
-                value = new ValueWithProvenance<string>(ConfigurationManager.AppSettings[key],
-                    "ConfigurationManager app setting");
-            }
+        if (value.Value == null)
+        {
+            value = new ValueWithProvenance<string>(ConfigurationManager.AppSettings[key],
+                "ConfigurationManager app setting");
+        }
 #else
             if (value?.Value == null)
             {
@@ -138,29 +137,29 @@ namespace NewRelic.Agent.Core.Config
                     value = new ValueWithProvenance<string>(configValue, configMgrStatic.AppSettingsFilePath);
             }
 #endif
-            return value;
-        }
+        return value;
+    }
 
-        /// <summary>
-        /// Returns the agent configuration file name.
-        /// </summary>
-        /// <returns>The name of the agent configuration file name, such as "newrelic.config".</returns>
-        public static string GetAgentConfigFileName()
-        {
-            var fileName = TryGetAgentConfigFileFromAppConfig()
-                ?? TryGetAgentConfigFileFromAppRoot()
-                ?? TryGetAgentConfigFileFromExecutionPath()
-                ?? TryGetAgentConfigFileFromNewRelicHome()
-                ?? TryGetAgentConfigFileFromCurrentDirectory();
+    /// <summary>
+    /// Returns the agent configuration file name.
+    /// </summary>
+    /// <returns>The name of the agent configuration file name, such as "newrelic.config".</returns>
+    public static string GetAgentConfigFileName()
+    {
+        var fileName = TryGetAgentConfigFileFromAppConfig()
+                       ?? TryGetAgentConfigFileFromAppRoot()
+                       ?? TryGetAgentConfigFileFromExecutionPath()
+                       ?? TryGetAgentConfigFileFromNewRelicHome()
+                       ?? TryGetAgentConfigFileFromCurrentDirectory();
 
-            if (fileName != null)
-                return fileName;
+        if (fileName != null)
+            return fileName;
 
-            throw new Exception(string.Format("Could not find {0} in {1} path, application root, New Relic home directory, or working directory.", NewRelicConfigFileName, Constants.AppSettingsConfigFile));
-        }
+        throw new Exception(string.Format("Could not find {0} in {1} path, application root, New Relic home directory, or working directory.", NewRelicConfigFileName, Constants.AppSettingsConfigFile));
+    }
 
-        private static string TryGetAgentConfigFileFromAppConfig()
-        {
+    private static string TryGetAgentConfigFileFromAppConfig()
+    {
 
 #if NETSTANDARD2_0
 
@@ -181,26 +180,26 @@ namespace NewRelic.Agent.Core.Config
             }
 
 #else
-            try
-            {
-                var fileName = GetConfigSetting(Constants.AppSettingsConfigFile).Value;
-                if (!FileExists(fileName))
-                {
-                    return null;
-                }
-
-                Log.Info("Configuration file found in path pointed to by {0} appSetting of app/web config: {1}", Constants.AppSettingsConfigFile, fileName);
-                return fileName;
-            }
-            catch (Exception)
+        try
+        {
+            var fileName = GetConfigSetting(Constants.AppSettingsConfigFile).Value;
+            if (!FileExists(fileName))
             {
                 return null;
             }
-#endif
-        }
 
-        private static string TryGetAgentConfigFileFromAppRoot()
+            Log.Info("Configuration file found in path pointed to by {0} appSetting of app/web config: {1}", Constants.AppSettingsConfigFile, fileName);
+            return fileName;
+        }
+        catch (Exception)
         {
+            return null;
+        }
+#endif
+    }
+
+    private static string TryGetAgentConfigFileFromAppRoot()
+    {
 #if NETSTANDARD2_0
             try
             {
@@ -233,408 +232,406 @@ namespace NewRelic.Agent.Core.Config
                 return null;
             }
 #else
-            try
-            {
-                if (GetAppDomainAppVirtualPath() == null) return null;
-
-                var appRoot = GetAppDomainAppPath();
-                if (appRoot == null)
-                    return null;
-
-                var fileName = Path.Combine(appRoot, NewRelicConfigFileName);
-                if (!FileExists(fileName))
-                    return null;
-
-                Log.Info("Configuration file found in app/web root directory: {0}", fileName);
-                return fileName;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-#endif
-        }
-
-        private static string TryGetAgentConfigFileFromExecutionPath()
+        try
         {
-            try
-            {
-                var mainModuleFilePath = _processStatic.GetCurrentProcess().MainModuleFileName;
-                var executionPath = PathGetDirectoryName(mainModuleFilePath);
-                if (executionPath == null)
-                    return null;
+            if (GetAppDomainAppVirtualPath() == null) return null;
 
-                var fileName = Path.Combine(executionPath, NewRelicConfigFileName);
-                if (!FileExists(fileName))
-                    return null;
-
-                Log.Info("Configuration file found in execution path: {0}", fileName);
-                return fileName;
-            }
-            catch (Exception)
-            {
+            var appRoot = GetAppDomainAppPath();
+            if (appRoot == null)
                 return null;
-            }
-        }
 
-        private static string TryGetAgentConfigFileFromNewRelicHome()
-        {
-            try
-            {
-                var newRelicHome = GetNewRelicHome();
-                if (newRelicHome == null)
-                    return null;
-
-                var fileName = Path.Combine(newRelicHome, NewRelicConfigFileName);
-                if (!FileExists(fileName))
-                    return null;
-
-                Log.Info("Configuration file found in New Relic home directory: {0}", fileName);
-                return fileName;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        private static string TryGetAgentConfigFileFromCurrentDirectory()
-        {
-            try
-            {
-                if (!FileExists(NewRelicConfigFileName))
-                    return null;
-
-                Log.Info("Configuration file found in current working directory: {0}", NewRelicConfigFileName);
-                return NewRelicConfigFileName;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        public static string GetConfigurationFilePath(string homeDirectory)
-        {
-            var fileName = Path.Combine(homeDirectory, NewRelicConfigFileName);
+            var fileName = Path.Combine(appRoot, NewRelicConfigFileName);
             if (!FileExists(fileName))
-            {
-                throw new Exception(string.Format("Could not find the config file in the new relic home directory. Check New Relic home directory for {0}.", NewRelicConfigFileName));
-            }
+                return null;
+
+            Log.Info("Configuration file found in app/web root directory: {0}", fileName);
             return fileName;
         }
-
-        /// <summary>
-        /// Initialize and return a BootstrapConfig, from a fixed, well-known file name.
-        /// </summary>
-        /// <returns></returns>
-        public static configuration Initialize(bool publishDeserializedEvent = true)
+        catch (Exception)
         {
-            var fileName = string.Empty;
-            try
-            {
-                fileName = GetAgentConfigFileName();
-                if (!FileExists(fileName))
-                {
-                    throw new ConfigurationLoaderException(string.Format("The New Relic Agent configuration file does not exist: {0}", fileName));
-                }
-                var config = Initialize(fileName, publishDeserializedEvent);
-                BootstrapConfig = new BootstrapConfiguration(config, fileName);
-                return config;
-            }
-            catch (FileNotFoundException ex)
-            {
-                throw HandleConfigError(string.Format("Unable to find the New Relic Agent configuration file {0}", fileName), ex);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                throw HandleConfigError(string.Format("Unable to access the New Relic Agent configuration file {0}", fileName), ex);
-            }
-            catch (Exception ex)
-            {
-                throw HandleConfigError(string.Format("An error occurred reading the New Relic Agent configuration file {0} - {1}", fileName, ex.Message), ex);
-            }
+            return null;
         }
+#endif
+    }
 
-        private static Exception HandleConfigError(string message, Exception originalException)
+    private static string TryGetAgentConfigFileFromExecutionPath()
+    {
+        try
         {
-            Log.Error(message);
-            return new ConfigurationLoaderException(message, originalException);
+            var mainModuleFilePath = _processStatic.GetCurrentProcess().MainModuleFileName;
+            var executionPath = PathGetDirectoryName(mainModuleFilePath);
+            if (executionPath == null)
+                return null;
+
+            var fileName = Path.Combine(executionPath, NewRelicConfigFileName);
+            if (!FileExists(fileName))
+                return null;
+
+            Log.Info("Configuration file found in execution path: {0}", fileName);
+            return fileName;
         }
-
-        /// <summary>
-        /// Initialize the configuration by reading xml contained in the file named fileName.
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="publishDeserializedEvent"></param>
-        /// <exception cref="">System.UnauthorizedAccessException</exception>
-        /// <returns>The configuration.</returns>
-        public static configuration Initialize(string fileName, bool publishDeserializedEvent = true)
+        catch (Exception)
         {
-            using (StreamReader stream = new StreamReader(fileName))
-            {
-                configuration config = InitializeFromXml(stream.ReadToEnd(), GetConfigSchemaContents, fileName, publishDeserializedEvent);
-                return config;
-            }
+            return null;
         }
+    }
 
-        private static void ValidationEventHandler(object sender, ValidationEventArgs e)
+    private static string TryGetAgentConfigFileFromNewRelicHome()
+    {
+        try
         {
-            switch (e.Severity)
-            {
-                case XmlSeverityType.Error:
-                    Log.Error(e.Exception, "An error occurred parsing {0}", NewRelicConfigFileName);
-                    break;
-                case XmlSeverityType.Warning:
-                    Log.Warn(e.Exception, "{0} warning", NewRelicConfigFileName);
-                    break;
-            }
+            var newRelicHome = GetNewRelicHome();
+            if (newRelicHome == null)
+                return null;
 
+            var fileName = Path.Combine(newRelicHome, NewRelicConfigFileName);
+            if (!FileExists(fileName))
+                return null;
+
+            Log.Info("Configuration file found in New Relic home directory: {0}", fileName);
+            return fileName;
         }
-
-        /// <summary>
-        /// Initialize the configuration by reading xml from a string.
-        /// </summary>
-        /// <param name="configXml"></param>
-        /// <param name="configSchemaSource">A method that returns a string containing the config schema (xsd).</param>
-        /// <param name="provenance">The file name or other user-friendly locus where the xml came from.</param>
-        /// <param name="publishDeserializedEvent"></param>
-        /// <returns>The configuration.</returns>
-        public static configuration InitializeFromXml(string configXml, Func<string> configSchemaSource, string provenance = "unknown", bool publishDeserializedEvent = true)
+        catch (Exception)
         {
-            configuration config;
+            return null;
+        }
+    }
 
-            // deserialize the xml, making sure to pass in the root attribute to avoid fusion log failures.
-            XmlRootAttribute root = new XmlRootAttribute();
-            root.ElementName = "configuration";
-            root.Namespace = "urn:newrelic-config";
-            XmlSerializer serializer = new XmlSerializer(typeof(configuration), root);
+    private static string TryGetAgentConfigFileFromCurrentDirectory()
+    {
+        try
+        {
+            if (!FileExists(NewRelicConfigFileName))
+                return null;
 
-            using (TextReader reader = new StringReader(configXml))
+            Log.Info("Configuration file found in current working directory: {0}", NewRelicConfigFileName);
+            return NewRelicConfigFileName;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public static string GetConfigurationFilePath(string homeDirectory)
+    {
+        var fileName = Path.Combine(homeDirectory, NewRelicConfigFileName);
+        if (!FileExists(fileName))
+        {
+            throw new Exception(string.Format("Could not find the config file in the new relic home directory. Check New Relic home directory for {0}.", NewRelicConfigFileName));
+        }
+        return fileName;
+    }
+
+    /// <summary>
+    /// Initialize and return a BootstrapConfig, from a fixed, well-known file name.
+    /// </summary>
+    /// <returns></returns>
+    public static configuration Initialize(bool publishDeserializedEvent = true)
+    {
+        var fileName = string.Empty;
+        try
+        {
+            fileName = GetAgentConfigFileName();
+            if (!FileExists(fileName))
             {
-                config = serializer.Deserialize(reader) as configuration;
-                if (config == null)
-                    throw new InvalidDataException(string.Format("Unable to deserialize the provided xml: {0}", configXml));
+                throw new ConfigurationLoaderException(string.Format("The New Relic Agent configuration file does not exist: {0}", fileName));
             }
-
-            // Validate the config xml with the supplied schema.  Note that any validation failures do not prevent
-            // agent initialization and only generate a warning log message.
-            try
-            {
-                ValidateConfigXmlWithSchema(configXml, configSchemaSource());
-            }
-            catch (Exception ex)
-            {
-                Log.Warn(ex, "An unknown error occurred when performing XML schema validation on config file {0}", NewRelicConfigFileName);
-            }
-
-            if (publishDeserializedEvent)
-                PublishDeserializedEvent(config);
-
+            var config = Initialize(fileName, publishDeserializedEvent);
+            BootstrapConfig = new BootstrapConfiguration(config, fileName);
             return config;
         }
-        public static void PublishDeserializedEvent(configuration config)
+        catch (FileNotFoundException ex)
         {
-            EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
+            throw HandleConfigError(string.Format("Unable to find the New Relic Agent configuration file {0}", fileName), ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw HandleConfigError(string.Format("Unable to access the New Relic Agent configuration file {0}", fileName), ex);
+        }
+        catch (Exception ex)
+        {
+            throw HandleConfigError(string.Format("An error occurred reading the New Relic Agent configuration file {0} - {1}", fileName, ex.Message), ex);
+        }
+    }
+
+    private static Exception HandleConfigError(string message, Exception originalException)
+    {
+        Log.Error(message);
+        return new ConfigurationLoaderException(message, originalException);
+    }
+
+    /// <summary>
+    /// Initialize the configuration by reading xml contained in the file named fileName.
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <param name="publishDeserializedEvent"></param>
+    /// <exception cref="">System.UnauthorizedAccessException</exception>
+    /// <returns>The configuration.</returns>
+    public static configuration Initialize(string fileName, bool publishDeserializedEvent = true)
+    {
+        using (StreamReader stream = new StreamReader(fileName))
+        {
+            configuration config = InitializeFromXml(stream.ReadToEnd(), GetConfigSchemaContents, fileName, publishDeserializedEvent);
+            return config;
+        }
+    }
+
+    private static void ValidationEventHandler(object sender, ValidationEventArgs e)
+    {
+        switch (e.Severity)
+        {
+            case XmlSeverityType.Error:
+                Log.Error(e.Exception, "An error occurred parsing {0}", NewRelicConfigFileName);
+                break;
+            case XmlSeverityType.Warning:
+                Log.Warn(e.Exception, "{0} warning", NewRelicConfigFileName);
+                break;
         }
 
-        /// <summary>
-        /// Used ONLY FOR TESTING!
-        /// </summary>
-        public static void UseBootstrapConfigurationForTesting(IBootstrapConfiguration bootstrapConfiguration)
+    }
+
+    /// <summary>
+    /// Initialize the configuration by reading xml from a string.
+    /// </summary>
+    /// <param name="configXml"></param>
+    /// <param name="configSchemaSource">A method that returns a string containing the config schema (xsd).</param>
+    /// <param name="provenance">The file name or other user-friendly locus where the xml came from.</param>
+    /// <param name="publishDeserializedEvent"></param>
+    /// <returns>The configuration.</returns>
+    public static configuration InitializeFromXml(string configXml, Func<string> configSchemaSource, string provenance = "unknown", bool publishDeserializedEvent = true)
+    {
+        configuration config;
+
+        // deserialize the xml, making sure to pass in the root attribute to avoid fusion log failures.
+        XmlRootAttribute root = new XmlRootAttribute();
+        root.ElementName = "configuration";
+        root.Namespace = "urn:newrelic-config";
+        XmlSerializer serializer = new XmlSerializer(typeof(configuration), root);
+
+        using (TextReader reader = new StringReader(configXml))
         {
-            BootstrapConfig = bootstrapConfiguration;
+            config = serializer.Deserialize(reader) as configuration;
+            if (config == null)
+                throw new InvalidDataException(string.Format("Unable to deserialize the provided xml: {0}", configXml));
         }
 
-
-        private static void ValidateConfigXmlWithSchema(string configXml, string schemaXml)
+        // Validate the config xml with the supplied schema.  Note that any validation failures do not prevent
+        // agent initialization and only generate a warning log message.
+        try
         {
-            // xml validation with schema
-            ValidationEventHandler eventHandler = new ValidationEventHandler(ValidationEventHandler);
-
-            using (var configStringReader = new StringReader(schemaXml))
-            using (var schemaReader = new XmlTextReader(configStringReader))
-            using (var stringReader = new StringReader(configXml))
-            using (var xmlReader = XmlReader.Create(stringReader))
-            {
-                XmlDocument document = new XmlDocument();
-
-                // validate the xml
-                try
-                {
-
-                    document.Load(xmlReader);
-                    RemoveApdexAttribute(document);
-                    RemoveSslAttribute(document);
-
-                    document.Schemas.Add(XmlSchema.Read(schemaReader, eventHandler));
-                    document.Validate(eventHandler);
-                }
-                catch (Exception ex)
-                {
-                    Log.Warn(ex, "An error occurred parsing {0}", NewRelicConfigFileName);
-                }
-            }
+            ValidateConfigXmlWithSchema(configXml, configSchemaSource());
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "An unknown error occurred when performing XML schema validation on config file {0}", NewRelicConfigFileName);
         }
 
-        private static string GetConfigSchemaContents()
-        {
-            var configSchemaContents = string.Empty;
+        if (publishDeserializedEvent)
+            PublishDeserializedEvent(config);
 
+        return config;
+    }
+    public static void PublishDeserializedEvent(configuration config)
+    {
+        EventBus<ConfigurationDeserializedEvent>.Publish(new ConfigurationDeserializedEvent(config));
+    }
+
+    /// <summary>
+    /// Used ONLY FOR TESTING!
+    /// </summary>
+    public static void UseBootstrapConfigurationForTesting(IBootstrapConfiguration bootstrapConfiguration)
+    {
+        BootstrapConfig = bootstrapConfiguration;
+    }
+
+
+    private static void ValidateConfigXmlWithSchema(string configXml, string schemaXml)
+    {
+        // xml validation with schema
+        ValidationEventHandler eventHandler = new ValidationEventHandler(ValidationEventHandler);
+
+        using (var configStringReader = new StringReader(schemaXml))
+        using (var schemaReader = new XmlTextReader(configStringReader))
+        using (var stringReader = new StringReader(configXml))
+        using (var xmlReader = XmlReader.Create(stringReader))
+        {
+            XmlDocument document = new XmlDocument();
+
+            // validate the xml
             try
             {
-                var home = AgentInstallConfiguration.NewRelicHome;
-                var xsdFile = Path.Combine(home, "newrelic.xsd");
-                configSchemaContents = FileReadAllText(xsdFile);
+
+                document.Load(xmlReader);
+                RemoveApdexAttribute(document);
+                RemoveSslAttribute(document);
+
+                document.Schemas.Add(XmlSchema.Read(schemaReader, eventHandler));
+                document.Validate(eventHandler);
             }
             catch (Exception ex)
             {
-                Log.Warn(ex, "An error occurred reading config file schema");
-            }
-
-            return configSchemaContents;
-        }
-
-        /// <summary>
-        /// Remove old apdexT nodes from the given document so they don't throw a validation exception.
-        /// </summary>
-        /// <param name="document">The handle on the document.</param>
-        private static void RemoveApdexAttribute(XmlDocument document)
-        {
-            try
-            {
-                XmlNamespaceManager ns = new XmlNamespaceManager(document.NameTable);
-                ns.AddNamespace("nr", "urn:newrelic-config");
-                XmlNode node = document.SelectSingleNode("//nr:configuration/nr:application", ns);
-                if (node != null)
-                {
-                    if (node.Attributes.RemoveNamedItem("apdexT") != null)
-                    {
-                        Log.Finest("Removed apdexT from configuration.");
-                    }
-                }
-            }
-            catch (Exception)
-            {
-            }
-        }
-
-        /// <summary>
-        /// Removes deprecated attribute to avoid validation errors. 
-        /// The generated error isn't super clear and could risk causing support tickets.
-        /// </summary>
-        /// <param name="document"></param>
-        private static void RemoveSslAttribute(XmlDocument document)
-        {
-            try
-            {
-                var ns = new XmlNamespaceManager(document.NameTable);
-                ns.AddNamespace("nr", "urn:newrelic-config");
-                var node = document.SelectSingleNode("//nr:configuration/nr:service", ns);
-
-                var sslAttribute = node?.Attributes?["ssl"];
-                if (sslAttribute != null)
-                {
-                    Log.Warn("'ssl' is no longer a configurable service attribute and cannot be disabled. Please remove from {0}.", NewRelicConfigFileName);
-
-                    node.Attributes.Remove(sslAttribute);
-                }
-            }
-            catch (Exception)
-            {
-                // ignored
+                Log.Warn(ex, "An error occurred parsing {0}", NewRelicConfigFileName);
             }
         }
     }
 
-    /// <summary>
-    /// Thrown when there is some problem loading the configuration.
-    /// </summary>
-    public class ConfigurationLoaderException : Exception
+    private static string GetConfigSchemaContents()
     {
-        public ConfigurationLoaderException(string message)
-            : base(message)
+        var configSchemaContents = string.Empty;
+
+        try
         {
+            var home = AgentInstallConfiguration.NewRelicHome;
+            var xsdFile = Path.Combine(home, "newrelic.xsd");
+            configSchemaContents = FileReadAllText(xsdFile);
+        }
+        catch (Exception ex)
+        {
+            Log.Warn(ex, "An error occurred reading config file schema");
         }
 
-        public ConfigurationLoaderException(string message, Exception original)
-            : base(message, original)
+        return configSchemaContents;
+    }
+
+    /// <summary>
+    /// Remove old apdexT nodes from the given document so they don't throw a validation exception.
+    /// </summary>
+    /// <param name="document">The handle on the document.</param>
+    private static void RemoveApdexAttribute(XmlDocument document)
+    {
+        try
+        {
+            XmlNamespaceManager ns = new XmlNamespaceManager(document.NameTable);
+            ns.AddNamespace("nr", "urn:newrelic-config");
+            XmlNode node = document.SelectSingleNode("//nr:configuration/nr:application", ns);
+            if (node != null)
+            {
+                if (node.Attributes.RemoveNamedItem("apdexT") != null)
+                {
+                    Log.Finest("Removed apdexT from configuration.");
+                }
+            }
+        }
+        catch (Exception)
         {
         }
     }
 
     /// <summary>
-    /// This class contains helper methods that allow resusing logic from the non-static DefaultConfiguration
-    /// class from within static contexts like the bootstrap process.
+    /// Removes deprecated attribute to avoid validation errors. 
+    /// The generated error isn't super clear and could risk causing support tickets.
     /// </summary>
-    public static class ConfigLoaderHelpers
+    /// <param name="document"></param>
+    private static void RemoveSslAttribute(XmlDocument document)
     {
-        // This field exists only for testing purposes. It allows bootstrap logic and regular
-        // configuration logic to use the same environment variable logic.
-        public static IEnvironment EnvironmentVariableProxy = new SharedInterfaces.Environment();
-
-        public static string GetEnvironmentVar(params string[] environmentVariableNames)
+        try
         {
-            var result = (environmentVariableNames ?? Enumerable.Empty<string>())
-                .Select(EnvironmentVariableProxy.GetEnvironmentVariable)
-                .FirstOrDefault(value => value != null);
+            var ns = new XmlNamespaceManager(document.NameTable);
+            ns.AddNamespace("nr", "urn:newrelic-config");
+            var node = document.SelectSingleNode("//nr:configuration/nr:service", ns);
 
-            // needs to return null instead of empty string
-            return result == string.Empty ? null : result;
-        }
-
-        public static string GetOverride(string name, string fallback)
-        {
-            return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name);
-        }
-        public static int GetOverride(string name, int fallback)
-        {
-            return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name).Value;
-        }
-
-        public static bool GetOverride(string name, bool fallback)
-        {
-            return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name);
-        }
-
-        public static bool TryToBoolean(this string val, out bool boolVal)
-        {
-            boolVal = false;
-
-            if (string.IsNullOrEmpty(val))
+            var sslAttribute = node?.Attributes?["ssl"];
+            if (sslAttribute != null)
             {
-                return false;
+                Log.Warn("'ssl' is no longer a configurable service attribute and cannot be disabled. Please remove from {0}.", NewRelicConfigFileName);
+
+                node.Attributes.Remove(sslAttribute);
             }
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
+    }
+}
 
-            val = val.ToLower();
+/// <summary>
+/// Thrown when there is some problem loading the configuration.
+/// </summary>
+public class ConfigurationLoaderException : Exception
+{
+    public ConfigurationLoaderException(string message)
+        : base(message)
+    {
+    }
 
-            if (bool.TryParse(val, out boolVal))
-            {
+    public ConfigurationLoaderException(string message, Exception original)
+        : base(message, original)
+    {
+    }
+}
+
+/// <summary>
+/// This class contains helper methods that allow resusing logic from the non-static DefaultConfiguration
+/// class from within static contexts like the bootstrap process.
+/// </summary>
+public static class ConfigLoaderHelpers
+{
+    // This field exists only for testing purposes. It allows bootstrap logic and regular
+    // configuration logic to use the same environment variable logic.
+    public static IEnvironment EnvironmentVariableProxy = new SharedInterfaces.Environment();
+
+    public static string GetEnvironmentVar(params string[] environmentVariableNames)
+    {
+        var result = (environmentVariableNames ?? Enumerable.Empty<string>())
+            .Select(EnvironmentVariableProxy.GetEnvironmentVariable)
+            .FirstOrDefault(value => value != null);
+
+        // needs to return null instead of empty string
+        return result == string.Empty ? null : result;
+    }
+
+    public static string GetOverride(string name, string fallback)
+    {
+        return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name);
+    }
+    public static int GetOverride(string name, int fallback)
+    {
+        return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name).Value;
+    }
+
+    public static bool GetOverride(string name, bool fallback)
+    {
+        return DefaultConfiguration.EnvironmentOverrides(EnvironmentVariableProxy, fallback, name);
+    }
+
+    public static bool TryToBoolean(this string val, out bool boolVal)
+    {
+        boolVal = false;
+
+        if (string.IsNullOrEmpty(val))
+        {
+            return false;
+        }
+
+        val = val.ToLower();
+
+        if (bool.TryParse(val, out boolVal))
+        {
+            return true;
+        }
+
+        switch (val)
+        {
+            case "0":
+                boolVal = false;
                 return true;
-            }
-
-            switch (val)
-            {
-                case "0":
-                    boolVal = false;
-                    return true;
-                case "1":
-                    boolVal = true;
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        public static bool GetLoggingEnabledValue(configurationLog localLogConfiguration)
-        {
-            return DefaultConfiguration.GetLoggingEnabledValue(EnvironmentVariableProxy, localLogConfiguration);
-        }
-
-        public static string GetLoggingLevelValue(configurationLog localLogConfiguration, bool isLoggingEnabled)
-        {
-            return DefaultConfiguration.GetLoggingLevelValue(EnvironmentVariableProxy, localLogConfiguration, isLoggingEnabled);
+            case "1":
+                boolVal = true;
+                return true;
+            default:
+                return false;
         }
     }
 
+    public static bool GetLoggingEnabledValue(configurationLog localLogConfiguration)
+    {
+        return DefaultConfiguration.GetLoggingEnabledValue(EnvironmentVariableProxy, localLogConfiguration);
+    }
+
+    public static string GetLoggingLevelValue(configurationLog localLogConfiguration, bool isLoggingEnabled)
+    {
+        return DefaultConfiguration.GetLoggingLevelValue(EnvironmentVariableProxy, localLogConfiguration, isLoggingEnabled);
+    }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/ConfigurationTracker.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ConfigurationTracker.cs
@@ -1,67 +1,65 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Threading;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Time;
-using NewRelic.Agent.Extensions.Logging;
-using System;
-using System.IO;
-using System.Threading;
 using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Config
+namespace NewRelic.Agent.Core.Config;
+
+/// <summary>
+/// The ConfigurationTracker starts a timer that runs every minute and checks the write timestamp of the
+/// newrelic.config file.  If it is newer than the last time it was checked, the file is read into a new
+/// AgentConfig and listeners are notified of the change.
+/// </summary>
+public class ConfigurationTracker : IDisposable
 {
-    /// <summary>
-    /// The ConfigurationTracker starts a timer that runs every minute and checks the write timestamp of the
-    /// newrelic.config file.  If it is newer than the last time it was checked, the file is read into a new
-    /// AgentConfig and listeners are notified of the change.
-    /// </summary>
-    public class ConfigurationTracker : IDisposable
+    private readonly Timer _timer;
+
+    private DateTime _lastWriteTime;
+
+    private readonly INativeMethods _nativeMethods;
+    private readonly IFileWrapper _fileWrapper;
+
+    public ConfigurationTracker(IConfigurationService configurationService, INativeMethods nativeMethods, IFileWrapper fileWrapper)
     {
-        private readonly Timer _timer;
-
-        private DateTime _lastWriteTime;
-
-        private readonly INativeMethods _nativeMethods;
-        private readonly IFileWrapper _fileWrapper;
-
-        public ConfigurationTracker(IConfigurationService configurationService, INativeMethods nativeMethods, IFileWrapper fileWrapper)
+        if (configurationService.Configuration.DisableFileSystemWatcher)
         {
-            if (configurationService.Configuration.DisableFileSystemWatcher)
+            Log.Debug("Live updates to newrelic.config will not be applied because they have been disabled by local configuration.");
+            return;
+        }
+
+        _nativeMethods = nativeMethods;
+        _fileWrapper = fileWrapper;
+        var fileName = configurationService.Configuration.NewRelicConfigFilePath;
+        if (fileName == null)
+            return;
+
+        Log.Info("Reading configuration from \"{0}\"", fileName);
+
+        _lastWriteTime = _fileWrapper.GetLastWriteTimeUtc(fileName);
+
+        _timer = Scheduler.CreateExecuteEveryTimer(() =>
+        {
+            var lastWriteTime = _fileWrapper.GetLastWriteTimeUtc(fileName);
+            if (lastWriteTime > _lastWriteTime)
             {
-                Log.Debug("Live updates to newrelic.config will not be applied because they have been disabled by local configuration.");
-                return;
+                Log.Debug("newrelic.config file changed, reloading.");
+                ConfigurationLoader.Initialize(fileName);
+                _lastWriteTime = lastWriteTime;
+                _nativeMethods.ReloadConfiguration();
             }
+        }, TimeSpan.FromMinutes(1));
+    }
 
-            _nativeMethods = nativeMethods;
-            _fileWrapper = fileWrapper;
-            var fileName = configurationService.Configuration.NewRelicConfigFilePath;
-            if (fileName == null)
-                return;
+    public void Dispose()
+    {
+        if (_timer == null)
+            return;
 
-            Log.Info("Reading configuration from \"{0}\"", fileName);
-
-            _lastWriteTime = _fileWrapper.GetLastWriteTimeUtc(fileName);
-
-            _timer = Scheduler.CreateExecuteEveryTimer(() =>
-            {
-                var lastWriteTime = _fileWrapper.GetLastWriteTimeUtc(fileName);
-                if (lastWriteTime > _lastWriteTime)
-                {
-                    Log.Debug("newrelic.config file changed, reloading.");
-                    ConfigurationLoader.Initialize(fileName);
-                    _lastWriteTime = lastWriteTime;
-                    _nativeMethods.ReloadConfiguration();
-                }
-            }, TimeSpan.FromMinutes(1));
-        }
-
-        public void Dispose()
-        {
-            if (_timer == null)
-                return;
-
-            _timer.Dispose();
-        }
+        _timer.Dispose();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/ILogConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ILogConfig.cs
@@ -3,46 +3,45 @@
 
 using System;
 
-namespace NewRelic.Agent.Core.Config
+namespace NewRelic.Agent.Core.Config;
+
+public interface ILogConfig
 {
-    public interface ILogConfig
+    bool Enabled { get; }
+
+    string LogLevel { get; }
+
+    string GetFullLogFileName();
+
+    bool Console { get; }
+
+    bool IsAuditLogEnabled { get; }
+
+    int MaxLogFileSizeMB { get; } // only used if LogRollingStrategy is "size"
+
+    int MaxLogFiles { get; }
+
+    LogRollingStrategy LogRollingStrategy { get; }
+}
+
+public enum LogRollingStrategy
+{
+    Size,
+    Day
+}
+
+public static class LogRollingStrategyExtensions
+{
+    public static LogRollingStrategy ToLogRollingStrategy(this configurationLogLogRollingStrategy value)
     {
-        bool Enabled { get; }
-
-        string LogLevel { get; }
-
-        string GetFullLogFileName();
-
-        bool Console { get; }
-
-        bool IsAuditLogEnabled { get; }
-
-        int MaxLogFileSizeMB { get; } // only used if LogRollingStrategy is "size"
-
-        int MaxLogFiles { get; }
-
-        LogRollingStrategy LogRollingStrategy { get; }
-    }
-
-    public enum LogRollingStrategy
-    {
-        Size,
-        Day
-    }
-
-    public static class LogRollingStrategyExtensions
-    {
-        public static LogRollingStrategy ToLogRollingStrategy(this configurationLogLogRollingStrategy value)
+        switch (value)
         {
-            switch (value)
-            {
-                case configurationLogLogRollingStrategy.size:
-                    return LogRollingStrategy.Size;
-                case configurationLogLogRollingStrategy.day:
-                    return LogRollingStrategy.Day;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(value), value, null);
-            }
+            case configurationLogLogRollingStrategy.size:
+                return LogRollingStrategy.Size;
+            case configurationLogLogRollingStrategy.day:
+                return LogRollingStrategy.Day;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(value), value, null);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Config/ValueWithProvenance.cs
+++ b/src/Agent/NewRelic/Agent/Core/Config/ValueWithProvenance.cs
@@ -1,22 +1,21 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Config
-{
-    /// <summary>
-    /// Manages a readonly only value of type T, which is tagged with its provenance.
-    /// Typically the provenance will be the name of a configuration file wherein the value was defined.
-    /// </summary>
-    /// <typeparam name="T">The type of the value being monitored.</typeparam>
-    public class ValueWithProvenance<T>
-    {
-        public T Value { get; private set; }
-        public string Provenance { get; private set; }
+namespace NewRelic.Agent.Core.Config;
 
-        public ValueWithProvenance(T Value, string Provenance)
-        {
-            this.Value = Value;
-            this.Provenance = Provenance;
-        }
-    };
-}
+/// <summary>
+/// Manages a readonly only value of type T, which is tagged with its provenance.
+/// Typically the provenance will be the name of a configuration file wherein the value was defined.
+/// </summary>
+/// <typeparam name="T">The type of the value being monitored.</typeparam>
+public class ValueWithProvenance<T>
+{
+    public T Value { get; private set; }
+    public string Provenance { get; private set; }
+
+    public ValueWithProvenance(T Value, string Provenance)
+    {
+        this.Value = Value;
+        this.Provenance = Provenance;
+    }
+};

--- a/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/AppSettingsConfigResolveWhenUsed.cs
@@ -9,101 +9,100 @@ using Microsoft.Extensions.Configuration;
 using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public static class AppSettingsConfigResolveWhenUsed
 {
-    public static class AppSettingsConfigResolveWhenUsed
+    private static IConfiguration _configuration;
+    private static string _appSettingsFilePaths;
+
+    private static IConfiguration Configuration
     {
-        private static IConfiguration _configuration;
-        private static string _appSettingsFilePaths;
-
-        private static IConfiguration Configuration
+        get
         {
-            get
-            {
-                return _configuration ?? (_configuration = InitializeConfiguration());
-            }
+            return _configuration ?? (_configuration = InitializeConfiguration());
+        }
+    }
+
+    public static string AppSettingsFilePath => _appSettingsFilePaths;
+
+    private static IConfigurationRoot InitializeConfiguration()
+    {
+        // Get application base directory, where appsettings*.json will be if they exist
+        var applicationDirectory = string.Empty;
+        try
+        {
+            applicationDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        }
+        catch (AppDomainUnloadedException)
+        {
+            // Fall back to previous behavior of agents <=8.35.0
+            applicationDirectory = Directory.GetCurrentDirectory();
         }
 
-        public static string AppSettingsFilePath => _appSettingsFilePaths;
+        // add default appsettings.json files to config builder
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(applicationDirectory)
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
 
-        private static IConfigurationRoot InitializeConfiguration()
+        _appSettingsFilePaths = Path.Combine(applicationDirectory, "appsettings.json");
+
+        // Determine if there is a .NET environment configured, or default to "Production"
+        var environment = GetDotnetEnvironment();
+        builder.AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false);
+        var appSettingsEnvPath = Path.Combine(applicationDirectory, $"appsettings.{environment}.json");
+        _appSettingsFilePaths = string.Join(", ", _appSettingsFilePaths, appSettingsEnvPath);
+
+        return builder.Build();
+    }
+
+    private static string GetDotnetEnvironment()
+    {
+        var env = new SharedInterfaces.Environment();
+        // Determine the environment (e.g. Production, Development, Staging, etc.) by considering the following env vars in order
+        // "DOTNET_ENVIRONMENT" takes precedence over "ASPNETCORE_ENVIRONMENT", even for ASP.NET Core applications
+        // EnvironmentName is proprietary to our agent and the behavior as of version 10.20 is to not take precedence over the .NET builtins
+        var envVarsToCheck = new List<string>() { "DOTNET_ENVIRONMENT", "ASPNETCORE_ENVIRONMENT", "EnvironmentName" };
+        foreach (var envVar in envVarsToCheck)
         {
-            // Get application base directory, where appsettings*.json will be if they exist
-            var applicationDirectory = string.Empty;
-            try
+            var environment = env.GetEnvironmentVariable(envVar);
+            if (!string.IsNullOrEmpty(environment))
             {
-                applicationDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                Log.Debug($".NET environment set to '{environment}' from env var '{envVar}'");
+                return environment;
             }
-            catch (AppDomainUnloadedException)
-            {
-                // Fall back to previous behavior of agents <=8.35.0
-                applicationDirectory = Directory.GetCurrentDirectory();
-            }
+        }
+        Log.Finest("No .NET environment configured in DOTNET_ENVIRONMENT, ASPNETCORE_ENVIRONMENT, or EnvironmentName. Defaulting to 'Production'");
+        return "Production";
+    }
 
-            // add default appsettings.json files to config builder
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(applicationDirectory)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
-
-            _appSettingsFilePaths = Path.Combine(applicationDirectory, "appsettings.json");
-
-            // Determine if there is a .NET environment configured, or default to "Production"
-            var environment = GetDotnetEnvironment();
-            builder.AddJsonFile($"appsettings.{environment}.json", optional: true, reloadOnChange: false);
-            var appSettingsEnvPath = Path.Combine(applicationDirectory, $"appsettings.{environment}.json");
-            _appSettingsFilePaths = string.Join(", ", _appSettingsFilePaths, appSettingsEnvPath);
-
-            return builder.Build();
+    public static string GetAppSetting(string key)
+    {
+        if (key == null)
+        {
+            return null;
         }
 
-        private static string GetDotnetEnvironment()
+        var value = Configuration[key];
+
+        if (Log.IsDebugEnabled)
         {
-            var env = new SharedInterfaces.Environment();
-            // Determine the environment (e.g. Production, Development, Staging, etc.) by considering the following env vars in order
-            // "DOTNET_ENVIRONMENT" takes precedence over "ASPNETCORE_ENVIRONMENT", even for ASP.NET Core applications
-            // EnvironmentName is proprietary to our agent and the behavior as of version 10.20 is to not take precedence over the .NET builtins
-            var envVarsToCheck = new List<string>() { "DOTNET_ENVIRONMENT", "ASPNETCORE_ENVIRONMENT", "EnvironmentName" };
-            foreach ( var envVar in envVarsToCheck )
+            if (string.IsNullOrWhiteSpace(value))
             {
-                var environment = env.GetEnvironmentVariable(envVar);
-                if (!string.IsNullOrEmpty(environment))
+                Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
+            }
+            else
+            {
+                var valueToLog = value;
+                if (key.Equals(Constants.AppSettingsLicenseKey))
                 {
-                    Log.Debug($".NET environment set to '{environment}' from env var '{envVar}'");
-                    return environment;
+                    valueToLog = Strings.ObfuscateLicenseKey(value);
                 }
+                Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={valueToLog}'");
             }
-            Log.Finest("No .NET environment configured in DOTNET_ENVIRONMENT, ASPNETCORE_ENVIRONMENT, or EnvironmentName. Defaulting to 'Production'");
-            return "Production";
         }
 
-        public static string GetAppSetting(string key)
-        {
-            if (key == null)
-            {
-                return null;
-            }
-            
-            var value = Configuration[key];
-
-            if (Log.IsDebugEnabled)
-            {
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}' not defined. Searched: {_appSettingsFilePaths}.");
-                }
-                else
-                {
-                    var valueToLog = value;
-                    if (key.Equals(Constants.AppSettingsLicenseKey))
-                    {
-                        valueToLog = Strings.ObfuscateLicenseKey(value);
-                    }
-                    Log.Debug($"Reading value from appsettings.json and appsettings.*.json: '{key}={valueToLog}'");
-                }
-            }
-
-            return value;
-        }
+        return value;
     }
 }
 #endif

--- a/src/Agent/NewRelic/Agent/Core/Configuration/BoolConfigurationItem.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/BoolConfigurationItem.cs
@@ -1,18 +1,16 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Configuration
-{
-    public class BoolConfigurationItem
-    {
-        public bool Value { get; }
-        public string Source { get; }
+namespace NewRelic.Agent.Core.Configuration;
 
-        public BoolConfigurationItem(bool value, string source)
-        {
-            Value = value;
-            Source = source;
-        }
+public class BoolConfigurationItem
+{
+    public bool Value { get; }
+    public string Source { get; }
+
+    public BoolConfigurationItem(bool value, string source)
+    {
+        Value = value;
+        Source = source;
     }
 }
-

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationBridge.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationBridge.cs
@@ -8,288 +8,381 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+/// <summary>
+/// Internal bridging logic for accessing the application's Microsoft.Extensions.Configuration system.
+/// This class is internal to prevent IoC containers from discovering and registering it.
+/// </summary>
+internal static class ConfigurationBridge
 {
-    /// <summary>
-    /// Internal bridging logic for accessing the application's Microsoft.Extensions.Configuration system.
-    /// This class is internal to prevent IoC containers from discovering and registering it.
-    /// </summary>
-    internal static class ConfigurationBridge
-    {
-        private static readonly ConcurrentDictionary<string, Type> _cachedTypes = new();
-        private static readonly object _initializationLock = new object();
-        private static volatile bool _initialized = false;
-        private static volatile bool _bridgeAvailable = false;
-        private static Func<string, string> _getConfigurationValueDelegate = null;
+    private static readonly ConcurrentDictionary<string, Type> _cachedTypes = new();
+    private static readonly object _initializationLock = new object();
+    private static volatile bool _initialized = false;
+    private static volatile bool _bridgeAvailable = false;
+    private static Func<string, string> _getConfigurationValueDelegate = null;
 
-        /// <summary>
-        /// Initializes the configuration bridge. Attempts to locate and bridge to the application's Microsoft.Extensions.Configuration system.
-        /// If the bridge cannot be established, falls back to ILRepacked configuration logic.
-        /// </summary>
-        public static void Initialize()
+    /// <summary>
+    /// Initializes the configuration bridge. Attempts to locate and bridge to the application's Microsoft.Extensions.Configuration system.
+    /// If the bridge cannot be established, falls back to ILRepacked configuration logic.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (_initialized)
+            return;
+
+        lock (_initializationLock)
         {
             if (_initialized)
                 return;
 
-            lock (_initializationLock)
-            {
-                if (_initialized)
-                    return;
-
-                try
-                {
-                    _bridgeAvailable = TryInitializeBridge();
-                    Log.Debug($"ConfigurationBridge initialization complete. Bridge available: {_bridgeAvailable}");
-                }
-                catch (Exception ex)
-                {
-                    Log.Debug(ex, "ConfigurationBridge initialization failed. Falling back to ILRepacked configuration.");
-                    _bridgeAvailable = false;
-                }
-                finally
-                {
-                    _initialized = true;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Retrieves the value for the specified configuration key from the application's configuration system.
-        /// Falls back to ILRepacked configuration if the bridge is unavailable or the key is not found.
-        /// </summary>
-        /// <param name="key">The configuration key to retrieve.</param>
-        /// <returns>The configuration value, or null if not found.</returns>
-        public static string GetAppSetting(string key)
-        {
-            // Fast path: null or empty key check before initialization
-            if (string.IsNullOrWhiteSpace(key))
-                return null;
-
-            Initialize();
-
-            if (!_bridgeAvailable || _getConfigurationValueDelegate == null)
-            {
-                // Fall back to ILRepacked configuration
-                return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
-            }
-
             try
             {
-                var value = _getConfigurationValueDelegate(key);
+                _bridgeAvailable = TryInitializeBridge();
+                Log.Debug($"ConfigurationBridge initialization complete. Bridge available: {_bridgeAvailable}");
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "ConfigurationBridge initialization failed. Falling back to ILRepacked configuration.");
+                _bridgeAvailable = false;
+            }
+            finally
+            {
+                _initialized = true;
+            }
+        }
+    }
 
-                // If value is found in application config, use it
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    if (Log.IsDebugEnabled)
-                    {
-                        var logValue = ShouldObfuscateKey(key)
-                            ? Strings.ObfuscateLicenseKey(value)
-                            : value;
-                        Log.Debug($"ConfigurationBridge: Retrieved '{key}={logValue}' from application configuration.");
-                    }
-                    return value;
-                }
+    /// <summary>
+    /// Retrieves the value for the specified configuration key from the application's configuration system.
+    /// Falls back to ILRepacked configuration if the bridge is unavailable or the key is not found.
+    /// </summary>
+    /// <param name="key">The configuration key to retrieve.</param>
+    /// <returns>The configuration value, or null if not found.</returns>
+    public static string GetAppSetting(string key)
+    {
+        // Fast path: null or empty key check before initialization
+        if (string.IsNullOrWhiteSpace(key))
+            return null;
 
-                // If not found in application config, try ILRepacked as fallback
+        Initialize();
+
+        if (!_bridgeAvailable || _getConfigurationValueDelegate == null)
+        {
+            // Fall back to ILRepacked configuration
+            return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
+        }
+
+        try
+        {
+            var value = _getConfigurationValueDelegate(key);
+
+            // If value is found in application config, use it
+            if (!string.IsNullOrWhiteSpace(value))
+            {
                 if (Log.IsDebugEnabled)
                 {
-                    Log.Debug($"ConfigurationBridge: '{key}' not found in application configuration, falling back to ILRepacked configuration.");
+                    var logValue = ShouldObfuscateKey(key)
+                        ? Strings.ObfuscateLicenseKey(value)
+                        : value;
+                    Log.Debug($"ConfigurationBridge: Retrieved '{key}={logValue}' from application configuration.");
                 }
-
-                return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
+                return value;
             }
-            catch (Exception ex)
+
+            // If not found in application config, try ILRepacked as fallback
+            if (Log.IsDebugEnabled)
             {
-                Log.Debug(ex, $"ConfigurationBridge: Error accessing application configuration for key '{key}', falling back to ILRepacked configuration.");
-                return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
+                Log.Debug($"ConfigurationBridge: '{key}' not found in application configuration, falling back to ILRepacked configuration.");
             }
-        }
 
-        /// <summary>
-        /// Gets the file path to the application's configuration file (e.g., appsettings.json).
-        /// Falls back to the ILRepacked configuration file path if the bridge is unavailable or the file is not found.
-        /// </summary>
-        /// <returns>The configuration file path.</returns>
-        public static string GetAppSettingsFilePath()
+            return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
+        }
+        catch (Exception ex)
         {
-            Initialize();
-
-            if (!_bridgeAvailable)
-            {
-                return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
-            }
-
-            try
-            {
-                // Try to determine application's config file path
-                var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                var appSettingsPath = Path.Combine(baseDirectory, "appsettings.json");
-
-                if (File.Exists(appSettingsPath))
-                {
-                    return appSettingsPath;
-                }
-
-                return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "ConfigurationBridge: Error determining application configuration file path.");
-                return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
-            }
+            Log.Debug(ex, $"ConfigurationBridge: Error accessing application configuration for key '{key}', falling back to ILRepacked configuration.");
+            return AppSettingsConfigResolveWhenUsed.GetAppSetting(key);
         }
+    }
 
-        private static bool ShouldObfuscateKey(string key)
+    /// <summary>
+    /// Gets the file path to the application's configuration file (e.g., appsettings.json).
+    /// Falls back to the ILRepacked configuration file path if the bridge is unavailable or the file is not found.
+    /// </summary>
+    /// <returns>The configuration file path.</returns>
+    public static string GetAppSettingsFilePath()
+    {
+        Initialize();
+
+        if (!_bridgeAvailable)
         {
-            return string.Equals(key, Constants.AppSettingsLicenseKey, StringComparison.Ordinal);
+            return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
         }
-        
-        private static bool TryInitializeBridge()
+
+        try
         {
-            // Try to find the application's IConfiguration type
-            var configurationType = FindApplicationConfigurationType();
-            if (configurationType == null)
+            // Try to determine application's config file path
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            var appSettingsPath = Path.Combine(baseDirectory, "appsettings.json");
+
+            if (File.Exists(appSettingsPath))
             {
-                Log.Debug("ConfigurationBridge: Microsoft.Extensions.Configuration.IConfiguration not found in application assemblies.");
-                return false;
+                return appSettingsPath;
             }
 
-            // Try to find an existing IConfiguration instance in the application
-            var configurationInstance = FindApplicationConfigurationInstance(configurationType);
-            if (configurationInstance == null)
-            {
-                Log.Debug("ConfigurationBridge: No application IConfiguration instance found.");
-                return false;
-            }
-
-            // Try to create a delegate for accessing configuration values
-            var getValueDelegate = CreateGetValueDelegate(configurationType, configurationInstance);
-            if (getValueDelegate == null)
-            {
-                Log.Debug("ConfigurationBridge: Failed to create configuration value accessor delegate.");
-                return false;
-            }
-
-            // Store only the delegate, not the configuration instance
-            _getConfigurationValueDelegate = getValueDelegate;
-
-            Log.Debug("ConfigurationBridge: Successfully bridged to application configuration system.");
-            return true;
+            return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
         }
-
-        private static Type FindApplicationConfigurationType()
+        catch (Exception ex)
         {
-            // Try to find the application's IConfiguration type in loaded assemblies
-            return _cachedTypes.GetOrAdd("IConfiguration", _ =>
-            {
-                try
-                {
-                    // Look for Microsoft.Extensions.Configuration.IConfiguration in loaded assemblies
-                    // Exclude our own ILRepacked assembly and system assemblies for better performance
-                    var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                        .Where(a => !a.FullName.Contains("NewRelic") &&
-                                   !a.FullName.Contains("ILRepacked") &&
-                                   !a.Location.Contains("NewRelic") &&
-                                   !a.GlobalAssemblyCache && // Exclude GAC assemblies
-                                   !string.IsNullOrEmpty(a.Location)) // Exclude dynamic assemblies
-                        .ToArray();
+            Log.Debug(ex, "ConfigurationBridge: Error determining application configuration file path.");
+            return AppSettingsConfigResolveWhenUsed.AppSettingsFilePath;
+        }
+    }
 
-                    foreach (var assembly in assemblies)
-                    {
-                        try
-                        {
-                            // Quick check: only scan assemblies that likely contain Microsoft.Extensions.Configuration
-                            if (!assembly.FullName.Contains("Microsoft.Extensions") &&
-                                !assembly.FullName.Contains("Extensions.Configuration") &&
-                                !assembly.GetReferencedAssemblies().Any(r => r.Name.Contains("Microsoft.Extensions")))
-                            {
-                                continue;
-                            }
+    private static bool ShouldObfuscateKey(string key)
+    {
+        return string.Equals(key, Constants.AppSettingsLicenseKey, StringComparison.Ordinal);
+    }
 
-                            var configType = assembly.GetTypes()
-                                .FirstOrDefault(t => t.FullName == "Microsoft.Extensions.Configuration.IConfiguration");
-
-                            if (configType != null)
-                            {
-                                Log.Debug($"ConfigurationBridge: Found IConfiguration type in assembly: {assembly.FullName}");
-                                return configType;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName}");
-                        }
-                    }
-
-                    return null;
-                }
-                catch (Exception ex)
-                {
-                    Log.Debug(ex, "ConfigurationBridge: Error finding application configuration type.");
-                    return null;
-                }
-            });
+    private static bool TryInitializeBridge()
+    {
+        // Try to find the application's IConfiguration type
+        var configurationType = FindApplicationConfigurationType();
+        if (configurationType == null)
+        {
+            Log.Debug("ConfigurationBridge: Microsoft.Extensions.Configuration.IConfiguration not found in application assemblies.");
+            return false;
         }
 
-        private static object FindApplicationConfigurationInstance(Type configurationType)
+        // Try to find an existing IConfiguration instance in the application
+        var configurationInstance = FindApplicationConfigurationInstance(configurationType);
+        if (configurationInstance == null)
+        {
+            Log.Debug("ConfigurationBridge: No application IConfiguration instance found.");
+            return false;
+        }
+
+        // Try to create a delegate for accessing configuration values
+        var getValueDelegate = CreateGetValueDelegate(configurationType, configurationInstance);
+        if (getValueDelegate == null)
+        {
+            Log.Debug("ConfigurationBridge: Failed to create configuration value accessor delegate.");
+            return false;
+        }
+
+        // Store only the delegate, not the configuration instance
+        _getConfigurationValueDelegate = getValueDelegate;
+
+        Log.Debug("ConfigurationBridge: Successfully bridged to application configuration system.");
+        return true;
+    }
+
+    private static Type FindApplicationConfigurationType()
+    {
+        // Try to find the application's IConfiguration type in loaded assemblies
+        return _cachedTypes.GetOrAdd("IConfiguration", _ =>
         {
             try
             {
-                // Try to find an IConfiguration instance via ServiceProvider
-                var serviceProviderInstance = FindServiceProvider();
-                if (serviceProviderInstance != null)
-                {
-                    var configInstance = GetServiceFromProvider(serviceProviderInstance, configurationType);
-                    if (configInstance != null)
-                    {
-                        Log.Debug("ConfigurationBridge: Found IConfiguration instance via ServiceProvider.");
-                        return configInstance;
-                    }
-                }
-
-                // Try to find a static IConfiguration instance in loaded types
-                var staticConfigInstance = FindStaticConfigurationInstance(configurationType);
-                if (staticConfigInstance != null)
-                {
-                    Log.Debug("ConfigurationBridge: Found IConfiguration instance via static field search.");
-                    return staticConfigInstance;
-                }
-
-                Log.Debug("ConfigurationBridge: No application configuration instance found.");
-                return null;
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "ConfigurationBridge: Error finding application configuration instance.");
-                return null;
-            }
-        }
-
-        // Fix for S3011: Ensure accessibility bypass is safe  
-        private static object FindServiceProvider()
-        {
-            // Try to find a static IServiceProvider instance in loaded assemblies
-            try
-            {
+                // Look for Microsoft.Extensions.Configuration.IConfiguration in loaded assemblies
+                // Exclude our own ILRepacked assembly and system assemblies for better performance
                 var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => !a.FullName.Contains("NewRelic") && !a.FullName.Contains("ILRepacked"))
+                    .Where(a => !a.FullName.Contains("NewRelic") &&
+                               !a.FullName.Contains("ILRepacked") &&
+                               !a.Location.Contains("NewRelic") &&
+                               !a.GlobalAssemblyCache && // Exclude GAC assemblies
+                               !string.IsNullOrEmpty(a.Location)) // Exclude dynamic assemblies
                     .ToArray();
 
                 foreach (var assembly in assemblies)
                 {
                     try
                     {
-                        var serviceProviderType = assembly.GetTypes()
-                            .FirstOrDefault(t => t.GetInterfaces().Any(i => i.Name == "IServiceProvider"));
-
-                        if (serviceProviderType != null)
+                        // Quick check: only scan assemblies that likely contain Microsoft.Extensions.Configuration
+                        if (!assembly.FullName.Contains("Microsoft.Extensions") &&
+                            !assembly.FullName.Contains("Extensions.Configuration") &&
+                            !assembly.GetReferencedAssemblies().Any(r => r.Name.Contains("Microsoft.Extensions")))
                         {
-                            // Try to find static fields of type IServiceProvider
-                            var staticFields = serviceProviderType.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                                .Where(f => f.FieldType.GetInterfaces().Any(i => i.Name == "IServiceProvider"))
+                            continue;
+                        }
+
+                        var configType = assembly.GetTypes()
+                            .FirstOrDefault(t => t.FullName == "Microsoft.Extensions.Configuration.IConfiguration");
+
+                        if (configType != null)
+                        {
+                            Log.Debug($"ConfigurationBridge: Found IConfiguration type in assembly: {assembly.FullName}");
+                            return configType;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName}");
+                    }
+                }
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "ConfigurationBridge: Error finding application configuration type.");
+                return null;
+            }
+        });
+    }
+
+    private static object FindApplicationConfigurationInstance(Type configurationType)
+    {
+        try
+        {
+            // Try to find an IConfiguration instance via ServiceProvider
+            var serviceProviderInstance = FindServiceProvider();
+            if (serviceProviderInstance != null)
+            {
+                var configInstance = GetServiceFromProvider(serviceProviderInstance, configurationType);
+                if (configInstance != null)
+                {
+                    Log.Debug("ConfigurationBridge: Found IConfiguration instance via ServiceProvider.");
+                    return configInstance;
+                }
+            }
+
+            // Try to find a static IConfiguration instance in loaded types
+            var staticConfigInstance = FindStaticConfigurationInstance(configurationType);
+            if (staticConfigInstance != null)
+            {
+                Log.Debug("ConfigurationBridge: Found IConfiguration instance via static field search.");
+                return staticConfigInstance;
+            }
+
+            Log.Debug("ConfigurationBridge: No application configuration instance found.");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "ConfigurationBridge: Error finding application configuration instance.");
+            return null;
+        }
+    }
+
+    // Fix for S3011: Ensure accessibility bypass is safe  
+    private static object FindServiceProvider()
+    {
+        // Try to find a static IServiceProvider instance in loaded assemblies
+        try
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !a.FullName.Contains("NewRelic") && !a.FullName.Contains("ILRepacked"))
+                .ToArray();
+
+            foreach (var assembly in assemblies)
+            {
+                try
+                {
+                    var serviceProviderType = assembly.GetTypes()
+                        .FirstOrDefault(t => t.GetInterfaces().Any(i => i.Name == "IServiceProvider"));
+
+                    if (serviceProviderType != null)
+                    {
+                        // Try to find static fields of type IServiceProvider
+                        var staticFields = serviceProviderType.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                            .Where(f => f.FieldType.GetInterfaces().Any(i => i.Name == "IServiceProvider"))
+                            .ToArray();
+
+                        foreach (var field in staticFields)
+                        {
+                            var instance = field.GetValue(null);
+                            if (instance != null)
+                            {
+                                return instance;
+                            }
+                        }
+
+                        // Try to find static properties of type IServiceProvider
+                        var staticProperties = serviceProviderType.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                            .Where(p => p.PropertyType.GetInterfaces().Any(i => i.Name == "IServiceProvider"))
+                            .ToArray();
+
+                        foreach (var property in staticProperties)
+                        {
+                            try
+                            {
+                                var instance = property.GetValue(null);
+                                if (instance != null)
+                                {
+                                    return instance;
+                                }
+                            }
+                            catch
+                            {
+                                // Ignore property access errors  
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName} for ServiceProvider.");
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "ConfigurationBridge: Error finding ServiceProvider.");
+            return null;
+        }
+    }
+
+    private static object GetServiceFromProvider(object serviceProvider, Type serviceType)
+    {
+        // Try to get a service from the IServiceProvider instance
+        try
+        {
+            var getServiceMethod = serviceProvider.GetType().GetMethod("GetService", new[] { typeof(Type) });
+            if (getServiceMethod != null)
+            {
+                return getServiceMethod.Invoke(serviceProvider, new object[] { serviceType });
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "ConfigurationBridge: Error getting service from ServiceProvider.");
+            return null;
+        }
+    }
+
+    private static object FindStaticConfigurationInstance(Type configurationType)
+    {
+        // Try to find a static IConfiguration instance in loaded types
+        try
+        {
+            // Fix for IDE0300: Simplify collection initialization  
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies()
+               .Where(a => !a.FullName.Contains("NewRelic") && !a.FullName.Contains("ILRepacked"))
+               .ToArray();
+
+            foreach (var assembly in assemblies)
+            {
+                try
+                {
+                    var types = assembly.GetTypes()
+                        .Where(t => t.IsClass && !t.IsAbstract) // Only scan concrete classes
+                        .ToArray();
+
+                    foreach (var type in types)
+                    {
+                        try
+                        {
+                            // Try to find static fields of type IConfiguration
+                            var staticFields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                                .Where(f => configurationType.IsAssignableFrom(f.FieldType))
                                 .ToArray();
 
                             foreach (var field in staticFields)
@@ -297,13 +390,14 @@ namespace NewRelic.Agent.Core.Configuration
                                 var instance = field.GetValue(null);
                                 if (instance != null)
                                 {
+                                    Log.Debug($"ConfigurationBridge: Found static configuration field '{field.Name}' in type '{type.FullName}'");
                                     return instance;
                                 }
                             }
 
-                            // Try to find static properties of type IServiceProvider
-                            var staticProperties = serviceProviderType.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                                .Where(p => p.PropertyType.GetInterfaces().Any(i => i.Name == "IServiceProvider"))
+                            // Try to find static properties of type IConfiguration
+                            var staticProperties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                                .Where(p => configurationType.IsAssignableFrom(p.PropertyType) && p.CanRead)
                                 .ToArray();
 
                             foreach (var property in staticProperties)
@@ -313,164 +407,69 @@ namespace NewRelic.Agent.Core.Configuration
                                     var instance = property.GetValue(null);
                                     if (instance != null)
                                     {
+                                        Log.Debug($"ConfigurationBridge: Found static configuration property '{property.Name}' in type '{type.FullName}'");
                                         return instance;
                                     }
                                 }
                                 catch
                                 {
-                                    // Ignore property access errors  
+                                    // Ignore property access errors
                                 }
                             }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName} for ServiceProvider.");
-                    }
-                }
-
-                return null;
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "ConfigurationBridge: Error finding ServiceProvider.");
-                return null;
-            }
-        }
-
-        private static object GetServiceFromProvider(object serviceProvider, Type serviceType)
-        {
-            // Try to get a service from the IServiceProvider instance
-            try
-            {
-                var getServiceMethod = serviceProvider.GetType().GetMethod("GetService", new[] { typeof(Type) });
-                if (getServiceMethod != null)
-                {
-                    return getServiceMethod.Invoke(serviceProvider, new object[] { serviceType });
-                }
-
-                return null;
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "ConfigurationBridge: Error getting service from ServiceProvider.");
-                return null;
-            }
-        }
-
-        private static object FindStaticConfigurationInstance(Type configurationType)
-        {
-            // Try to find a static IConfiguration instance in loaded types
-            try
-            {
-                // Fix for IDE0300: Simplify collection initialization  
-                var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                   .Where(a => !a.FullName.Contains("NewRelic") && !a.FullName.Contains("ILRepacked"))
-                   .ToArray();
-
-                foreach (var assembly in assemblies)
-                {
-                    try
-                    {
-                        var types = assembly.GetTypes()
-                            .Where(t => t.IsClass && !t.IsAbstract) // Only scan concrete classes
-                            .ToArray();
-
-                        foreach (var type in types)
+                        catch (Exception ex)
                         {
-                            try
-                            {
-                                // Try to find static fields of type IConfiguration
-                                var staticFields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                                    .Where(f => configurationType.IsAssignableFrom(f.FieldType))
-                                    .ToArray();
-
-                                foreach (var field in staticFields)
-                                {
-                                    var instance = field.GetValue(null);
-                                    if (instance != null)
-                                    {
-                                        Log.Debug($"ConfigurationBridge: Found static configuration field '{field.Name}' in type '{type.FullName}'");
-                                        return instance;
-                                    }
-                                }
-
-                                // Try to find static properties of type IConfiguration
-                                var staticProperties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                                    .Where(p => configurationType.IsAssignableFrom(p.PropertyType) && p.CanRead)
-                                    .ToArray();
-
-                                foreach (var property in staticProperties)
-                                {
-                                    try
-                                    {
-                                        var instance = property.GetValue(null);
-                                        if (instance != null)
-                                        {
-                                            Log.Debug($"ConfigurationBridge: Found static configuration property '{property.Name}' in type '{type.FullName}'");
-                                            return instance;
-                                        }
-                                    }
-                                    catch
-                                    {
-                                        // Ignore property access errors
-                                    }
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Debug(ex, $"ConfigurationBridge: Error examining type {type.FullName}");
-                            }
+                            Log.Debug(ex, $"ConfigurationBridge: Error examining type {type.FullName}");
                         }
                     }
-                    catch (Exception ex)
-                    {
-                        Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName} for static configuration.");
-                    }
                 }
-
-                return null;
-            }
-            catch (Exception ex)
-            {
-                Log.Debug(ex, "ConfigurationBridge: Error finding static configuration instance.");
-                return null;
-            }
-        }
-
-        private static Func<string, string> CreateGetValueDelegate(Type configurationType, object configurationInstance)
-        {
-            // Try to create a delegate for accessing configuration values via the indexer
-            try
-            {
-                // Look for the indexer property: string this[string key] { get; }
-                var indexerProperty = configurationType.GetProperties()
-                    .FirstOrDefault(p => p.GetIndexParameters().Length == 1 &&
-                                        p.GetIndexParameters()[0].ParameterType == typeof(string) &&
-                                        p.PropertyType == typeof(string));
-
-                if (indexerProperty == null)
+                catch (Exception ex)
                 {
-                    Log.Debug("ConfigurationBridge: IConfiguration indexer property not found.");
-                    return null;
+                    Log.Debug(ex, $"ConfigurationBridge: Error examining assembly {assembly.FullName} for static configuration.");
                 }
-
-                // Create a compiled expression to access the indexer: (key) => configuration[key]
-                var keyParameter = Expression.Parameter(typeof(string), "key");
-                var configurationConstant = Expression.Constant(configurationInstance, configurationType);
-                var indexerAccess = Expression.Property(configurationConstant, indexerProperty, keyParameter);
-
-                var lambda = Expression.Lambda<Func<string, string>>(indexerAccess, keyParameter);
-                var compiledDelegate = lambda.Compile();
-
-                Log.Debug("ConfigurationBridge: Successfully created configuration value accessor delegate.");
-                return compiledDelegate;
             }
-            catch (Exception ex)
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "ConfigurationBridge: Error finding static configuration instance.");
+            return null;
+        }
+    }
+
+    private static Func<string, string> CreateGetValueDelegate(Type configurationType, object configurationInstance)
+    {
+        // Try to create a delegate for accessing configuration values via the indexer
+        try
+        {
+            // Look for the indexer property: string this[string key] { get; }
+            var indexerProperty = configurationType.GetProperties()
+                .FirstOrDefault(p => p.GetIndexParameters().Length == 1 &&
+                                    p.GetIndexParameters()[0].ParameterType == typeof(string) &&
+                                    p.PropertyType == typeof(string));
+
+            if (indexerProperty == null)
             {
-                Log.Debug(ex, "ConfigurationBridge: Error creating configuration value accessor delegate.");
+                Log.Debug("ConfigurationBridge: IConfiguration indexer property not found.");
                 return null;
             }
+
+            // Create a compiled expression to access the indexer: (key) => configuration[key]
+            var keyParameter = Expression.Parameter(typeof(string), "key");
+            var configurationConstant = Expression.Constant(configurationInstance, configurationType);
+            var indexerAccess = Expression.Property(configurationConstant, indexerProperty, keyParameter);
+
+            var lambda = Expression.Lambda<Func<string, string>>(indexerAccess, keyParameter);
+            var compiledDelegate = lambda.Compile();
+
+            Log.Debug("ConfigurationBridge: Successfully created configuration value accessor delegate.");
+            return compiledDelegate;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "ConfigurationBridge: Error creating configuration value accessor delegate.");
+            return null;
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationEnumHelpers.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationEnumHelpers.cs
@@ -5,94 +5,93 @@ using System;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Config;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public static class ConfigurationEnumHelpers
 {
-    public static class ConfigurationEnumHelpers
+    public static SamplerType ToRemoteParentSamplerType(this RemoteParentSampledBehaviorType localConfigEnumValue)
     {
-        public static SamplerType ToRemoteParentSamplerType(this RemoteParentSampledBehaviorType localConfigEnumValue)
+        switch (localConfigEnumValue)
         {
-            switch (localConfigEnumValue)
-            {
-                case RemoteParentSampledBehaviorType.@default:
-                case RemoteParentSampledBehaviorType.adaptive:
-                    return SamplerType.Adaptive;
-                case RemoteParentSampledBehaviorType.alwaysOn:
-                    return SamplerType.AlwaysOn;
-                case RemoteParentSampledBehaviorType.alwaysOff:
-                    return SamplerType.AlwaysOff;
-                    case RemoteParentSampledBehaviorType.traceIdRatioBased:
-                        return SamplerType.TraceIdRatioBased;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(localConfigEnumValue), localConfigEnumValue, null);
-            }
+            case RemoteParentSampledBehaviorType.@default:
+            case RemoteParentSampledBehaviorType.adaptive:
+                return SamplerType.Adaptive;
+            case RemoteParentSampledBehaviorType.alwaysOn:
+                return SamplerType.AlwaysOn;
+            case RemoteParentSampledBehaviorType.alwaysOff:
+                return SamplerType.AlwaysOff;
+            case RemoteParentSampledBehaviorType.traceIdRatioBased:
+                return SamplerType.TraceIdRatioBased;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(localConfigEnumValue), localConfigEnumValue, null);
         }
+    }
 
-        public static SamplerType ToRemoteParentSamplerType(this string remoteParentSampledBehavior)
+    public static SamplerType ToRemoteParentSamplerType(this string remoteParentSampledBehavior)
+    {
+        switch (remoteParentSampledBehavior.ToLower())
         {
-            switch (remoteParentSampledBehavior.ToLower())
-            {
-                case "default":
-                case "adaptive":
-                    return SamplerType.Adaptive;
-                case "alwayson":
-                    return SamplerType.AlwaysOn;
-                case "alwaysoff":
-                    return SamplerType.AlwaysOff;
-                case "traceidratiobased":
-                    return SamplerType.TraceIdRatioBased;
-                default:
-                    return SamplerType.Adaptive; // default to adaptive if unrecognized value
-            }
+            case "default":
+            case "adaptive":
+                return SamplerType.Adaptive;
+            case "alwayson":
+                return SamplerType.AlwaysOn;
+            case "alwaysoff":
+                return SamplerType.AlwaysOff;
+            case "traceidratiobased":
+                return SamplerType.TraceIdRatioBased;
+            default:
+                return SamplerType.Adaptive; // default to adaptive if unrecognized value
         }
+    }
 
 
-        public static object ToConfigurationSamplerTypeInstance(this SamplerType samplerType)
+    public static object ToConfigurationSamplerTypeInstance(this SamplerType samplerType)
+    {
+        switch (samplerType)
         {
-            switch (samplerType)
-            {
-                case SamplerType.Adaptive:
-                    return new AdaptiveSamplerType();
-                case SamplerType.AlwaysOn:
-                    return new AlwaysOnSamplerType();
-                case SamplerType.AlwaysOff:
-                    return new AlwaysOffSamplerType();
-                case SamplerType.TraceIdRatioBased:
-                    return new TraceIdRatioBasedSamplerType();
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(samplerType), samplerType, null);
-            }
+            case SamplerType.Adaptive:
+                return new AdaptiveSamplerType();
+            case SamplerType.AlwaysOn:
+                return new AlwaysOnSamplerType();
+            case SamplerType.AlwaysOff:
+                return new AlwaysOffSamplerType();
+            case SamplerType.TraceIdRatioBased:
+                return new TraceIdRatioBasedSamplerType();
+            default:
+                throw new ArgumentOutOfRangeException(nameof(samplerType), samplerType, null);
         }
+    }
 
-        public static string ToSamplerTypeString(this SamplerType samplerType)
+    public static string ToSamplerTypeString(this SamplerType samplerType)
+    {
+        switch (samplerType)
         {
-            switch (samplerType)
-            {
-                case SamplerType.Adaptive:
-                    return "adaptive";
-                case SamplerType.AlwaysOn:
-                    return "always_on";
-                case SamplerType.AlwaysOff:
-                    return "always_off";
-                case SamplerType.TraceIdRatioBased:
-                    return "trace_id_ratio_based";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(samplerType), samplerType, null);
-            }
+            case SamplerType.Adaptive:
+                return "adaptive";
+            case SamplerType.AlwaysOn:
+                return "always_on";
+            case SamplerType.AlwaysOff:
+                return "always_off";
+            case SamplerType.TraceIdRatioBased:
+                return "trace_id_ratio_based";
+            default:
+                throw new ArgumentOutOfRangeException(nameof(samplerType), samplerType, null);
         }
+    }
 
-        public static string ToSamplerLevelString(this SamplerLevel samplerLevel)
+    public static string ToSamplerLevelString(this SamplerLevel samplerLevel)
+    {
+        switch (samplerLevel)
         {
-            switch (samplerLevel)
-            {
-                case SamplerLevel.Root:
-                    return "root";
-                case SamplerLevel.RemoteParentSampled:
-                    return "remote_parent_sampled";
-                case SamplerLevel.RemoteParentNotSampled:
-                    return "remote_parent_not_sampled";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null);
-            }
+            case SamplerLevel.Root:
+                return "root";
+            case SamplerLevel.RemoteParentSampled:
+                return "remote_parent_sampled";
+            case SamplerLevel.RemoteParentNotSampled:
+                return "remote_parent_not_sampled";
+            default:
+                throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null);
         }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ConfigurationService.cs
@@ -1,144 +1,142 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
+using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Config;
 using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Requests;
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.SharedInterfaces.Web;
-using System;
-using System.Linq;
-using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class ConfigurationService : IConfigurationService, IDisposable
 {
-    public class ConfigurationService : IConfigurationService, IDisposable
+    private readonly IEnvironment _environment;
+    private configuration _localConfiguration = new configuration();
+    private ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
+    private SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+    private RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
+    private readonly IBootstrapConfiguration _bootstrapConfiguration = ConfigurationLoader.BootstrapConfig;
+    private readonly Subscriptions _subscriptions = new Subscriptions();
+    private readonly IProcessStatic _processStatic;
+    private readonly IHttpRuntimeStatic _httpRuntimeStatic;
+    private readonly IConfigurationManagerStatic _configurationManagerStatic;
+    private readonly IDnsStatic _dnsStatic;
+
+    /// <summary>
+    /// Do not use this field outside of this class. It only exists for testing purposes.
+    /// </summary>
+    public Action<string> ChangeLogLevelAction = LoggerBootstrapper.SetLoggingLevel;
+
+    public IConfiguration Configuration { get; private set; }
+
+    public ConfigurationService(IEnvironment environment, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
     {
-        private readonly IEnvironment _environment;
-        private configuration _localConfiguration = new configuration();
-        private ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
-        private SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
-        private RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
-        private readonly IBootstrapConfiguration _bootstrapConfiguration = ConfigurationLoader.BootstrapConfig;
-        private readonly Subscriptions _subscriptions = new Subscriptions();
-        private readonly IProcessStatic _processStatic;
-        private readonly IHttpRuntimeStatic _httpRuntimeStatic;
-        private readonly IConfigurationManagerStatic _configurationManagerStatic;
-        private readonly IDnsStatic _dnsStatic;
+        _environment = environment;
+        _processStatic = processStatic;
+        _httpRuntimeStatic = httpRuntimeStatic;
+        _configurationManagerStatic = configurationManagerStatic;
+        _dnsStatic = dnsStatic;
 
-        /// <summary>
-        /// Do not use this field outside of this class. It only exists for testing purposes.
-        /// </summary>
-        public Action<string> ChangeLogLevelAction = LoggerBootstrapper.SetLoggingLevel;
+        Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, dnsStatic);
 
-        public IConfiguration Configuration { get; private set; }
+        _subscriptions.Add<ConfigurationDeserializedEvent>(OnConfigurationDeserialized);
+        _subscriptions.Add<ServerConfigurationUpdatedEvent>(OnServerConfigurationUpdated);
+        _subscriptions.Add<AppNameUpdateEvent>(OnAppNameUpdate);
+        _subscriptions.Add<ErrorGroupCallbackUpdateEvent>(OnErrorGroupCallbackUpdate);
+        _subscriptions.Add<LlmTokenCountingCallbackUpdateEvent>(OnLlmTokenCountingCallbackUpdate);
+        _subscriptions.Add<GetCurrentConfigurationRequest, IConfiguration>(OnGetCurrentConfiguration);
+        _subscriptions.Add<SecurityPoliciesConfigurationUpdatedEvent>(OnSecurityPoliciesUpdated);
+    }
 
-        public ConfigurationService(IEnvironment environment, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
+    private void OnSecurityPoliciesUpdated(SecurityPoliciesConfigurationUpdatedEvent securityPoliciesConfigurationUpdatedEvent)
+    {
+        _securityPoliciesConfiguration = securityPoliciesConfigurationUpdatedEvent.Configuration;
+        UpdateAndPublishConfiguration(ConfigurationUpdateSource.SecurityPolicies);
+    }
+
+    private void OnConfigurationDeserialized(ConfigurationDeserializedEvent configurationDeserializedEvent)
+    {
+        _localConfiguration = configurationDeserializedEvent.Configuration;
+        UpdateAndPublishConfiguration(ConfigurationUpdateSource.Local);
+    }
+
+    private void UpdateLogLevel(string previousLogLevel)
+    {
+        var newLogLevel = Configuration.LoggingLevel;
+        if (previousLogLevel == newLogLevel)
         {
-            _environment = environment;
-            _processStatic = processStatic;
-            _httpRuntimeStatic = httpRuntimeStatic;
-            _configurationManagerStatic = configurationManagerStatic;
-            _dnsStatic = dnsStatic;
-
-            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, dnsStatic);
-
-            _subscriptions.Add<ConfigurationDeserializedEvent>(OnConfigurationDeserialized);
-            _subscriptions.Add<ServerConfigurationUpdatedEvent>(OnServerConfigurationUpdated);
-            _subscriptions.Add<AppNameUpdateEvent>(OnAppNameUpdate);
-            _subscriptions.Add<ErrorGroupCallbackUpdateEvent>(OnErrorGroupCallbackUpdate);
-            _subscriptions.Add<LlmTokenCountingCallbackUpdateEvent>(OnLlmTokenCountingCallbackUpdate);
-            _subscriptions.Add<GetCurrentConfigurationRequest, IConfiguration>(OnGetCurrentConfiguration);
-            _subscriptions.Add<SecurityPoliciesConfigurationUpdatedEvent>(OnSecurityPoliciesUpdated);
+            return;
         }
 
-        private void OnSecurityPoliciesUpdated(SecurityPoliciesConfigurationUpdatedEvent securityPoliciesConfigurationUpdatedEvent)
+        Log.Info("The log level was updated to {0} from {1}", newLogLevel, previousLogLevel);
+        ChangeLogLevelAction(newLogLevel);
+    }
+
+    private void OnServerConfigurationUpdated(ServerConfigurationUpdatedEvent serverConfigurationUpdatedEvent)
+    {
+        try
         {
-            _securityPoliciesConfiguration = securityPoliciesConfigurationUpdatedEvent.Configuration;
-            UpdateAndPublishConfiguration(ConfigurationUpdateSource.SecurityPolicies);
+            _serverConfiguration = serverConfigurationUpdatedEvent.Configuration;
+            UpdateAndPublishConfiguration(ConfigurationUpdateSource.Server);
         }
-
-        private void OnConfigurationDeserialized(ConfigurationDeserializedEvent configurationDeserializedEvent)
+        catch (Exception exception)
         {
-            _localConfiguration = configurationDeserializedEvent.Configuration;
-            UpdateAndPublishConfiguration(ConfigurationUpdateSource.Local);
+            Log.Error(exception, "Unable to parse the Configuration data from the server so no server side configuration was applied");
         }
+    }
 
-        private void UpdateLogLevel(string previousLogLevel)
-        {
-            var newLogLevel = Configuration.LoggingLevel;
-            if (previousLogLevel == newLogLevel)
-            {
-                return;
-            }
+    private void OnAppNameUpdate(AppNameUpdateEvent appNameUpdateEvent)
+    {
+        if (_runTimeConfiguration.ApplicationNames.SequenceEqual(appNameUpdateEvent.AppNames))
+            return;
 
-            Log.Info("The log level was updated to {0} from {1}", newLogLevel, previousLogLevel);
-            ChangeLogLevelAction(newLogLevel);
-        }
+        _runTimeConfiguration = new RunTimeConfiguration(appNameUpdateEvent.AppNames, _runTimeConfiguration.ErrorGroupCallback, _runTimeConfiguration.LlmTokenCountingCallback);
+        UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
+    }
 
-        private void OnServerConfigurationUpdated(ServerConfigurationUpdatedEvent serverConfigurationUpdatedEvent)
-        {
-            try
-            {
-                _serverConfiguration = serverConfigurationUpdatedEvent.Configuration;
-                UpdateAndPublishConfiguration(ConfigurationUpdateSource.Server);
-            }
-            catch (Exception exception)
-            {
-                Log.Error(exception, "Unable to parse the Configuration data from the server so no server side configuration was applied");
-            }
-        }
+    private void OnErrorGroupCallbackUpdate(ErrorGroupCallbackUpdateEvent errorGroupCallbackUpdateEvent)
+    {
+        if (_runTimeConfiguration.ErrorGroupCallback == errorGroupCallbackUpdateEvent.ErrorGroupCallback)
+            return;
 
-        private void OnAppNameUpdate(AppNameUpdateEvent appNameUpdateEvent)
-        {
-            if (_runTimeConfiguration.ApplicationNames.SequenceEqual(appNameUpdateEvent.AppNames))
-                return;
+        _runTimeConfiguration = new RunTimeConfiguration(_runTimeConfiguration.ApplicationNames, errorGroupCallbackUpdateEvent.ErrorGroupCallback, _runTimeConfiguration.LlmTokenCountingCallback);
+        UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
+    }
 
-            _runTimeConfiguration = new RunTimeConfiguration(appNameUpdateEvent.AppNames, _runTimeConfiguration.ErrorGroupCallback, _runTimeConfiguration.LlmTokenCountingCallback);
-            UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
-        }
+    private void OnLlmTokenCountingCallbackUpdate(LlmTokenCountingCallbackUpdateEvent llmTokenCountingCallbackUpdateEvent)
+    {
+        if (_runTimeConfiguration.LlmTokenCountingCallback == llmTokenCountingCallbackUpdateEvent.LlmTokenCountingCallback)
+            return;
 
-        private void OnErrorGroupCallbackUpdate(ErrorGroupCallbackUpdateEvent errorGroupCallbackUpdateEvent)
-        {
-            if (_runTimeConfiguration.ErrorGroupCallback == errorGroupCallbackUpdateEvent.ErrorGroupCallback)
-                return;
+        _runTimeConfiguration = new RunTimeConfiguration(_runTimeConfiguration.ApplicationNames, _runTimeConfiguration.ErrorGroupCallback, llmTokenCountingCallbackUpdateEvent.LlmTokenCountingCallback);
+        UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
+    }
 
-            _runTimeConfiguration = new RunTimeConfiguration(_runTimeConfiguration.ApplicationNames, errorGroupCallbackUpdateEvent.ErrorGroupCallback, _runTimeConfiguration.LlmTokenCountingCallback);
-            UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
-        }
+    private void UpdateAndPublishConfiguration(ConfigurationUpdateSource configurationUpdateSource)
+    {
+        var previousLogLevel = Configuration.LoggingLevel;
 
-        private void OnLlmTokenCountingCallbackUpdate(LlmTokenCountingCallbackUpdateEvent llmTokenCountingCallbackUpdateEvent)
-        {
-            if (_runTimeConfiguration.LlmTokenCountingCallback == llmTokenCountingCallbackUpdateEvent.LlmTokenCountingCallback)
-                return;
+        Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
 
-            _runTimeConfiguration = new RunTimeConfiguration(_runTimeConfiguration.ApplicationNames, _runTimeConfiguration.ErrorGroupCallback, llmTokenCountingCallbackUpdateEvent.LlmTokenCountingCallback);
-            UpdateAndPublishConfiguration(ConfigurationUpdateSource.RunTime);
-        }
+        UpdateLogLevel(previousLogLevel);
 
-        private void UpdateAndPublishConfiguration(ConfigurationUpdateSource configurationUpdateSource)
-        {
-            var previousLogLevel = Configuration.LoggingLevel;
+        var configurationUpdatedEvent = new ConfigurationUpdatedEvent(Configuration, configurationUpdateSource);
+        EventBus<ConfigurationUpdatedEvent>.Publish(configurationUpdatedEvent);
+    }
 
-            Configuration = new InternalConfiguration(_environment, _localConfiguration, _serverConfiguration, _runTimeConfiguration, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+    private void OnGetCurrentConfiguration(GetCurrentConfigurationRequest eventData, RequestBus<GetCurrentConfigurationRequest, IConfiguration>.ResponseCallback callback)
+    {
+        callback(Configuration);
+    }
 
-            UpdateLogLevel(previousLogLevel);
-
-            var configurationUpdatedEvent = new ConfigurationUpdatedEvent(Configuration, configurationUpdateSource);
-            EventBus<ConfigurationUpdatedEvent>.Publish(configurationUpdatedEvent);
-        }
-
-        private void OnGetCurrentConfiguration(GetCurrentConfigurationRequest eventData, RequestBus<GetCurrentConfigurationRequest, IConfiguration>.ResponseCallback callback)
-        {
-            callback(Configuration);
-        }
-
-        public void Dispose()
-        {
-            _subscriptions.Dispose();
-        }
+    public void Dispose()
+    {
+        _subscriptions.Dispose();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/Constants.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/Constants.cs
@@ -1,15 +1,14 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Configuration
-{
-    public static class Constants
-    {
-        public const string AppSettingsLicenseKey = "NewRelic.LicenseKey";
-        public const string AppSettingsAgentEnabled = "NewRelic.AgentEnabled";
-        public const string AppSettingsAppName = "NewRelic.AppName";
-        public const string AppSettingsLabels = "NewRelic.Labels";
-        public const string AppSettingsConfigFile = "NewRelic.ConfigFile";
+namespace NewRelic.Agent.Core.Configuration;
 
-    }
+public static class Constants
+{
+    public const string AppSettingsLicenseKey = "NewRelic.LicenseKey";
+    public const string AppSettingsAgentEnabled = "NewRelic.AgentEnabled";
+    public const string AppSettingsAppName = "NewRelic.AppName";
+    public const string AppSettingsLabels = "NewRelic.Labels";
+    public const string AppSettingsConfigFile = "NewRelic.ConfigFile";
+
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1,16 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Core.Config;
-using NewRelic.Agent.Core.Metrics;
-using NewRelic.Agent.Helpers;
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Extensions.SystemExtensions;
-using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
-using NewRelic.Agent.Core.SharedInterfaces;
-using NewRelic.Agent.Core.SharedInterfaces.Web;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -18,2990 +8,2999 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.Config;
+using NewRelic.Agent.Core.Metrics;
+using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.SharedInterfaces.Web;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
+using NewRelic.Agent.Extensions.SystemExtensions;
+using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
+using NewRelic.Agent.Helpers;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+/// <summary>
+/// Default implementation of IConfiguration.  This should only be used by ConfigurationService.  If you need configuration, get it from the ConfigurationService, not here.
+/// </summary>
+public class DefaultConfiguration : IConfiguration
 {
+    private const int DefaultSslPort = 443;
+    private const int DefaultSqlStatementCacheCapacity = 1000;
+
+    public static readonly string RawStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.raw);
+    public static readonly string ObfuscatedStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.obfuscated);
+    public static readonly string OffStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.off);
+    private static readonly char HyphenChar = '-';
+
+    private const string HighSecurityConfigSource = "High Security Mode";
+    private const string SecurityPolicyConfigSource = "Security Policy";
+    private const string LocalConfigSource = "Local Configuration";
+    private const string ServerConfigSource = "Server Configuration";
+    private const int MaxExptectedErrorConfigEntries = 50;
+    private const int MaxIgnoreErrorConfigEntries = 50;
+
+    private static long _currentConfigurationVersion;
+    private readonly IEnvironment _environment = new EnvironmentMock();
+    private readonly IProcessStatic _processStatic = new ProcessStatic();
+    private readonly IHttpRuntimeStatic _httpRuntimeStatic = new HttpRuntimeStatic();
+    private readonly IConfigurationManagerStatic _configurationManagerStatic = new ConfigurationManagerStaticMock();
+    private readonly IDnsStatic _dnsStatic;
+
     /// <summary>
-    /// Default implementation of IConfiguration.  This should only be used by ConfigurationService.  If you need configuration, get it from the ConfigurationService, not here.
+    /// Default configuration.  It will contain reasonable default values for everything and never anything more.  Useful when you don't have configuration off disk or a collector response yet.
     /// </summary>
-    public class DefaultConfiguration : IConfiguration
-    {
-        private const int DefaultSslPort = 443;
-        private const int DefaultSqlStatementCacheCapacity = 1000;
+    public static readonly DefaultConfiguration Instance = new DefaultConfiguration();
+    private readonly configuration _localConfiguration = new configuration();
+    private readonly ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
+    private readonly RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
+    private readonly SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
+    private readonly IBootstrapConfiguration _bootstrapConfiguration = BootstrapConfiguration.GetDefault();
+    private readonly Dictionary<string, string> _newRelicAppSettings;
 
-        public static readonly string RawStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.raw);
-        public static readonly string ObfuscatedStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.obfuscated);
-        public static readonly string OffStringValue = Enum.GetName(typeof(configurationTransactionTracerRecordSql), configurationTransactionTracerRecordSql.off);
-        private static readonly char HyphenChar = '-';
-
-        private const string HighSecurityConfigSource = "High Security Mode";
-        private const string SecurityPolicyConfigSource = "Security Policy";
-        private const string LocalConfigSource = "Local Configuration";
-        private const string ServerConfigSource = "Server Configuration";
-        private const int MaxExptectedErrorConfigEntries = 50;
-        private const int MaxIgnoreErrorConfigEntries = 50;
-
-        private static long _currentConfigurationVersion;
-        private readonly IEnvironment _environment = new EnvironmentMock();
-        private readonly IProcessStatic _processStatic = new ProcessStatic();
-        private readonly IHttpRuntimeStatic _httpRuntimeStatic = new HttpRuntimeStatic();
-        private readonly IConfigurationManagerStatic _configurationManagerStatic = new ConfigurationManagerStaticMock();
-        private readonly IDnsStatic _dnsStatic;
-
-        /// <summary>
-        /// Default configuration.  It will contain reasonable default values for everything and never anything more.  Useful when you don't have configuration off disk or a collector response yet.
-        /// </summary>
-        public static readonly DefaultConfiguration Instance = new DefaultConfiguration();
-        private readonly configuration _localConfiguration = new configuration();
-        private readonly ServerConfiguration _serverConfiguration = ServerConfiguration.GetDefault();
-        private readonly RunTimeConfiguration _runTimeConfiguration = new RunTimeConfiguration();
-        private readonly SecurityPoliciesConfiguration _securityPoliciesConfiguration = new SecurityPoliciesConfiguration();
-        private readonly IBootstrapConfiguration _bootstrapConfiguration = BootstrapConfiguration.GetDefault();
-        private readonly Dictionary<string, string> _newRelicAppSettings;
-
-        public bool UseResourceBasedNamingForWCFEnabled { get; private set; }
+    public bool UseResourceBasedNamingForWCFEnabled { get; private set; }
         
-        private bool _hasLoggedEventListenerSamplersDisabled;
+    private bool _hasLoggedEventListenerSamplersDisabled;
 
-        public TimeSpan DefaultHarvestCycle => TimeSpan.FromMinutes(1);
+    public TimeSpan DefaultHarvestCycle => TimeSpan.FromMinutes(1);
 
-        /// <summary>
-        /// Default configuration constructor.  It will contain reasonable default values for everything and never anything more.
-        /// </summary>
-        private DefaultConfiguration()
+    /// <summary>
+    /// Default configuration constructor.  It will contain reasonable default values for everything and never anything more.
+    /// </summary>
+    private DefaultConfiguration()
+    {
+        ConfigurationVersion = Interlocked.Increment(ref _currentConfigurationVersion);
+    }
+
+    protected DefaultConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
+        : this()
+    {
+        _environment = environment;
+        _processStatic = processStatic;
+        _httpRuntimeStatic = httpRuntimeStatic;
+        _configurationManagerStatic = configurationManagerStatic;
+        _dnsStatic = dnsStatic;
+
+        _utilizationFullHostName = new Lazy<string>(_dnsStatic.GetFullHostName);
+        _utilizationHostName = new Lazy<string>(_dnsStatic.GetHostName);
+
+        if (localConfiguration != null)
         {
-            ConfigurationVersion = Interlocked.Increment(ref _currentConfigurationVersion);
+            _localConfiguration = localConfiguration;
+        }
+        if (serverConfiguration != null)
+        {
+            _serverConfiguration = serverConfiguration;
+        }
+        if (runTimeConfiguration != null)
+        {
+            _runTimeConfiguration = runTimeConfiguration;
+        }
+        if (securityPoliciesConfiguration != null)
+        {
+            _securityPoliciesConfiguration = securityPoliciesConfiguration;
+        }
+        if (_bootstrapConfiguration != null)
+        {
+            _bootstrapConfiguration = bootstrapConfiguration;
         }
 
-        protected DefaultConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic)
-            : this()
+        LogDisabledWarnings();
+
+        _newRelicAppSettings = TransformAppSettings();
+
+        UseResourceBasedNamingForWCFEnabled = TryGetAppSettingAsBoolWithDefault("NewRelic.UseResourceBasedNamingForWCF", false);
+
+        EventListenerSamplersEnabled = TryGetAppSettingAsBoolWithDefault("NewRelic.EventListenerSamplersEnabled", true);
+
+        ParseExpectedErrorConfigurations();
+        ParseIgnoreErrorConfigurations();
+    }
+
+    public IReadOnlyDictionary<string, string> GetAppSettings()
+    {
+        return _newRelicAppSettings;
+    }
+
+    private Dictionary<string, string> TransformAppSettings()
+    {
+        if (_localConfiguration.appSettings == null)
+            return [];
+
+        return _localConfiguration.appSettings
+            .Where(setting => setting != null)
+            .Select(setting => new KeyValuePair<string, string>(setting.key, setting.value))
+            .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+    }
+
+    private bool TryGetAppSettingAsBoolWithDefault(string key, bool defaultValue)
+    {
+        var value = _newRelicAppSettings.GetValueOrDefault(key);
+
+        var parsedSuccessfully = bool.TryParse(value, out var parsedBool);
+        if (!parsedSuccessfully)
+            return defaultValue;
+
+        return parsedBool;
+    }
+
+    private string TryGetAppSettingAsString(string key)
+    {
+        return _newRelicAppSettings.TryGetValue(key, out var valueStr) ? valueStr : null;
+    }
+
+    private float? TryGetAppSettingAsFloat(string key)
+    {
+        if (_newRelicAppSettings.TryGetValue(key, out var valueStr))
         {
-            _environment = environment;
-            _processStatic = processStatic;
-            _httpRuntimeStatic = httpRuntimeStatic;
-            _configurationManagerStatic = configurationManagerStatic;
-            _dnsStatic = dnsStatic;
-
-            _utilizationFullHostName = new Lazy<string>(_dnsStatic.GetFullHostName);
-            _utilizationHostName = new Lazy<string>(_dnsStatic.GetHostName);
-
-            if (localConfiguration != null)
+            if (float.TryParse(valueStr, out var valueFloat))
             {
-                _localConfiguration = localConfiguration;
+                return valueFloat;
             }
-            if (serverConfiguration != null)
+        }
+        return null;
+    }
+
+    private int TryGetAppSettingAsIntWithDefault(string key, int defaultValue)
+    {
+        return TryGetAppSettingAsInt(key).GetValueOrDefault(defaultValue);
+    }
+
+    private int? TryGetAppSettingAsInt(string key)
+    {
+        if (_newRelicAppSettings.TryGetValue(key, out var valueStr))
+        {
+            if (int.TryParse(valueStr, out var valueInt))
             {
-                _serverConfiguration = serverConfiguration;
+                return valueInt;
             }
-            if (runTimeConfiguration != null)
+        }
+        return null;
+    }
+
+    public bool SecurityPoliciesTokenExists => !string.IsNullOrEmpty(SecurityPoliciesToken);
+
+    #region IConfiguration Properties
+
+    public object AgentRunId { get { return _serverConfiguration.AgentRunId; } }
+
+    private static readonly object _lockObj = new object();
+
+
+    public virtual bool AgentEnabled => _bootstrapConfiguration.AgentEnabled;
+
+    public string AgentEnabledAt => _bootstrapConfiguration.AgentEnabledAt;
+
+    public bool ServerlessModeEnabled => _bootstrapConfiguration.ServerlessModeEnabled;
+
+    public string ServerlessFunctionName => _bootstrapConfiguration.ServerlessFunctionName;
+
+    public string ServerlessFunctionVersion => _bootstrapConfiguration.ServerlessFunctionVersion;
+
+    private string _agentLicenseKey;
+    public virtual string AgentLicenseKey
+    {
+        get
+        {
+            _agentLicenseKey ??= TryGetLicenseKey();
+            return _agentLicenseKey;
+        }
+    }
+
+    private string TryGetLicenseKey()
+    {
+        // same order as old process - appsettings > env var(a/b) > newrelic.config
+        var candidateKeys = new Dictionary<string, string>
+        {
+            { "AppSettings", _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLicenseKey) },
+            { "EnvironmentVariable", _environment.GetEnvironmentVariableFromList("NEW_RELIC_LICENSE_KEY", "NEWRELIC_LICENSEKEY") },
+            { "newrelic.config", _localConfiguration.service.licenseKey }
+        };
+
+        foreach (var candidateKey in candidateKeys)
+        {
+            // Did we find a key?
+            if (string.IsNullOrWhiteSpace(candidateKey.Value))
             {
-                _runTimeConfiguration = runTimeConfiguration;
+                continue;
             }
-            if (securityPoliciesConfiguration != null)
+
+            // We found something, but is it a valid key?
+
+            // If the key is the default value from newrelic.config, we return the default value
+            // AgentManager.AssertAgentEnabled() relies on this behavior and will throw an exception if the key is the default value
+            if (candidateKey.Value.ToLower().Contains("license"))
             {
-                _securityPoliciesConfiguration = securityPoliciesConfiguration;
+                // newrelic.config is the last place to look
+                return candidateKey.Value;
             }
-            if (_bootstrapConfiguration != null)
+
+            // Keys are only 40 characters long, but we trim to be safe
+            var trimmedCandidateKey = candidateKey.Value.Trim();
+            if (trimmedCandidateKey.Length != 40)
             {
-                _bootstrapConfiguration = bootstrapConfiguration;
+                Log.Warn($"License key from {candidateKey.Key} is not 40 characters long. Checking for other license keys.");
+                continue;
             }
 
-            LogDisabledWarnings();
+            // Keys can only contain printable ASCII characters from 0x21 to 0x7E
+            if (!trimmedCandidateKey.All(c => c >= 0x21 && c <= 0x7E))
+            {
+                Log.Warn($"License key from {candidateKey.Key} contains invalid characters. Checking for other license keys.");
+                continue;
+            }
 
-            _newRelicAppSettings = TransformAppSettings();
-
-            UseResourceBasedNamingForWCFEnabled = TryGetAppSettingAsBoolWithDefault("NewRelic.UseResourceBasedNamingForWCF", false);
-
-            EventListenerSamplersEnabled = TryGetAppSettingAsBoolWithDefault("NewRelic.EventListenerSamplersEnabled", true);
-
-            ParseExpectedErrorConfigurations();
-            ParseIgnoreErrorConfigurations();
+            Log.Info($"License key from {candidateKey.Key} appears to be in the correct format.");
+            return trimmedCandidateKey;
         }
 
-        public IReadOnlyDictionary<string, string> GetAppSettings()
+        // return string.Empty instead of null to allow caching and prevent checking repeatedly
+        Log.Warn("No valid license key found.");
+        return string.Empty;
+    }
+
+    private IEnumerable<string> _applicationNames;
+    public virtual IEnumerable<string> ApplicationNames => _applicationNames ??= GetApplicationNames();
+
+    private string _applicationNamesSource;
+    public virtual string ApplicationNamesSource => _applicationNamesSource;
+
+    private IEnumerable<string> GetApplicationNames()
+    {
+        // Wrapper that throws if no application names could be resolved.
+        if (TryGetApplicationNames(out var names))
         {
-            return _newRelicAppSettings;
+            return names;
         }
 
-        private Dictionary<string, string> TransformAppSettings()
-        {
-            if (_localConfiguration.appSettings == null)
-                return [];
+        throw new Exception("An application name must be provided");
+    }
 
-            return _localConfiguration.appSettings
-                .Where(setting => setting != null)
-                .Select(setting => new KeyValuePair<string, string>(setting.key, setting.value))
-                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+    /// <summary>
+    /// Attempts to resolve the application names following the same ordered precedence
+    /// as the legacy <see cref="GetApplicationNames"/> implementation without throwing.
+    /// </summary>
+    /// <param name="names">Resolved application names when successful; null otherwise.</param>
+    /// <returns>True if application names were found; false if none could be resolved.</returns>
+    /// <remarks>
+    /// Side effects:
+    /// - Sets <see cref="_applicationNamesSource"/> to the source of the resolved names.
+    /// - Sets <see cref="_applicationNamesMissing"/> to true only when resolution fails.
+    /// Logging behavior is preserved exactly from the original implementation.
+    /// </remarks>
+    public bool TryGetApplicationNames(out IEnumerable<string> names)  // CHANGED: was private
+    {
+        // 1. Agent API
+        var runtimeAppNames = _runTimeConfiguration.ApplicationNames.ToList();
+        if (runtimeAppNames.Any())
+        {
+            Log.Info("Application name from SetApplicationName API.");
+            _applicationNamesSource = "API";
+            names = runtimeAppNames;
+            return true;
         }
 
-        private bool TryGetAppSettingAsBoolWithDefault(string key, bool defaultValue)
+        // 2. App/web config (web.config/app.config/appsettings.json)
+        var appName = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName);
+        if (appName != null)
         {
-            var value = _newRelicAppSettings.GetValueOrDefault(key);
-
-            var parsedSuccessfully = bool.TryParse(value, out var parsedBool);
-            if (!parsedSuccessfully)
-                return defaultValue;
-
-            return parsedBool;
+            Log.Info("Application name from web.config or app.config.");
+            _applicationNamesSource = "Application Config";
+            names = appName.Split(StringSeparators.Comma);
+            return true;
         }
 
-        private string TryGetAppSettingAsString(string key)
+        // 3. IISEXPRESS_SITENAME
+        appName = _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME");
+        if (appName != null)
         {
-            return _newRelicAppSettings.TryGetValue(key, out var valueStr) ? valueStr : null;
+            Log.Info("Application name from IISEXPRESS_SITENAME Environment Variable.");
+            _applicationNamesSource = "Environment Variable (IISEXPRESS_SITENAME)";
+            names = appName.Split(StringSeparators.Comma);
+            return true;
         }
 
-        private float? TryGetAppSettingAsFloat(string key)
+        // 4. NEW_RELIC_APP_NAME
+        appName = _environment.GetEnvironmentVariable("NEW_RELIC_APP_NAME");
+        if (appName != null)
         {
-            if (_newRelicAppSettings.TryGetValue(key, out var valueStr))
-            {
-                if (float.TryParse(valueStr, out var valueFloat))
-                {
-                    return valueFloat;
-                }
-            }
+            Log.Info("Application name from NEW_RELIC_APP_NAME Environment Variable.");
+            _applicationNamesSource = "Environment Variable (NEW_RELIC_APP_NAME)";
+            names = appName.Split(StringSeparators.Comma);
+            return true;
+        }
+
+        // 5. Azure Function site name (when detected & enabled)
+        if (AzureFunctionModeDetected && AzureFunctionModeEnabled && !string.IsNullOrEmpty(AzureFunctionAppName))
+        {
+            Log.Info("Application name from Azure Function site name.");
+            _applicationNamesSource = "Azure Function";
+            names = [AzureFunctionAppName];
+            return true;
+        }
+
+        // 6. RoleName
+        appName = _environment.GetEnvironmentVariable("RoleName");
+        if (appName != null)
+        {
+            Log.Info("Application name from RoleName Environment Variable.");
+            _applicationNamesSource = "Environment Variable (RoleName)";
+            names = appName.Split(StringSeparators.Comma);
+            return true;
+        }
+
+        // 7. Serverless (Lambda)
+        if (ServerlessModeEnabled && !string.IsNullOrEmpty(ServerlessFunctionName))
+        {
+            Log.Info("Application name from Lambda Function Name.");
+            _applicationNamesSource = "Environment Variable (AWS_LAMBDA_FUNCTION_NAME)";
+            names = [ServerlessFunctionName];
+            return true;
+        }
+
+        // 8. newrelic.config
+        if (_localConfiguration.application.name.Count > 0)
+        {
+            Log.Info("Application name from newrelic.config.");
+            _applicationNamesSource = "NewRelic Config";
+            names = _localConfiguration.application.name;
+            return true;
+        }
+
+        // 9. Application Pool
+        appName = GetAppPoolId();
+        if (!string.IsNullOrWhiteSpace(appName))
+        {
+            Log.Info("Application name from Application Pool name.");
+            _applicationNamesSource = "Application Pool";
+            names = appName.Split(StringSeparators.Comma);
+            return true;
+        }
+
+        // 10. Process name (only when AppDomain virtual path is null)
+        if (_httpRuntimeStatic.AppDomainAppVirtualPath == null)
+        {
+            Log.Info("Application name from process name.");
+            _applicationNamesSource = "Process Name";
+            names = [_processStatic.GetCurrentProcess().ProcessName];
+            return true;
+        }
+
+        // Failure path
+        names = null;
+        return false;
+    }
+
+    private string GetAppPoolId()
+    {
+        var appPoolId = _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID");
+        if (!string.IsNullOrEmpty(appPoolId))
+            return appPoolId;
+
+        var isW3wp = _processStatic.GetCurrentProcess().ProcessName?.Equals("w3wp", StringComparison.InvariantCultureIgnoreCase);
+        if (!isW3wp.HasValue || !isW3wp.Value)
             return null;
-        }
 
-        private int TryGetAppSettingAsIntWithDefault(string key, int defaultValue)
+        var commandLineArgs = _environment.GetCommandLineArgs();
+        const string appPoolCommandLineArg = "-ap";
+        for (var i = 0; i < commandLineArgs.Length - 1; ++i)
         {
-            return TryGetAppSettingAsInt(key).GetValueOrDefault(defaultValue);
-        }
-
-        private int? TryGetAppSettingAsInt(string key)
-        {
-            if (_newRelicAppSettings.TryGetValue(key, out var valueStr))
+            if (commandLineArgs[i].Equals(appPoolCommandLineArg))
             {
-                if (int.TryParse(valueStr, out var valueInt))
+                appPoolId = commandLineArgs[i + 1];
+                if (appPoolId.Length >= 3 && appPoolId[0] == '"')
                 {
-                    return valueInt;
-                }
-            }
-            return null;
-        }
-
-        public bool SecurityPoliciesTokenExists => !string.IsNullOrEmpty(SecurityPoliciesToken);
-
-        #region IConfiguration Properties
-
-        public object AgentRunId { get { return _serverConfiguration.AgentRunId; } }
-
-        private static readonly object _lockObj = new object();
-
-
-        public virtual bool AgentEnabled => _bootstrapConfiguration.AgentEnabled;
-
-        public string AgentEnabledAt => _bootstrapConfiguration.AgentEnabledAt;
-
-        public bool ServerlessModeEnabled => _bootstrapConfiguration.ServerlessModeEnabled;
-
-        public string ServerlessFunctionName => _bootstrapConfiguration.ServerlessFunctionName;
-
-        public string ServerlessFunctionVersion => _bootstrapConfiguration.ServerlessFunctionVersion;
-
-        private string _agentLicenseKey;
-        public virtual string AgentLicenseKey
-        {
-            get
-            {
-                _agentLicenseKey ??= TryGetLicenseKey();
-                return _agentLicenseKey;
-            }
-        }
-
-        private string TryGetLicenseKey()
-        {
-            // same order as old process - appsettings > env var(a/b) > newrelic.config
-            var candidateKeys = new Dictionary<string, string>
-            {
-                { "AppSettings", _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLicenseKey) },
-                { "EnvironmentVariable", _environment.GetEnvironmentVariableFromList("NEW_RELIC_LICENSE_KEY", "NEWRELIC_LICENSEKEY") },
-                { "newrelic.config", _localConfiguration.service.licenseKey }
-            };
-
-            foreach (var candidateKey in candidateKeys)
-            {
-                // Did we find a key?
-                if (string.IsNullOrWhiteSpace(candidateKey.Value))
-                {
-                    continue;
+                    appPoolId = appPoolId.Substring(1, appPoolId.Length - 2);
                 }
 
-                // We found something, but is it a valid key?
-
-                // If the key is the default value from newrelic.config, we return the default value
-                // AgentManager.AssertAgentEnabled() relies on this behavior and will throw an exception if the key is the default value
-                if (candidateKey.Value.ToLower().Contains("license"))
-                {
-                    // newrelic.config is the last place to look
-                    return candidateKey.Value;
-                }
-
-                // Keys are only 40 characters long, but we trim to be safe
-                var trimmedCandidateKey = candidateKey.Value.Trim();
-                if (trimmedCandidateKey.Length != 40)
-                {
-                    Log.Warn($"License key from {candidateKey.Key} is not 40 characters long. Checking for other license keys.");
-                    continue;
-                }
-
-                // Keys can only contain printable ASCII characters from 0x21 to 0x7E
-                if (!trimmedCandidateKey.All(c => c >= 0x21 && c <= 0x7E))
-                {
-                    Log.Warn($"License key from {candidateKey.Key} contains invalid characters. Checking for other license keys.");
-                    continue;
-                }
-
-                Log.Info($"License key from {candidateKey.Key} appears to be in the correct format.");
-                return trimmedCandidateKey;
+                Log.Info($"Found application pool name from command line: {appPoolId}");
+                return appPoolId;
             }
-
-            // return string.Empty instead of null to allow caching and prevent checking repeatedly
-            Log.Warn("No valid license key found.");
-            return string.Empty;
         }
 
-        private IEnumerable<string> _applicationNames;
-        public virtual IEnumerable<string> ApplicationNames => _applicationNames ??= GetApplicationNames();
+        return appPoolId;
+    }
 
-        private string _applicationNamesSource;
-        public virtual string ApplicationNamesSource => _applicationNamesSource;
+    public bool AutoStartAgent { get { return _localConfiguration.service.autoStart; } }
 
-        private IEnumerable<string> GetApplicationNames()
+    public int WrapperExceptionLimit { get { return TryGetAppSettingAsIntWithDefault("WrapperExceptionLimit", 5); } }
+
+    #region Browser Monitoring
+
+    public virtual string BrowserMonitoringApplicationId { get { return _serverConfiguration.RumSettingsApplicationId ?? string.Empty; } }
+    public virtual bool BrowserMonitoringAutoInstrument => EnvironmentOverrides(_localConfiguration.browserMonitoring.autoInstrument, "NEW_RELIC_BROWSER_MONITORING_AUTO_INSTRUMENT");
+    public virtual string BrowserMonitoringBeaconAddress { get { return _serverConfiguration.RumSettingsBeacon ?? string.Empty; } }
+    public virtual string BrowserMonitoringErrorBeaconAddress { get { return _serverConfiguration.RumSettingsErrorBeacon ?? string.Empty; } }
+    public virtual string BrowserMonitoringJavaScriptAgent { get { return _serverConfiguration.RumSettingsJavaScriptAgentLoader ?? string.Empty; } }
+    public virtual string BrowserMonitoringJavaScriptAgentFile { get { return _serverConfiguration.RumSettingsJavaScriptAgentFile ?? string.Empty; } }
+    public virtual string BrowserMonitoringJavaScriptAgentLoaderType { get { return ServerOverrides(_serverConfiguration.RumSettingsBrowserMonitoringLoader, _localConfiguration.browserMonitoring.loader); } }
+    public virtual string BrowserMonitoringKey { get { return _serverConfiguration.RumSettingsBrowserKey ?? string.Empty; } }
+    public virtual bool BrowserMonitoringUseSsl { get { return HighSecurityModeOverrides(true, _localConfiguration.browserMonitoring.sslForHttp); } }
+
+    #endregion
+
+    private string _securityPoliciesToken;
+
+    public virtual string SecurityPoliciesToken =>
+        _securityPoliciesToken ??=
+            EnvironmentOverrides(_localConfiguration.securityPoliciesToken ?? string.Empty, "NEW_RELIC_SECURITY_POLICIES_TOKEN")
+                .Trim();
+
+    private string _processHostDisplayName;
+
+    public string ProcessHostDisplayName
+    {
+        get
         {
-            // Wrapper that throws if no application names could be resolved.
-            if (TryGetApplicationNames(out var names))
+            if (_processHostDisplayName != null)
             {
-                return names;
+                return _processHostDisplayName;
             }
 
-            throw new Exception("An application name must be provided");
+            _processHostDisplayName = string.IsNullOrWhiteSpace(_localConfiguration.processHost.displayName)
+                ? _dnsStatic.GetHostName() : _localConfiguration.processHost.displayName;
+
+            _processHostDisplayName = EnvironmentOverrides(_processHostDisplayName, "NEW_RELIC_PROCESS_HOST_DISPLAY_NAME").Trim();
+
+            return _processHostDisplayName;
+        }
+    }
+
+    private bool? _ignoreServerSideConfiguration;
+
+    public bool IgnoreServerSideConfiguration
+    {
+        get
+        {
+            _ignoreServerSideConfiguration ??= EnvironmentOverrides(false, "NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG");
+
+            return _ignoreServerSideConfiguration.Value;
+        }
+    }
+
+    public bool AllowAllRequestHeaders
+    {
+        get
+        {
+            return HighSecurityModeOverrides(false,
+                EnvironmentOverrides(_localConfiguration.allowAllHeaders.enabled,
+                    "NEW_RELIC_ALLOW_ALL_HEADERS"));
+        }
+    }
+
+    #region Attributes
+
+    public virtual bool CaptureAttributes
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.attributes.enabled,
+                "NEW_RELIC_ATTRIBUTES_ENABLED");
+        }
+    }
+
+    private BoolConfigurationItem _canUseAttributesIncludes;
+
+    public string CanUseAttributesIncludesSource
+    {
+        get
+        {
+            _canUseAttributesIncludes ??= GetCanUseAttributesIncludesConfiguration();
+
+            return _canUseAttributesIncludes.Source;
+        }
+    }
+
+    public virtual bool CanUseAttributesIncludes
+    {
+        get
+        {
+            _canUseAttributesIncludes ??= GetCanUseAttributesIncludesConfiguration();
+
+            return _canUseAttributesIncludes.Value;
+        }
+    }
+
+    private BoolConfigurationItem GetCanUseAttributesIncludesConfiguration()
+    {
+        if (HighSecurityModeEnabled)
+        {
+            return new BoolConfigurationItem(false, HighSecurityConfigSource);
         }
 
-        /// <summary>
-        /// Attempts to resolve the application names following the same ordered precedence
-        /// as the legacy <see cref="GetApplicationNames"/> implementation without throwing.
-        /// </summary>
-        /// <param name="names">Resolved application names when successful; null otherwise.</param>
-        /// <returns>True if application names were found; false if none could be resolved.</returns>
-        /// <remarks>
-        /// Side effects:
-        /// - Sets <see cref="_applicationNamesSource"/> to the source of the resolved names.
-        /// - Sets <see cref="_applicationNamesMissing"/> to true only when resolution fails.
-        /// Logging behavior is preserved exactly from the original implementation.
-        /// </remarks>
-        public bool TryGetApplicationNames(out IEnumerable<string> names)  // CHANGED: was private
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName)
+            && (_securityPoliciesConfiguration.AttributesInclude.Enabled == false))
         {
-            // 1. Agent API
-            var runtimeAppNames = _runTimeConfiguration.ApplicationNames.ToList();
-            if (runtimeAppNames.Any())
+            return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
+        }
+
+        return new BoolConfigurationItem(CaptureAttributes, LocalConfigSource);
+    }
+
+    private IEnumerable<string> _captureAttributesIncludes;
+
+    public virtual IEnumerable<string> CaptureAttributesIncludes =>
+        CanUseAttributesIncludes
+            ? _captureAttributesIncludes ??=
+                [.. EnvironmentOverrides(_localConfiguration.attributes.include, "NEW_RELIC_ATTRIBUTES_INCLUDE")]
+            : _captureAttributesIncludes ??= [];
+
+    private IEnumerable<string> _captureAttributesExcludes;
+    public virtual IEnumerable<string> CaptureAttributesExcludes => _captureAttributesExcludes ??= [.. EnvironmentOverrides(_localConfiguration.attributes.exclude, "NEW_RELIC_ATTRIBUTES_EXCLUDE")];
+
+    private IEnumerable<string> _captureAttributesDefaultExcludes;
+    public virtual IEnumerable<string> CaptureAttributesDefaultExcludes => _captureAttributesDefaultExcludes ??= ["identity.*"];
+
+    private bool IsAttributesAllowedByConfigurableSecurityPolicy
+    {
+        get
+        {
+            if (HighSecurityModeEnabled) return false;
+
+            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
             {
-                Log.Info("Application name from SetApplicationName API.");
-                _applicationNamesSource = "API";
-                names = runtimeAppNames;
-                return true;
+                return _securityPoliciesConfiguration.AttributesInclude.Enabled;
             }
 
-            // 2. App/web config (web.config/app.config/appsettings.json)
-            var appName = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsAppName);
-            if (appName != null)
-            {
-                Log.Info("Application name from web.config or app.config.");
-                _applicationNamesSource = "Application Config";
-                names = appName.Split(StringSeparators.Comma);
-                return true;
-            }
+            return true;
+        }
+    }
 
-            // 3. IISEXPRESS_SITENAME
-            appName = _environment.GetEnvironmentVariable("IISEXPRESS_SITENAME");
-            if (appName != null)
-            {
-                Log.Info("Application name from IISEXPRESS_SITENAME Environment Variable.");
-                _applicationNamesSource = "Environment Variable (IISEXPRESS_SITENAME)";
-                names = appName.Split(StringSeparators.Comma);
-                return true;
-            }
+    public virtual bool TransactionEventsAttributesEnabled => CaptureAttributes && _localConfiguration.transactionEvents.attributes.enabled;
 
-            // 4. NEW_RELIC_APP_NAME
-            appName = _environment.GetEnvironmentVariable("NEW_RELIC_APP_NAME");
-            if (appName != null)
-            {
-                Log.Info("Application name from NEW_RELIC_APP_NAME Environment Variable.");
-                _applicationNamesSource = "Environment Variable (NEW_RELIC_APP_NAME)";
-                names = appName.Split(StringSeparators.Comma);
-                return true;
-            }
+    private HashSet<string> _transactionEventsAttributesInclude;
+    public HashSet<string> TransactionEventsAttributesInclude =>
+        _transactionEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && TransactionEventsAttributesEnabled
+            ? [.. _localConfiguration.transactionEvents.attributes.include]
+            : [];
 
-            // 5. Azure Function site name (when detected & enabled)
-            if (AzureFunctionModeDetected && AzureFunctionModeEnabled && !string.IsNullOrEmpty(AzureFunctionAppName))
-            {
-                Log.Info("Application name from Azure Function site name.");
-                _applicationNamesSource = "Azure Function";
-                names = [AzureFunctionAppName];
-                return true;
-            }
+    private HashSet<string> _transactionEventsAttributesExclude;
+    public HashSet<string> TransactionEventsAttributesExclude =>
+        _transactionEventsAttributesExclude ??= [.. _localConfiguration.transactionEvents.attributes.exclude];
 
-            // 6. RoleName
-            appName = _environment.GetEnvironmentVariable("RoleName");
-            if (appName != null)
-            {
-                Log.Info("Application name from RoleName Environment Variable.");
-                _applicationNamesSource = "Environment Variable (RoleName)";
-                names = appName.Split(StringSeparators.Comma);
-                return true;
-            }
+    public virtual bool CaptureTransactionTraceAttributes => ShouldCaptureTransactionTraceAttributes();
 
-            // 7. Serverless (Lambda)
-            if (ServerlessModeEnabled && !string.IsNullOrEmpty(ServerlessFunctionName))
-            {
-                Log.Info("Application name from Lambda Function Name.");
-                _applicationNamesSource = "Environment Variable (AWS_LAMBDA_FUNCTION_NAME)";
-                names = [ServerlessFunctionName];
-                return true;
-            }
-
-            // 8. newrelic.config
-            if (_localConfiguration.application.name.Count > 0)
-            {
-                Log.Info("Application name from newrelic.config.");
-                _applicationNamesSource = "NewRelic Config";
-                names = _localConfiguration.application.name;
-                return true;
-            }
-
-            // 9. Application Pool
-            appName = GetAppPoolId();
-            if (!string.IsNullOrWhiteSpace(appName))
-            {
-                Log.Info("Application name from Application Pool name.");
-                _applicationNamesSource = "Application Pool";
-                names = appName.Split(StringSeparators.Comma);
-                return true;
-            }
-
-            // 10. Process name (only when AppDomain virtual path is null)
-            if (_httpRuntimeStatic.AppDomainAppVirtualPath == null)
-            {
-                Log.Info("Application name from process name.");
-                _applicationNamesSource = "Process Name";
-                names = [_processStatic.GetCurrentProcess().ProcessName];
-                return true;
-            }
-
-            // Failure path
-            names = null;
+    private bool ShouldCaptureTransactionTraceAttributes()
+    {
+        if (_localConfiguration.attributes.enabled == false)
+        {
             return false;
         }
 
-        private string GetAppPoolId()
+        if (_localConfiguration.transactionTracer.attributes.enabledSpecified)
         {
-            var appPoolId = _environment.GetEnvironmentVariableFromList("APP_POOL_ID", "ASPNETCORE_IIS_APP_POOL_ID");
-            if (!string.IsNullOrEmpty(appPoolId))
-                return appPoolId;
-
-            var isW3wp = _processStatic.GetCurrentProcess().ProcessName?.Equals("w3wp", StringComparison.InvariantCultureIgnoreCase);
-            if (!isW3wp.HasValue || !isW3wp.Value)
-                return null;
-
-            var commandLineArgs = _environment.GetCommandLineArgs();
-            const string appPoolCommandLineArg = "-ap";
-            for (var i = 0; i < commandLineArgs.Length - 1; ++i)
-            {
-                if (commandLineArgs[i].Equals(appPoolCommandLineArg))
-                {
-                    appPoolId = commandLineArgs[i + 1];
-                    if (appPoolId.Length >= 3 && appPoolId[0] == '"')
-                    {
-                        appPoolId = appPoolId.Substring(1, appPoolId.Length - 2);
-                    }
-
-                    Log.Info($"Found application pool name from command line: {appPoolId}");
-                    return appPoolId;
-                }
-            }
-
-            return appPoolId;
+            return _localConfiguration.transactionTracer.attributes.enabled;
         }
 
-        public bool AutoStartAgent { get { return _localConfiguration.service.autoStart; } }
+        return CaptureTransactionTraceAttributesDefault;
+    }
 
-        public int WrapperExceptionLimit { get { return TryGetAppSettingAsIntWithDefault("WrapperExceptionLimit", 5); } }
+    private IEnumerable<string> _captureTransactionTraceAttributesIncludes;
 
-        #region Browser Monitoring
+    public virtual IEnumerable<string> CaptureTransactionTraceAttributesIncludes =>
+        ShouldCaptureTransactionTraceAttributesIncludes()
+            ? _captureTransactionTraceAttributesIncludes ??= [.. _localConfiguration.transactionTracer.attributes.include]
+            : _captureTransactionTraceAttributesIncludes ??= [];
 
-        public virtual string BrowserMonitoringApplicationId { get { return _serverConfiguration.RumSettingsApplicationId ?? string.Empty; } }
-        public virtual bool BrowserMonitoringAutoInstrument => EnvironmentOverrides(_localConfiguration.browserMonitoring.autoInstrument, "NEW_RELIC_BROWSER_MONITORING_AUTO_INSTRUMENT");
-        public virtual string BrowserMonitoringBeaconAddress { get { return _serverConfiguration.RumSettingsBeacon ?? string.Empty; } }
-        public virtual string BrowserMonitoringErrorBeaconAddress { get { return _serverConfiguration.RumSettingsErrorBeacon ?? string.Empty; } }
-        public virtual string BrowserMonitoringJavaScriptAgent { get { return _serverConfiguration.RumSettingsJavaScriptAgentLoader ?? string.Empty; } }
-        public virtual string BrowserMonitoringJavaScriptAgentFile { get { return _serverConfiguration.RumSettingsJavaScriptAgentFile ?? string.Empty; } }
-        public virtual string BrowserMonitoringJavaScriptAgentLoaderType { get { return ServerOverrides(_serverConfiguration.RumSettingsBrowserMonitoringLoader, _localConfiguration.browserMonitoring.loader); } }
-        public virtual string BrowserMonitoringKey { get { return _serverConfiguration.RumSettingsBrowserKey ?? string.Empty; } }
-        public virtual bool BrowserMonitoringUseSsl { get { return HighSecurityModeOverrides(true, _localConfiguration.browserMonitoring.sslForHttp); } }
-
-        #endregion
-
-        private string _securityPoliciesToken;
-
-        public virtual string SecurityPoliciesToken =>
-            _securityPoliciesToken ??=
-                EnvironmentOverrides(_localConfiguration.securityPoliciesToken ?? string.Empty, "NEW_RELIC_SECURITY_POLICIES_TOKEN")
-                    .Trim();
-
-        private string _processHostDisplayName;
-
-        public string ProcessHostDisplayName
+    private bool? _shouldCaptureTransactionTraceAttributesIncludes;
+    private bool ShouldCaptureTransactionTraceAttributesIncludes()
+    {
+        if (_shouldCaptureTransactionTraceAttributesIncludes.HasValue)
         {
-            get
-            {
-                if (_processHostDisplayName != null)
-                {
-                    return _processHostDisplayName;
-                }
-
-                _processHostDisplayName = string.IsNullOrWhiteSpace(_localConfiguration.processHost.displayName)
-                    ? _dnsStatic.GetHostName() : _localConfiguration.processHost.displayName;
-
-                _processHostDisplayName = EnvironmentOverrides(_processHostDisplayName, "NEW_RELIC_PROCESS_HOST_DISPLAY_NAME").Trim();
-
-                return _processHostDisplayName;
-            }
-        }
-
-        private bool? _ignoreServerSideConfiguration;
-
-        public bool IgnoreServerSideConfiguration
-        {
-            get
-            {
-                _ignoreServerSideConfiguration ??= EnvironmentOverrides(false, "NEW_RELIC_IGNORE_SERVER_SIDE_CONFIG");
-
-                return _ignoreServerSideConfiguration.Value;
-            }
-        }
-
-        public bool AllowAllRequestHeaders
-        {
-            get
-            {
-                return HighSecurityModeOverrides(false,
-                    EnvironmentOverrides(_localConfiguration.allowAllHeaders.enabled,
-                    "NEW_RELIC_ALLOW_ALL_HEADERS"));
-            }
-        }
-
-        #region Attributes
-
-        public virtual bool CaptureAttributes
-        {
-            get
-            {
-                return EnvironmentOverrides(_localConfiguration.attributes.enabled,
-                    "NEW_RELIC_ATTRIBUTES_ENABLED");
-            }
-        }
-
-        private BoolConfigurationItem _canUseAttributesIncludes;
-
-        public string CanUseAttributesIncludesSource
-        {
-            get
-            {
-                _canUseAttributesIncludes ??= GetCanUseAttributesIncludesConfiguration();
-
-                return _canUseAttributesIncludes.Source;
-            }
-        }
-
-        public virtual bool CanUseAttributesIncludes
-        {
-            get
-            {
-                _canUseAttributesIncludes ??= GetCanUseAttributesIncludesConfiguration();
-
-                return _canUseAttributesIncludes.Value;
-            }
-        }
-
-        private BoolConfigurationItem GetCanUseAttributesIncludesConfiguration()
-        {
-            if (HighSecurityModeEnabled)
-            {
-                return new BoolConfigurationItem(false, HighSecurityConfigSource);
-            }
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName)
-                && (_securityPoliciesConfiguration.AttributesInclude.Enabled == false))
-            {
-                return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
-            }
-
-            return new BoolConfigurationItem(CaptureAttributes, LocalConfigSource);
-        }
-
-        private IEnumerable<string> _captureAttributesIncludes;
-
-        public virtual IEnumerable<string> CaptureAttributesIncludes =>
-            CanUseAttributesIncludes
-                ? _captureAttributesIncludes ??=
-                    [.. EnvironmentOverrides(_localConfiguration.attributes.include, "NEW_RELIC_ATTRIBUTES_INCLUDE")]
-                : _captureAttributesIncludes ??= [];
-
-        private IEnumerable<string> _captureAttributesExcludes;
-        public virtual IEnumerable<string> CaptureAttributesExcludes => _captureAttributesExcludes ??= [.. EnvironmentOverrides(_localConfiguration.attributes.exclude, "NEW_RELIC_ATTRIBUTES_EXCLUDE")];
-
-        private IEnumerable<string> _captureAttributesDefaultExcludes;
-        public virtual IEnumerable<string> CaptureAttributesDefaultExcludes => _captureAttributesDefaultExcludes ??= ["identity.*"];
-
-        private bool IsAttributesAllowedByConfigurableSecurityPolicy
-        {
-            get
-            {
-                if (HighSecurityModeEnabled) return false;
-
-                if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
-                {
-                    return _securityPoliciesConfiguration.AttributesInclude.Enabled;
-                }
-
-                return true;
-            }
-        }
-
-        public virtual bool TransactionEventsAttributesEnabled => CaptureAttributes && _localConfiguration.transactionEvents.attributes.enabled;
-
-        private HashSet<string> _transactionEventsAttributesInclude;
-        public HashSet<string> TransactionEventsAttributesInclude =>
-            _transactionEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && TransactionEventsAttributesEnabled
-                ? [.. _localConfiguration.transactionEvents.attributes.include]
-                : [];
-
-        private HashSet<string> _transactionEventsAttributesExclude;
-        public HashSet<string> TransactionEventsAttributesExclude =>
-            _transactionEventsAttributesExclude ??= [.. _localConfiguration.transactionEvents.attributes.exclude];
-
-        public virtual bool CaptureTransactionTraceAttributes => ShouldCaptureTransactionTraceAttributes();
-
-        private bool ShouldCaptureTransactionTraceAttributes()
-        {
-            if (_localConfiguration.attributes.enabled == false)
-            {
-                return false;
-            }
-
-            if (_localConfiguration.transactionTracer.attributes.enabledSpecified)
-            {
-                return _localConfiguration.transactionTracer.attributes.enabled;
-            }
-
-            return CaptureTransactionTraceAttributesDefault;
-        }
-
-        private IEnumerable<string> _captureTransactionTraceAttributesIncludes;
-
-        public virtual IEnumerable<string> CaptureTransactionTraceAttributesIncludes =>
-            ShouldCaptureTransactionTraceAttributesIncludes()
-                ? _captureTransactionTraceAttributesIncludes ??= [.. _localConfiguration.transactionTracer.attributes.include]
-                : _captureTransactionTraceAttributesIncludes ??= [];
-
-        private bool? _shouldCaptureTransactionTraceAttributesIncludes;
-        private bool ShouldCaptureTransactionTraceAttributesIncludes()
-        {
-            if (_shouldCaptureTransactionTraceAttributesIncludes.HasValue)
-            {
-                return _shouldCaptureTransactionTraceAttributesIncludes.Value;
-            }
-
-            var shouldCapture = !HighSecurityModeEnabled && CaptureTransactionTraceAttributes;
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
-            {
-                shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
-            }
-
-            _shouldCaptureTransactionTraceAttributesIncludes = shouldCapture;
-
             return _shouldCaptureTransactionTraceAttributesIncludes.Value;
         }
 
-        private IEnumerable<string> _captureTransactionTraceAttributesExcludes;
-        public virtual IEnumerable<string> CaptureTransactionTraceAttributesExcludes =>
-            _captureTransactionTraceAttributesExcludes ??= [.. _localConfiguration.transactionTracer.attributes.exclude];
+        var shouldCapture = !HighSecurityModeEnabled && CaptureTransactionTraceAttributes;
 
-
-        public virtual bool CaptureErrorCollectorAttributes => ShouldCaptureErrorCollectorAttributes();
-
-        private bool ShouldCaptureErrorCollectorAttributes()
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
         {
-            if (_localConfiguration.attributes.enabled == false)
-            {
-                return false;
-            }
-
-            if (_localConfiguration.errorCollector.attributes.enabledSpecified)
-            {
-                return _localConfiguration.errorCollector.attributes.enabled;
-            }
-
-            return CaptureErrorCollectorAttributesDefault;
+            shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
         }
 
+        _shouldCaptureTransactionTraceAttributesIncludes = shouldCapture;
 
-        private IEnumerable<string> _captureErrorCollectorAttributesIncludes;
-        public virtual IEnumerable<string> CaptureErrorCollectorAttributesIncludes =>
-            ShouldCaptureErrorCollectorAttributesIncludes()
-                ? _captureErrorCollectorAttributesIncludes ??= [.. _localConfiguration.errorCollector.attributes.include]
-                : _captureErrorCollectorAttributesExcludes ??= [];
+        return _shouldCaptureTransactionTraceAttributesIncludes.Value;
+    }
 
-        private bool? _shouldCaptureErrorCollectorAttributesIncludes;
-        private bool ShouldCaptureErrorCollectorAttributesIncludes()
+    private IEnumerable<string> _captureTransactionTraceAttributesExcludes;
+    public virtual IEnumerable<string> CaptureTransactionTraceAttributesExcludes =>
+        _captureTransactionTraceAttributesExcludes ??= [.. _localConfiguration.transactionTracer.attributes.exclude];
+
+
+    public virtual bool CaptureErrorCollectorAttributes => ShouldCaptureErrorCollectorAttributes();
+
+    private bool ShouldCaptureErrorCollectorAttributes()
+    {
+        if (_localConfiguration.attributes.enabled == false)
         {
-            if (_shouldCaptureErrorCollectorAttributesIncludes.HasValue)
-                return _shouldCaptureErrorCollectorAttributesIncludes.Value;
+            return false;
+        }
 
-            var shouldCapture = !HighSecurityModeEnabled && CaptureErrorCollectorAttributes;
+        if (_localConfiguration.errorCollector.attributes.enabledSpecified)
+        {
+            return _localConfiguration.errorCollector.attributes.enabled;
+        }
 
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
-            {
-                shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
-            }
+        return CaptureErrorCollectorAttributesDefault;
+    }
 
-            _shouldCaptureErrorCollectorAttributesIncludes = shouldCapture;
+
+    private IEnumerable<string> _captureErrorCollectorAttributesIncludes;
+    public virtual IEnumerable<string> CaptureErrorCollectorAttributesIncludes =>
+        ShouldCaptureErrorCollectorAttributesIncludes()
+            ? _captureErrorCollectorAttributesIncludes ??= [.. _localConfiguration.errorCollector.attributes.include]
+            : _captureErrorCollectorAttributesExcludes ??= [];
+
+    private bool? _shouldCaptureErrorCollectorAttributesIncludes;
+    private bool ShouldCaptureErrorCollectorAttributesIncludes()
+    {
+        if (_shouldCaptureErrorCollectorAttributesIncludes.HasValue)
             return _shouldCaptureErrorCollectorAttributesIncludes.Value;
+
+        var shouldCapture = !HighSecurityModeEnabled && CaptureErrorCollectorAttributes;
+
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
+        {
+            shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
         }
 
-        private IEnumerable<string> _captureErrorCollectorAttributesExcludes;
-        public virtual IEnumerable<string> CaptureErrorCollectorAttributesExcludes => _captureErrorCollectorAttributesExcludes ??= [.. _localConfiguration.errorCollector.attributes.exclude];
+        _shouldCaptureErrorCollectorAttributesIncludes = shouldCapture;
+        return _shouldCaptureErrorCollectorAttributesIncludes.Value;
+    }
 
-        public virtual bool CaptureBrowserMonitoringAttributes => ShouldCaptureBrowserMonitorAttributes();
+    private IEnumerable<string> _captureErrorCollectorAttributesExcludes;
+    public virtual IEnumerable<string> CaptureErrorCollectorAttributesExcludes => _captureErrorCollectorAttributesExcludes ??= [.. _localConfiguration.errorCollector.attributes.exclude];
 
-        private bool ShouldCaptureBrowserMonitorAttributes()
+    public virtual bool CaptureBrowserMonitoringAttributes => ShouldCaptureBrowserMonitorAttributes();
+
+    private bool ShouldCaptureBrowserMonitorAttributes()
+    {
+        if (_localConfiguration.attributes.enabled == false)
         {
-            if (_localConfiguration.attributes.enabled == false)
-            {
-                return false;
-            }
-
-            if (_localConfiguration.browserMonitoring.attributes.enabledSpecified)
-            {
-                return _localConfiguration.browserMonitoring.attributes.enabled;
-            }
-
-            return CaptureBrowserMonitoringAttributesDefault;
+            return false;
         }
 
-        private IEnumerable<string> _captureBrowserMonitoringAttributesIncludes;
-        public virtual IEnumerable<string> CaptureBrowserMonitoringAttributesIncludes =>
-            ShouldCaptureBrowserMonitoringAttributesIncludes()
-                ? _captureBrowserMonitoringAttributesIncludes ??= [.. _localConfiguration.browserMonitoring.attributes.include]
-                : _captureBrowserMonitoringAttributesIncludes ??= [];
-
-        private bool? _shouldCaptureBrowserMonitoringAttributesIncludes;
-        private bool ShouldCaptureBrowserMonitoringAttributesIncludes()
+        if (_localConfiguration.browserMonitoring.attributes.enabledSpecified)
         {
-            if (_shouldCaptureBrowserMonitoringAttributesIncludes.HasValue)
-                return _shouldCaptureBrowserMonitoringAttributesIncludes.Value;
+            return _localConfiguration.browserMonitoring.attributes.enabled;
+        }
 
-            var shouldCapture = !HighSecurityModeEnabled && CaptureBrowserMonitoringAttributes;
+        return CaptureBrowserMonitoringAttributesDefault;
+    }
 
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
-            {
-                shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
-            }
+    private IEnumerable<string> _captureBrowserMonitoringAttributesIncludes;
+    public virtual IEnumerable<string> CaptureBrowserMonitoringAttributesIncludes =>
+        ShouldCaptureBrowserMonitoringAttributesIncludes()
+            ? _captureBrowserMonitoringAttributesIncludes ??= [.. _localConfiguration.browserMonitoring.attributes.include]
+            : _captureBrowserMonitoringAttributesIncludes ??= [];
 
-            _shouldCaptureBrowserMonitoringAttributesIncludes = shouldCapture;
+    private bool? _shouldCaptureBrowserMonitoringAttributesIncludes;
+    private bool ShouldCaptureBrowserMonitoringAttributesIncludes()
+    {
+        if (_shouldCaptureBrowserMonitoringAttributesIncludes.HasValue)
             return _shouldCaptureBrowserMonitoringAttributesIncludes.Value;
+
+        var shouldCapture = !HighSecurityModeEnabled && CaptureBrowserMonitoringAttributes;
+
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AttributesIncludePolicyName))
+        {
+            shouldCapture = shouldCapture && _securityPoliciesConfiguration.AttributesInclude.Enabled;
         }
 
-        private IEnumerable<string> _captureBrowserMonitoringAttributesExcludes;
-        public virtual IEnumerable<string> CaptureBrowserMonitoringAttributesExcludes => _captureBrowserMonitoringAttributesExcludes ??= [.. _localConfiguration.browserMonitoring.attributes.exclude];
+        _shouldCaptureBrowserMonitoringAttributesIncludes = shouldCapture;
+        return _shouldCaptureBrowserMonitoringAttributesIncludes.Value;
+    }
+
+    private IEnumerable<string> _captureBrowserMonitoringAttributesExcludes;
+    public virtual IEnumerable<string> CaptureBrowserMonitoringAttributesExcludes => _captureBrowserMonitoringAttributesExcludes ??= [.. _localConfiguration.browserMonitoring.attributes.exclude];
 
 
-        private BoolConfigurationItem _shouldCaptureCustomParameters;
+    private BoolConfigurationItem _shouldCaptureCustomParameters;
 
-        public string CaptureCustomParametersSource
+    public string CaptureCustomParametersSource
+    {
+        get
         {
-            get
-            {
-                _shouldCaptureCustomParameters ??= GetShouldCaptureCustomParametersConfiguration();
+            _shouldCaptureCustomParameters ??= GetShouldCaptureCustomParametersConfiguration();
 
-                return _shouldCaptureCustomParameters.Source;
-            }
+            return _shouldCaptureCustomParameters.Source;
+        }
+    }
+
+    public virtual bool CaptureCustomParameters
+    {
+        get
+        {
+            _shouldCaptureCustomParameters ??= GetShouldCaptureCustomParametersConfiguration();
+
+            return _shouldCaptureCustomParameters.Value;
+        }
+    }
+
+    private BoolConfigurationItem GetShouldCaptureCustomParametersConfiguration()
+    {
+        if (HighSecurityModeEnabled)
+        {
+            return new BoolConfigurationItem(false, HighSecurityConfigSource);
         }
 
-        public virtual bool CaptureCustomParameters
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomParametersPolicyName)
+            && (_securityPoliciesConfiguration.CustomParameters.Enabled == false))
         {
-            get
-            {
-                _shouldCaptureCustomParameters ??= GetShouldCaptureCustomParametersConfiguration();
-
-                return _shouldCaptureCustomParameters.Value;
-            }
+            return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
         }
 
-        private BoolConfigurationItem GetShouldCaptureCustomParametersConfiguration()
+        var localConfigValue = GetLocalShouldCaptureCustomParameters();
+
+        return new BoolConfigurationItem(localConfigValue, LocalConfigSource);
+    }
+
+    private bool GetLocalShouldCaptureCustomParameters()
+    {
+        return _localConfiguration.customParameters.enabledSpecified ? _localConfiguration.customParameters.enabled : CaptureCustomParametersAttributesDefault;
+    }
+
+    #endregion
+
+    #region Collector Connection
+
+    public virtual string CollectorHost { get { return EnvironmentOverrides(_localConfiguration.service.host, @"NEW_RELIC_HOST"); } }
+    public virtual int CollectorPort => EnvironmentOverrides(_localConfiguration.service.port > 0 ? _localConfiguration.service.port : (int?)null, "NEW_RELIC_PORT") ?? DefaultSslPort;
+    public virtual bool CollectorSendDataOnExit { get { return EnvironmentOverrides(_localConfiguration.service.sendDataOnExit, "NEW_RELIC_SEND_DATA_ON_EXIT"); } }
+    public virtual float CollectorSendDataOnExitThreshold { get { return EnvironmentOverrides((uint?)null, "NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS") ?? _localConfiguration.service.sendDataOnExitThreshold; } }
+    public virtual bool CollectorSendEnvironmentInfo { get { return _localConfiguration.service.sendEnvironmentInfo; } }
+    public virtual bool CollectorSyncStartup { get { return _localConfiguration.service.syncStartup; } }
+    public virtual uint CollectorTimeout { get { return (_localConfiguration.service.requestTimeout > 0) ? (uint)_localConfiguration.service.requestTimeout : CollectorSendDataOnExit ? 2000u : 60 * 2 * 1000; } }
+    public virtual int CollectorMaxPayloadSizeInBytes { get { return _serverConfiguration.MaxPayloadSizeInBytes ?? MaxPayloadSizeInBytes; } }
+    #endregion
+
+    public virtual bool CompleteTransactionsOnThread { get { return _localConfiguration.service.completeTransactionsOnThread || ServerlessModeEnabled; } }
+
+    public long ConfigurationVersion { get; private set; }
+
+    #region Cross Application Tracing
+
+    public virtual string CrossApplicationTracingCrossProcessId { get { return _serverConfiguration.CatId; } }
+
+    private bool? _crossApplicationTracingEnabled;
+    public virtual bool CrossApplicationTracingEnabled => _crossApplicationTracingEnabled ?? (_crossApplicationTracingEnabled = IsCatEnabled()).Value;
+
+    private bool IsCatEnabled()
+    {
+        // CAT must be disabled in serverless mode
+        if (ServerlessModeEnabled)
+            return false;
+
+        var localenabled = _localConfiguration.crossApplicationTracingEnabled;
+        //If config.crossApplicationTracingEnabled is true or default then we want to check the
+        //config.crossApplicationTracer, if that object is not null then use it's default or value
+        if (localenabled && _localConfiguration.crossApplicationTracer != null)
         {
-            if (HighSecurityModeEnabled)
-            {
-                return new BoolConfigurationItem(false, HighSecurityConfigSource);
-            }
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomParametersPolicyName)
-                && (_securityPoliciesConfiguration.CustomParameters.Enabled == false))
-            {
-                return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
-            }
-
-            var localConfigValue = GetLocalShouldCaptureCustomParameters();
-
-            return new BoolConfigurationItem(localConfigValue, LocalConfigSource);
+            localenabled = _localConfiguration.crossApplicationTracer.enabled;
         }
 
-        private bool GetLocalShouldCaptureCustomParameters()
+        var enabled = ServerCanDisable(_serverConfiguration.RpmConfig.CrossApplicationTracerEnabled, localenabled);
+
+        if (enabled && CrossApplicationTracingCrossProcessId == null)
         {
-            return _localConfiguration.customParameters.enabledSpecified ? _localConfiguration.customParameters.enabled : CaptureCustomParametersAttributesDefault;
+            Log.Warn("CAT is enabled but CrossProcessID is null. Disabling CAT.");
+            enabled = false;
         }
 
-        #endregion
+        return enabled;
+    }
 
-        #region Collector Connection
+    #endregion Cross Application Tracing
 
-        public virtual string CollectorHost { get { return EnvironmentOverrides(_localConfiguration.service.host, @"NEW_RELIC_HOST"); } }
-        public virtual int CollectorPort => EnvironmentOverrides(_localConfiguration.service.port > 0 ? _localConfiguration.service.port : (int?)null, "NEW_RELIC_PORT") ?? DefaultSslPort;
-        public virtual bool CollectorSendDataOnExit { get { return EnvironmentOverrides(_localConfiguration.service.sendDataOnExit, "NEW_RELIC_SEND_DATA_ON_EXIT"); } }
-        public virtual float CollectorSendDataOnExitThreshold { get { return EnvironmentOverrides((uint?)null, "NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS") ?? _localConfiguration.service.sendDataOnExitThreshold; } }
-        public virtual bool CollectorSendEnvironmentInfo { get { return _localConfiguration.service.sendEnvironmentInfo; } }
-        public virtual bool CollectorSyncStartup { get { return _localConfiguration.service.syncStartup; } }
-        public virtual uint CollectorTimeout { get { return (_localConfiguration.service.requestTimeout > 0) ? (uint)_localConfiguration.service.requestTimeout : CollectorSendDataOnExit ? 2000u : 60 * 2 * 1000; } }
-        public virtual int CollectorMaxPayloadSizeInBytes { get { return _serverConfiguration.MaxPayloadSizeInBytes ?? MaxPayloadSizeInBytes; } }
-        #endregion
+    #region Span Events
 
-        public virtual bool CompleteTransactionsOnThread { get { return _localConfiguration.service.completeTransactionsOnThread || ServerlessModeEnabled; } }
-
-        public long ConfigurationVersion { get; private set; }
-
-        #region Cross Application Tracing
-
-        public virtual string CrossApplicationTracingCrossProcessId { get { return _serverConfiguration.CatId; } }
-
-        private bool? _crossApplicationTracingEnabled;
-        public virtual bool CrossApplicationTracingEnabled => _crossApplicationTracingEnabled ?? (_crossApplicationTracingEnabled = IsCatEnabled()).Value;
-
-        private bool IsCatEnabled()
+    bool? _spanEventsEnabled = null;
+    public virtual bool SpanEventsEnabled
+    {
+        get
         {
-            // CAT must be disabled in serverless mode
-            if (ServerlessModeEnabled)
-                return false;
-
-            var localenabled = _localConfiguration.crossApplicationTracingEnabled;
-            //If config.crossApplicationTracingEnabled is true or default then we want to check the
-            //config.crossApplicationTracer, if that object is not null then use it's default or value
-            if (localenabled && _localConfiguration.crossApplicationTracer != null)
+            if (!_spanEventsEnabled.HasValue)
             {
-                localenabled = _localConfiguration.crossApplicationTracer.enabled;
+                var enabled = ServerCanDisable(_serverConfiguration.SpanEventCollectionEnabled, EnvironmentOverrides(_localConfiguration.spanEvents.enabled, "NEW_RELIC_SPAN_EVENTS_ENABLED"));
+                _spanEventsEnabled = enabled && DistributedTracingEnabled;
             }
 
-            var enabled = ServerCanDisable(_serverConfiguration.RpmConfig.CrossApplicationTracerEnabled, localenabled);
-
-            if (enabled && CrossApplicationTracingCrossProcessId == null)
-            {
-                Log.Warn("CAT is enabled but CrossProcessID is null. Disabling CAT.");
-                enabled = false;
-            }
-
-            return enabled;
+            return _spanEventsEnabled.Value;
         }
+    }
 
-        #endregion Cross Application Tracing
-
-        #region Span Events
-
-        bool? _spanEventsEnabled = null;
-        public virtual bool SpanEventsEnabled
+    private TimeSpan? _spanEventsHarvestCycleOverride = null;
+    public TimeSpan SpanEventsHarvestCycle
+    {
+        get
         {
-            get
+            if (_spanEventsHarvestCycleOverride.HasValue)
             {
-                if (!_spanEventsEnabled.HasValue)
+                return _spanEventsHarvestCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideSpanEventsHarvestCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
-                    var enabled = ServerCanDisable(_serverConfiguration.SpanEventCollectionEnabled, EnvironmentOverrides(_localConfiguration.spanEvents.enabled, "NEW_RELIC_SPAN_EVENTS_ENABLED"));
-                    _spanEventsEnabled = enabled && DistributedTracingEnabled;
-                }
-
-                return _spanEventsEnabled.Value;
-            }
-        }
-
-        private TimeSpan? _spanEventsHarvestCycleOverride = null;
-        public TimeSpan SpanEventsHarvestCycle
-        {
-            get
-            {
-                if (_spanEventsHarvestCycleOverride.HasValue)
-                {
+                    Log.Info("Span events harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _spanEventsHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _spanEventsHarvestCycleOverride.Value;
                 }
+            }
 
-                if (_newRelicAppSettings.TryGetValue("OverrideSpanEventsHarvestCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Span events harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _spanEventsHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _spanEventsHarvestCycleOverride.Value;
-                    }
-                }
+            return ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestCycle, DefaultHarvestCycle);
+        }
+    }
 
-                return ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestCycle, DefaultHarvestCycle);
+    public bool SpanEventsAttributesEnabled => CaptureAttributes && _localConfiguration.spanEvents.attributes.enabled;
+
+    private HashSet<string> _spanEventsAttributesInclude;
+    public HashSet<string> SpanEventsAttributesInclude =>
+        _spanEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && SpanEventsAttributesEnabled
+            ? [.. _localConfiguration.spanEvents.attributes.include]
+            : [];
+
+    private HashSet<string> _spanEventsAttributesExclude;
+    public virtual HashSet<string> SpanEventsAttributesExclude => _spanEventsAttributesExclude ??= [.. _localConfiguration.spanEvents.attributes.exclude];
+
+    #endregion
+
+    #region Distributed Tracing
+
+    private bool? _distributedTracingEnabled;
+    public virtual bool DistributedTracingEnabled => _distributedTracingEnabled ?? (_distributedTracingEnabled = IsDistributedTracingEnabled()).Value;
+
+    private bool IsDistributedTracingEnabled()
+    {
+        return EnvironmentOverrides(_localConfiguration.distributedTracing.enabled, "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED");
+    }
+
+    public string PrimaryApplicationId => ServerlessModeEnabled ?
+        EnvironmentOverrides(_localConfiguration.distributedTracing.primary_application_id, "NEW_RELIC_PRIMARY_APPLICATION_ID")
+        : _serverConfiguration.PrimaryApplicationId;
+
+    public string TrustedAccountKey => ServerlessModeEnabled ?
+        EnvironmentOverrides(_localConfiguration.distributedTracing.trusted_account_key, "NEW_RELIC_TRUSTED_ACCOUNT_KEY")
+        : _serverConfiguration.TrustedAccountKey;
+
+    public string AccountId => ServerlessModeEnabled ?
+        EnvironmentOverrides(_localConfiguration.distributedTracing.account_id, "NEW_RELIC_ACCOUNT_ID")
+        : _serverConfiguration.AccountId;
+
+    public int? SamplingTarget => ServerlessModeEnabled ? 10 : _serverConfiguration.SamplingTarget;
+
+    // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
+    public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
+        EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
+
+    public int? SamplingTargetPeriodInSeconds => ServerlessModeEnabled ? 60 : _serverConfiguration.SamplingTargetPeriodInSeconds;
+
+    public bool PayloadSuccessMetricsEnabled => _localConfiguration.distributedTracing.enableSuccessMetrics;
+
+    public bool ExcludeNewrelicHeader => _localConfiguration.distributedTracing.excludeNewrelicHeader;
+
+    public SamplerType RootSamplerType => GetSamplerType(SamplerLevel.Root);
+    public SamplerType RemoteParentSampledSamplerType => GetSamplerType(SamplerLevel.RemoteParentSampled);
+    public SamplerType RemoteParentNotSampledSamplerType => GetSamplerType(SamplerLevel.RemoteParentNotSampled);
+    public float? RootTraceIdRatioSamplerRatio { get => RootSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.Root) : null; }
+    public float? RemoteParentSampledTraceIdRatioSamplerRatio { get => RemoteParentSampledSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.RemoteParentSampled) : null; }
+    public float? RemoteParentNotSampledTraceIdRatioSamplerRatio { get => RemoteParentNotSampledSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.RemoteParentNotSampled) : null; }
+
+    private SamplerType GetSamplerType(SamplerLevel samplerLevel)
+    {
+        // Environment variable (if present) always wins
+        var envVarName = samplerLevel switch
+        {
+            SamplerLevel.Root => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT",
+            SamplerLevel.RemoteParentSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED",
+            SamplerLevel.RemoteParentNotSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED",
+            _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
+        };
+
+        var envValue = _environment.GetEnvironmentVariableFromList(envVarName);
+        if (!string.IsNullOrEmpty(envValue))
+        {
+            return envValue.ToRemoteParentSamplerType();
+        }
+
+        // use local config if no env var override
+        var samplerItem = samplerLevel switch
+        {
+            SamplerLevel.Root => _localConfiguration.distributedTracing.sampler.root.Item,
+            SamplerLevel.RemoteParentSampled => _localConfiguration.distributedTracing.sampler.remoteParentSampled.Item,
+            SamplerLevel.RemoteParentNotSampled => _localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item,
+            _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
+        };
+
+        //if samplerLevel is one of the remote parent levels and samplerItem is null (not configured), we need to check the legacy attributes
+        if (samplerLevel != SamplerLevel.Root && samplerItem == null)
+        {
+            var remoteParentSampledBehaviorType = samplerLevel == SamplerLevel.RemoteParentSampled ?
+                _localConfiguration.distributedTracing.sampler.remoteParentSampled1 :
+                _localConfiguration.distributedTracing.sampler.remoteParentNotSampled1;
+
+            if (remoteParentSampledBehaviorType != RemoteParentSampledBehaviorType.@default)
+            {
+                Log.Warn($"Using deprecated configuration for {samplerLevel}. Please use the new distributed tracing sampler configuration.");
+                return remoteParentSampledBehaviorType.ToRemoteParentSamplerType();
             }
         }
 
-        public bool SpanEventsAttributesEnabled => CaptureAttributes && _localConfiguration.spanEvents.attributes.enabled;
+        return MapSamplerItem(samplerItem);
+    }
 
-        private HashSet<string> _spanEventsAttributesInclude;
-        public HashSet<string> SpanEventsAttributesInclude =>
-            _spanEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && SpanEventsAttributesEnabled
-                ? [.. _localConfiguration.spanEvents.attributes.include]
-                : [];
-
-        private HashSet<string> _spanEventsAttributesExclude;
-        public virtual HashSet<string> SpanEventsAttributesExclude => _spanEventsAttributesExclude ??= [.. _localConfiguration.spanEvents.attributes.exclude];
-
-        #endregion
-
-        #region Distributed Tracing
-
-        private bool? _distributedTracingEnabled;
-        public virtual bool DistributedTracingEnabled => _distributedTracingEnabled ?? (_distributedTracingEnabled = IsDistributedTracingEnabled()).Value;
-
-        private bool IsDistributedTracingEnabled()
+    private static SamplerType MapSamplerItem(object samplerItem) =>
+        samplerItem switch
         {
-            return EnvironmentOverrides(_localConfiguration.distributedTracing.enabled, "NEW_RELIC_DISTRIBUTED_TRACING_ENABLED");
+            null => SamplerType.Adaptive, // not configured, default to Adaptive
+            AdaptiveSamplerType => SamplerType.Adaptive,
+            AlwaysOnSamplerType => SamplerType.AlwaysOn,
+            AlwaysOffSamplerType => SamplerType.AlwaysOff,
+            TraceIdRatioBasedSamplerType => SamplerType.TraceIdRatioBased,
+            _ => throw new ArgumentOutOfRangeException(nameof(samplerItem), samplerItem, "Unknown sampler type in configuration.")
+        };
+
+    private float? TraceIdSamplerRatio(SamplerLevel samplerLevel)
+    {
+        var envVarName = samplerLevel switch
+        {
+            SamplerLevel.Root => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO",
+            SamplerLevel.RemoteParentSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO",
+            SamplerLevel.RemoteParentNotSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO",
+            _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
+        };
+
+        var envValue = _environment.GetEnvironmentVariableFromList(envVarName);
+        if (!string.IsNullOrEmpty(envValue) && float.TryParse(envValue, out var ratioFromEnv))
+        {
+            return ratioFromEnv;
         }
 
-        public string PrimaryApplicationId => ServerlessModeEnabled ?
-            EnvironmentOverrides(_localConfiguration.distributedTracing.primary_application_id, "NEW_RELIC_PRIMARY_APPLICATION_ID")
-            : _serverConfiguration.PrimaryApplicationId;
-
-        public string TrustedAccountKey => ServerlessModeEnabled ?
-            EnvironmentOverrides(_localConfiguration.distributedTracing.trusted_account_key, "NEW_RELIC_TRUSTED_ACCOUNT_KEY")
-            : _serverConfiguration.TrustedAccountKey;
-
-        public string AccountId => ServerlessModeEnabled ?
-            EnvironmentOverrides(_localConfiguration.distributedTracing.account_id, "NEW_RELIC_ACCOUNT_ID")
-            : _serverConfiguration.AccountId;
-
-        public int? SamplingTarget => ServerlessModeEnabled ? 10 : _serverConfiguration.SamplingTarget;
-
-        // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
-        public int SpanEventsMaxSamplesStored => ServerOverrides(_serverConfiguration.SpanEventHarvestConfig?.HarvestLimit,
-           EnvironmentOverrides(_localConfiguration.spanEvents.maximumSamplesStored, "NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED").GetValueOrDefault());
-
-        public int? SamplingTargetPeriodInSeconds => ServerlessModeEnabled ? 60 : _serverConfiguration.SamplingTargetPeriodInSeconds;
-
-        public bool PayloadSuccessMetricsEnabled => _localConfiguration.distributedTracing.enableSuccessMetrics;
-
-        public bool ExcludeNewrelicHeader => _localConfiguration.distributedTracing.excludeNewrelicHeader;
-
-        public SamplerType RootSamplerType => GetSamplerType(SamplerLevel.Root);
-        public SamplerType RemoteParentSampledSamplerType => GetSamplerType(SamplerLevel.RemoteParentSampled);
-        public SamplerType RemoteParentNotSampledSamplerType => GetSamplerType(SamplerLevel.RemoteParentNotSampled);
-        public float? RootTraceIdRatioSamplerRatio { get => RootSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.Root) : null; }
-        public float? RemoteParentSampledTraceIdRatioSamplerRatio { get => RemoteParentSampledSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.RemoteParentSampled) : null; }
-        public float? RemoteParentNotSampledTraceIdRatioSamplerRatio { get => RemoteParentNotSampledSamplerType == SamplerType.TraceIdRatioBased ? TraceIdSamplerRatio(SamplerLevel.RemoteParentNotSampled) : null; }
-
-        private SamplerType GetSamplerType(SamplerLevel samplerLevel)
+        // use local config if no env var override
+        switch (samplerLevel)
         {
-            // Environment variable (if present) always wins
-            var envVarName = samplerLevel switch
-            {
-                SamplerLevel.Root => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT",
-                SamplerLevel.RemoteParentSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED",
-                SamplerLevel.RemoteParentNotSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED",
-                _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
-            };
+            case SamplerLevel.Root:
+                if (_localConfiguration.distributedTracing.sampler.root.Item is TraceIdRatioBasedSamplerType rootTraceIdRatioSamplerType)
+                    return (float)rootTraceIdRatioSamplerType.ratio;
+                return null;
+            case SamplerLevel.RemoteParentSampled:
+                if (_localConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioBasedSamplerType remoteParentSampledTraceIdRatioSamplerType)
+                    return (float)remoteParentSampledTraceIdRatioSamplerType.ratio;
+                return null;
+            case SamplerLevel.RemoteParentNotSampled:
+                if (_localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioBasedSamplerType remoteParentNotSampledTraceIdRatioSamplerType)
+                    return (float)remoteParentNotSampledTraceIdRatioSamplerType.ratio;
+                return null;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null);
+        }
+    }
 
-            var envValue = _environment.GetEnvironmentVariableFromList(envVarName);
-            if (!string.IsNullOrEmpty(envValue))
-            {
-                return envValue.ToRemoteParentSamplerType();
-            }
+    #endregion Distributed Tracing
 
-            // use local config if no env var override
-            var samplerItem = samplerLevel switch
-            {
-                SamplerLevel.Root => _localConfiguration.distributedTracing.sampler.root.Item,
-                SamplerLevel.RemoteParentSampled => _localConfiguration.distributedTracing.sampler.remoteParentSampled.Item,
-                SamplerLevel.RemoteParentNotSampled => _localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item,
-                _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
-            };
+    #region Infinite Tracing
 
-            //if samplerLevel is one of the remote parent levels and samplerItem is null (not configured), we need to check the legacy attributes
-            if (samplerLevel != SamplerLevel.Root && samplerItem == null)
-            {
-                var remoteParentSampledBehaviorType = samplerLevel == SamplerLevel.RemoteParentSampled ?
-                    _localConfiguration.distributedTracing.sampler.remoteParentSampled1 :
-                    _localConfiguration.distributedTracing.sampler.remoteParentNotSampled1;
+    private int? _infiniteTracingTimeoutMsConnect = null;
+    public int InfiniteTracingTraceTimeoutMsConnect => (_infiniteTracingTimeoutMsConnect
+                                                        ?? (_infiniteTracingTimeoutMsConnect = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingTimeoutConnect", 10000), "NEW_RELIC_INFINITE_TRACING_TIMEOUT_CONNECT")).Value);
 
-                if (remoteParentSampledBehaviorType != RemoteParentSampledBehaviorType.@default)
-                {
-                    Log.Warn($"Using deprecated configuration for {samplerLevel}. Please use the new distributed tracing sampler configuration.");
-                    return remoteParentSampledBehaviorType.ToRemoteParentSamplerType();
-                }
-            }
+    private int? _infiniteTracingTimeoutMsSendData = null;
+    public int InfiniteTracingTraceTimeoutMsSendData => (_infiniteTracingTimeoutMsSendData
+                                                         ?? (_infiniteTracingTimeoutMsSendData = EnvironmentOverrides(
+                                                             TryGetAppSettingAsIntWithDefault("InfiniteTracingTimeoutSend", 10000)
+                                                             , "NEW_RELIC_INFINITE_TRACING_TIMEOUT_SEND")).Value);
 
-            return MapSamplerItem(samplerItem);
+    private int? _infiniteTracingExitTimeoutMs = null;
+    public int InfiniteTracingExitTimeoutMs => GetInfiniteTracingExitTimeoutMs();
+    private int GetInfiniteTracingExitTimeoutMs()
+    {
+        const int infiniteTracingExitTimeoutMsDefault = 5000;
+        return _infiniteTracingExitTimeoutMs
+               ?? (_infiniteTracingExitTimeoutMs = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingExitTimeout", infiniteTracingExitTimeoutMsDefault), "NEW_RELIC_INFINITE_TRACING_EXIT_TIMEOUT")).GetValueOrDefault();
+    }
+
+    private int? _infiniteTracingCountWorkers = null;
+    public int InfiniteTracingTraceCountConsumers => GetInfiniteTracingCountWorkers();
+
+    private int GetInfiniteTracingCountWorkers()
+    {
+        const int countWorkersDefault = 10;
+        return _infiniteTracingCountWorkers
+               ?? (_infiniteTracingCountWorkers = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingSpanEventsStreamsCount", countWorkersDefault), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_STREAMS_COUNT")).GetValueOrDefault();
+    }
+
+
+    private bool _infiniteTracingObserverObtained;
+    private void GetInfiniteTracingObserver()
+    {
+        _infiniteTracingTraceObserverHost = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST");
+        if (_infiniteTracingTraceObserverHost != null)
+        {
+            _infiniteTracingTraceObserverPort = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_PORT");
+            _infiniteTracingTraceObserverSsl = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_SSL");
+        }
+        else
+        {
+            _infiniteTracingTraceObserverHost = _localConfiguration.infiniteTracing?.trace_observer?.host;
+            _infiniteTracingTraceObserverPort = _localConfiguration.infiniteTracing?.trace_observer?.port;
+            _infiniteTracingTraceObserverSsl = TryGetAppSettingAsString("InfiniteTracingTraceObserverSsl");
         }
 
-        private static SamplerType MapSamplerItem(object samplerItem) =>
-            samplerItem switch
-            {
-                null => SamplerType.Adaptive, // not configured, default to Adaptive
-                AdaptiveSamplerType => SamplerType.Adaptive,
-                AlwaysOnSamplerType => SamplerType.AlwaysOn,
-                AlwaysOffSamplerType => SamplerType.AlwaysOff,
-                TraceIdRatioBasedSamplerType => SamplerType.TraceIdRatioBased,
-                _ => throw new ArgumentOutOfRangeException(nameof(samplerItem), samplerItem, "Unknown sampler type in configuration.")
-            };
+        _infiniteTracingObserverObtained = true;
+    }
 
-        private float? TraceIdSamplerRatio(SamplerLevel samplerLevel)
+    private string _infiniteTracingTraceObserverHost = null;
+    public string InfiniteTracingTraceObserverHost
+    {
+        get
         {
-            var envVarName = samplerLevel switch
+            if (!_infiniteTracingObserverObtained)
             {
-                SamplerLevel.Root => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO",
-                SamplerLevel.RemoteParentSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO",
-                SamplerLevel.RemoteParentNotSampled => "NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO",
-                _ => throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null)
-            };
-
-            var envValue = _environment.GetEnvironmentVariableFromList(envVarName);
-            if (!string.IsNullOrEmpty(envValue) && float.TryParse(envValue, out var ratioFromEnv))
-            {
-                return ratioFromEnv;
+                GetInfiniteTracingObserver();
             }
 
-            // use local config if no env var override
-            switch (samplerLevel)
+            return _infiniteTracingTraceObserverHost;
+        }
+    }
+
+    private string _infiniteTracingTraceObserverPort = null;
+    public string InfiniteTracingTraceObserverPort
+    {
+        get
+        {
+            if (!_infiniteTracingObserverObtained)
             {
-                case SamplerLevel.Root:
-                    if (_localConfiguration.distributedTracing.sampler.root.Item is TraceIdRatioBasedSamplerType rootTraceIdRatioSamplerType)
-                        return (float)rootTraceIdRatioSamplerType.ratio;
-                    return null;
-                case SamplerLevel.RemoteParentSampled:
-                    if (_localConfiguration.distributedTracing.sampler.remoteParentSampled.Item is TraceIdRatioBasedSamplerType remoteParentSampledTraceIdRatioSamplerType)
-                        return (float)remoteParentSampledTraceIdRatioSamplerType.ratio;
-                    return null;
-                case SamplerLevel.RemoteParentNotSampled:
-                    if (_localConfiguration.distributedTracing.sampler.remoteParentNotSampled.Item is TraceIdRatioBasedSamplerType remoteParentNotSampledTraceIdRatioSamplerType)
-                        return (float)remoteParentNotSampledTraceIdRatioSamplerType.ratio;
-                    return null;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(samplerLevel), samplerLevel, null);
+                GetInfiniteTracingObserver();
             }
+
+            return _infiniteTracingTraceObserverPort;
+        }
+    }
+
+    private string _infiniteTracingTraceObserverSsl = null;
+    public string InfiniteTracingTraceObserverSsl
+    {
+        get
+        {
+            if (!_infiniteTracingObserverObtained)
+            {
+                GetInfiniteTracingObserver();
+            }
+
+            return _infiniteTracingTraceObserverSsl;
+        }
+    }
+
+
+    private int? _infiniteTracingQueueSizeSpans;
+    public int InfiniteTracingQueueSizeSpans => GetInfiniteTracingQueueSizeSpans();
+
+    private int GetInfiniteTracingQueueSizeSpans()
+    {
+        return _infiniteTracingQueueSizeSpans
+               ?? (_infiniteTracingQueueSizeSpans = EnvironmentOverrides(_localConfiguration.infiniteTracing?.span_events?.queue_size, "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE"))
+               .GetValueOrDefault(100000);
+    }
+
+    private int? _infiniteTracingPartitionCountSpans;
+    public int InfiniteTracingPartitionCountSpans => _infiniteTracingPartitionCountSpans
+                                                     ?? (_infiniteTracingPartitionCountSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsPartitionCount"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_PARTITION_COUNT").GetValueOrDefault(62)).Value;
+
+    private int? _infiniteTracingBatchSizeSpans;
+    public int InfiniteTracingBatchSizeSpans => _infiniteTracingBatchSizeSpans
+                                                ?? (_infiniteTracingBatchSizeSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsBatchSize"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_BATCH_SIZE").GetValueOrDefault(700)).Value;
+
+    private bool _infiniteTracingObtainedSettingsForTest;
+    private void GetInfiniteTracingFlakyAndDelayTestSettings()
+    {
+
+        if (float.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY"), out var flakyVal))
+        {
+            _infiniteTracingObserverTestFlaky = flakyVal;
+        }
+        else
+        {
+            _infiniteTracingObserverTestFlaky = TryGetAppSettingAsFloat("InfiniteTracingSpanEventsTestFlaky");
         }
 
-        #endregion Distributed Tracing
-
-        #region Infinite Tracing
-
-        private int? _infiniteTracingTimeoutMsConnect = null;
-        public int InfiniteTracingTraceTimeoutMsConnect => (_infiniteTracingTimeoutMsConnect
-            ?? (_infiniteTracingTimeoutMsConnect = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingTimeoutConnect", 10000), "NEW_RELIC_INFINITE_TRACING_TIMEOUT_CONNECT")).Value);
-
-        private int? _infiniteTracingTimeoutMsSendData = null;
-        public int InfiniteTracingTraceTimeoutMsSendData => (_infiniteTracingTimeoutMsSendData
-            ?? (_infiniteTracingTimeoutMsSendData = EnvironmentOverrides(
-                TryGetAppSettingAsIntWithDefault("InfiniteTracingTimeoutSend", 10000)
-                , "NEW_RELIC_INFINITE_TRACING_TIMEOUT_SEND")).Value);
-
-        private int? _infiniteTracingExitTimeoutMs = null;
-        public int InfiniteTracingExitTimeoutMs => GetInfiniteTracingExitTimeoutMs();
-        private int GetInfiniteTracingExitTimeoutMs()
+        if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY_CODE"), out var flakyCodeVal))
         {
-            const int infiniteTracingExitTimeoutMsDefault = 5000;
-            return _infiniteTracingExitTimeoutMs
-                ?? (_infiniteTracingExitTimeoutMs = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingExitTimeout", infiniteTracingExitTimeoutMsDefault), "NEW_RELIC_INFINITE_TRACING_EXIT_TIMEOUT")).GetValueOrDefault();
+            _infiniteTracingObserverTestFlakyCode = flakyCodeVal;
+        }
+        else
+        {
+            _infiniteTracingObserverTestFlakyCode = TryGetAppSettingAsInt("InfiniteTracingSpanEventsTestFlakyCode");
         }
 
-        private int? _infiniteTracingCountWorkers = null;
-        public int InfiniteTracingTraceCountConsumers => GetInfiniteTracingCountWorkers();
-
-        private int GetInfiniteTracingCountWorkers()
+        if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_DELAY"), out var delayVal))
         {
-            const int countWorkersDefault = 10;
-            return _infiniteTracingCountWorkers
-                ?? (_infiniteTracingCountWorkers = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("InfiniteTracingSpanEventsStreamsCount", countWorkersDefault), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_STREAMS_COUNT")).GetValueOrDefault();
+            _infiniteTracingObserverTestDelayMs = delayVal;
+        }
+        else
+        {
+            _infiniteTracingObserverTestDelayMs = TryGetAppSettingAsInt("InfiniteTracingSpanEventsTestDelay");
         }
 
+        _infiniteTracingObtainedSettingsForTest = true;
+    }
 
-        private bool _infiniteTracingObserverObtained;
-        private void GetInfiniteTracingObserver()
+    private float? _infiniteTracingObserverTestFlaky;
+    public float? InfiniteTracingTraceObserverTestFlaky
+    {
+        get
         {
-            _infiniteTracingTraceObserverHost = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST");
-            if (_infiniteTracingTraceObserverHost != null)
+            if (!_infiniteTracingObtainedSettingsForTest)
             {
-                _infiniteTracingTraceObserverPort = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_PORT");
-                _infiniteTracingTraceObserverSsl = _environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_SSL");
-            }
-            else
-            {
-                _infiniteTracingTraceObserverHost = _localConfiguration.infiniteTracing?.trace_observer?.host;
-                _infiniteTracingTraceObserverPort = _localConfiguration.infiniteTracing?.trace_observer?.port;
-                _infiniteTracingTraceObserverSsl = TryGetAppSettingAsString("InfiniteTracingTraceObserverSsl");
+                GetInfiniteTracingFlakyAndDelayTestSettings();
             }
 
-            _infiniteTracingObserverObtained = true;
+            return _infiniteTracingObserverTestFlaky;
         }
+    }
 
-        private string _infiniteTracingTraceObserverHost = null;
-        public string InfiniteTracingTraceObserverHost
+    private int? _infiniteTracingObserverTestFlakyCode;
+    public int? InfiniteTracingTraceObserverTestFlakyCode
+    {
+        get
         {
-            get
+            if (!_infiniteTracingObtainedSettingsForTest)
             {
-                if (!_infiniteTracingObserverObtained)
-                {
-                    GetInfiniteTracingObserver();
-                }
-
-                return _infiniteTracingTraceObserverHost;
+                GetInfiniteTracingFlakyAndDelayTestSettings();
             }
+
+            return _infiniteTracingObserverTestFlakyCode;
         }
+    }
 
-        private string _infiniteTracingTraceObserverPort = null;
-        public string InfiniteTracingTraceObserverPort
+    private int? _infiniteTracingObserverTestDelayMs;
+    public int? InfiniteTracingTraceObserverTestDelayMs
+    {
+        get
         {
-            get
+            if (!_infiniteTracingObtainedSettingsForTest)
             {
-                if (!_infiniteTracingObserverObtained)
-                {
-                    GetInfiniteTracingObserver();
-                }
-
-                return _infiniteTracingTraceObserverPort;
+                GetInfiniteTracingFlakyAndDelayTestSettings();
             }
+
+            return _infiniteTracingObserverTestDelayMs;
         }
+    }
 
-        private string _infiniteTracingTraceObserverSsl = null;
-        public string InfiniteTracingTraceObserverSsl
+    private bool? _infiniteTracingCompression;
+    public bool InfiniteTracingCompression
+    {
+        get
         {
-            get
+            if (!_infiniteTracingCompression.HasValue)
             {
-                if (!_infiniteTracingObserverObtained)
-                {
-                    GetInfiniteTracingObserver();
-                }
-
-                return _infiniteTracingTraceObserverSsl;
+                _infiniteTracingCompression = EnvironmentOverrides(_localConfiguration.infiniteTracing.compression, "NEW_RELIC_INFINITE_TRACING_COMPRESSION");
             }
+            return _infiniteTracingCompression.Value;
         }
+    }
 
 
-        private int? _infiniteTracingQueueSizeSpans;
-        public int InfiniteTracingQueueSizeSpans => GetInfiniteTracingQueueSizeSpans();
 
-        private int GetInfiniteTracingQueueSizeSpans()
+
+    #endregion
+
+    #region Errors
+
+    public virtual bool ErrorCollectorEnabled
+    {
+        get
         {
-            return _infiniteTracingQueueSizeSpans
-                ?? (_infiniteTracingQueueSizeSpans = EnvironmentOverrides(_localConfiguration.infiniteTracing?.span_events?.queue_size, "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE"))
-                .GetValueOrDefault(100000);
+            var configuredValue = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorEnabled, _localConfiguration.errorCollector.enabled);
+            return ServerCanDisable(_serverConfiguration.ErrorCollectionEnabled, configuredValue);
         }
+    }
 
-        private int? _infiniteTracingPartitionCountSpans;
-        public int InfiniteTracingPartitionCountSpans => _infiniteTracingPartitionCountSpans
-                ?? (_infiniteTracingPartitionCountSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsPartitionCount"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_PARTITION_COUNT").GetValueOrDefault(62)).Value;
-
-        private int? _infiniteTracingBatchSizeSpans;
-        public int InfiniteTracingBatchSizeSpans => _infiniteTracingBatchSizeSpans
-                ?? (_infiniteTracingBatchSizeSpans = EnvironmentOverrides(TryGetAppSettingAsInt("InfiniteTracingSpanEventsBatchSize"), "NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_BATCH_SIZE").GetValueOrDefault(700)).Value;
-
-        private bool _infiniteTracingObtainedSettingsForTest;
-        private void GetInfiniteTracingFlakyAndDelayTestSettings()
+    public virtual bool ErrorCollectorCaptureEvents
+    {
+        get
         {
-
-            if (float.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY"), out var flakyVal))
+            if (ErrorCollectorMaxEventSamplesStored == 0)
             {
-                _infiniteTracingObserverTestFlaky = flakyVal;
+                return false;
             }
-            else
-            {
-                _infiniteTracingObserverTestFlaky = TryGetAppSettingAsFloat("InfiniteTracingSpanEventsTestFlaky");
-            }
-
-            if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_FLAKY_CODE"), out var flakyCodeVal))
-            {
-                _infiniteTracingObserverTestFlakyCode = flakyCodeVal;
-            }
-            else
-            {
-                _infiniteTracingObserverTestFlakyCode = TryGetAppSettingAsInt("InfiniteTracingSpanEventsTestFlakyCode");
-            }
-
-            if (int.TryParse(_environment.GetEnvironmentVariable("NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_TEST_DELAY"), out var delayVal))
-            {
-                _infiniteTracingObserverTestDelayMs = delayVal;
-            }
-            else
-            {
-                _infiniteTracingObserverTestDelayMs = TryGetAppSettingAsInt("InfiniteTracingSpanEventsTestDelay");
-            }
-
-            _infiniteTracingObtainedSettingsForTest = true;
+            return ServerCanDisable(_serverConfiguration.ErrorEventCollectionEnabled, _localConfiguration.errorCollector.captureEvents);
         }
+    }
 
-        private float? _infiniteTracingObserverTestFlaky;
-        public float? InfiniteTracingTraceObserverTestFlaky
+    public virtual int ErrorCollectorMaxEventSamplesStored
+    {
+        get
         {
-            get
-            {
-                if (!_infiniteTracingObtainedSettingsForTest)
-                {
-                    GetInfiniteTracingFlakyAndDelayTestSettings();
-                }
-
-                return _infiniteTracingObserverTestFlaky;
-            }
+            // Faster Event Harvest configuration rules apply here, if/when we add an environment variable for this property we need to make sure that
+            // ServerOverrides takes precedence over EnvironmentOverrides
+            return ServerOverrides(_serverConfiguration.EventHarvestConfig?.ErrorEventHarvestLimit(), _localConfiguration.errorCollector.maxEventSamplesStored);
         }
+    }
 
-        private int? _infiniteTracingObserverTestFlakyCode;
-        public int? InfiniteTracingTraceObserverTestFlakyCode
+    public TimeSpan ErrorEventsHarvestCycle
+    {
+        get
         {
-            get
-            {
-                if (!_infiniteTracingObtainedSettingsForTest)
-                {
-                    GetInfiniteTracingFlakyAndDelayTestSettings();
-                }
-
-                return _infiniteTracingObserverTestFlakyCode;
-            }
+            return ServerOverrides(_serverConfiguration.EventHarvestConfig?.ErrorEventHarvestCycle(), TimeSpan.FromMinutes(1));
         }
+    }
 
-        private int? _infiniteTracingObserverTestDelayMs;
-        public int? InfiniteTracingTraceObserverTestDelayMs
+    public virtual uint ErrorsMaximumPerPeriod { get { return 20; } }
+
+    public IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration { get; private set; }
+    public IEnumerable<string> IgnoreErrorClassesForAgentSettings { get; private set; }
+    public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings { get; private set; }
+
+    private IEnumerable<MatchRule> ParseExpectedStatusCodesArray(IEnumerable<string> expectedStatusCodeArray)
+    {
+        var expectedStatusCodes = new List<MatchRule>();
+
+        if (expectedStatusCodeArray == null)
         {
-            get
-            {
-                if (!_infiniteTracingObtainedSettingsForTest)
-                {
-                    GetInfiniteTracingFlakyAndDelayTestSettings();
-                }
-
-                return _infiniteTracingObserverTestDelayMs;
-            }
-        }
-
-        private bool? _infiniteTracingCompression;
-        public bool InfiniteTracingCompression
-        {
-            get
-            {
-                if (!_infiniteTracingCompression.HasValue)
-                {
-                    _infiniteTracingCompression = EnvironmentOverrides(_localConfiguration.infiniteTracing.compression, "NEW_RELIC_INFINITE_TRACING_COMPRESSION");
-                }
-                return _infiniteTracingCompression.Value;
-            }
-        }
-
-
-
-
-        #endregion
-
-        #region Errors
-
-        public virtual bool ErrorCollectorEnabled
-        {
-            get
-            {
-                var configuredValue = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorEnabled, _localConfiguration.errorCollector.enabled);
-                return ServerCanDisable(_serverConfiguration.ErrorCollectionEnabled, configuredValue);
-            }
-        }
-
-        public virtual bool ErrorCollectorCaptureEvents
-        {
-            get
-            {
-                if (ErrorCollectorMaxEventSamplesStored == 0)
-                {
-                    return false;
-                }
-                return ServerCanDisable(_serverConfiguration.ErrorEventCollectionEnabled, _localConfiguration.errorCollector.captureEvents);
-            }
-        }
-
-        public virtual int ErrorCollectorMaxEventSamplesStored
-        {
-            get
-            {
-                // Faster Event Harvest configuration rules apply here, if/when we add an environment variable for this property we need to make sure that
-                // ServerOverrides takes precedence over EnvironmentOverrides
-                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.ErrorEventHarvestLimit(), _localConfiguration.errorCollector.maxEventSamplesStored);
-            }
-        }
-
-        public TimeSpan ErrorEventsHarvestCycle
-        {
-            get
-            {
-                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.ErrorEventHarvestCycle(), TimeSpan.FromMinutes(1));
-            }
-        }
-
-        public virtual uint ErrorsMaximumPerPeriod { get { return 20; } }
-
-        public IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration { get; private set; }
-        public IEnumerable<string> IgnoreErrorClassesForAgentSettings { get; private set; }
-        public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings { get; private set; }
-
-        private IEnumerable<MatchRule> ParseExpectedStatusCodesArray(IEnumerable<string> expectedStatusCodeArray)
-        {
-            var expectedStatusCodes = new List<MatchRule>();
-
-            if (expectedStatusCodeArray == null)
-            {
-                return expectedStatusCodes;
-            }
-
-            foreach (var singleCodeOrRange in expectedStatusCodeArray)
-            {
-                MatchRule matchRule;
-                var index = singleCodeOrRange.IndexOf(HyphenChar);
-                if (index != -1)
-                {
-                    var lowerBoundString = singleCodeOrRange.Substring(0, index).Trim();
-                    var upperBoundString = singleCodeOrRange.Substring(index + 1).Trim();
-
-                    matchRule = StatusCodeInRangeMatchRule.GenerateRule(lowerBoundString, upperBoundString);
-                }
-                else
-                {
-                    matchRule = StatusCodeExactMatchRule.GenerateRule(singleCodeOrRange);
-                }
-
-                if (matchRule == null)
-                {
-                    Log.Warn($"Cannot parse {singleCodeOrRange} status code. This status code format is not supported.");
-                    continue;
-                }
-
-                expectedStatusCodes.Add(matchRule);
-            }
-
             return expectedStatusCodes;
         }
 
-        public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; private set; }
-        public IEnumerable<MatchRule> ExpectedStatusCodes { get; private set; }
-        public IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; private set; }
-        public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; private set; }
-        public IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings { get; private set; }
-
-        public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback => _runTimeConfiguration.ErrorGroupCallback;
-
-        #endregion
-
-        public Dictionary<string, string> RequestHeadersMap => _serverConfiguration.RequestHeadersMap;
-
-        public virtual string EncodingKey { get { return _serverConfiguration.EncodingKey; } }
-
-        public virtual string EntityGuid { get { return _serverConfiguration.EntityGuid; } }
-
-        private bool? _highSecurityModeEnabled;
-        public virtual bool HighSecurityModeEnabled
+        foreach (var singleCodeOrRange in expectedStatusCodeArray)
         {
-            get
+            MatchRule matchRule;
+            var index = singleCodeOrRange.IndexOf(HyphenChar);
+            if (index != -1)
             {
-                _highSecurityModeEnabled ??= EnvironmentOverrides(_localConfiguration.highSecurity.enabled, "NEW_RELIC_HIGH_SECURITY");
+                var lowerBoundString = singleCodeOrRange.Substring(0, index).Trim();
+                var upperBoundString = singleCodeOrRange.Substring(index + 1).Trim();
 
-                return _highSecurityModeEnabled.Value;
+                matchRule = StatusCodeInRangeMatchRule.GenerateRule(lowerBoundString, upperBoundString);
             }
+            else
+            {
+                matchRule = StatusCodeExactMatchRule.GenerateRule(singleCodeOrRange);
+            }
+
+            if (matchRule == null)
+            {
+                Log.Warn($"Cannot parse {singleCodeOrRange} status code. This status code format is not supported.");
+                continue;
+            }
+
+            expectedStatusCodes.Add(matchRule);
         }
 
+        return expectedStatusCodes;
+    }
 
-        private BoolConfigurationItem _customInstrumentationEditorIsEnabled;
+    public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration { get; private set; }
+    public IEnumerable<MatchRule> ExpectedStatusCodes { get; private set; }
+    public IEnumerable<string> ExpectedErrorClassesForAgentSettings { get; private set; }
+    public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings { get; private set; }
+    public IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings { get; private set; }
 
-        public string CustomInstrumentationEditorEnabledSource
+    public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback => _runTimeConfiguration.ErrorGroupCallback;
+
+    #endregion
+
+    public Dictionary<string, string> RequestHeadersMap => _serverConfiguration.RequestHeadersMap;
+
+    public virtual string EncodingKey { get { return _serverConfiguration.EncodingKey; } }
+
+    public virtual string EntityGuid { get { return _serverConfiguration.EntityGuid; } }
+
+    private bool? _highSecurityModeEnabled;
+    public virtual bool HighSecurityModeEnabled
+    {
+        get
         {
-            get
+            _highSecurityModeEnabled ??= EnvironmentOverrides(_localConfiguration.highSecurity.enabled, "NEW_RELIC_HIGH_SECURITY");
+
+            return _highSecurityModeEnabled.Value;
+        }
+    }
+
+
+    private BoolConfigurationItem _customInstrumentationEditorIsEnabled;
+
+    public string CustomInstrumentationEditorEnabledSource
+    {
+        get
+        {
+            if (_customInstrumentationEditorIsEnabled == null)
             {
-                if (_customInstrumentationEditorIsEnabled == null)
+                _customInstrumentationEditorIsEnabled = GetCustomInstrumentationEditorConfiguration();
+            }
+
+            return _customInstrumentationEditorIsEnabled.Source;
+        }
+    }
+
+    public virtual bool CustomInstrumentationEditorEnabled
+    {
+        get
+        {
+            if (_customInstrumentationEditorIsEnabled == null)
+            {
+                _customInstrumentationEditorIsEnabled = GetCustomInstrumentationEditorConfiguration();
+            }
+
+            return _customInstrumentationEditorIsEnabled.Value;
+        }
+    }
+
+    private BoolConfigurationItem GetCustomInstrumentationEditorConfiguration()
+    {
+        if (HighSecurityModeEnabled)
+        {
+            return new BoolConfigurationItem(false, HighSecurityConfigSource);
+        }
+
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomInstrumentationEditorPolicyName)
+            && (_securityPoliciesConfiguration.CustomInstrumentationEditor.Enabled == false))
+        {
+            return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
+        }
+
+        return new BoolConfigurationItem(_localConfiguration.customInstrumentationEditor.enabled, LocalConfigSource);
+    }
+
+    private BoolConfigurationItem _shouldStripExceptionMessages;
+
+    public string StripExceptionMessagesSource
+    {
+        get
+        {
+            if (_shouldStripExceptionMessages == null)
+            {
+                _shouldStripExceptionMessages = GetShouldStripExceptionMessagesConfiguration();
+            }
+
+            return _shouldStripExceptionMessages.Source;
+        }
+    }
+
+    public virtual bool StripExceptionMessages
+    {
+        get
+        {
+            if (_shouldStripExceptionMessages == null)
+            {
+                _shouldStripExceptionMessages = GetShouldStripExceptionMessagesConfiguration();
+            }
+
+            return _shouldStripExceptionMessages.Value;
+        }
+    }
+
+    private BoolConfigurationItem GetShouldStripExceptionMessagesConfiguration()
+    {
+        // true is the more secure state, which will remove raw exception messages
+
+        if (HighSecurityModeEnabled)
+        {
+            return new BoolConfigurationItem(true, HighSecurityConfigSource);
+        }
+
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AllowRawExceptionMessagePolicyName)
+            && (_securityPoliciesConfiguration.AllowRawExceptionMessage.Enabled == false))
+        {
+            return new BoolConfigurationItem(true, SecurityPolicyConfigSource);
+        }
+
+        return new BoolConfigurationItem(_localConfiguration.stripExceptionMessages.enabled, LocalConfigSource);
+    }
+
+    public virtual bool InstrumentationLoggingEnabled { get { return _localConfiguration.instrumentation.log; } }
+
+    #region Labels
+
+    private string _labels;
+    private bool _labelsChecked;
+    public virtual string Labels
+    {
+        get
+        {
+            if (!_labelsChecked)
+            {
+                var labels = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLabels);
+                if (labels != null)
                 {
-                    _customInstrumentationEditorIsEnabled = GetCustomInstrumentationEditorConfiguration();
+                    Log.Info("Application labels from web.config, app.config, or appsettings.json.");
+                    _labels = labels;
+                }
+                else
+                {
+                    _labels = EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
+                }
+                _labelsChecked = true;
+            }
+            return _labels;
+        }
+    }
+
+    #endregion
+
+    #region Proxy
+
+    public virtual string ProxyHost
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.service.proxy.host, "NEW_RELIC_PROXY_HOST");
+        }
+    }
+
+    public virtual string ProxyUriPath
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.service.proxy.uriPath, "NEW_RELIC_PROXY_URI_PATH");
+        }
+    }
+
+    public virtual int ProxyPort
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.service.proxy.port, "NEW_RELIC_PROXY_PORT").Value;
+        }
+    }
+
+    public virtual string ProxyUsername
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.service.proxy.user, "NEW_RELIC_PROXY_USER");
+        }
+    }
+
+
+    private bool _obscuringKeyEvaluated;
+    private string _obscuringKey;
+    public string ObscuringKey
+    {
+        get
+        {
+            if (!_obscuringKeyEvaluated)
+            {
+                _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, "NEW_RELIC_CONFIG_OBSCURING_KEY");
+                _obscuringKeyEvaluated = true;
+            }
+
+            return _obscuringKey;
+        }
+    }
+
+    private bool _proxyPasswordEvaluated;
+    private string _proxyPassword;
+    public virtual string ProxyPassword
+    {
+        get
+        {
+            if (!_proxyPasswordEvaluated)
+            {
+                var hasObscuringKey = !string.IsNullOrWhiteSpace(ObscuringKey);
+                var passwordObfuscated = EnvironmentOverrides(_localConfiguration.service.proxy.passwordObfuscated, "NEW_RELIC_PROXY_PASS_OBFUSCATED");
+                var hasObfuscatedPassword = !string.IsNullOrWhiteSpace(passwordObfuscated);
+
+                if (hasObscuringKey && hasObfuscatedPassword)
+                {
+                    _proxyPassword = Strings.Base64Decode(passwordObfuscated, ObscuringKey);
+                }
+                else
+                {
+                    _proxyPassword = EnvironmentOverrides(_localConfiguration.service.proxy.password, "NEW_RELIC_PROXY_PASS");
                 }
 
-                return _customInstrumentationEditorIsEnabled.Source;
+                _proxyPasswordEvaluated = true;
             }
+
+            return _proxyPassword;
+        }
+    }
+
+    public virtual string ProxyDomain
+    {
+        get
+        {
+            return EnvironmentOverrides(_localConfiguration.service.proxy.domain, "NEW_RELIC_PROXY_DOMAIN") ?? string.Empty;
+        }
+    }
+
+    #endregion
+
+    #region DataTransmission
+    public bool PutForDataSend { get { return _localConfiguration.dataTransmission.putForDataSend; } }
+
+    public string CompressedContentEncoding
+    {
+        get
+        {
+            return _localConfiguration.dataTransmission.compressedContentEncoding.ToString();
+        }
+    }
+
+    #endregion
+
+    #region DatastoreTracer
+    public bool InstanceReportingEnabled { get { return _localConfiguration.datastoreTracer.instanceReporting.enabled; } }
+
+    public bool DatabaseNameReportingEnabled { get { return _localConfiguration.datastoreTracer.databaseNameReporting.enabled; } }
+
+    public bool DatastoreTracerQueryParametersEnabled => _localConfiguration.datastoreTracer.queryParameters.enabled && TransactionTracerRecordSql == RawStringValue;
+
+    #endregion
+
+    #region Sql
+
+    public bool SlowSqlEnabled => ServerOverrides(_serverConfiguration.RpmConfig.SlowSqlEnabled, _localConfiguration.slowSql.enabled);
+
+    public virtual TimeSpan SqlExplainPlanThreshold
+    {
+        get
+        {
+            var serverThreshold = _serverConfiguration.RpmConfig.TransactionTracerExplainThreshold;
+
+            return serverThreshold.HasValue ?
+                TimeSpan.FromSeconds(serverThreshold.Value) :
+                TimeSpan.FromMilliseconds(_localConfiguration.transactionTracer.explainThreshold);
+        }
+    }
+
+    public virtual bool SqlExplainPlansEnabled =>
+        ServerOverrides(_serverConfiguration.RpmConfig.TransactionTracerExplainEnabled,
+            _localConfiguration.transactionTracer.explainEnabled);
+
+    public virtual int SqlExplainPlansMax => _localConfiguration.transactionTracer.maxExplainPlans;
+    public virtual uint SqlStatementsPerTransaction => 500;
+    public virtual int SqlTracesPerPeriod => 10;
+
+    #endregion
+
+    public virtual int StackTraceMaximumFrames => _localConfiguration.maxStackTraceLines;
+    public virtual IEnumerable<string> HttpStatusCodesToIgnore { get; private set; }
+
+    public virtual IEnumerable<string> ThreadProfilingIgnoreMethods => _localConfiguration.threadProfiling ?? [];
+
+    #region Custom Events
+
+
+    private BoolConfigurationItem _customEventsAreEnabled;
+
+    public string CustomEventsEnabledSource
+    {
+        get
+        {
+            _customEventsAreEnabled ??= GetCustomEventsAreEnabledConfiguration();
+
+            return _customEventsAreEnabled.Source;
+        }
+    }
+
+    public virtual bool CustomEventsEnabled
+    {
+        get
+        {
+            _customEventsAreEnabled ??= GetCustomEventsAreEnabledConfiguration();
+
+            return _customEventsAreEnabled.Value;
+        }
+    }
+
+    private BoolConfigurationItem GetCustomEventsAreEnabledConfiguration()
+    {
+        if (HighSecurityModeEnabled)
+        {
+            return new BoolConfigurationItem(false, HighSecurityConfigSource);
         }
 
-        public virtual bool CustomInstrumentationEditorEnabled
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomEventsPolicyName)
+            && (_securityPoliciesConfiguration.CustomEvents.Enabled == false))
         {
-            get
-            {
-                if (_customInstrumentationEditorIsEnabled == null)
-                {
-                    _customInstrumentationEditorIsEnabled = GetCustomInstrumentationEditorConfiguration();
-                }
-
-                return _customInstrumentationEditorIsEnabled.Value;
-            }
+            return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
         }
 
-        private BoolConfigurationItem GetCustomInstrumentationEditorConfiguration()
+        if (_serverConfiguration.CustomEventCollectionEnabled.HasValue
+            && (_serverConfiguration.CustomEventCollectionEnabled.Value == false))
         {
-            if (HighSecurityModeEnabled)
-            {
-                return new BoolConfigurationItem(false, HighSecurityConfigSource);
-            }
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomInstrumentationEditorPolicyName)
-                && (_securityPoliciesConfiguration.CustomInstrumentationEditor.Enabled == false))
-            {
-                return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
-            }
-
-            return new BoolConfigurationItem(_localConfiguration.customInstrumentationEditor.enabled, LocalConfigSource);
+            return new BoolConfigurationItem(false, ServerConfigSource);
         }
 
-        private BoolConfigurationItem _shouldStripExceptionMessages;
-
-        public string StripExceptionMessagesSource
+        if (CustomEventsMaximumSamplesStored == 0)
         {
-            get
-            {
-                if (_shouldStripExceptionMessages == null)
-                {
-                    _shouldStripExceptionMessages = GetShouldStripExceptionMessagesConfiguration();
-                }
-
-                return _shouldStripExceptionMessages.Source;
-            }
+            return new BoolConfigurationItem(false, $"{nameof(CustomEventsMaximumSamplesStored)} set to 0");
         }
 
-        public virtual bool StripExceptionMessages
-        {
-            get
-            {
-                if (_shouldStripExceptionMessages == null)
-                {
-                    _shouldStripExceptionMessages = GetShouldStripExceptionMessagesConfiguration();
-                }
+        return new BoolConfigurationItem(_localConfiguration.customEvents.enabled, LocalConfigSource);
+    }
 
-                return _shouldStripExceptionMessages.Value;
-            }
+    public virtual int CustomEventsMaximumSamplesStored
+    {
+        get
+        {
+            // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
+            var maxValue = _localConfiguration.customEvents.maximumSamplesStored;
+            return ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_EVENT_SAMPLES_STORED"));
+        }
+    }
+
+    public TimeSpan CustomEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestCycle(), TimeSpan.FromMinutes(1));
+
+    public bool CustomEventsAttributesEnabled => CaptureAttributes && _localConfiguration.customEvents.attributes.enabled;
+
+
+    private HashSet<string> _customEventsAttributesInclude;
+    public HashSet<string> CustomEventsAttributesInclude =>
+        _customEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && CustomEventsAttributesEnabled
+            ? [.. _localConfiguration.customEvents.attributes.include]
+            : [];
+
+    private HashSet<string> _customEventsAttributesExclude;
+    public HashSet<string> CustomEventsAttributesExclude => _customEventsAttributesExclude ??= [.. _localConfiguration.customEvents.attributes.exclude];
+
+    #endregion
+
+    public bool DisableSamplers { get { return EnvironmentOverrides(_localConfiguration.application.disableSamplers, "NEW_RELIC_DISABLE_SAMPLERS"); } }
+
+    public bool ThreadProfilingEnabled { get { return _localConfiguration.threadProfilingEnabled; } }
+
+    #region Transaction Events
+
+    public virtual bool TransactionEventsEnabled
+    {
+        get
+        {
+            return TransactionEventsMaximumSamplesStored > 0 && ServerCanDisable(
+                _serverConfiguration.AnalyticsEventCollectionEnabled,
+                _localConfiguration.transactionEvents.enabled);
+        }
+    }
+
+    public virtual int TransactionEventsMaximumSamplesStored
+    {
+        get
+        {
+            // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
+            var maxValue = _localConfiguration.transactionEvents.maximumSamplesStored;
+
+            return ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_TRANSACTION_SAMPLES_STORED"));
+        }
+    }
+
+    public TimeSpan TransactionEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestCycle(), TimeSpan.FromMinutes(1));
+
+    public virtual bool TransactionEventsTransactionsEnabled => _localConfiguration.transactionEvents.transactions.enabledSpecified ? _localConfiguration.transactionEvents.transactions.enabled : TransactionEventsTransactionsEnabledDefault;
+
+    #endregion
+
+    #region Transaction Tracer
+
+    public virtual TimeSpan TransactionTraceApdexF => TransactionTraceApdexT.Multiply(4);
+
+    public virtual TimeSpan TransactionTraceApdexT =>
+        // get apdex_t from environment variable if running in serverless mode
+        TimeSpan.FromSeconds(ServerlessModeEnabled ?
+            EnvironmentOverrides(0.5, "NEW_RELIC_APDEX_T").GetValueOrDefault() : ServerOverrides(_serverConfiguration.ApdexT, 0.5));
+
+    public virtual TimeSpan TransactionTraceThreshold =>
+        (_serverConfiguration.RpmConfig.TransactionTracerThreshold == null)
+            ? ParseTransactionThreshold(_localConfiguration.transactionTracer.transactionThreshold, TimeSpan.FromMilliseconds)
+            : ParseTransactionThreshold(_serverConfiguration.RpmConfig.TransactionTracerThreshold.ToString(), TimeSpan.FromSeconds);
+
+    public virtual bool TransactionTracerEnabled
+    {
+        get
+        {
+            var configuredValue = ServerOverrides(_serverConfiguration.RpmConfig.TransactionTracerEnabled, _localConfiguration.transactionTracer.enabled);
+            return ServerCanDisable(_serverConfiguration.TraceCollectionEnabled, configuredValue);
+        }
+    }
+    public virtual int TransactionTracerMaxSegments => _localConfiguration.transactionTracer.maxSegments;
+
+    private RecordSqlConfigurationItem _recordSqlConfiguration;
+
+    public string TransactionTracerRecordSqlSource
+    {
+        get
+        {
+            _recordSqlConfiguration ??= GetRecordSqlConfiguration();
+
+            return _recordSqlConfiguration.Source;
+        }
+    }
+
+    public virtual string TransactionTracerRecordSql
+    {
+        get
+        {
+            _recordSqlConfiguration ??= GetRecordSqlConfiguration();
+
+            return _recordSqlConfiguration.Value;
+        }
+    }
+
+    private RecordSqlConfigurationItem GetRecordSqlConfiguration()
+    {
+        if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.RecordSqlPolicyName))
+        {
+            var localRecordSql = _localConfiguration.transactionTracer.recordSql;
+            var serverConfigRecordSql = _serverConfiguration.RpmConfig.TransactionTracerRecordSql;
+
+            // "raw" is never allowed with security policies
+            var policyValue = _securityPoliciesConfiguration.RecordSql.Enabled ? ObfuscatedStringValue : OffStringValue;
+
+            var mostRestrictiveConfiguration = new RecordSqlConfigurationItem(policyValue, SecurityPolicyConfigSource)
+                .ApplyIfMoreRestrictive(serverConfigRecordSql, ServerConfigSource)
+                .ApplyIfMoreRestrictive(localRecordSql, LocalConfigSource);
+
+            return mostRestrictiveConfiguration;
         }
 
-        private BoolConfigurationItem GetShouldStripExceptionMessagesConfiguration()
+        var serverOrLocalConfiguration = GetServerOverrideOrLocalRecordSqlConfiguration();
+
+        if (HighSecurityModeEnabled)
         {
-            // true is the more secure state, which will remove raw exception messages
+            // "raw" is never allowed with high security
+            var hsmConfiguration = new RecordSqlConfigurationItem(ObfuscatedStringValue, HighSecurityConfigSource)
+                .ApplyIfMoreRestrictive(serverOrLocalConfiguration);
 
-            if (HighSecurityModeEnabled)
-            {
-                return new BoolConfigurationItem(true, HighSecurityConfigSource);
-            }
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.AllowRawExceptionMessagePolicyName)
-                && (_securityPoliciesConfiguration.AllowRawExceptionMessage.Enabled == false))
-            {
-                return new BoolConfigurationItem(true, SecurityPolicyConfigSource);
-            }
-
-            return new BoolConfigurationItem(_localConfiguration.stripExceptionMessages.enabled, LocalConfigSource);
+            return hsmConfiguration;
         }
 
-        public virtual bool InstrumentationLoggingEnabled { get { return _localConfiguration.instrumentation.log; } }
+        return serverOrLocalConfiguration;
+    }
 
-        #region Labels
-
-        private string _labels;
-        private bool _labelsChecked;
-        public virtual string Labels
+    private RecordSqlConfigurationItem GetServerOverrideOrLocalRecordSqlConfiguration()
+    {
+        if (string.IsNullOrWhiteSpace(_serverConfiguration.RpmConfig.TransactionTracerRecordSql) == false)
         {
-            get
-            {
-                if (!_labelsChecked)
-                {
-                    var labels = _configurationManagerStatic.GetAppSetting(Constants.AppSettingsLabels);
-                    if (labels != null)
-                    {
-                        Log.Info("Application labels from web.config, app.config, or appsettings.json.");
-                        _labels = labels;
-                    }
-                    else
-                    {
-                        _labels = EnvironmentOverrides(_localConfiguration.labels, @"NEW_RELIC_LABELS");
-                    }
-                    _labelsChecked = true;
-                }
-                return _labels;
-            }
+            return new RecordSqlConfigurationItem(_serverConfiguration.RpmConfig.TransactionTracerRecordSql, ServerConfigSource);
         }
 
-        #endregion
+        var localRecordSqlString = Enum.GetName(typeof(configurationTransactionTracerRecordSql), _localConfiguration.transactionTracer.recordSql);
+        return new RecordSqlConfigurationItem(localRecordSqlString, LocalConfigSource);
+    }
 
-        #region Proxy
+    public virtual int TransactionTracerMaxStackTraces => _localConfiguration.transactionTracer.maxStackTrace;
 
-        public virtual string ProxyHost
+    private IList<Regex> _requestPathExclusionList;
+    public virtual IEnumerable<Regex> RequestPathExclusionList => _requestPathExclusionList ??= ReadUrlBlacklist(_localConfiguration);
+
+
+    #endregion
+
+    public virtual IEnumerable<long> TrustedAccountIds => _serverConfiguration.TrustedIds ?? [];
+
+    public bool ServerSideConfigurationEnabled => _serverConfiguration.ServerSideConfigurationEnabled;
+
+    #region Metric naming
+
+    private IEnumerable<RegexRule> _metricNameRegexRules;
+    public IEnumerable<RegexRule> MetricNameRegexRules => _metricNameRegexRules ??= GetRegexRules(_serverConfiguration.MetricNameRegexRules);
+
+    private IEnumerable<RegexRule> _transactionNameRegexRules;
+    public IEnumerable<RegexRule> TransactionNameRegexRules => _transactionNameRegexRules ??= GetRegexRules(_serverConfiguration.TransactionNameRegexRules);
+
+    private IEnumerable<RegexRule> _rrlRegexRules;
+    public IEnumerable<RegexRule> UrlRegexRules => _rrlRegexRules ??= GetRegexRules(_serverConfiguration.UrlRegexRules);
+
+    private IDictionary<string, IEnumerable<string>> _transactionNameWhitelistRules;
+    public IDictionary<string, IEnumerable<string>> TransactionNameWhitelistRules => _transactionNameWhitelistRules ??= GetWhitelistRules(_serverConfiguration.TransactionNameWhitelistRules);
+
+    private IDictionary<string, double> _webTransactionsApdex;
+
+    public IDictionary<string, double> WebTransactionsApdex => _webTransactionsApdex ??= _serverConfiguration.WebTransactionsApdex ?? new Dictionary<string, double>();
+
+    #endregion Metric naming
+
+    public string NewRelicConfigFilePath => _bootstrapConfiguration.ConfigurationFileName;
+    public string AppSettingsConfigFilePath => _configurationManagerStatic.AppSettingsFilePath;
+
+    #region Utilization
+
+    public bool UtilizationDetectAws => EnvironmentOverrides(_localConfiguration.utilization.detectAws, "NEW_RELIC_UTILIZATION_DETECT_AWS");
+
+    public bool UtilizationDetectAzure => EnvironmentOverrides(_localConfiguration.utilization.detectAzure, "NEW_RELIC_UTILIZATION_DETECT_AZURE");
+
+    public bool UtilizationDetectGcp => EnvironmentOverrides(_localConfiguration.utilization.detectGcp, "NEW_RELIC_UTILIZATION_DETECT_GCP");
+
+    public bool UtilizationDetectPcf => EnvironmentOverrides(_localConfiguration.utilization.detectPcf, "NEW_RELIC_UTILIZATION_DETECT_PCF");
+
+    public bool UtilizationDetectDocker => EnvironmentOverrides(_localConfiguration.utilization.detectDocker, "NEW_RELIC_UTILIZATION_DETECT_DOCKER");
+
+    public bool UtilizationDetectKubernetes => EnvironmentOverrides(_localConfiguration.utilization.detectKubernetes, "NEW_RELIC_UTILIZATION_DETECT_KUBERNETES");
+
+    public bool UtilizationDetectAzureFunction => AzureFunctionModeEnabled && EnvironmentOverrides(_localConfiguration.utilization.detectAzureFunction, "NEW_RELIC_UTILIZATION_DETECT_AZURE_FUNCTION");
+
+    public bool UtilizationDetectAzureAppService => EnvironmentOverrides(_localConfiguration.utilization.detectAzureAppService, "NEW_RELIC_UTILIZATION_DETECT_AZURE_APPSERVICE");
+
+    public int? UtilizationLogicalProcessors
+    {
+        get
         {
-            get
-            {
-                return EnvironmentOverrides(_localConfiguration.service.proxy.host, "NEW_RELIC_PROXY_HOST");
-            }
+            var localValue = GetNullableIntValue(_localConfiguration.utilization.logicalProcessorsSpecified, _localConfiguration.utilization.logicalProcessors);
+            return EnvironmentOverrides(localValue, "NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS");
         }
+    }
 
-        public virtual string ProxyUriPath
+    public int? UtilizationTotalRamMib
+    {
+        get
         {
-            get
-            {
-                return EnvironmentOverrides(_localConfiguration.service.proxy.uriPath, "NEW_RELIC_PROXY_URI_PATH");
-            }
+            var localValue = GetNullableIntValue(_localConfiguration.utilization.totalRamMibSpecified, _localConfiguration.utilization.totalRamMib);
+            return EnvironmentOverrides(localValue, "NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB");
         }
+    }
 
-        public virtual int ProxyPort
+    public string UtilizationBillingHost
+    {
+        get
         {
-            get
-            {
-                return EnvironmentOverrides(_localConfiguration.service.proxy.port, "NEW_RELIC_PROXY_PORT").Value;
-            }
+            var value = EnvironmentOverrides(_localConfiguration.utilization.billingHost, "NEW_RELIC_UTILIZATION_BILLING_HOSTNAME");
+            return string.IsNullOrEmpty(value) ? null : value.Trim(); //Keeping IsNullOrEmpty just in case customer sets value to "".
         }
+    }
 
-        public virtual string ProxyUsername
+    private readonly Lazy<string> _utilizationFullHostName;
+    public string UtilizationFullHostName => _utilizationFullHostName.Value;
+
+    private readonly Lazy<string> _utilizationHostName;
+    public string UtilizationHostName => _utilizationHostName.Value;
+
+    #endregion
+
+    #region Log Events and Metrics
+
+    public virtual bool ApplicationLoggingEnabled => EnvironmentOverrides(_localConfiguration.applicationLogging.enabled, "NEW_RELIC_APPLICATION_LOGGING_ENABLED");
+
+    public virtual bool LogMetricsCollectorEnabled =>
+        ApplicationLoggingEnabled &&
+        EnvironmentOverrides(_localConfiguration.applicationLogging.metrics.enabled, "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED");
+
+    public virtual bool LogEventCollectorEnabled =>
+        ApplicationLoggingEnabled &&
+        LogEventsMaxSamplesStored > 0 &&
+        !SecurityPoliciesTokenExists &&
+        HighSecurityModeOverrides(false,
+            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED"));
+
+    public bool ContextDataEnabled =>
+        LogEventCollectorEnabled &&
+        EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED");
+
+    public IEnumerable<string> ContextDataInclude =>
+        EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.include,
+                "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE")
+            .Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries);
+
+    public IEnumerable<string> ContextDataExclude =>
+        EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.exclude,
+                "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE")
+            .Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries);
+
+    public TimeSpan LogEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestCycle(), TimeSpan.FromSeconds(5));
+
+    public virtual int LogEventsMaxSamplesStored =>
+        // This is different from the other faster event harvest settings since we want to ensure that local values are properly distributed across the harvest.
+        // Using the GetValueOrDefault to ensure that a value is provided if all other values are removed.
+        ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(),
+            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.maxSamplesStored,
+                "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED").GetValueOrDefault(10000));
+
+    public virtual bool LogDecoratorEnabled =>
+        ApplicationLoggingEnabled &&
+        EnvironmentOverrides(_localConfiguration.applicationLogging.localDecorating.enabled, "NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED");
+
+    private HashSet<string> _logLevelDenyList;
+    public virtual HashSet<string> LogLevelDenyList
+    {
+        get
         {
-            get
+            if (_logLevelDenyList == null)
             {
-                return EnvironmentOverrides(_localConfiguration.service.proxy.user, "NEW_RELIC_PROXY_USER");
-            }
-        }
-
-
-        private bool _obscuringKeyEvaluated;
-        private string _obscuringKey;
-        public string ObscuringKey
-        {
-            get
-            {
-                if (!_obscuringKeyEvaluated)
-                {
-                    _obscuringKey = EnvironmentOverrides(_localConfiguration.service.obscuringKey, "NEW_RELIC_CONFIG_OBSCURING_KEY");
-                    _obscuringKeyEvaluated = true;
-                }
-
-                return _obscuringKey;
-            }
-        }
-
-        private bool _proxyPasswordEvaluated;
-        private string _proxyPassword;
-        public virtual string ProxyPassword
-        {
-            get
-            {
-                if (!_proxyPasswordEvaluated)
-                {
-                    var hasObscuringKey = !string.IsNullOrWhiteSpace(ObscuringKey);
-                    var passwordObfuscated = EnvironmentOverrides(_localConfiguration.service.proxy.passwordObfuscated, "NEW_RELIC_PROXY_PASS_OBFUSCATED");
-                    var hasObfuscatedPassword = !string.IsNullOrWhiteSpace(passwordObfuscated);
-
-                    if (hasObscuringKey && hasObfuscatedPassword)
-                    {
-                        _proxyPassword = Strings.Base64Decode(passwordObfuscated, ObscuringKey);
-                    }
-                    else
-                    {
-                        _proxyPassword = EnvironmentOverrides(_localConfiguration.service.proxy.password, "NEW_RELIC_PROXY_PASS");
-                    }
-
-                    _proxyPasswordEvaluated = true;
-                }
-
-                return _proxyPassword;
-            }
-        }
-
-        public virtual string ProxyDomain
-        {
-            get
-            {
-                return EnvironmentOverrides(_localConfiguration.service.proxy.domain, "NEW_RELIC_PROXY_DOMAIN") ?? string.Empty;
-            }
-        }
-
-        #endregion
-
-        #region DataTransmission
-        public bool PutForDataSend { get { return _localConfiguration.dataTransmission.putForDataSend; } }
-
-        public string CompressedContentEncoding
-        {
-            get
-            {
-                return _localConfiguration.dataTransmission.compressedContentEncoding.ToString();
-            }
-        }
-
-        #endregion
-
-        #region DatastoreTracer
-        public bool InstanceReportingEnabled { get { return _localConfiguration.datastoreTracer.instanceReporting.enabled; } }
-
-        public bool DatabaseNameReportingEnabled { get { return _localConfiguration.datastoreTracer.databaseNameReporting.enabled; } }
-
-        public bool DatastoreTracerQueryParametersEnabled => _localConfiguration.datastoreTracer.queryParameters.enabled && TransactionTracerRecordSql == RawStringValue;
-
-        #endregion
-
-        #region Sql
-
-        public bool SlowSqlEnabled => ServerOverrides(_serverConfiguration.RpmConfig.SlowSqlEnabled, _localConfiguration.slowSql.enabled);
-
-        public virtual TimeSpan SqlExplainPlanThreshold
-        {
-            get
-            {
-                var serverThreshold = _serverConfiguration.RpmConfig.TransactionTracerExplainThreshold;
-
-                return serverThreshold.HasValue ?
-                    TimeSpan.FromSeconds(serverThreshold.Value) :
-                    TimeSpan.FromMilliseconds(_localConfiguration.transactionTracer.explainThreshold);
-            }
-        }
-
-        public virtual bool SqlExplainPlansEnabled =>
-            ServerOverrides(_serverConfiguration.RpmConfig.TransactionTracerExplainEnabled,
-                _localConfiguration.transactionTracer.explainEnabled);
-
-        public virtual int SqlExplainPlansMax => _localConfiguration.transactionTracer.maxExplainPlans;
-        public virtual uint SqlStatementsPerTransaction => 500;
-        public virtual int SqlTracesPerPeriod => 10;
-
-        #endregion
-
-        public virtual int StackTraceMaximumFrames => _localConfiguration.maxStackTraceLines;
-        public virtual IEnumerable<string> HttpStatusCodesToIgnore { get; private set; }
-
-        public virtual IEnumerable<string> ThreadProfilingIgnoreMethods => _localConfiguration.threadProfiling ?? [];
-
-        #region Custom Events
-
-
-        private BoolConfigurationItem _customEventsAreEnabled;
-
-        public string CustomEventsEnabledSource
-        {
-            get
-            {
-                _customEventsAreEnabled ??= GetCustomEventsAreEnabledConfiguration();
-
-                return _customEventsAreEnabled.Source;
-            }
-        }
-
-        public virtual bool CustomEventsEnabled
-        {
-            get
-            {
-                _customEventsAreEnabled ??= GetCustomEventsAreEnabledConfiguration();
-
-                return _customEventsAreEnabled.Value;
-            }
-        }
-
-        private BoolConfigurationItem GetCustomEventsAreEnabledConfiguration()
-        {
-            if (HighSecurityModeEnabled)
-            {
-                return new BoolConfigurationItem(false, HighSecurityConfigSource);
-            }
-
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.CustomEventsPolicyName)
-                && (_securityPoliciesConfiguration.CustomEvents.Enabled == false))
-            {
-                return new BoolConfigurationItem(false, SecurityPolicyConfigSource);
-            }
-
-            if (_serverConfiguration.CustomEventCollectionEnabled.HasValue
-                && (_serverConfiguration.CustomEventCollectionEnabled.Value == false))
-            {
-                return new BoolConfigurationItem(false, ServerConfigSource);
-            }
-
-            if (CustomEventsMaximumSamplesStored == 0)
-            {
-                return new BoolConfigurationItem(false, $"{nameof(CustomEventsMaximumSamplesStored)} set to 0");
-            }
-
-            return new BoolConfigurationItem(_localConfiguration.customEvents.enabled, LocalConfigSource);
-        }
-
-        public virtual int CustomEventsMaximumSamplesStored
-        {
-            get
-            {
-                // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
-                var maxValue = _localConfiguration.customEvents.maximumSamplesStored;
-                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_EVENT_SAMPLES_STORED"));
-            }
-        }
-
-        public TimeSpan CustomEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.CustomEventHarvestCycle(), TimeSpan.FromMinutes(1));
-
-        public bool CustomEventsAttributesEnabled => CaptureAttributes && _localConfiguration.customEvents.attributes.enabled;
-
-
-        private HashSet<string> _customEventsAttributesInclude;
-        public HashSet<string> CustomEventsAttributesInclude =>
-            _customEventsAttributesInclude ??= IsAttributesAllowedByConfigurableSecurityPolicy && CustomEventsAttributesEnabled
-                ? [.. _localConfiguration.customEvents.attributes.include]
-                : [];
-
-        private HashSet<string> _customEventsAttributesExclude;
-        public HashSet<string> CustomEventsAttributesExclude => _customEventsAttributesExclude ??= [.. _localConfiguration.customEvents.attributes.exclude];
-
-        #endregion
-
-        public bool DisableSamplers { get { return EnvironmentOverrides(_localConfiguration.application.disableSamplers, "NEW_RELIC_DISABLE_SAMPLERS"); } }
-
-        public bool ThreadProfilingEnabled { get { return _localConfiguration.threadProfilingEnabled; } }
-
-        #region Transaction Events
-
-        public virtual bool TransactionEventsEnabled
-        {
-            get
-            {
-                return TransactionEventsMaximumSamplesStored > 0 && ServerCanDisable(
-                    _serverConfiguration.AnalyticsEventCollectionEnabled,
-                    _localConfiguration.transactionEvents.enabled);
-            }
-        }
-
-        public virtual int TransactionEventsMaximumSamplesStored
-        {
-            get
-            {
-                // Faster Event Harvest configuration rules apply here, which is why ServerOverrides takes precedence over EnvironmentOverrides
-                var maxValue = _localConfiguration.transactionEvents.maximumSamplesStored;
-
-                return ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestLimit(), (int)EnvironmentOverrides(maxValue, "MAX_TRANSACTION_SAMPLES_STORED"));
-            }
-        }
-
-        public TimeSpan TransactionEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.TransactionEventHarvestCycle(), TimeSpan.FromMinutes(1));
-
-        public virtual bool TransactionEventsTransactionsEnabled => _localConfiguration.transactionEvents.transactions.enabledSpecified ? _localConfiguration.transactionEvents.transactions.enabled : TransactionEventsTransactionsEnabledDefault;
-
-        #endregion
-
-        #region Transaction Tracer
-
-        public virtual TimeSpan TransactionTraceApdexF => TransactionTraceApdexT.Multiply(4);
-
-        public virtual TimeSpan TransactionTraceApdexT =>
-            // get apdex_t from environment variable if running in serverless mode
-            TimeSpan.FromSeconds(ServerlessModeEnabled ?
-                EnvironmentOverrides(0.5, "NEW_RELIC_APDEX_T").GetValueOrDefault() : ServerOverrides(_serverConfiguration.ApdexT, 0.5));
-
-        public virtual TimeSpan TransactionTraceThreshold =>
-            (_serverConfiguration.RpmConfig.TransactionTracerThreshold == null)
-                ? ParseTransactionThreshold(_localConfiguration.transactionTracer.transactionThreshold, TimeSpan.FromMilliseconds)
-                : ParseTransactionThreshold(_serverConfiguration.RpmConfig.TransactionTracerThreshold.ToString(), TimeSpan.FromSeconds);
-
-        public virtual bool TransactionTracerEnabled
-        {
-            get
-            {
-                var configuredValue = ServerOverrides(_serverConfiguration.RpmConfig.TransactionTracerEnabled, _localConfiguration.transactionTracer.enabled);
-                return ServerCanDisable(_serverConfiguration.TraceCollectionEnabled, configuredValue);
-            }
-        }
-        public virtual int TransactionTracerMaxSegments => _localConfiguration.transactionTracer.maxSegments;
-
-        private RecordSqlConfigurationItem _recordSqlConfiguration;
-
-        public string TransactionTracerRecordSqlSource
-        {
-            get
-            {
-                _recordSqlConfiguration ??= GetRecordSqlConfiguration();
-
-                return _recordSqlConfiguration.Source;
-            }
-        }
-
-        public virtual string TransactionTracerRecordSql
-        {
-            get
-            {
-                _recordSqlConfiguration ??= GetRecordSqlConfiguration();
-
-                return _recordSqlConfiguration.Value;
-            }
-        }
-
-        private RecordSqlConfigurationItem GetRecordSqlConfiguration()
-        {
-            if (_securityPoliciesConfiguration.SecurityPolicyExistsFor(SecurityPoliciesConfiguration.RecordSqlPolicyName))
-            {
-                var localRecordSql = _localConfiguration.transactionTracer.recordSql;
-                var serverConfigRecordSql = _serverConfiguration.RpmConfig.TransactionTracerRecordSql;
-
-                // "raw" is never allowed with security policies
-                var policyValue = _securityPoliciesConfiguration.RecordSql.Enabled ? ObfuscatedStringValue : OffStringValue;
-
-                var mostRestrictiveConfiguration = new RecordSqlConfigurationItem(policyValue, SecurityPolicyConfigSource)
-                    .ApplyIfMoreRestrictive(serverConfigRecordSql, ServerConfigSource)
-                    .ApplyIfMoreRestrictive(localRecordSql, LocalConfigSource);
-
-                return mostRestrictiveConfiguration;
-            }
-
-            var serverOrLocalConfiguration = GetServerOverrideOrLocalRecordSqlConfiguration();
-
-            if (HighSecurityModeEnabled)
-            {
-                // "raw" is never allowed with high security
-                var hsmConfiguration = new RecordSqlConfigurationItem(ObfuscatedStringValue, HighSecurityConfigSource)
-                    .ApplyIfMoreRestrictive(serverOrLocalConfiguration);
-
-                return hsmConfiguration;
-            }
-
-            return serverOrLocalConfiguration;
-        }
-
-        private RecordSqlConfigurationItem GetServerOverrideOrLocalRecordSqlConfiguration()
-        {
-            if (string.IsNullOrWhiteSpace(_serverConfiguration.RpmConfig.TransactionTracerRecordSql) == false)
-            {
-                return new RecordSqlConfigurationItem(_serverConfiguration.RpmConfig.TransactionTracerRecordSql, ServerConfigSource);
-            }
-
-            var localRecordSqlString = Enum.GetName(typeof(configurationTransactionTracerRecordSql), _localConfiguration.transactionTracer.recordSql);
-            return new RecordSqlConfigurationItem(localRecordSqlString, LocalConfigSource);
-        }
-
-        public virtual int TransactionTracerMaxStackTraces => _localConfiguration.transactionTracer.maxStackTrace;
-
-        private IList<Regex> _requestPathExclusionList;
-        public virtual IEnumerable<Regex> RequestPathExclusionList => _requestPathExclusionList ??= ReadUrlBlacklist(_localConfiguration);
-
-
-        #endregion
-
-        public virtual IEnumerable<long> TrustedAccountIds => _serverConfiguration.TrustedIds ?? [];
-
-        public bool ServerSideConfigurationEnabled => _serverConfiguration.ServerSideConfigurationEnabled;
-
-        #region Metric naming
-
-        private IEnumerable<RegexRule> _metricNameRegexRules;
-        public IEnumerable<RegexRule> MetricNameRegexRules => _metricNameRegexRules ??= GetRegexRules(_serverConfiguration.MetricNameRegexRules);
-
-        private IEnumerable<RegexRule> _transactionNameRegexRules;
-        public IEnumerable<RegexRule> TransactionNameRegexRules => _transactionNameRegexRules ??= GetRegexRules(_serverConfiguration.TransactionNameRegexRules);
-
-        private IEnumerable<RegexRule> _rrlRegexRules;
-        public IEnumerable<RegexRule> UrlRegexRules => _rrlRegexRules ??= GetRegexRules(_serverConfiguration.UrlRegexRules);
-
-        private IDictionary<string, IEnumerable<string>> _transactionNameWhitelistRules;
-        public IDictionary<string, IEnumerable<string>> TransactionNameWhitelistRules => _transactionNameWhitelistRules ??= GetWhitelistRules(_serverConfiguration.TransactionNameWhitelistRules);
-
-        private IDictionary<string, double> _webTransactionsApdex;
-
-        public IDictionary<string, double> WebTransactionsApdex => _webTransactionsApdex ??= _serverConfiguration.WebTransactionsApdex ?? new Dictionary<string, double>();
-
-        #endregion Metric naming
-
-        public string NewRelicConfigFilePath => _bootstrapConfiguration.ConfigurationFileName;
-        public string AppSettingsConfigFilePath => _configurationManagerStatic.AppSettingsFilePath;
-
-        #region Utilization
-
-        public bool UtilizationDetectAws => EnvironmentOverrides(_localConfiguration.utilization.detectAws, "NEW_RELIC_UTILIZATION_DETECT_AWS");
-
-        public bool UtilizationDetectAzure => EnvironmentOverrides(_localConfiguration.utilization.detectAzure, "NEW_RELIC_UTILIZATION_DETECT_AZURE");
-
-        public bool UtilizationDetectGcp => EnvironmentOverrides(_localConfiguration.utilization.detectGcp, "NEW_RELIC_UTILIZATION_DETECT_GCP");
-
-        public bool UtilizationDetectPcf => EnvironmentOverrides(_localConfiguration.utilization.detectPcf, "NEW_RELIC_UTILIZATION_DETECT_PCF");
-
-        public bool UtilizationDetectDocker => EnvironmentOverrides(_localConfiguration.utilization.detectDocker, "NEW_RELIC_UTILIZATION_DETECT_DOCKER");
-
-        public bool UtilizationDetectKubernetes => EnvironmentOverrides(_localConfiguration.utilization.detectKubernetes, "NEW_RELIC_UTILIZATION_DETECT_KUBERNETES");
-
-        public bool UtilizationDetectAzureFunction => AzureFunctionModeEnabled && EnvironmentOverrides(_localConfiguration.utilization.detectAzureFunction, "NEW_RELIC_UTILIZATION_DETECT_AZURE_FUNCTION");
-
-        public bool UtilizationDetectAzureAppService => EnvironmentOverrides(_localConfiguration.utilization.detectAzureAppService, "NEW_RELIC_UTILIZATION_DETECT_AZURE_APPSERVICE");
-
-        public int? UtilizationLogicalProcessors
-        {
-            get
-            {
-                var localValue = GetNullableIntValue(_localConfiguration.utilization.logicalProcessorsSpecified, _localConfiguration.utilization.logicalProcessors);
-                return EnvironmentOverrides(localValue, "NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS");
-            }
-        }
-
-        public int? UtilizationTotalRamMib
-        {
-            get
-            {
-                var localValue = GetNullableIntValue(_localConfiguration.utilization.totalRamMibSpecified, _localConfiguration.utilization.totalRamMib);
-                return EnvironmentOverrides(localValue, "NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB");
-            }
-        }
-
-        public string UtilizationBillingHost
-        {
-            get
-            {
-                var value = EnvironmentOverrides(_localConfiguration.utilization.billingHost, "NEW_RELIC_UTILIZATION_BILLING_HOSTNAME");
-                return string.IsNullOrEmpty(value) ? null : value.Trim(); //Keeping IsNullOrEmpty just in case customer sets value to "".
-            }
-        }
-
-        private readonly Lazy<string> _utilizationFullHostName;
-        public string UtilizationFullHostName => _utilizationFullHostName.Value;
-
-        private readonly Lazy<string> _utilizationHostName;
-        public string UtilizationHostName => _utilizationHostName.Value;
-
-        #endregion
-
-        #region Log Events and Metrics
-
-        public virtual bool ApplicationLoggingEnabled => EnvironmentOverrides(_localConfiguration.applicationLogging.enabled, "NEW_RELIC_APPLICATION_LOGGING_ENABLED");
-
-        public virtual bool LogMetricsCollectorEnabled =>
-            ApplicationLoggingEnabled &&
-            EnvironmentOverrides(_localConfiguration.applicationLogging.metrics.enabled, "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED");
-
-        public virtual bool LogEventCollectorEnabled =>
-            ApplicationLoggingEnabled &&
-            LogEventsMaxSamplesStored > 0 &&
-            !SecurityPoliciesTokenExists &&
-            HighSecurityModeOverrides(false,
-                EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED"));
-
-        public bool ContextDataEnabled =>
-            LogEventCollectorEnabled &&
-            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED");
-
-        public IEnumerable<string> ContextDataInclude =>
-            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.include,
-                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE")
-                .Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries);
-
-        public IEnumerable<string> ContextDataExclude =>
-            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.contextData.exclude,
-                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE")
-                .Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries);
-
-        public TimeSpan LogEventsHarvestCycle => ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestCycle(), TimeSpan.FromSeconds(5));
-
-        public virtual int LogEventsMaxSamplesStored =>
-            // This is different from the other faster event harvest settings since we want to ensure that local values are properly distributed across the harvest.
-            // Using the GetValueOrDefault to ensure that a value is provided if all other values are removed.
-            ServerOverrides(_serverConfiguration.EventHarvestConfig?.LogEventHarvestLimit(),
-                EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.maxSamplesStored,
-                    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED").GetValueOrDefault(10000));
-
-        public virtual bool LogDecoratorEnabled =>
-            ApplicationLoggingEnabled &&
-            EnvironmentOverrides(_localConfiguration.applicationLogging.localDecorating.enabled, "NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED");
-
-        private HashSet<string> _logLevelDenyList;
-        public virtual HashSet<string> LogLevelDenyList
-        {
-            get
-            {
-                if (_logLevelDenyList == null)
-                {
-                    _logLevelDenyList =
-                    [
-                        ..EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.logLevelDenyList,
-                                  "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST")
-                              ?.Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries)
-                              .Select(s => s.ToUpper())
-                          ?? []
-                    ];
-
-                    if (_logLevelDenyList.Count > 0)
-                    {
-                        var logLevels = string.Join(",", _logLevelDenyList);
-                        Log.Info($"Log Level Filtering is enabled for the following levels: {logLevels}");
-                    }
-                }
-
-                return _logLevelDenyList;
-            }
-        }
-
-        public virtual bool LabelsEnabled =>
-            LogEventCollectorEnabled &&
-            EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.labels.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED");
-
-        private HashSet<string> _labelsExclude;
-        public virtual IEnumerable<string> LabelsExclude
-        {
-            get
-            {
-                return _labelsExclude ??= [
-                    ..EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.labels.exclude,
-                              "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE")
+                _logLevelDenyList =
+                [
+                    ..EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.logLevelDenyList,
+                              "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST")
                           ?.Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries)
+                          .Select(s => s.ToUpper())
                       ?? []
                 ];
-            }
-        }
 
-        #endregion
-
-        private IEnumerable<IDictionary<string, string>> _ignoredInstrumentation;
-        public IEnumerable<IDictionary<string, string>> IgnoredInstrumentation =>
-            _ignoredInstrumentation ??= _localConfiguration.instrumentation.rules
-                .Select(i => new ReadOnlyDictionary<string, string>(
-                    new Dictionary<string, string>
-                    {
-                        { "assemblyName", i.assemblyName }, { "className", i.className }
-                    }
-                ))
-                .ToList();
-
-        public bool DisableFileSystemWatcher =>
-            ServerlessModeEnabled ||
-            !LoggingEnabled ||
-            EnvironmentOverrides(_localConfiguration.service.disableFileSystemWatcher, "NEW_RELIC_DISABLE_FILE_SYSTEM_WATCHER");
-
-        #region AI Monitoring
-
-        public bool AiMonitoringEnabled =>
-            // AI Monitoring is disabled in High Security Mode and can be disabled at the account level
-            !HighSecurityModeEnabled && ServerCanDisable(_serverConfiguration.AICollectionEnabled, EnvironmentOverrides(_localConfiguration.aiMonitoring.enabled, "NEW_RELIC_AI_MONITORING_ENABLED"));
-
-        public bool AiMonitoringStreamingEnabled =>
-            AiMonitoringEnabled &&
-            EnvironmentOverrides(_localConfiguration.aiMonitoring.streaming.enabled, "NEW_RELIC_AI_MONITORING_STREAMING_ENABLED");
-
-        public bool AiMonitoringRecordContentEnabled =>
-            AiMonitoringEnabled &&
-            EnvironmentOverrides(_localConfiguration.aiMonitoring.recordContent.enabled, "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED");
-
-        public Func<string, string, int> LlmTokenCountingCallback => _runTimeConfiguration.LlmTokenCountingCallback;
-
-        #region Azure function support
-
-        public bool AzureFunctionModeDetected => _bootstrapConfiguration.AzureFunctionModeDetected;
-
-        private bool? _azureFunctionModeEnabled;
-        public bool AzureFunctionModeEnabled =>
-            _azureFunctionModeEnabled ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AzureFunctionModeEnabled", true), "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED");
-
-        // Code to support AWS Lambda APM mode for transaction naming [ By default it is disabled ]
-        private bool? _awsLambdaApmModeEnabled;
-        public bool AwsLambdaApmModeEnabled =>
-            _awsLambdaApmModeEnabled ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AwsLambdaApmModeEnabled", false), "NEW_RELIC_APM_LAMBDA_MODE");
-
-        public string AzureFunctionResourceId
-        {
-            get
-            {
-                var websiteResourceGroup = AzureFunctionResourceGroupName;
-                var subscriptionId = AzureFunctionSubscriptionId;
-
-                if (string.IsNullOrEmpty(websiteResourceGroup) || string.IsNullOrEmpty(subscriptionId))
+                if (_logLevelDenyList.Count > 0)
                 {
-                    return string.Empty;
+                    var logLevels = string.Join(",", _logLevelDenyList);
+                    Log.Info($"Log Level Filtering is enabled for the following levels: {logLevels}");
                 }
-
-                return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{(string.IsNullOrEmpty(AzureFunctionAppName) ? "unknown" : AzureFunctionAppName)}";
             }
-        }
 
-        public string AzureFunctionResourceIdWithFunctionName(string functionName)
-        {
-            return string.IsNullOrEmpty(AzureFunctionResourceId) || string.IsNullOrEmpty(functionName)
-                ? string.Empty
-                : $"{AzureFunctionResourceId}/functions/{functionName}";
+            return _logLevelDenyList;
         }
+    }
 
-        public string AzureFunctionResourceGroupName
+    public virtual bool LabelsEnabled =>
+        LogEventCollectorEnabled &&
+        EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.labels.enabled, "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED");
+
+    private HashSet<string> _labelsExclude;
+    public virtual IEnumerable<string> LabelsExclude
+    {
+        get
         {
-            get
-            {
-                // WEBSITE_RESOURCE_GROUP doesn't seem to always be available for Linux.
-                var websiteResourceGroup = _environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
-                if (!string.IsNullOrEmpty(websiteResourceGroup))
+            return _labelsExclude ??= [
+                ..EnvironmentOverrides(_localConfiguration.applicationLogging.forwarding.labels.exclude,
+                          "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE")
+                      ?.Split([StringSeparators.CommaChar, ' '], StringSplitOptions.RemoveEmptyEntries)
+                  ?? []
+            ];
+        }
+    }
+
+    #endregion
+
+    private IEnumerable<IDictionary<string, string>> _ignoredInstrumentation;
+    public IEnumerable<IDictionary<string, string>> IgnoredInstrumentation =>
+        _ignoredInstrumentation ??= _localConfiguration.instrumentation.rules
+            .Select(i => new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>
                 {
-                    return websiteResourceGroup; // Must be Windows function
+                    { "assemblyName", i.assemblyName }, { "className", i.className }
                 }
+            ))
+            .ToList();
 
-                // The WEBSITE_OWNER_NAME variable also has the resource group name, but we need to parse it out.
-                // Must be a Linux function.
-                var websiteOwnerName = _environment.GetEnvironmentVariable("WEBSITE_OWNER_NAME");
-                if (string.IsNullOrEmpty(websiteOwnerName))
-                {
-                    return websiteOwnerName; // This should not happen, but just in case.
-                }
+    public bool DisableFileSystemWatcher =>
+        ServerlessModeEnabled ||
+        !LoggingEnabled ||
+        EnvironmentOverrides(_localConfiguration.service.disableFileSystemWatcher, "NEW_RELIC_DISABLE_FILE_SYSTEM_WATCHER");
 
-                var idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
-                if (idx <= 0)
-                {
-                    return websiteOwnerName; // This means that the format of the WEBSITE_OWNER_NAME is not as expected (subscription+resourcegroup-region-Linux).
-                }
+    #region AI Monitoring
 
-                // We should have a WEBSITE_OWNER_NAME in the expected format here.
-                idx += 1; // move past the "+"
-                var resourceData = websiteOwnerName.Substring(idx, websiteOwnerName.Length - idx - 6); // -6 to remove the "-Linux" suffix.
+    public bool AiMonitoringEnabled =>
+        // AI Monitoring is disabled in High Security Mode and can be disabled at the account level
+        !HighSecurityModeEnabled && ServerCanDisable(_serverConfiguration.AICollectionEnabled, EnvironmentOverrides(_localConfiguration.aiMonitoring.enabled, "NEW_RELIC_AI_MONITORING_ENABLED"));
 
-                // Remove the region from the resourceData.
-                return resourceData.Substring(0, resourceData.LastIndexOf("-", StringComparison.Ordinal));
-            }
-        }
+    public bool AiMonitoringStreamingEnabled =>
+        AiMonitoringEnabled &&
+        EnvironmentOverrides(_localConfiguration.aiMonitoring.streaming.enabled, "NEW_RELIC_AI_MONITORING_STREAMING_ENABLED");
 
-        public string AzureFunctionRegion => _environment.GetEnvironmentVariable("REGION_NAME");
+    public bool AiMonitoringRecordContentEnabled =>
+        AiMonitoringEnabled &&
+        EnvironmentOverrides(_localConfiguration.aiMonitoring.recordContent.enabled, "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED");
 
-        public string AzureFunctionSubscriptionId
+    public Func<string, string, int> LlmTokenCountingCallback => _runTimeConfiguration.LlmTokenCountingCallback;
+
+    #region Azure function support
+
+    public bool AzureFunctionModeDetected => _bootstrapConfiguration.AzureFunctionModeDetected;
+
+    private bool? _azureFunctionModeEnabled;
+    public bool AzureFunctionModeEnabled =>
+        _azureFunctionModeEnabled ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AzureFunctionModeEnabled", true), "NEW_RELIC_AZURE_FUNCTION_MODE_ENABLED");
+
+    // Code to support AWS Lambda APM mode for transaction naming [ By default it is disabled ]
+    private bool? _awsLambdaApmModeEnabled;
+    public bool AwsLambdaApmModeEnabled =>
+        _awsLambdaApmModeEnabled ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("AwsLambdaApmModeEnabled", false), "NEW_RELIC_APM_LAMBDA_MODE");
+
+    public string AzureFunctionResourceId
+    {
+        get
         {
-            get
+            var websiteResourceGroup = AzureFunctionResourceGroupName;
+            var subscriptionId = AzureFunctionSubscriptionId;
+
+            if (string.IsNullOrEmpty(websiteResourceGroup) || string.IsNullOrEmpty(subscriptionId))
             {
-                var websiteOwnerName = _environment.GetEnvironmentVariable("WEBSITE_OWNER_NAME") ?? string.Empty;
-                var idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
-                return idx > 0 ? websiteOwnerName.Substring(0, idx) : websiteOwnerName;
-            }
-        }
-
-        public string AzureFunctionAppName => _environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
-        #endregion
-
-        #endregion
-
-        public virtual bool AppDomainCachingDisabled => EnvironmentOverrides(false, "NEW_RELIC_DISABLE_APPDOMAIN_CACHING");
-
-        public virtual bool ForceNewTransactionOnNewThread => EnvironmentOverrides(_localConfiguration.service.forceNewTransactionOnNewThread, "NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD");
-
-        private bool? _diagnosticsCaptureAgentTiming;
-        public bool DiagnosticsCaptureAgentTiming
-        {
-            get
-            {
-                if (_diagnosticsCaptureAgentTiming == null)
-                {
-                    UpdateDiagnosticsAgentTimingSettings();
-                }
-
-                return _diagnosticsCaptureAgentTiming!.Value;
-
-            }
-        }
-
-        private int? _diagnosticsCaptureAgentTimingFrequency;
-        public int DiagnosticsCaptureAgentTimingFrequency
-        {
-            get
-            {
-                if (_diagnosticsCaptureAgentTimingFrequency == null)
-                {
-                    UpdateDiagnosticsAgentTimingSettings();
-                }
-
-                return _diagnosticsCaptureAgentTimingFrequency!.Value;
-
-            }
-        }
-
-        private void UpdateDiagnosticsAgentTimingSettings()
-        {
-            var captureTiming = _localConfiguration.diagnostics.captureAgentTiming;
-            var configFreq = _localConfiguration.diagnostics.captureAgentTimingFrequency;
-
-            if (configFreq <= 0)
-            {
-                captureTiming = false;
+                return string.Empty;
             }
 
-            _diagnosticsCaptureAgentTiming = captureTiming;
-            _diagnosticsCaptureAgentTimingFrequency = configFreq;
+            return $"/subscriptions/{subscriptionId}/resourceGroups/{websiteResourceGroup}/providers/Microsoft.Web/sites/{(string.IsNullOrEmpty(AzureFunctionAppName) ? "unknown" : AzureFunctionAppName)}";
+        }
+    }
+
+    public string AzureFunctionResourceIdWithFunctionName(string functionName)
+    {
+        return string.IsNullOrEmpty(AzureFunctionResourceId) || string.IsNullOrEmpty(functionName)
+            ? string.Empty
+            : $"{AzureFunctionResourceId}/functions/{functionName}";
+    }
+
+    public string AzureFunctionResourceGroupName
+    {
+        get
+        {
+            // WEBSITE_RESOURCE_GROUP doesn't seem to always be available for Linux.
+            var websiteResourceGroup = _environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
+            if (!string.IsNullOrEmpty(websiteResourceGroup))
+            {
+                return websiteResourceGroup; // Must be Windows function
+            }
+
+            // The WEBSITE_OWNER_NAME variable also has the resource group name, but we need to parse it out.
+            // Must be a Linux function.
+            var websiteOwnerName = _environment.GetEnvironmentVariable("WEBSITE_OWNER_NAME");
+            if (string.IsNullOrEmpty(websiteOwnerName))
+            {
+                return websiteOwnerName; // This should not happen, but just in case.
+            }
+
+            var idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
+            if (idx <= 0)
+            {
+                return websiteOwnerName; // This means that the format of the WEBSITE_OWNER_NAME is not as expected (subscription+resourcegroup-region-Linux).
+            }
+
+            // We should have a WEBSITE_OWNER_NAME in the expected format here.
+            idx += 1; // move past the "+"
+            var resourceData = websiteOwnerName.Substring(idx, websiteOwnerName.Length - idx - 6); // -6 to remove the "-Linux" suffix.
+
+            // Remove the region from the resourceData.
+            return resourceData.Substring(0, resourceData.LastIndexOf("-", StringComparison.Ordinal));
+        }
+    }
+
+    public string AzureFunctionRegion => _environment.GetEnvironmentVariable("REGION_NAME");
+
+    public string AzureFunctionSubscriptionId
+    {
+        get
+        {
+            var websiteOwnerName = _environment.GetEnvironmentVariable("WEBSITE_OWNER_NAME") ?? string.Empty;
+            var idx = websiteOwnerName.IndexOf("+", StringComparison.Ordinal);
+            return idx > 0 ? websiteOwnerName.Substring(0, idx) : websiteOwnerName;
+        }
+    }
+
+    public string AzureFunctionAppName => _environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+    #endregion
+
+    #endregion
+
+    public virtual bool AppDomainCachingDisabled => EnvironmentOverrides(false, "NEW_RELIC_DISABLE_APPDOMAIN_CACHING");
+
+    public virtual bool ForceNewTransactionOnNewThread => EnvironmentOverrides(_localConfiguration.service.forceNewTransactionOnNewThread, "NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD");
+
+    private bool? _diagnosticsCaptureAgentTiming;
+    public bool DiagnosticsCaptureAgentTiming
+    {
+        get
+        {
+            if (_diagnosticsCaptureAgentTiming == null)
+            {
+                UpdateDiagnosticsAgentTimingSettings();
+            }
+
+            return _diagnosticsCaptureAgentTiming!.Value;
+
+        }
+    }
+
+    private int? _diagnosticsCaptureAgentTimingFrequency;
+    public int DiagnosticsCaptureAgentTimingFrequency
+    {
+        get
+        {
+            if (_diagnosticsCaptureAgentTimingFrequency == null)
+            {
+                UpdateDiagnosticsAgentTimingSettings();
+            }
+
+            return _diagnosticsCaptureAgentTimingFrequency!.Value;
+
+        }
+    }
+
+    private void UpdateDiagnosticsAgentTimingSettings()
+    {
+        var captureTiming = _localConfiguration.diagnostics.captureAgentTiming;
+        var configFreq = _localConfiguration.diagnostics.captureAgentTimingFrequency;
+
+        if (configFreq <= 0)
+        {
+            captureTiming = false;
         }
 
-        private bool? _forceSynchronousTimingCalculationHttpClient;
-        public bool ForceSynchronousTimingCalculationHttpClient => _forceSynchronousTimingCalculationHttpClient ??= TryGetAppSettingAsBoolWithDefault("ForceSynchronousTimingCalculation.HttpClient", false);
+        _diagnosticsCaptureAgentTiming = captureTiming;
+        _diagnosticsCaptureAgentTimingFrequency = configFreq;
+    }
 
-        private bool? _enableAspNetCore6PlusBrowserInjection;
-        public bool EnableAspNetCore6PlusBrowserInjection =>
-            _enableAspNetCore6PlusBrowserInjection ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", true), "NEW_RELIC_ENABLE_ASPNETCORE6PLUS_BROWSER_INJECTION");
+    private bool? _forceSynchronousTimingCalculationHttpClient;
+    public bool ForceSynchronousTimingCalculationHttpClient => _forceSynchronousTimingCalculationHttpClient ??= TryGetAppSettingAsBoolWithDefault("ForceSynchronousTimingCalculation.HttpClient", false);
 
-        private TimeSpan? _metricsHarvestCycleOverride = null;
-        public TimeSpan MetricsHarvestCycle
+    private bool? _enableAspNetCore6PlusBrowserInjection;
+    public bool EnableAspNetCore6PlusBrowserInjection =>
+        _enableAspNetCore6PlusBrowserInjection ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", true), "NEW_RELIC_ENABLE_ASPNETCORE6PLUS_BROWSER_INJECTION");
+
+    private TimeSpan? _metricsHarvestCycleOverride = null;
+    public TimeSpan MetricsHarvestCycle
+    {
+        get
         {
-            get
+            if (_metricsHarvestCycleOverride.HasValue)
             {
-                if (_metricsHarvestCycleOverride.HasValue)
+                return _metricsHarvestCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideMetricsHarvestCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("Metrics harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _metricsHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _metricsHarvestCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideMetricsHarvestCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Metrics harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _metricsHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _metricsHarvestCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _transactionTraceHarvestCycleOverride = null;
-        public TimeSpan TransactionTracesHarvestCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _transactionTraceHarvestCycleOverride = null;
+    public TimeSpan TransactionTracesHarvestCycle
+    {
+        get
         {
-            get
+            if (_transactionTraceHarvestCycleOverride.HasValue)
             {
-                if (_transactionTraceHarvestCycleOverride.HasValue)
+                return _transactionTraceHarvestCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideTransactionTracesHarvestCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("Transaction traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _transactionTraceHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _transactionTraceHarvestCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideTransactionTracesHarvestCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Transaction traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _transactionTraceHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _transactionTraceHarvestCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _errorTracesHarvestCycleOverride = null;
-        public TimeSpan ErrorTracesHarvestCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _errorTracesHarvestCycleOverride = null;
+    public TimeSpan ErrorTracesHarvestCycle
+    {
+        get
         {
-            get
+            if (_errorTracesHarvestCycleOverride.HasValue)
             {
-                if (_errorTracesHarvestCycleOverride.HasValue)
+                return _errorTracesHarvestCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideErrorTracesHarvestCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("Error traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _errorTracesHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _errorTracesHarvestCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideErrorTracesHarvestCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Error traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _errorTracesHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _errorTracesHarvestCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _getAgentCommandsCycleOverride = null;
-        public TimeSpan GetAgentCommandsCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _getAgentCommandsCycleOverride = null;
+    public TimeSpan GetAgentCommandsCycle
+    {
+        get
         {
-            get
+            if (_getAgentCommandsCycleOverride.HasValue)
             {
-                if (_getAgentCommandsCycleOverride.HasValue)
+                return _getAgentCommandsCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideGetAgentCommandsCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("Get agent commands cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _getAgentCommandsCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _getAgentCommandsCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideGetAgentCommandsCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Get agent commands cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _getAgentCommandsCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _getAgentCommandsCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _sqlTracesHarvestCycleOverride = null;
-        public TimeSpan SqlTracesHarvestCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _sqlTracesHarvestCycleOverride = null;
+    public TimeSpan SqlTracesHarvestCycle
+    {
+        get
         {
-            get
+            if (_sqlTracesHarvestCycleOverride.HasValue)
             {
-                if (_sqlTracesHarvestCycleOverride.HasValue)
+                return _sqlTracesHarvestCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideSqlTracesHarvestCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("SQL traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _sqlTracesHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _sqlTracesHarvestCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideSqlTracesHarvestCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("SQL traces harvest cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _sqlTracesHarvestCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _sqlTracesHarvestCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _updateLoadedModulesCycleOverride = null;
-        public TimeSpan UpdateLoadedModulesCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _updateLoadedModulesCycleOverride = null;
+    public TimeSpan UpdateLoadedModulesCycle
+    {
+        get
         {
-            get
+            if (_updateLoadedModulesCycleOverride.HasValue)
             {
-                if (_updateLoadedModulesCycleOverride.HasValue)
+                return _updateLoadedModulesCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideUpdateLoadedModulesCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("Update loaded modules cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _updateLoadedModulesCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _updateLoadedModulesCycleOverride.Value;
                 }
-
-                if (_newRelicAppSettings.TryGetValue("OverrideUpdateLoadedModulesCycle", out var harvestCycle))
-                {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("Update loaded modules cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _updateLoadedModulesCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _updateLoadedModulesCycleOverride.Value;
-                    }
-                }
-
-                return DefaultHarvestCycle;
             }
-        }
 
-        private TimeSpan? _stackExchangeRedisCleanupCycleOverride = null;
-        public TimeSpan StackExchangeRedisCleanupCycle
+            return DefaultHarvestCycle;
+        }
+    }
+
+    private TimeSpan? _stackExchangeRedisCleanupCycleOverride = null;
+    public TimeSpan StackExchangeRedisCleanupCycle
+    {
+        get
         {
-            get
+            if (_stackExchangeRedisCleanupCycleOverride.HasValue)
             {
-                if (_stackExchangeRedisCleanupCycleOverride.HasValue)
+                return _stackExchangeRedisCleanupCycleOverride.Value;
+            }
+
+            if (_newRelicAppSettings.TryGetValue("OverrideStackExchangeRedisCleanupCycle", out var harvestCycle))
+            {
+                if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
                 {
+                    Log.Info("StackExchange.Redis cleanup cycle overridden to " + parsedHarvestCycle + " seconds.");
+                    _stackExchangeRedisCleanupCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
                     return _stackExchangeRedisCleanupCycleOverride.Value;
                 }
+            }
 
-                if (_newRelicAppSettings.TryGetValue("OverrideStackExchangeRedisCleanupCycle", out var harvestCycle))
+            return DefaultHarvestCycle;
+        }
+    }
+
+    public bool GCSamplerV2Enabled => _bootstrapConfiguration.GCSamplerV2Enabled;
+
+    #region Agent Control
+
+    public bool AgentControlEnabled => _bootstrapConfiguration.AgentControlEnabled;
+
+    public string HealthDeliveryLocation => _bootstrapConfiguration.HealthDeliveryLocation;
+
+    public int HealthFrequency => _bootstrapConfiguration.HealthFrequency;
+
+    #endregion Agent Control
+
+    #endregion Properties
+
+    #region Helpers
+
+    private TimeSpan ParseTransactionThreshold(string threshold, Func<double, TimeSpan> numberToTimeSpanConverter)
+    {
+        return string.IsNullOrEmpty(threshold)
+            ? TransactionTraceApdexF
+            : double.TryParse(threshold, out var parsedTransactionThreshold)
+                ? numberToTimeSpanConverter(parsedTransactionThreshold)
+                : TransactionTraceApdexF;
+    }
+
+    private static bool ServerCanDisable(bool? server, bool local)
+    {
+        return server == null ? local : server.Value && local;
+    }
+
+    private static string ServerOverrides(string server, string local)
+    {
+        return server ?? local ?? string.Empty;
+    }
+
+    private static T ServerOverrides<T>(T? server, T local) where T : struct
+    {
+        return server ?? local;
+    }
+
+    private T HighSecurityModeOverrides<T>(T overriddenValue, T originalValue)
+    {
+        return HighSecurityModeEnabled ? overriddenValue : originalValue;
+    }
+
+    private static T ServerOverrides<T>(T server, T local) where T : class
+    {
+        return server ?? local;
+    }
+
+    private IEnumerable<string> EnvironmentOverrides(IEnumerable<string> local, params string[] environmentVariableNames)
+    {
+        var envValue = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        // took this approach to eliminate a null object issue when combining the different calls together. Also a bit easier to read.
+        if (string.IsNullOrWhiteSpace(envValue))
+        {
+            return local;
+        }
+
+        char[] delimiters = [',', ' '];
+        return envValue
+            .Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+    }
+
+    private string EnvironmentOverrides(string local, params string[] environmentVariableNames)
+    {
+        return EnvironmentOverrides(_environment, local, environmentVariableNames);
+    }
+
+    public static string EnvironmentOverrides(IEnvironment environment, string local, params string[] environmentVariableNames)
+    {
+        var envValue = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        // if we get a null, we use local - should not get whitespace
+        if (string.IsNullOrWhiteSpace(envValue))
+        {
+            return local;
+        }
+
+        return envValue.Trim();
+    }
+
+    private uint? EnvironmentOverrides(uint? local, params string[] environmentVariableNames)
+    {
+        var env = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        return uint.TryParse(env, out uint parsedValue) ? parsedValue : local;
+    }
+
+    private int? EnvironmentOverrides(int? local, params string[] environmentVariableNames)
+    {
+        return EnvironmentOverrides(_environment, local, environmentVariableNames);
+    }
+
+    public static int? EnvironmentOverrides(IEnvironment environment, int? local, params string[] environmentVariableNames)
+    {
+        var env = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        return int.TryParse(env, out int parsedValue) ? parsedValue : local;
+    }
+
+    private double? EnvironmentOverrides(double? local, params string[] environmentVariableNames)
+    {
+        var env = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        return double.TryParse(env, out double parsedValue) ? parsedValue : local;
+    }
+
+    private bool EnvironmentOverrides(bool local, params string[] environmentVariableNames)
+    {
+        return EnvironmentOverrides(_environment, local, environmentVariableNames);
+    }
+
+    public static bool EnvironmentOverrides(IEnvironment environment, bool local, params string[] environmentVariableNames)
+    {
+        var env = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
+
+        env = env?.ToLower();
+
+        if (bool.TryParse(env, out var parsedValue))
+        {
+            return parsedValue;
+        }
+
+        return env switch
+        {
+            "0" => false,
+            "1" => true,
+            _ => local
+        };
+    }
+
+    private IList<Regex> ReadUrlBlacklist(configuration config)
+    {
+        var list = new List<Regex>();
+
+        if (config.browserMonitoring.requestPathsExcluded is { Count: > 0 })
+        {
+            foreach (var p in config.browserMonitoring.requestPathsExcluded)
+            {
+                try
                 {
-                    if (int.TryParse(harvestCycle, out var parsedHarvestCycle) && parsedHarvestCycle > 0)
-                    {
-                        Log.Info("StackExchange.Redis cleanup cycle overridden to " + parsedHarvestCycle + " seconds.");
-                        _stackExchangeRedisCleanupCycleOverride = TimeSpan.FromSeconds(parsedHarvestCycle);
-                        return _stackExchangeRedisCleanupCycleOverride.Value;
-                    }
+                    Regex regex = new Regex(p.regex,
+                        RegexOptions.Compiled |
+                        RegexOptions.Multiline |
+                        RegexOptions.IgnoreCase);
+                    list.Add(regex);
                 }
-
-                return DefaultHarvestCycle;
-            }
-        }
-
-        public bool GCSamplerV2Enabled => _bootstrapConfiguration.GCSamplerV2Enabled;
-
-        #region Agent Control
-
-        public bool AgentControlEnabled => _bootstrapConfiguration.AgentControlEnabled;
-
-        public string HealthDeliveryLocation => _bootstrapConfiguration.HealthDeliveryLocation;
-
-        public int HealthFrequency => _bootstrapConfiguration.HealthFrequency;
-
-        #endregion Agent Control
-
-        #endregion Properties
-
-        #region Helpers
-
-        private TimeSpan ParseTransactionThreshold(string threshold, Func<double, TimeSpan> numberToTimeSpanConverter)
-        {
-            return string.IsNullOrEmpty(threshold)
-                ? TransactionTraceApdexF
-                : double.TryParse(threshold, out var parsedTransactionThreshold)
-                    ? numberToTimeSpanConverter(parsedTransactionThreshold)
-                    : TransactionTraceApdexF;
-        }
-
-        private static bool ServerCanDisable(bool? server, bool local)
-        {
-            return server == null ? local : server.Value && local;
-        }
-
-        private static string ServerOverrides(string server, string local)
-        {
-            return server ?? local ?? string.Empty;
-        }
-
-        private static T ServerOverrides<T>(T? server, T local) where T : struct
-        {
-            return server ?? local;
-        }
-
-        private T HighSecurityModeOverrides<T>(T overriddenValue, T originalValue)
-        {
-            return HighSecurityModeEnabled ? overriddenValue : originalValue;
-        }
-
-        private static T ServerOverrides<T>(T server, T local) where T : class
-        {
-            return server ?? local;
-        }
-
-        private IEnumerable<string> EnvironmentOverrides(IEnumerable<string> local, params string[] environmentVariableNames)
-        {
-            var envValue = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            // took this approach to eliminate a null object issue when combining the different calls together. Also a bit easier to read.
-            if (string.IsNullOrWhiteSpace(envValue))
-            {
-                return local;
-            }
-
-            char[] delimiters = [',', ' '];
-            return envValue
-                .Split(delimiters, StringSplitOptions.RemoveEmptyEntries)
-                .ToList();
-        }
-
-        private string EnvironmentOverrides(string local, params string[] environmentVariableNames)
-        {
-            return EnvironmentOverrides(_environment, local, environmentVariableNames);
-        }
-
-        public static string EnvironmentOverrides(IEnvironment environment, string local, params string[] environmentVariableNames)
-        {
-            var envValue = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            // if we get a null, we use local - should not get whitespace
-            if (string.IsNullOrWhiteSpace(envValue))
-            {
-                return local;
-            }
-
-            return envValue.Trim();
-        }
-
-        private uint? EnvironmentOverrides(uint? local, params string[] environmentVariableNames)
-        {
-            var env = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            return uint.TryParse(env, out uint parsedValue) ? parsedValue : local;
-        }
-
-        private int? EnvironmentOverrides(int? local, params string[] environmentVariableNames)
-        {
-            return EnvironmentOverrides(_environment, local, environmentVariableNames);
-        }
-
-        public static int? EnvironmentOverrides(IEnvironment environment, int? local, params string[] environmentVariableNames)
-        {
-            var env = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            return int.TryParse(env, out int parsedValue) ? parsedValue : local;
-        }
-
-        private double? EnvironmentOverrides(double? local, params string[] environmentVariableNames)
-        {
-            var env = _environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            return double.TryParse(env, out double parsedValue) ? parsedValue : local;
-        }
-
-        private bool EnvironmentOverrides(bool local, params string[] environmentVariableNames)
-        {
-            return EnvironmentOverrides(_environment, local, environmentVariableNames);
-        }
-
-        public static bool EnvironmentOverrides(IEnvironment environment, bool local, params string[] environmentVariableNames)
-        {
-            var env = environment.GetEnvironmentVariableFromList(environmentVariableNames ?? []);
-
-            env = env?.ToLower();
-
-            if (bool.TryParse(env, out var parsedValue))
-            {
-                return parsedValue;
-            }
-
-            return env switch
-            {
-                "0" => false,
-                "1" => true,
-                _ => local
-            };
-        }
-
-        private IList<Regex> ReadUrlBlacklist(configuration config)
-        {
-            var list = new List<Regex>();
-
-            if (config.browserMonitoring.requestPathsExcluded is { Count: > 0 })
-            {
-                foreach (var p in config.browserMonitoring.requestPathsExcluded)
+                catch (Exception ex)
                 {
-                    try
-                    {
-                        Regex regex = new Regex(p.regex,
-                            RegexOptions.Compiled |
-                            RegexOptions.Multiline |
-                            RegexOptions.IgnoreCase);
-                        list.Add(regex);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "A Browser Monitoring Request Path failed regular expression parsing: {0}",
-                            p.regex);
-                    }
+                    Log.Error(ex, "A Browser Monitoring Request Path failed regular expression parsing: {0}",
+                        p.regex);
                 }
             }
-
-            return list;
         }
 
-        public static IEnumerable<RegexRule> GetRegexRules(IEnumerable<ServerConfiguration.RegexRule> rules)
-        {
-            if (rules == null)
-                return [];
+        return list;
+    }
 
-            return rules
-                .Select(TryGetRegexRule)
+    public static IEnumerable<RegexRule> GetRegexRules(IEnumerable<ServerConfiguration.RegexRule> rules)
+    {
+        if (rules == null)
+            return [];
+
+        return rules
+            .Select(TryGetRegexRule)
+            .Where(rule => rule != null)
+            .Select(rule => rule.Value)
+            .ToList();
+    }
+
+    private static RegexRule? TryGetRegexRule(ServerConfiguration.RegexRule rule)
+    {
+        if (rule?.MatchExpression == null)
+            return null;
+
+        var matchExpression = rule.MatchExpression;
+        var replacement = UpdateRegexForDotNet(rule.Replacement);
+        var ignore = rule.Ignore ?? false;
+        var evaluationOrder = rule.EvaluationOrder ?? 0;
+        var terminateChain = rule.TerminateChain ?? false;
+        var eachSegment = rule.EachSegment ?? false;
+        var replaceAll = rule.ReplaceAll ?? false;
+
+        return new RegexRule(matchExpression, replacement, ignore, evaluationOrder, terminateChain, eachSegment, replaceAll);
+    }
+
+    private static string UpdateRegexForDotNet(string replacement)
+    {
+        if (string.IsNullOrEmpty(replacement))
+            return replacement;
+
+        //search for \1, \2 etc, and replace with $1, $2, etc
+        var backreferencePattern = new Regex(@"\\(\d+)");
+        return backreferencePattern.Replace(replacement, "$$$1");
+    }
+
+    public static IDictionary<string, IEnumerable<string>> GetWhitelistRules(IEnumerable<ServerConfiguration.WhitelistRule> whitelistRules)
+    {
+        return whitelistRules == null
+            ? []
+            : whitelistRules
+                .Where(rule => rule != null)
+                .Select(TryGetValidPrefixAndTerms)
                 .Where(rule => rule != null)
                 .Select(rule => rule.Value)
+                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepLast);
+    }
+
+    private static KeyValuePair<string, IEnumerable<string>>? TryGetValidPrefixAndTerms(ServerConfiguration.WhitelistRule rule)
+    {
+        if (rule.Terms == null)
+        {
+            Log.Warn("Ignoring transaction_segment_term with null terms for prefix '{0}'", rule.Prefix);
+            return null;
+        }
+
+        var prefix = TryGetValidPrefix(rule.Prefix);
+        if (prefix == null)
+        {
+            Log.Warn("Ignoring transaction_segment_term with invalid prefix '{0}'", rule.Prefix);
+            return null;
+        }
+
+        var terms = rule.Terms;
+        return new KeyValuePair<string, IEnumerable<string>>(prefix, terms);
+    }
+
+    private void ParseExpectedErrorConfigurations()
+    {
+        var expectedErrorInfo = _serverConfiguration.RpmConfig.ErrorCollectorExpectedMessages?.ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+
+        if (expectedErrorInfo == null)
+        {
+            expectedErrorInfo = _localConfiguration.errorCollector.expectedMessages
+                .Where(x => x.message != null)
+                .Select(x => new KeyValuePair<string, IEnumerable<string>>(x.name, x.message))
+                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+        }
+
+        //Keeping the original expected messages configuration for agent setting report on connect before
+        //the expectedErrorInfo dictionary gets mixed up between expected messages and expected classes configurations.
+        var expectedMessages = new Dictionary<string, IEnumerable<string>>(expectedErrorInfo);
+
+        var expectedClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorExpectedClasses, _localConfiguration.errorCollector.expectedClasses.errorClass);
+
+        var count = expectedErrorInfo.Count;
+
+        foreach (var className in expectedClasses)
+        {
+            if (expectedErrorInfo.ContainsKey(className))
+            {
+                expectedErrorInfo[className] = Enumerable.Empty<string>();
+                Log.Warn($"Expected Errors - {className} class is specified in both errorCollector.expectedClasses and errorCollector.expectedMessages configurations. Any errors of this class will be marked as expected.");
+            }
+            else if (count >= MaxExptectedErrorConfigEntries)
+            {
+                Log.Warn($"Expected Errors - {className} Exceeds the limit of {MaxExptectedErrorConfigEntries} and will be ignored.");
+            }
+            else
+            {
+                expectedErrorInfo[className] = Enumerable.Empty<string>();
+                count++;
+            }
+        }
+
+        var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
+        var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
+
+        var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
+
+        ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
+        ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? [];
+
+        ExpectedErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
+        ExpectedErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedMessages);
+        ExpectedErrorClassesForAgentSettings = expectedClasses;
+    }
+
+    private void ParseIgnoreErrorConfigurations()
+    {
+        var ignoreErrorInfo = _serverConfiguration.RpmConfig.ErrorCollectorIgnoreMessages?
+            .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+
+        if (ignoreErrorInfo == null)
+        {
+            ignoreErrorInfo = _localConfiguration.errorCollector.ignoreMessages
+                .Where(x => x.message != null)
+                .Select(x => new KeyValuePair<string, IEnumerable<string>>(x.name, x.message))
+                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+        }
+
+        //Keeping the original ignore messages configuration for agent setting report on connect before
+        //the ignoreErrorInfo dictionary gets mixed up between ignore messages and ignore classes configurations.
+        var ignoreMessages = new Dictionary<string, IEnumerable<string>>(ignoreErrorInfo);
+
+        var ignoreClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorIgnoreClasses, _localConfiguration.errorCollector.ignoreClasses.errorClass);
+
+        var count = ignoreErrorInfo.Count;
+
+        foreach (var className in ignoreClasses)
+        {
+            if (ignoreErrorInfo.ContainsKey(className))
+            {
+                ignoreErrorInfo[className] = Enumerable.Empty<string>();
+                Log.Warn($"Ignore Errors - {className} class is specified in both errorCollector.ignoreClasses and errorCollector.ingoreMessages configurations. Any errors of this class will be ignored.");
+            }
+            else if (count >= MaxIgnoreErrorConfigEntries)
+            {
+                Log.Warn($"Ignore Errors - {className} Exceeds the limit of {MaxIgnoreErrorConfigEntries} and will be ignored.");
+            }
+            else
+            {
+                ignoreErrorInfo.Add(className, Enumerable.Empty<string>());
+                count++;
+            }
+        }
+
+        IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore, "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
+        if (ignoreStatusCodes == null)
+        {
+            ignoreStatusCodes = _localConfiguration.errorCollector.ignoreStatusCodes.code
+                .Select(x => x.ToString(CultureInfo.InvariantCulture))
                 .ToList();
         }
 
-        private static RegexRule? TryGetRegexRule(ServerConfiguration.RegexRule rule)
+        foreach (var code in ignoreStatusCodes)
         {
-            if (rule?.MatchExpression == null)
-                return null;
-
-            var matchExpression = rule.MatchExpression;
-            var replacement = UpdateRegexForDotNet(rule.Replacement);
-            var ignore = rule.Ignore ?? false;
-            var evaluationOrder = rule.EvaluationOrder ?? 0;
-            var terminateChain = rule.TerminateChain ?? false;
-            var eachSegment = rule.EachSegment ?? false;
-            var replaceAll = rule.ReplaceAll ?? false;
-
-            return new RegexRule(matchExpression, replacement, ignore, evaluationOrder, terminateChain, eachSegment, replaceAll);
+            if (!ignoreErrorInfo.ContainsKey(code))
+            {
+                ignoreErrorInfo.Add(code, Enumerable.Empty<string>());
+            }
         }
 
-        private static string UpdateRegexForDotNet(string replacement)
-        {
-            if (string.IsNullOrEmpty(replacement))
-                return replacement;
+        IgnoreErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreErrorInfo);
+        IgnoreErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreMessages);
+        IgnoreErrorClassesForAgentSettings = ignoreClasses;
+        HttpStatusCodesToIgnore = ignoreStatusCodes;
+    }
 
-            //search for \1, \2 etc, and replace with $1, $2, etc
-            var backreferencePattern = new Regex(@"\\(\d+)");
-            return backreferencePattern.Replace(replacement, "$$$1");
+
+    private static string TryGetValidPrefix(string prefix)
+    {
+        if (prefix == null)
+            return null;
+
+        // A single trailing slash on prefix can be ignored
+        prefix = prefix.TrimEnd(MetricNames.PathSeparatorChar, 1);
+
+        // Prefixes should always be exactly two segments
+        if (prefix.Count(c => c == MetricNames.PathSeparatorChar) != 1)
+            return null;
+
+        return prefix;
+    }
+
+    private static int? GetNullableIntValue(bool specified, int value) => specified ? value : null;
+
+    #endregion
+
+    #region deprecated/disabled parameter group settings
+
+    private void LogDisabledWarnings()
+    {
+        // analyticsEvents.*
+        if (_localConfiguration.analyticsEvents.transactions.enabledSpecified)
+        {
+            LogDisabledPropertyUse("analyticsEvents.transactions.enabled", "transactionEvents.transactions.enabled");
+        }
+        if (_localConfiguration.analyticsEvents.enabledSpecified)
+        {
+            LogDisabledPropertyUse("analyticsEvents.enabled", "transactionEvents.enabled");
+        }
+        if (_localConfiguration.analyticsEvents.captureAttributesSpecified)
+        {
+            LogDisabledPropertyUse("analyticsEvents.captureAttributes", "transaction_events.attributes.enabled");
+        }
+        if (_localConfiguration.analyticsEvents.maximumSamplesStoredSpecified)
+        {
+            LogDisabledPropertyUse("analyticsEvents.maximumSamplesStored", "transaction_events.maximumSamplesStored");
+        }
+        if (_localConfiguration.analyticsEvents.maximumSamplesPerMinuteSpecified)
+        {
+            LogDisabledPropertyUse("analyticsEvents.maximumSamplesPerMinute");
         }
 
-        public static IDictionary<string, IEnumerable<string>> GetWhitelistRules(IEnumerable<ServerConfiguration.WhitelistRule> whitelistRules)
+        // transactionEvents.maximumSamplesPerMinute
+        if (_localConfiguration.transactionEvents.maximumSamplesPerMinuteSpecified)
         {
-            return whitelistRules == null
-                ? []
-                : whitelistRules
-                    .Where(rule => rule != null)
-                    .Select(TryGetValidPrefixAndTerms)
-                    .Where(rule => rule != null)
-                    .Select(rule => rule.Value)
-                    .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepLast);
+            LogDisabledPropertyUse("transactionEvents.maximumSamplesPerMinute");
         }
 
-        private static KeyValuePair<string, IEnumerable<string>>? TryGetValidPrefixAndTerms(ServerConfiguration.WhitelistRule rule)
+        // parameterGroups.*
+        // parameterGroups.responseHeaderParameters.* has no replacement equivalent, the others
+        // are replaced with attributes.include/exclude
+        if (_localConfiguration.parameterGroups.identityParameters.enabledSpecified)
         {
-            if (rule.Terms == null)
-            {
-                Log.Warn("Ignoring transaction_segment_term with null terms for prefix '{0}'", rule.Prefix);
-                return null;
-            }
-
-            var prefix = TryGetValidPrefix(rule.Prefix);
-            if (prefix == null)
-            {
-                Log.Warn("Ignoring transaction_segment_term with invalid prefix '{0}'", rule.Prefix);
-                return null;
-            }
-
-            var terms = rule.Terms;
-            return new KeyValuePair<string, IEnumerable<string>>(prefix, terms);
+            LogDisabledPropertyUse("parameterGroups.identityParameters.enabled", "attributes.include");
+        }
+        if (_localConfiguration.parameterGroups.identityParameters?.ignore?.Count > 0)
+        {
+            LogDisabledPropertyUse("parameterGroups.identityParameters.ignore", "attributes.exclude");
+        }
+        if (_localConfiguration.parameterGroups.responseHeaderParameters.enabledSpecified)
+        {
+            LogDisabledPropertyUse("parameterGroups.responseHeaderParameters.enabled");
+        }
+        if (_localConfiguration.parameterGroups.responseHeaderParameters?.ignore?.Count > 0)
+        {
+            LogDisabledPropertyUse("parameterGroups.responseHeaderParameters.ignore");
+        }
+        if (_localConfiguration.parameterGroups.customParameters.enabledSpecified)
+        {
+            LogDisabledPropertyUse("parameterGroups.customParameters.enabled", "attributes.include");
+        }
+        if (_localConfiguration.parameterGroups.customParameters?.ignore?.Count > 0)
+        {
+            LogDisabledPropertyUse("parameterGroups.customParameters.ignore", "attributes.exclude");
+        }
+        if (_localConfiguration.parameterGroups.requestHeaderParameters.enabledSpecified)
+        {
+            LogDisabledPropertyUse("parameterGroups.requestHeaderParameters.enabled", "attributes.include");
+        }
+        if (_localConfiguration.parameterGroups.requestHeaderParameters?.ignore?.Count > 0)
+        {
+            LogDisabledPropertyUse("parameterGroups.requestHeaderParameters.ignore", "attributes.exclude");
         }
 
-        private void ParseExpectedErrorConfigurations()
+        //requestParameters.*
+        //requestParameters.ignore
+        //requestParameters.enabled
+        if (_localConfiguration.requestParameters?.ignore?.Count > 0)
         {
-            var expectedErrorInfo = _serverConfiguration.RpmConfig.ErrorCollectorExpectedMessages?.ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
-
-            if (expectedErrorInfo == null)
-            {
-                expectedErrorInfo = _localConfiguration.errorCollector.expectedMessages
-                .Where(x => x.message != null)
-                .Select(x => new KeyValuePair<string, IEnumerable<string>>(x.name, x.message))
-                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
-            }
-
-            //Keeping the original expected messages configuration for agent setting report on connect before
-            //the expectedErrorInfo dictionary gets mixed up between expected messages and expected classes configurations.
-            var expectedMessages = new Dictionary<string, IEnumerable<string>>(expectedErrorInfo);
-
-            var expectedClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorExpectedClasses, _localConfiguration.errorCollector.expectedClasses.errorClass);
-
-            var count = expectedErrorInfo.Count;
-
-            foreach (var className in expectedClasses)
-            {
-                if (expectedErrorInfo.ContainsKey(className))
-                {
-                    expectedErrorInfo[className] = Enumerable.Empty<string>();
-                    Log.Warn($"Expected Errors - {className} class is specified in both errorCollector.expectedClasses and errorCollector.expectedMessages configurations. Any errors of this class will be marked as expected.");
-                }
-                else if (count >= MaxExptectedErrorConfigEntries)
-                {
-                    Log.Warn($"Expected Errors - {className} Exceeds the limit of {MaxExptectedErrorConfigEntries} and will be ignored.");
-                }
-                else
-                {
-                    expectedErrorInfo[className] = Enumerable.Empty<string>();
-                    count++;
-                }
-            }
-
-            var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
-            var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
-
-            var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
-
-            ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
-            ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? [];
-
-            ExpectedErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedErrorInfo);
-            ExpectedErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(expectedMessages);
-            ExpectedErrorClassesForAgentSettings = expectedClasses;
+            LogDisabledPropertyUse("requestParameters.ignore", "attributes.exclude");
+        }
+        if (_localConfiguration.requestParameters?.enabledSpecified == true)
+        {
+            LogDisabledPropertyUse("requestParameters.enabled", "request.parameters.* in attributes.include");
         }
 
-        private void ParseIgnoreErrorConfigurations()
+
+        //transactionTracer.captureAttributes
+        if (_localConfiguration.transactionTracer.captureAttributesSpecified)
         {
-            var ignoreErrorInfo = _serverConfiguration.RpmConfig.ErrorCollectorIgnoreMessages?
-                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
+            LogDisabledPropertyUse("transactionTracer.captureAttributes", "transactionTracer.attributes.enabled");
+        }
+        //errorCollector.captureAttributes
+        if (_localConfiguration.errorCollector.captureAttributesSpecified)
+        {
+            LogDisabledPropertyUse("errorCollector.captureAttributes", "errorCollector.attributes.enabled");
+        }
+        //browserMonitoring.captureAttributes
+        if (_localConfiguration.browserMonitoring.captureAttributesSpecified)
+        {
+            LogDisabledPropertyUse("browserMonitoring.captureAttributes", "browserMonitoring.attributes.enabled");
+        }
 
-            if (ignoreErrorInfo == null)
+        //errorColelctor.ignoreErrors
+        if (_localConfiguration.errorCollector.ignoreErrors?.exception?.Any() ?? false)
+        {
+            LogDisabledPropertyUse("errorCollector.ignoreErrors", "errorCollector.ignoreClasses");
+        }
+    }
+
+    // This method is now unused as all previously deprecated config properties have been fully disabled.
+    // However, we may wish to deprecate more config properties in the future, so it seems prudent to
+    // leave this code in here, commented out.
+    //private void LogDeprecatedPropertyUse(string deprecatedPropertyName, string newPropertyName)
+    //{
+    //    Log.WarnFormat("Deprecated configuration property '{0}'.  Use '{1}'.  See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ for details.", deprecatedPropertyName, newPropertyName);
+    //}
+
+    private void LogDisabledPropertyUse(string disabledPropertyName, string newPropertyName = "")
+    {
+        var replacementText = "No replacement is available";
+        if (newPropertyName != "")
+        {
+            replacementText = $"Use {newPropertyName} instead.";
+        }
+        Log.Warn("Configuration property '{0}' is disabled (unused) and will be removed from the config schema in a future release.  {1}  See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ for details.", disabledPropertyName, replacementText);
+    }
+
+    int? _databaseStatementCacheCapacity = null;
+    public int DatabaseStatementCacheCapacity => _databaseStatementCacheCapacity ?? (_databaseStatementCacheCapacity =
+        TryGetAppSettingAsIntWithDefault("SqlStatementCacheCapacity", DefaultSqlStatementCacheCapacity)).Value;
+
+    private bool? _codeLevelMetricsEnabled;
+    public bool CodeLevelMetricsEnabled => _codeLevelMetricsEnabled ??= EnvironmentOverrides(_localConfiguration.codeLevelMetrics.enabled, "NEW_RELIC_CODE_LEVEL_METRICS_ENABLED");
+
+    #endregion
+
+    #region Cloud
+    private string _awsAccountId;
+    public string AwsAccountId => _awsAccountId ??= EnvironmentOverrides(_localConfiguration.cloud.aws.accountId, "NEW_RELIC_CLOUD_AWS_ACCOUNT_ID");
+
+    #endregion
+
+    public int MaxCustomInstrumentationSupportabilityMetrics => 25; // in case we want to make this configurable in the future
+
+    #region OpenTelemetry Configuration
+
+    public bool OpenTelemetryEnabled => EnvironmentOverrides(_localConfiguration.openTelemetry.enabled, "NEW_RELIC_OPENTELEMETRY_ENABLED");
+
+    public bool OpenTelemetryTracingEnabled => OpenTelemetryEnabled && EnvironmentOverrides(_localConfiguration.openTelemetry.traces.enabled, "NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED");
+
+    public List<string> OpenTelemetryTracingIncludedActivitySources
+    {
+        get
+        {
+            if (field == null)
             {
-                ignoreErrorInfo = _localConfiguration.errorCollector.ignoreMessages
-                .Where(x => x.message != null)
-                .Select(x => new KeyValuePair<string, IEnumerable<string>>(x.name, x.message))
-                .ToDictionary(IEnumerableExtensions.DuplicateKeyBehavior.KeepFirst);
-            }
-
-            //Keeping the original ignore messages configuration for agent setting report on connect before
-            //the ignoreErrorInfo dictionary gets mixed up between ignore messages and ignore classes configurations.
-            var ignoreMessages = new Dictionary<string, IEnumerable<string>>(ignoreErrorInfo);
-
-            var ignoreClasses = ServerOverrides(_serverConfiguration.RpmConfig.ErrorCollectorIgnoreClasses, _localConfiguration.errorCollector.ignoreClasses.errorClass);
-
-            var count = ignoreErrorInfo.Count;
-
-            foreach (var className in ignoreClasses)
-            {
-                if (ignoreErrorInfo.ContainsKey(className))
-                {
-                    ignoreErrorInfo[className] = Enumerable.Empty<string>();
-                    Log.Warn($"Ignore Errors - {className} class is specified in both errorCollector.ignoreClasses and errorCollector.ingoreMessages configurations. Any errors of this class will be ignored.");
-                }
-                else if (count >= MaxIgnoreErrorConfigEntries)
-                {
-                    Log.Warn($"Ignore Errors - {className} Exceeds the limit of {MaxIgnoreErrorConfigEntries} and will be ignored.");
-                }
-                else
-                {
-                    ignoreErrorInfo.Add(className, Enumerable.Empty<string>());
-                    count++;
-                }
-            }
-
-            IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore, "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
-            if (ignoreStatusCodes == null)
-            {
-                ignoreStatusCodes = _localConfiguration.errorCollector.ignoreStatusCodes.code
-                    .Select(x => x.ToString(CultureInfo.InvariantCulture))
+                var includeString = EnvironmentOverrides(_localConfiguration.openTelemetry.traces.include, "NEW_RELIC_OPENTELEMETRY_TRACES_INCLUDE") ?? string.Empty;
+                field = includeString
+                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .Distinct()
                     .ToList();
             }
 
-            foreach (var code in ignoreStatusCodes)
-            {
-                if (!ignoreErrorInfo.ContainsKey(code))
-                {
-                    ignoreErrorInfo.Add(code, Enumerable.Empty<string>());
-                }
-            }
-
-            IgnoreErrorsConfiguration = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreErrorInfo);
-            IgnoreErrorMessagesForAgentSettings = new ReadOnlyDictionary<string, IEnumerable<string>>(ignoreMessages);
-            IgnoreErrorClassesForAgentSettings = ignoreClasses;
-            HttpStatusCodesToIgnore = ignoreStatusCodes;
+            return field;
         }
-
-
-        private static string TryGetValidPrefix(string prefix)
-        {
-            if (prefix == null)
-                return null;
-
-            // A single trailing slash on prefix can be ignored
-            prefix = prefix.TrimEnd(MetricNames.PathSeparatorChar, 1);
-
-            // Prefixes should always be exactly two segments
-            if (prefix.Count(c => c == MetricNames.PathSeparatorChar) != 1)
-                return null;
-
-            return prefix;
-        }
-
-        private static int? GetNullableIntValue(bool specified, int value) => specified ? value : null;
-
-        #endregion
-
-        #region deprecated/disabled parameter group settings
-
-        private void LogDisabledWarnings()
-        {
-            // analyticsEvents.*
-            if (_localConfiguration.analyticsEvents.transactions.enabledSpecified)
-            {
-                LogDisabledPropertyUse("analyticsEvents.transactions.enabled", "transactionEvents.transactions.enabled");
-            }
-            if (_localConfiguration.analyticsEvents.enabledSpecified)
-            {
-                LogDisabledPropertyUse("analyticsEvents.enabled", "transactionEvents.enabled");
-            }
-            if (_localConfiguration.analyticsEvents.captureAttributesSpecified)
-            {
-                LogDisabledPropertyUse("analyticsEvents.captureAttributes", "transaction_events.attributes.enabled");
-            }
-            if (_localConfiguration.analyticsEvents.maximumSamplesStoredSpecified)
-            {
-                LogDisabledPropertyUse("analyticsEvents.maximumSamplesStored", "transaction_events.maximumSamplesStored");
-            }
-            if (_localConfiguration.analyticsEvents.maximumSamplesPerMinuteSpecified)
-            {
-                LogDisabledPropertyUse("analyticsEvents.maximumSamplesPerMinute");
-            }
-
-            // transactionEvents.maximumSamplesPerMinute
-            if (_localConfiguration.transactionEvents.maximumSamplesPerMinuteSpecified)
-            {
-                LogDisabledPropertyUse("transactionEvents.maximumSamplesPerMinute");
-            }
-
-            // parameterGroups.*
-            // parameterGroups.responseHeaderParameters.* has no replacement equivalent, the others
-            // are replaced with attributes.include/exclude
-            if (_localConfiguration.parameterGroups.identityParameters.enabledSpecified)
-            {
-                LogDisabledPropertyUse("parameterGroups.identityParameters.enabled", "attributes.include");
-            }
-            if (_localConfiguration.parameterGroups.identityParameters?.ignore?.Count > 0)
-            {
-                LogDisabledPropertyUse("parameterGroups.identityParameters.ignore", "attributes.exclude");
-            }
-            if (_localConfiguration.parameterGroups.responseHeaderParameters.enabledSpecified)
-            {
-                LogDisabledPropertyUse("parameterGroups.responseHeaderParameters.enabled");
-            }
-            if (_localConfiguration.parameterGroups.responseHeaderParameters?.ignore?.Count > 0)
-            {
-                LogDisabledPropertyUse("parameterGroups.responseHeaderParameters.ignore");
-            }
-            if (_localConfiguration.parameterGroups.customParameters.enabledSpecified)
-            {
-                LogDisabledPropertyUse("parameterGroups.customParameters.enabled", "attributes.include");
-            }
-            if (_localConfiguration.parameterGroups.customParameters?.ignore?.Count > 0)
-            {
-                LogDisabledPropertyUse("parameterGroups.customParameters.ignore", "attributes.exclude");
-            }
-            if (_localConfiguration.parameterGroups.requestHeaderParameters.enabledSpecified)
-            {
-                LogDisabledPropertyUse("parameterGroups.requestHeaderParameters.enabled", "attributes.include");
-            }
-            if (_localConfiguration.parameterGroups.requestHeaderParameters?.ignore?.Count > 0)
-            {
-                LogDisabledPropertyUse("parameterGroups.requestHeaderParameters.ignore", "attributes.exclude");
-            }
-
-            //requestParameters.*
-            //requestParameters.ignore
-            //requestParameters.enabled
-            if (_localConfiguration.requestParameters?.ignore?.Count > 0)
-            {
-                LogDisabledPropertyUse("requestParameters.ignore", "attributes.exclude");
-            }
-            if (_localConfiguration.requestParameters?.enabledSpecified == true)
-            {
-                LogDisabledPropertyUse("requestParameters.enabled", "request.parameters.* in attributes.include");
-            }
-
-
-            //transactionTracer.captureAttributes
-            if (_localConfiguration.transactionTracer.captureAttributesSpecified)
-            {
-                LogDisabledPropertyUse("transactionTracer.captureAttributes", "transactionTracer.attributes.enabled");
-            }
-            //errorCollector.captureAttributes
-            if (_localConfiguration.errorCollector.captureAttributesSpecified)
-            {
-                LogDisabledPropertyUse("errorCollector.captureAttributes", "errorCollector.attributes.enabled");
-            }
-            //browserMonitoring.captureAttributes
-            if (_localConfiguration.browserMonitoring.captureAttributesSpecified)
-            {
-                LogDisabledPropertyUse("browserMonitoring.captureAttributes", "browserMonitoring.attributes.enabled");
-            }
-
-            //errorColelctor.ignoreErrors
-            if (_localConfiguration.errorCollector.ignoreErrors?.exception?.Any() ?? false)
-            {
-                LogDisabledPropertyUse("errorCollector.ignoreErrors", "errorCollector.ignoreClasses");
-            }
-        }
-
-        // This method is now unused as all previously deprecated config properties have been fully disabled.
-        // However, we may wish to deprecate more config properties in the future, so it seems prudent to
-        // leave this code in here, commented out.
-        //private void LogDeprecatedPropertyUse(string deprecatedPropertyName, string newPropertyName)
-        //{
-        //    Log.WarnFormat("Deprecated configuration property '{0}'.  Use '{1}'.  See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ for details.", deprecatedPropertyName, newPropertyName);
-        //}
-
-        private void LogDisabledPropertyUse(string disabledPropertyName, string newPropertyName = "")
-        {
-            var replacementText = "No replacement is available";
-            if (newPropertyName != "")
-            {
-                replacementText = $"Use {newPropertyName} instead.";
-            }
-            Log.Warn("Configuration property '{0}' is disabled (unused) and will be removed from the config schema in a future release.  {1}  See https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration/ for details.", disabledPropertyName, replacementText);
-        }
-
-        int? _databaseStatementCacheCapacity = null;
-        public int DatabaseStatementCacheCapacity => _databaseStatementCacheCapacity ?? (_databaseStatementCacheCapacity =
-            TryGetAppSettingAsIntWithDefault("SqlStatementCacheCapacity", DefaultSqlStatementCacheCapacity)).Value;
-
-        private bool? _codeLevelMetricsEnabled;
-        public bool CodeLevelMetricsEnabled => _codeLevelMetricsEnabled ??= EnvironmentOverrides(_localConfiguration.codeLevelMetrics.enabled, "NEW_RELIC_CODE_LEVEL_METRICS_ENABLED");
-
-        #endregion
-
-        #region Cloud
-        private string _awsAccountId;
-        public string AwsAccountId => _awsAccountId ??= EnvironmentOverrides(_localConfiguration.cloud.aws.accountId, "NEW_RELIC_CLOUD_AWS_ACCOUNT_ID");
-
-        #endregion
-
-        public int MaxCustomInstrumentationSupportabilityMetrics => 25; // in case we want to make this configurable in the future
-
-        #region OpenTelemetry Configuration
-
-        public bool OpenTelemetryEnabled => EnvironmentOverrides(_localConfiguration.openTelemetry.enabled, "NEW_RELIC_OPENTELEMETRY_ENABLED");
-
-        public bool OpenTelemetryTracingEnabled => OpenTelemetryEnabled && EnvironmentOverrides(_localConfiguration.openTelemetry.traces.enabled, "NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED");
-
-        public List<string> OpenTelemetryTracingIncludedActivitySources
-        {
-            get
-            {
-                if (field == null)
-                {
-                    var includeString = EnvironmentOverrides(_localConfiguration.openTelemetry.traces.include, "NEW_RELIC_OPENTELEMETRY_TRACES_INCLUDE") ?? string.Empty;
-                    field = includeString
-                        .Split([','], StringSplitOptions.RemoveEmptyEntries)
-                        .Select(s => s.Trim())
-                        .Where(s => !string.IsNullOrEmpty(s))
-                        .Distinct()
-                        .ToList();
-                }
-
-                return field;
-            }
-        }
-
-        // These are activity sources that are excluded by default unless explicitly included via configuration
-        public List<string> OpenTelemetryTracingDefaultExcludedActivitySources => new List<string>()
-        { "AWSSDK.Bedrock Runtime",
-          "AWSSDK.Bedrock",
-          "AWSSDK.DynamoDB",
-          "AWSSDK.Firehose",
-          "AWSSDK.Kinesis",
-          "AWSSDK.Lambda",
-          "AWSSDK.SQS",
-          "Azure.Cosmos.Operation",
-          "Azure.Messaging.ServiceBus.Message",
-          "Azure.Messaging.ServiceBus.ServiceBusProcessor",
-          "Azure.Messaging.ServiceBus.ServiceBusReceiver",
-          "Azure.Messaging.ServiceBus.ServiceBusSender",
-          "connector-net",
-          "Couchbase.DotnetSdk.OpenTelemetryRequestTracer",
-          "MassTransit",
-          "Microsoft.AspNetCore",
-          "Microsoft.AspNetCore.Components",
-          "Microsoft.AspNetCore.Components.Server.Circuits",
-          "Microsoft.AspNetCore.SignalR.Server",
-          "Microsoft.Azure.Functions.Worker",
-          "Microsoft.Data.SqlClient",
-          "MongoDB.Driver.Core.Extensions.DiagnosticSources",
-          "MySqlConnector",
-          "Npgsql",
-          "NServiceBus.Core",
-          "OpenAI.ChatClient",
-          "OpenTelemetry.AutoInstrumentation.Kafka",
-          "OpenTelemetry.AutoInstrumentation.MongoDB",
-          "OpenTelemetry.Instrumentation.AspNet",
-          "OpenTelemetry.Instrumentation.AWSLambda",
-          "OpenTelemetry.Instrumentation.Owin",
-          "OpenTelemetry.Instrumentation.StackExchangeRedis",
-          "OpenTelemetry.Instrumentation.Wcf",
-          "Oracle.ManagedDataAccess",
-          "Oracle.ManagedDataAccess.Core",
-          "System.Data",
-          "System.Data.SqlClient",
-          "System.Net.Http",
-          "System.Web.Mvc" };
-
-        public List<string> OpenTelemetryTracingExcludedActivitySources
-        {
-            get
-            {
-                if (field == null)
-                {
-                    var excludeString = EnvironmentOverrides(_localConfiguration.openTelemetry.traces.exclude, "NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE") ?? string.Empty;
-
-                    field = excludeString
-                        .Split([','], StringSplitOptions.RemoveEmptyEntries)
-                        .Select(s => s.Trim())
-                        .Where(s => !string.IsNullOrEmpty(s))
-                        .Distinct()
-                        .ToList();
-                }
-
-                return field;
-            }
-        }
-
-
-        public bool OpenTelemetryMetricsEnabled
-        {
-            get
-            {
-                // Both the global OpenTelemetry setting and the metrics-specific setting must be true
-                return OpenTelemetryEnabled && EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.enabled, "NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED");
-            }
-        }
-
-        public IEnumerable<string> OpenTelemetryMetricsIncludeFilters
-        {
-            get
-            {
-                if (field == null)
-                {
-                    var includeString = EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.include, "NEW_RELIC_OPENTELEMETRY_METRICS_INCLUDE") ?? string.Empty;
-                    field = includeString
-                        .Split([','], StringSplitOptions.RemoveEmptyEntries)
-                        .Select(s => s.Trim())
-                        .Where(s => !string.IsNullOrEmpty(s))
-                        .ToList();
-                }
-                return field;
-            }
-        }
-
-        public IEnumerable<string> OpenTelemetryMetricsExcludeFilters
-        {
-            get
-            {
-                if (field == null)
-                {
-                    var excludeString = EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.exclude, "NEW_RELIC_OPENTELEMETRY_METRICS_EXCLUDE") ?? string.Empty;
-                    field = excludeString
-                        .Split([','], StringSplitOptions.RemoveEmptyEntries)
-                        .Select(s => s.Trim())
-                        .Where(s => !string.IsNullOrEmpty(s))
-                        .ToList();
-                }
-                return field;
-            }
-        }
-
-        public int OpenTelemetryOtlpTimeoutSeconds
-        {
-            get
-            {
-                var value = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("OpenTelemetryOtlpTimeoutSeconds", 10), "NEW_RELIC_OPENTELEMETRY_OTLP_TIMEOUT_SECONDS").GetValueOrDefault(10);
-                return value > 0 ? value : 10;
-            }
-        }
-
-        public int OpenTelemetryOtlpExportIntervalSeconds
-        {
-            get
-            {
-                var value = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("OpenTelemetryOtlpExportIntervalSeconds", 5), "NEW_RELIC_OPENTELEMETRY_OTLP_EXPORT_INTERVAL_SECONDS").GetValueOrDefault(5);
-                return value > 0 ? value : 5;
-            }
-        }
-
-        /// <summary>
-        /// Controls whether EventListener-based samplers (GCSamplerNetCore, ThreadStatsSampler) are enabled.
-        /// Automatically returns false when OpenTelemetry metrics are enabled to prevent EventListener conflicts.
-        /// </summary>
-        public bool EventListenerSamplersEnabled
-        {
-            get
-            {
-                if (OpenTelemetryMetricsEnabled)
-                {
-                    if (field && !_hasLoggedEventListenerSamplersDisabled)
-                    {
-                        Log.Info("EventListener-based samplers (GCSamplerNetCore, ThreadStatsSampler) have been automatically disabled because OpenTelemetry metrics are enabled.");
-                        _hasLoggedEventListenerSamplersDisabled = true;
-                        field = false;
-                    }
-                }
-
-                return field;
-            }
-            set => field = value;
-        }
-        #endregion
-
-        public bool HybridHttpContextStorageEnabled => EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("HybridHttpContextStorageEnabled", false), "NEW_RELIC_HYBRID_HTTP_CONTEXT_STORAGE_ENABLED");
-
-        public static bool GetLoggingEnabledValue(IEnvironment environment, configurationLog localLogConfiguration)
-        {
-            return EnvironmentOverrides(environment, localLogConfiguration.enabled, "NEW_RELIC_LOG_ENABLED");
-        }
-
-        private bool? _loggingEnabled;
-        public bool LoggingEnabled => _loggingEnabled ??= GetLoggingEnabledValue(_environment, _localConfiguration.log);
-
-        public static string GetLoggingLevelValue(IEnvironment environment, configurationLog localLogConfiguration, bool isLoggingEnabled)
-        {
-            var logLevel = "off";
-            if (isLoggingEnabled)
-            {
-                logLevel = EnvironmentOverrides(environment, localLogConfiguration.level, "NEW_RELIC_LOG_LEVEL", "NEWRELIC_LOG_LEVEL").ToUpper();
-            }
-
-            return logLevel;
-        }
-
-        private string _loggingLevel;
-        public string LoggingLevel => _loggingLevel ??= GetLoggingLevelValue(_environment, _localConfiguration.log, LoggingEnabled);
-
-        private const bool CaptureTransactionTraceAttributesDefault = true;
-        private const bool CaptureErrorCollectorAttributesDefault = true;
-        private const bool CaptureBrowserMonitoringAttributesDefault = false;
-        private const bool CaptureCustomParametersAttributesDefault = true;
-
-        private const bool TransactionEventsTransactionsEnabledDefault = true;
-        private const int MaxPayloadSizeInBytes = 1000000; // 1 MiB
     }
+
+    // These are activity sources that are excluded by default unless explicitly included via configuration
+    public List<string> OpenTelemetryTracingDefaultExcludedActivitySources => new List<string>()
+    { "AWSSDK.Bedrock Runtime",
+        "AWSSDK.Bedrock",
+        "AWSSDK.DynamoDB",
+        "AWSSDK.Firehose",
+        "AWSSDK.Kinesis",
+        "AWSSDK.Lambda",
+        "AWSSDK.SQS",
+        "Azure.Cosmos.Operation",
+        "Azure.Messaging.ServiceBus.Message",
+        "Azure.Messaging.ServiceBus.ServiceBusProcessor",
+        "Azure.Messaging.ServiceBus.ServiceBusReceiver",
+        "Azure.Messaging.ServiceBus.ServiceBusSender",
+        "connector-net",
+        "Couchbase.DotnetSdk.OpenTelemetryRequestTracer",
+        "MassTransit",
+        "Microsoft.AspNetCore",
+        "Microsoft.AspNetCore.Components",
+        "Microsoft.AspNetCore.Components.Server.Circuits",
+        "Microsoft.AspNetCore.SignalR.Server",
+        "Microsoft.Azure.Functions.Worker",
+        "Microsoft.Data.SqlClient",
+        "MongoDB.Driver.Core.Extensions.DiagnosticSources",
+        "MySqlConnector",
+        "Npgsql",
+        "NServiceBus.Core",
+        "OpenAI.ChatClient",
+        "OpenTelemetry.AutoInstrumentation.Kafka",
+        "OpenTelemetry.AutoInstrumentation.MongoDB",
+        "OpenTelemetry.Instrumentation.AspNet",
+        "OpenTelemetry.Instrumentation.AWSLambda",
+        "OpenTelemetry.Instrumentation.Owin",
+        "OpenTelemetry.Instrumentation.StackExchangeRedis",
+        "OpenTelemetry.Instrumentation.Wcf",
+        "Oracle.ManagedDataAccess",
+        "Oracle.ManagedDataAccess.Core",
+        "System.Data",
+        "System.Data.SqlClient",
+        "System.Net.Http",
+        "System.Web.Mvc" };
+
+    public List<string> OpenTelemetryTracingExcludedActivitySources
+    {
+        get
+        {
+            if (field == null)
+            {
+                var excludeString = EnvironmentOverrides(_localConfiguration.openTelemetry.traces.exclude, "NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE") ?? string.Empty;
+
+                field = excludeString
+                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .Distinct()
+                    .ToList();
+            }
+
+            return field;
+        }
+    }
+
+
+    public bool OpenTelemetryMetricsEnabled
+    {
+        get
+        {
+            // Both the global OpenTelemetry setting and the metrics-specific setting must be true
+            return OpenTelemetryEnabled && EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.enabled, "NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED");
+        }
+    }
+
+    public IEnumerable<string> OpenTelemetryMetricsIncludeFilters
+    {
+        get
+        {
+            if (field == null)
+            {
+                var includeString = EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.include, "NEW_RELIC_OPENTELEMETRY_METRICS_INCLUDE") ?? string.Empty;
+                field = includeString
+                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .ToList();
+            }
+            return field;
+        }
+    }
+
+    public IEnumerable<string> OpenTelemetryMetricsExcludeFilters
+    {
+        get
+        {
+            if (field == null)
+            {
+                var excludeString = EnvironmentOverrides(_localConfiguration.openTelemetry.metrics.exclude, "NEW_RELIC_OPENTELEMETRY_METRICS_EXCLUDE") ?? string.Empty;
+                field = excludeString
+                    .Split([','], StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .ToList();
+            }
+            return field;
+        }
+    }
+
+    public int OpenTelemetryOtlpTimeoutSeconds
+    {
+        get
+        {
+            var value = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("OpenTelemetryOtlpTimeoutSeconds", 10), "NEW_RELIC_OPENTELEMETRY_OTLP_TIMEOUT_SECONDS").GetValueOrDefault(10);
+            return value > 0 ? value : 10;
+        }
+    }
+
+    public int OpenTelemetryOtlpExportIntervalSeconds
+    {
+        get
+        {
+            var value = EnvironmentOverrides(TryGetAppSettingAsIntWithDefault("OpenTelemetryOtlpExportIntervalSeconds", 5), "NEW_RELIC_OPENTELEMETRY_OTLP_EXPORT_INTERVAL_SECONDS").GetValueOrDefault(5);
+            return value > 0 ? value : 5;
+        }
+    }
+
+    /// <summary>
+    /// Controls whether EventListener-based samplers (GCSamplerNetCore, ThreadStatsSampler) are enabled.
+    /// Automatically returns false when OpenTelemetry metrics are enabled to prevent EventListener conflicts.
+    /// </summary>
+    public bool EventListenerSamplersEnabled
+    {
+        get
+        {
+            if (OpenTelemetryMetricsEnabled)
+            {
+                if (field && !_hasLoggedEventListenerSamplersDisabled)
+                {
+                    Log.Info("EventListener-based samplers (GCSamplerNetCore, ThreadStatsSampler) have been automatically disabled because OpenTelemetry metrics are enabled.");
+                    _hasLoggedEventListenerSamplersDisabled = true;
+                    field = false;
+                }
+            }
+
+            return field;
+        }
+        set => field = value;
+    }
+    #endregion
+
+    public bool HybridHttpContextStorageEnabled => EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("HybridHttpContextStorageEnabled", false), "NEW_RELIC_HYBRID_HTTP_CONTEXT_STORAGE_ENABLED");
+
+    public static bool GetLoggingEnabledValue(IEnvironment environment, configurationLog localLogConfiguration)
+    {
+        return EnvironmentOverrides(environment, localLogConfiguration.enabled, "NEW_RELIC_LOG_ENABLED");
+    }
+
+    private bool? _loggingEnabled;
+    public bool LoggingEnabled => _loggingEnabled ??= GetLoggingEnabledValue(_environment, _localConfiguration.log);
+
+    public static string GetLoggingLevelValue(IEnvironment environment, configurationLog localLogConfiguration, bool isLoggingEnabled)
+    {
+        var logLevel = "off";
+        if (isLoggingEnabled)
+        {
+            logLevel = EnvironmentOverrides(environment, localLogConfiguration.level, "NEW_RELIC_LOG_LEVEL", "NEWRELIC_LOG_LEVEL").ToUpper();
+        }
+
+        return logLevel;
+    }
+
+    private string _loggingLevel;
+    public string LoggingLevel => _loggingLevel ??= GetLoggingLevelValue(_environment, _localConfiguration.log, LoggingEnabled);
+
+    private const bool CaptureTransactionTraceAttributesDefault = true;
+    private const bool CaptureErrorCollectorAttributesDefault = true;
+    private const bool CaptureBrowserMonitoringAttributesDefault = false;
+    private const bool CaptureCustomParametersAttributesDefault = true;
+
+    private const bool TransactionEventsTransactionsEnabledDefault = true;
+    private const int MaxPayloadSizeInBytes = 1000000; // 1 MiB
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/EventHarvestConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/EventHarvestConfig.cs
@@ -4,74 +4,72 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class EventHarvestConfig
 {
-    public class EventHarvestConfig
+    public const string ErrorEventHarvestLimitKey = "error_event_data";
+    public const string CustomEventHarvestLimitKey = "custom_event_data";
+    public const string TransactionEventHarvestLimitKey = "analytic_event_data";
+    public const string LogEventHarvestLimitKey = "log_event_data";
+
+    [JsonProperty("report_period_ms")]
+    public int? ReportPeriodMs { get; set; }
+
+    [JsonProperty("harvest_limits")]
+    public Dictionary<string, int> HarvestLimits { get; set; }
+
+    public int? ErrorEventHarvestLimit()
     {
-        public const string ErrorEventHarvestLimitKey = "error_event_data";
-        public const string CustomEventHarvestLimitKey = "custom_event_data";
-        public const string TransactionEventHarvestLimitKey = "analytic_event_data";
-        public const string LogEventHarvestLimitKey = "log_event_data";
+        return GetEventHarvestLimitFor(ErrorEventHarvestLimitKey);
+    }
 
-        [JsonProperty("report_period_ms")]
-        public int? ReportPeriodMs { get; set; }
+    public TimeSpan? ErrorEventHarvestCycle()
+    {
+        return GetEventHarvestCycleFor(ErrorEventHarvestLimitKey);
+    }
 
-        [JsonProperty("harvest_limits")]
-        public Dictionary<string, int> HarvestLimits { get; set; }
+    public int? CustomEventHarvestLimit()
+    {
+        return GetEventHarvestLimitFor(CustomEventHarvestLimitKey);
+    }
 
-        public int? ErrorEventHarvestLimit()
-        {
-            return GetEventHarvestLimitFor(ErrorEventHarvestLimitKey);
-        }
+    public TimeSpan? CustomEventHarvestCycle()
+    {
+        return GetEventHarvestCycleFor(CustomEventHarvestLimitKey);
+    }
 
-        public TimeSpan? ErrorEventHarvestCycle()
-        {
-            return GetEventHarvestCycleFor(ErrorEventHarvestLimitKey);
-        }
+    public int? TransactionEventHarvestLimit()
+    {
+        return GetEventHarvestLimitFor(TransactionEventHarvestLimitKey);
+    }
 
-        public int? CustomEventHarvestLimit()
-        {
-            return GetEventHarvestLimitFor(CustomEventHarvestLimitKey);
-        }
+    public TimeSpan? TransactionEventHarvestCycle()
+    {
+        return GetEventHarvestCycleFor(TransactionEventHarvestLimitKey);
+    }
 
-        public TimeSpan? CustomEventHarvestCycle()
-        {
-            return GetEventHarvestCycleFor(CustomEventHarvestLimitKey);
-        }
+    public int? LogEventHarvestLimit()
+    {
+        return GetEventHarvestLimitFor(LogEventHarvestLimitKey);
+    }
 
-        public int? TransactionEventHarvestLimit()
-        {
-            return GetEventHarvestLimitFor(TransactionEventHarvestLimitKey);
-        }
+    public TimeSpan? LogEventHarvestCycle()
+    {
+        return GetEventHarvestCycleFor(LogEventHarvestLimitKey);
+    }
 
-        public TimeSpan? TransactionEventHarvestCycle()
-        {
-            return GetEventHarvestCycleFor(TransactionEventHarvestLimitKey);
-        }
+    private int? GetEventHarvestLimitFor(string eventType)
+    {
+        if (HarvestLimits == null || !ReportPeriodMs.HasValue || !HarvestLimits.ContainsKey(eventType)) return null;
 
-        public int? LogEventHarvestLimit()
-        {
-            return GetEventHarvestLimitFor(LogEventHarvestLimitKey);
-        }
+        return HarvestLimits[eventType];
+    }
 
-        public TimeSpan? LogEventHarvestCycle()
-        {
-            return GetEventHarvestCycleFor(LogEventHarvestLimitKey);
-        }
-
-        private int? GetEventHarvestLimitFor(string eventType)
-        {
-            if (HarvestLimits == null || !ReportPeriodMs.HasValue || !HarvestLimits.ContainsKey(eventType)) return null;
-
-            return HarvestLimits[eventType];
-        }
-
-        private TimeSpan? GetEventHarvestCycleFor(string eventType)
-        {
-            var harvestLimit = GetEventHarvestLimitFor(eventType);
-            return harvestLimit.HasValue && harvestLimit > 0 ? TimeSpan.FromMilliseconds(ReportPeriodMs.Value) : null as TimeSpan?;
-        }
+    private TimeSpan? GetEventHarvestCycleFor(string eventType)
+    {
+        var harvestLimit = GetEventHarvestLimitFor(eventType);
+        return harvestLimit.HasValue && harvestLimit > 0 ? TimeSpan.FromMilliseconds(ReportPeriodMs.Value) : null as TimeSpan?;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/InternalConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/InternalConfiguration.cs
@@ -1,20 +1,18 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.Config;
 using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.SharedInterfaces.Web;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+/// <summary>
+/// IConfiguration implementation for use by ConfigurationService only.  Other classes should use DefaultConfiguration and listen to ConfigurationUpdatedEvent.
+/// </summary>
+internal class InternalConfiguration : DefaultConfiguration
 {
-    /// <summary>
-    /// IConfiguration implementation for use by ConfigurationService only.  Other classes should use DefaultConfiguration and listen to ConfigurationUpdatedEvent.
-    /// </summary>
-    internal class InternalConfiguration : DefaultConfiguration
-    {
-        public InternalConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) :
-            base(environment, localConfiguration, serverConfiguration, runTimeConfiguration, securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic)
-        { }
-    }
+    public InternalConfiguration(IEnvironment environment, configuration localConfiguration, ServerConfiguration serverConfiguration, RunTimeConfiguration runTimeConfiguration, SecurityPoliciesConfiguration securityPoliciesConfiguration, IBootstrapConfiguration bootstrapConfiguration, IProcessStatic processStatic, IHttpRuntimeStatic httpRuntimeStatic, IConfigurationManagerStatic configurationManagerStatic, IDnsStatic dnsStatic) :
+        base(environment, localConfiguration, serverConfiguration, runTimeConfiguration, securityPoliciesConfiguration, bootstrapConfiguration, processStatic, httpRuntimeStatic, configurationManagerStatic, dnsStatic)
+    { }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/RecordSqlConfigurationItem.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/RecordSqlConfigurationItem.cs
@@ -4,71 +4,70 @@
 using System;
 using NewRelic.Agent.Core.Config;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class RecordSqlConfigurationItem
 {
-    public class RecordSqlConfigurationItem
+    public string Value { get; private set; }
+    public string Source { get; private set; }
+
+    public RecordSqlConfigurationItem(string value, string source)
     {
-        public string Value { get; private set; }
-        public string Source { get; private set; }
+        Value = value;
+        Source = source;
+    }
 
-        public RecordSqlConfigurationItem(string value, string source)
+    public RecordSqlConfigurationItem ApplyIfMoreRestrictive(RecordSqlConfigurationItem newConfiguration)
+    {
+        if (newConfiguration == null)
         {
-            Value = value;
-            Source = source;
-        }
-
-        public RecordSqlConfigurationItem ApplyIfMoreRestrictive(RecordSqlConfigurationItem newConfiguration)
-        {
-            if (newConfiguration == null)
-            {
-                return this;
-            }
-
-            return ApplyIfMoreRestrictive(newConfiguration.Value, newConfiguration.Source);
-        }
-
-        public RecordSqlConfigurationItem ApplyIfMoreRestrictive(string newValue, string newSource)
-        {
-            if (DefaultConfiguration.OffStringValue.Equals(Value, StringComparison.InvariantCultureIgnoreCase))
-            {
-                return this;
-            }
-
-            if (DefaultConfiguration.OffStringValue.Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-            {
-                Value = DefaultConfiguration.OffStringValue;
-                Source = newSource;
-            }
-            else if (DefaultConfiguration.ObfuscatedStringValue.Equals(newValue, StringComparison.InvariantCultureIgnoreCase)
-                && DefaultConfiguration.RawStringValue.Equals(Value, StringComparison.InvariantCultureIgnoreCase))
-            {
-                Value = DefaultConfiguration.ObfuscatedStringValue;
-                Source = newSource;
-            }
-
             return this;
         }
 
-        public RecordSqlConfigurationItem ApplyIfMoreRestrictive(configurationTransactionTracerRecordSql newValue, string newSource)
+        return ApplyIfMoreRestrictive(newConfiguration.Value, newConfiguration.Source);
+    }
+
+    public RecordSqlConfigurationItem ApplyIfMoreRestrictive(string newValue, string newSource)
+    {
+        if (DefaultConfiguration.OffStringValue.Equals(Value, StringComparison.InvariantCultureIgnoreCase))
         {
-            if (Value == DefaultConfiguration.OffStringValue)
-            {
-                return this;
-            }
-
-            if (newValue == configurationTransactionTracerRecordSql.off)
-            {
-                Value = DefaultConfiguration.OffStringValue;
-                Source = newSource;
-            }
-            else if (newValue == configurationTransactionTracerRecordSql.obfuscated
-                && Value == DefaultConfiguration.RawStringValue)
-            {
-                Value = DefaultConfiguration.ObfuscatedStringValue;
-                Source = newSource;
-            }
-
             return this;
         }
+
+        if (DefaultConfiguration.OffStringValue.Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
+        {
+            Value = DefaultConfiguration.OffStringValue;
+            Source = newSource;
+        }
+        else if (DefaultConfiguration.ObfuscatedStringValue.Equals(newValue, StringComparison.InvariantCultureIgnoreCase)
+                 && DefaultConfiguration.RawStringValue.Equals(Value, StringComparison.InvariantCultureIgnoreCase))
+        {
+            Value = DefaultConfiguration.ObfuscatedStringValue;
+            Source = newSource;
+        }
+
+        return this;
+    }
+
+    public RecordSqlConfigurationItem ApplyIfMoreRestrictive(configurationTransactionTracerRecordSql newValue, string newSource)
+    {
+        if (Value == DefaultConfiguration.OffStringValue)
+        {
+            return this;
+        }
+
+        if (newValue == configurationTransactionTracerRecordSql.off)
+        {
+            Value = DefaultConfiguration.OffStringValue;
+            Source = newSource;
+        }
+        else if (newValue == configurationTransactionTracerRecordSql.obfuscated
+                 && Value == DefaultConfiguration.RawStringValue)
+        {
+            Value = DefaultConfiguration.ObfuscatedStringValue;
+            Source = newSource;
+        }
+
+        return this;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -5,808 +5,806 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Core.SharedInterfaces;
 using Newtonsoft.Json;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+/// <summary>
+/// The configuration that is reported to the collector using the agent_settings command, and in connect.settings.
+/// </summary>
+[JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
+public class ReportedConfiguration : IConfiguration
 {
-    /// <summary>
-    /// The configuration that is reported to the collector using the agent_settings command, and in connect.settings.
-    /// </summary>
-    [JsonObject(ItemNullValueHandling = NullValueHandling.Ignore)]
-    public class ReportedConfiguration : IConfiguration
+    private readonly IConfiguration _configuration;
+    public ReportedConfiguration(IConfiguration configuration)
     {
-        private readonly IConfiguration _configuration;
-        public ReportedConfiguration(IConfiguration configuration)
-        {
-            _configuration = configuration;
-        }
-
-        [JsonProperty("agent.name")]
-        public const string Agent = ".NET Agent";
-
-        #region IConfiguration
-
-        [JsonProperty("agent.run_id")]
-        public object AgentRunId => _configuration.AgentRunId?.ToString();
-
-        [JsonProperty("agent.enabled")]
-        public bool AgentEnabled => _configuration.AgentEnabled;
-
-        [JsonIgnore]
-        public string AgentEnabledAt => _configuration.AgentEnabledAt;
-
-        [JsonIgnore]
-        public bool ServerlessModeEnabled => _configuration.ServerlessModeEnabled;
-
-        [JsonIgnore]
-        public string ServerlessFunctionName => _configuration.ServerlessFunctionName;
-
-        [JsonIgnore]
-        public string ServerlessFunctionVersion => _configuration.ServerlessFunctionVersion;
-
-        [JsonIgnore]
-        public string AgentLicenseKey => _configuration.AgentLicenseKey;
-
-        [JsonProperty("agent.license_key.configured")]
-        public bool AgentLicenseKeyConfigured => !string.IsNullOrWhiteSpace(AgentLicenseKey);
-
-        [JsonProperty("agent.application_names")]
-        public IEnumerable<string> ApplicationNames => _configuration.ApplicationNames;
-
-        public bool TryGetApplicationNames(out IEnumerable<string> names) => _configuration.TryGetApplicationNames(out names);
-
-        [JsonProperty("agent.application_names_source")]
-        public string ApplicationNamesSource => _configuration.ApplicationNamesSource;
-
-        [JsonProperty("agent.auto_start")]
-        public bool AutoStartAgent => _configuration.AutoStartAgent;
-
-        [JsonProperty("browser_monitoring.application_id")]
-        public string BrowserMonitoringApplicationId => _configuration.BrowserMonitoringApplicationId;
-
-        [JsonProperty("browser_monitoring.auto_instrument")]
-        public bool BrowserMonitoringAutoInstrument => _configuration.BrowserMonitoringAutoInstrument;
-
-        [JsonProperty("browser_monitoring.beacon_address")]
-        public string BrowserMonitoringBeaconAddress => _configuration.BrowserMonitoringBeaconAddress;
-
-        [JsonProperty("browser_monitoring.error_beacon_address")]
-        public string BrowserMonitoringErrorBeaconAddress => _configuration.BrowserMonitoringErrorBeaconAddress;
-
-        [JsonIgnore]
-        public string BrowserMonitoringJavaScriptAgent => _configuration.BrowserMonitoringJavaScriptAgent;
-
-        [JsonProperty("browser_monitoring.javascript_agent.populated")]
-        public bool BrowserMonitoringJavaScriptAgentPopulated => !string.IsNullOrWhiteSpace(BrowserMonitoringJavaScriptAgent);
-
-        [JsonProperty("browser_monitoring.javascript_agent_file")]
-        public string BrowserMonitoringJavaScriptAgentFile => _configuration.BrowserMonitoringJavaScriptAgentFile;
-
-        [JsonProperty("browser_monitoring.loader")]
-        public string BrowserMonitoringJavaScriptAgentLoaderType => _configuration.BrowserMonitoringJavaScriptAgentLoaderType;
-
-        // Not an IConfiguration member, but this is here to replicate the behavior of the old 'connect' payload
-        [JsonProperty("browser_monitoring.loader_debug")]
-        public bool LoaderDebug => false;
-
-        [JsonIgnore]
-        public string BrowserMonitoringKey => _configuration.BrowserMonitoringKey;
-
-        [JsonProperty("browser_monitoring.monitoring_key.populated")]
-        public bool BrowserMonitoringKeyPopulated => !string.IsNullOrWhiteSpace(BrowserMonitoringKey);
-
-        [JsonProperty("browser_monitoring.use_ssl")]
-        public bool BrowserMonitoringUseSsl => _configuration.BrowserMonitoringUseSsl;
-
-        [JsonProperty("security.policies_token")]
-        public string SecurityPoliciesToken => _configuration.SecurityPoliciesToken;
-
-        [JsonProperty("security.policies_token_exists")]
-        public bool SecurityPoliciesTokenExists => _configuration.SecurityPoliciesTokenExists;
-
-        [JsonProperty("agent.allow_all_request_headers")]
-        public bool AllowAllRequestHeaders => _configuration.AllowAllRequestHeaders;
-
-        [JsonProperty("agent.attributes_enabled")]
-        public bool CaptureAttributes => _configuration.CaptureAttributes;
-
-        [JsonProperty("agent.can_use_attributes_includes")]
-        public bool CanUseAttributesIncludes => _configuration.CanUseAttributesIncludes;
-
-        [JsonProperty("agent.can_use_attributes_includes_source")]
-        public string CanUseAttributesIncludesSource => _configuration.CanUseAttributesIncludesSource;
-
-        [JsonProperty("agent.attributes_include")]
-        public IEnumerable<string> CaptureAttributesIncludes => _configuration.CaptureAttributesIncludes;
-
-        [JsonProperty("agent.attributes_exclude")]
-        public IEnumerable<string> CaptureAttributesExcludes => _configuration.CaptureAttributesExcludes;
-
-        [JsonProperty("agent.attributes_default_excludes")]
-        public IEnumerable<string> CaptureAttributesDefaultExcludes => _configuration.CaptureAttributesDefaultExcludes;
-
-        [JsonProperty("transaction_events.attributes_enabled")]
-        public bool TransactionEventsAttributesEnabled => _configuration.TransactionEventsAttributesEnabled;
-
-        [JsonProperty("transaction_events.attributes_include")]
-        public HashSet<string> TransactionEventsAttributesInclude => _configuration.TransactionEventsAttributesInclude;
-
-        [JsonProperty("transaction_events.attributes_exclude")]
-        public HashSet<string> TransactionEventsAttributesExclude => _configuration.TransactionEventsAttributesExclude;
-
-        [JsonProperty("transaction_trace.attributes_enabled")]
-        public bool CaptureTransactionTraceAttributes => _configuration.CaptureTransactionTraceAttributes;
-
-        [JsonProperty("transaction_trace.attributes_include")]
-        public IEnumerable<string> CaptureTransactionTraceAttributesIncludes => _configuration.CaptureTransactionTraceAttributesIncludes;
-
-        [JsonProperty("transaction_trace.attributes_exclude")]
-        public IEnumerable<string> CaptureTransactionTraceAttributesExcludes => _configuration.CaptureTransactionTraceAttributesExcludes;
-
-        [JsonProperty("error_collector.attributes_enabled")]
-        public bool CaptureErrorCollectorAttributes => _configuration.CaptureErrorCollectorAttributes;
-
-        [JsonProperty("error_collector.attributes_include")]
-        public IEnumerable<string> CaptureErrorCollectorAttributesIncludes => _configuration.CaptureErrorCollectorAttributesIncludes;
-
-        [JsonProperty("error_collector.attributes_exclude")]
-        public IEnumerable<string> CaptureErrorCollectorAttributesExcludes => _configuration.CaptureErrorCollectorAttributesExcludes;
-
-        [JsonProperty("browser_monitoring.attributes_enabled")]
-        public bool CaptureBrowserMonitoringAttributes => _configuration.CaptureBrowserMonitoringAttributes;
-
-        [JsonProperty("browser_monitoring.attributes_include")]
-        public IEnumerable<string> CaptureBrowserMonitoringAttributesIncludes => _configuration.CaptureBrowserMonitoringAttributesIncludes;
-
-        [JsonProperty("browser_monitoring.attributes_exclude")]
-        public IEnumerable<string> CaptureBrowserMonitoringAttributesExcludes => _configuration.CaptureBrowserMonitoringAttributesExcludes;
-
-        [JsonProperty("custom_parameters.enabled")]
-        public bool CaptureCustomParameters => _configuration.CaptureCustomParameters;
-
-        [JsonProperty("custom_parameters.source")]
-        public string CaptureCustomParametersSource => _configuration.CaptureCustomParametersSource;
-
-        [JsonProperty("collector.host")]
-        public string CollectorHost => _configuration.CollectorHost;
-
-        [JsonProperty("collector.port")]
-        public int CollectorPort => _configuration.CollectorPort;
-
-        [JsonProperty("collector.send_data_on_exit")]
-        public bool CollectorSendDataOnExit => _configuration.CollectorSendDataOnExit;
-
-        [JsonProperty("collector.send_data_on_exit_threshold")]
-        public float CollectorSendDataOnExitThreshold => _configuration.CollectorSendDataOnExitThreshold;
-
-        [JsonProperty("collector.send_environment_info")]
-        public bool CollectorSendEnvironmentInfo => _configuration.CollectorSendEnvironmentInfo;
-
-        [JsonProperty("collector.sync_startup")]
-        public bool CollectorSyncStartup => _configuration.CollectorSyncStartup;
-
-        [JsonProperty("collector.timeout")]
-        public uint CollectorTimeout => _configuration.CollectorTimeout;
-
-        [JsonProperty("collector.max_payload_size_in_bytes")]
-        public int CollectorMaxPayloadSizeInBytes => _configuration.CollectorMaxPayloadSizeInBytes;
-
-        [JsonProperty("agent.complete_transactions_on_thread")]
-        public bool CompleteTransactionsOnThread => _configuration.CompleteTransactionsOnThread;
-
-        [JsonProperty("agent.compressed_content_encoding")]
-        public string CompressedContentEncoding => _configuration.CompressedContentEncoding;
-
-        [JsonProperty("agent.configuration_version")]
-        public long ConfigurationVersion => _configuration.ConfigurationVersion;
-
-        [JsonProperty("cross_application_tracer.cross_process_id")]
-        public string CrossApplicationTracingCrossProcessId => _configuration.CrossApplicationTracingCrossProcessId;
-
-        [JsonProperty("cross_application_tracer.enabled")]
-        public bool CrossApplicationTracingEnabled => _configuration.CrossApplicationTracingEnabled;
-
-        [JsonProperty("distributed_tracing.enabled")]
-        public bool DistributedTracingEnabled => _configuration.DistributedTracingEnabled;
-
-        [JsonProperty("distributed_tracing.sampler.root.sampler_type")]
-        public string RootSamplerName => RootSamplerType.ToSamplerTypeString();
-        [JsonIgnore]
-        public SamplerType RootSamplerType => _configuration.RootSamplerType;
-
-        [JsonProperty("distributed_tracing.sampler.remote_parent_sampled.sampler_type")]
-        public string RemoteParentSampledSamplerName => RemoteParentSampledSamplerType.ToSamplerTypeString();
-        [JsonIgnore]
-        public SamplerType RemoteParentSampledSamplerType => _configuration.RemoteParentSampledSamplerType;
-
-        [JsonProperty("distributed_tracing.sampler.remote_parent_not_sampled.sampler_type")]
-        public string RemoteParentNotSampledSamplerName => RemoteParentNotSampledSamplerType.ToSamplerTypeString();
-        [JsonIgnore]
-        public SamplerType RemoteParentNotSampledSamplerType => _configuration.RemoteParentNotSampledSamplerType;
-
-        [JsonProperty("distributed_tracing.sampler.root.trace_id_ratio_based.ratio")]
-        public float? RootTraceIdRatioSamplerRatio => _configuration.RootTraceIdRatioSamplerRatio;
-        [JsonProperty("distributed_tracing.sampler.remote_parent_sampled.trace_id_ratio_based.ratio")]
-        public float? RemoteParentSampledTraceIdRatioSamplerRatio => _configuration.RemoteParentSampledTraceIdRatioSamplerRatio;
-        [JsonProperty("distributed_tracing.sampler.remote_parent_not_sampled.trace_id_ratio_based.ratio")]
-        public float? RemoteParentNotSampledTraceIdRatioSamplerRatio => _configuration.RemoteParentNotSampledTraceIdRatioSamplerRatio;
-
-        [JsonProperty("span_events.enabled")]
-        public bool SpanEventsEnabled => _configuration.SpanEventsEnabled;
-
-        [JsonProperty("span_events.harvest_cycle")]
-        public TimeSpan SpanEventsHarvestCycle => _configuration.SpanEventsHarvestCycle;
-
-        [JsonProperty("span_events.attributes_enabled")]
-        public bool SpanEventsAttributesEnabled => _configuration.SpanEventsAttributesEnabled;
-
-        [JsonProperty("span_events.attributes_include")]
-        public HashSet<string> SpanEventsAttributesInclude => _configuration.SpanEventsAttributesInclude;
-
-        [JsonProperty("span_events.attributes_exclude")]
-        public HashSet<string> SpanEventsAttributesExclude => _configuration.SpanEventsAttributesExclude;
-
-        [JsonProperty("infinite_tracing.trace_count_consumers")]
-        public int InfiniteTracingTraceCountConsumers => _configuration.InfiniteTracingTraceCountConsumers;
-
-        [JsonProperty("infinite_tracing.trace_observer_host")]
-        public string InfiniteTracingTraceObserverHost => _configuration.InfiniteTracingTraceObserverHost;
-
-        [JsonProperty("infinite_tracing.trace_observer_port")]
-        public string InfiniteTracingTraceObserverPort => _configuration.InfiniteTracingTraceObserverPort;
-
-        [JsonProperty("infinite_tracing.trace_observer_ssl")]
-        public string InfiniteTracingTraceObserverSsl => _configuration.InfiniteTracingTraceObserverSsl;
-
-        [JsonProperty("infinite_tracing.dev.test_flaky")]
-        public float? InfiniteTracingTraceObserverTestFlaky => _configuration.InfiniteTracingTraceObserverTestFlaky;
-
-        [JsonProperty("infinite_tracing.dev.test_flaky_code")]
-        public int? InfiniteTracingTraceObserverTestFlakyCode => _configuration.InfiniteTracingTraceObserverTestFlakyCode;
-
-        [JsonProperty("infinite_tracing.dev.test_delay_ms")]
-        public int? InfiniteTracingTraceObserverTestDelayMs => _configuration.InfiniteTracingTraceObserverTestDelayMs;
-
-        [JsonProperty("infinite_tracing.spans_queue_size")]
-        public int InfiniteTracingQueueSizeSpans => _configuration.InfiniteTracingQueueSizeSpans;
-
-        [JsonProperty("infinite_tracing.spans_partition_count")]
-        public int InfiniteTracingPartitionCountSpans => _configuration.InfiniteTracingPartitionCountSpans;
-
-        [JsonProperty("infinite_tracing.spans_batch_size")]
-        public int InfiniteTracingBatchSizeSpans => _configuration.InfiniteTracingBatchSizeSpans;
-
-        [JsonProperty("infinite_tracing.connect_timeout_ms")]
-        public int InfiniteTracingTraceTimeoutMsConnect => _configuration.InfiniteTracingTraceTimeoutMsConnect;
-
-        [JsonProperty("infinite_tracing.send_data_timeout_ms")]
-        public int InfiniteTracingTraceTimeoutMsSendData => _configuration.InfiniteTracingTraceTimeoutMsSendData;
-
-        [JsonProperty("infinite_tracing.exit_timeout_ms")]
-        public int InfiniteTracingExitTimeoutMs => _configuration.InfiniteTracingExitTimeoutMs;
-
-        [JsonProperty("infinite_tracing.compression")]
-        public bool InfiniteTracingCompression => _configuration.InfiniteTracingCompression;
-
-        [JsonProperty("agent.primary_application_id")]
-        public string PrimaryApplicationId => _configuration.PrimaryApplicationId;
-
-        [JsonProperty("agent.trusted_account_key")]
-        public string TrustedAccountKey => _configuration.TrustedAccountKey;
-
-        [JsonProperty("agent.account_id")]
-        public string AccountId => _configuration.AccountId;
-
-        [JsonProperty("datastore_tracer.name_reporting_enabled")]
-        public bool DatabaseNameReportingEnabled => _configuration.DatabaseNameReportingEnabled;
-
-        [JsonProperty("datastore_tracer.query_parameters_enabled")]
-        public bool DatastoreTracerQueryParametersEnabled => _configuration.DatastoreTracerQueryParametersEnabled;
-
-        [JsonProperty("error_collector.enabled")]
-        public bool ErrorCollectorEnabled => _configuration.ErrorCollectorEnabled;
-
-        [JsonProperty("error_collector.capture_events_enabled")]
-        public bool ErrorCollectorCaptureEvents => _configuration.ErrorCollectorCaptureEvents;
-
-        [JsonProperty("error_collector.max_samples_stored")]
-        public int ErrorCollectorMaxEventSamplesStored => _configuration.ErrorCollectorMaxEventSamplesStored;
-
-        [JsonProperty("error_collector.harvest_cycle")]
-        public TimeSpan ErrorEventsHarvestCycle => _configuration.ErrorEventsHarvestCycle;
-
-        [JsonProperty("error_collector.max_per_period")]
-        public uint ErrorsMaximumPerPeriod => _configuration.ErrorsMaximumPerPeriod;
-
-        [JsonProperty("error_collector.expected_classes")]
-        public IEnumerable<string> ExpectedErrorClassesForAgentSettings => _configuration.ExpectedErrorClassesForAgentSettings;
-
-        [JsonProperty("error_collector.expected_messages")]
-        public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings => _configuration.ExpectedErrorMessagesForAgentSettings;
-
-        // The following IConfiguration property `ExpectedErrorStatusCodesForAgentSettings` actually reports the same information in a more friendly way
-        [JsonIgnore]
-        public IEnumerable<MatchRule> ExpectedStatusCodes => _configuration.ExpectedStatusCodes;
-
-        [JsonProperty("error_collector.expected_status_codes")]
-        public IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings => _configuration.ExpectedErrorStatusCodesForAgentSettings;
-
-        [JsonProperty("error_collector.expected_errors_config")]
-        public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration => _configuration.ExpectedErrorsConfiguration;
-
-        [JsonProperty("error_collector.ignore_errors_config")]
-        public IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration => _configuration.IgnoreErrorsConfiguration;
-
-        [JsonProperty("error_collector.ignore_classes")]
-        public IEnumerable<string> IgnoreErrorClassesForAgentSettings => _configuration.IgnoreErrorClassesForAgentSettings;
-
-        [JsonProperty("error_collector.ignore_messages")]
-        public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings => _configuration.IgnoreErrorMessagesForAgentSettings;
-
-        // Serializing this Func doesn't provide us with more information than the supportability metrics
-        [JsonIgnore]
-        public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback => _configuration.ErrorGroupCallback;
-
-        [JsonProperty("agent.request_headers_map")]
-        public Dictionary<string, string> RequestHeadersMap => _configuration.RequestHeadersMap;
-                
-        [JsonProperty("cross_application_tracer.encoding_key")]
-        public string EncodingKey => _configuration.EncodingKey;
-
-        [JsonProperty("agent.entity_guid")]
-        public string EntityGuid => _configuration.EntityGuid;
-
-        [JsonProperty("agent.high_security_mode_enabled")]
-        public bool HighSecurityModeEnabled => _configuration.HighSecurityModeEnabled;
-
-        [JsonProperty("agent.custom_instrumentation_editor_enabled")]
-        public bool CustomInstrumentationEditorEnabled => _configuration.CustomInstrumentationEditorEnabled;
-
-        [JsonProperty("agent.custom_instrumentation_editor_enabled_source")]
-        public string CustomInstrumentationEditorEnabledSource => _configuration.CustomInstrumentationEditorEnabledSource;
-
-        [JsonProperty("agent.strip_exception_messages")]
-        public bool StripExceptionMessages => _configuration.StripExceptionMessages;
-
-        [JsonProperty("agent.strip_exception_messages_source")]
-        public string StripExceptionMessagesSource => _configuration.StripExceptionMessagesSource;
-
-        [JsonProperty("agent.instance_reporting_enabled")]
-        public bool InstanceReportingEnabled => _configuration.InstanceReportingEnabled;
-
-        [JsonProperty("agent.instrumentation_logging_enabled")]
-        public bool InstrumentationLoggingEnabled => _configuration.InstrumentationLoggingEnabled;
-
-        [JsonProperty("agent.labels")]
-        public string Labels => _configuration.Labels;
-
-        [JsonProperty("agent.metric_name_regex_rules")]
-        public IEnumerable<RegexRule> MetricNameRegexRules => _configuration.MetricNameRegexRules;
-
-        [JsonProperty("agent.new_relic_config_file_path")]
-        public string NewRelicConfigFilePath => _configuration.NewRelicConfigFilePath;
-
-        [JsonProperty("agent.app_settings_config_file_path")]
-        public string AppSettingsConfigFilePath => _configuration.AppSettingsConfigFilePath;
-
-        [JsonIgnore]
-        public string ProxyHost => _configuration.ProxyHost;
-
-        [JsonProperty("proxy.host.configured")]
-        public bool ProxyHostConfigured => !string.IsNullOrWhiteSpace(ProxyHost);
-
-        [JsonIgnore]
-        public string ProxyUriPath => _configuration.ProxyUriPath;
-
-        [JsonProperty("proxy.uri_path.configured")]
-        public bool ProxyUriPathConfigured => !string.IsNullOrWhiteSpace(ProxyUriPath);
-
-        [JsonIgnore]
-        public int ProxyPort => _configuration.ProxyPort;
-
-        [JsonProperty("proxy.port.configured")]
-        public bool ProxyPortConfigured => true; // as this is an integer with a default value, it will always be 'configured'
-
-        [JsonIgnore]
-        public string ProxyUsername => _configuration.ProxyUsername;
-
-        [JsonProperty("proxy.username.configured")]
-        public bool ProxyUsernameConfigured => !string.IsNullOrWhiteSpace(ProxyUsername);
-
-        [JsonIgnore]
-        public string ProxyPassword => _configuration.ProxyPassword;
-
-        [JsonProperty("proxy.password.configured")]
-        public bool ProxyPasswordConfigured => !string.IsNullOrWhiteSpace(ProxyPassword);
-
-        [JsonIgnore]
-        public string ProxyDomain => _configuration.ProxyDomain;
-
-        [JsonProperty("proxy.domain.configured")]
-        public bool ProxyDomainConfigured => !string.IsNullOrWhiteSpace(ProxyDomain);
-
-        [JsonProperty("agent.put_for_data_sent")]
-        public bool PutForDataSend => _configuration.PutForDataSend;
-
-        [JsonProperty("slow_sql.enabled")]
-        public bool SlowSqlEnabled => _configuration.SlowSqlEnabled;
-
-        [JsonProperty("transaction_tracer.explain_threshold")]
-        public TimeSpan SqlExplainPlanThreshold => _configuration.SqlExplainPlanThreshold;
-
-        [JsonProperty("transaction_tracer.explain_enabled")]
-        public bool SqlExplainPlansEnabled => _configuration.SqlExplainPlansEnabled;
-
-        [JsonProperty("transaction_tracer.max_explain_plans")]
-        public int SqlExplainPlansMax => _configuration.SqlExplainPlansMax;
-
-        [JsonProperty("transaction_tracer.max_sql_statements")]
-        public uint SqlStatementsPerTransaction => _configuration.SqlStatementsPerTransaction;
-
-        [JsonProperty("transaction_tracer.sql_traces_per_period")]
-        public int SqlTracesPerPeriod => _configuration.SqlTracesPerPeriod;
-
-        [JsonProperty("transaction_tracer.max_stack_trace_lines")]
-        public int StackTraceMaximumFrames => _configuration.StackTraceMaximumFrames;
-
-        [JsonProperty("error_collector.ignore_status_codes")]
-        public IEnumerable<string> HttpStatusCodesToIgnore => _configuration.HttpStatusCodesToIgnore;
-
-        [JsonProperty("agent.thread_profiling_methods_to_ignore")]
-        public IEnumerable<string> ThreadProfilingIgnoreMethods => _configuration.ThreadProfilingIgnoreMethods;
-
-        [JsonProperty("custom_events.enabled")]
-        public bool CustomEventsEnabled => _configuration.CustomEventsEnabled;
-
-        [JsonProperty("custom_events.enabled_source")]
-        public string CustomEventsEnabledSource => _configuration.CustomEventsEnabledSource;
-
-        [JsonProperty("custom_events.attributes_enabled")]
-        public bool CustomEventsAttributesEnabled => _configuration.CustomEventsAttributesEnabled;
-
-        [JsonProperty("custom_events.attributes_include")]
-        public HashSet<string> CustomEventsAttributesInclude => _configuration.CustomEventsAttributesInclude;
-
-        [JsonProperty("custom_events.attributes_exclude")]
-        public HashSet<string> CustomEventsAttributesExclude => _configuration.CustomEventsAttributesExclude;
-
-        [JsonProperty("custom_events.max_samples_stored")]
-        public int CustomEventsMaximumSamplesStored => _configuration.CustomEventsMaximumSamplesStored;
-
-        [JsonProperty("custom_events.harvest_cycle")]
-        public TimeSpan CustomEventsHarvestCycle => _configuration.CustomEventsHarvestCycle;
-
-        [JsonProperty("agent.disable_samplers")]
-        public bool DisableSamplers => _configuration.DisableSamplers;
-
-        [JsonProperty("thread_profiler.enabled")]
-        public bool ThreadProfilingEnabled => _configuration.ThreadProfilingEnabled;
-
-        [JsonProperty("transaction_events.enabled")]
-        public bool TransactionEventsEnabled => _configuration.TransactionEventsEnabled;
-
-        [JsonProperty("transaction_events.max_samples_stored")]
-        public int TransactionEventsMaximumSamplesStored => _configuration.TransactionEventsMaximumSamplesStored;
-
-        [JsonProperty("transaction_events.harvest_cycle")]
-        public TimeSpan TransactionEventsHarvestCycle => _configuration.TransactionEventsHarvestCycle;
-
-        [JsonProperty("transaction_events.transactions_enabled")]
-        public bool TransactionEventsTransactionsEnabled => _configuration.TransactionEventsTransactionsEnabled;
-
-        [JsonProperty("transaction_name.regex_rules")]
-        public IEnumerable<RegexRule> TransactionNameRegexRules => _configuration.TransactionNameRegexRules;
-
-        [JsonProperty("transaction_name.whitelist_rules")]
-        public IDictionary<string, IEnumerable<string>> TransactionNameWhitelistRules => _configuration.TransactionNameWhitelistRules;
-
-        [JsonProperty("transaction_tracer.apdex_f")]
-        public TimeSpan TransactionTraceApdexF => _configuration.TransactionTraceApdexF;
-
-        [JsonProperty("transaction_tracer.apdex_t")]
-        public TimeSpan TransactionTraceApdexT => _configuration.TransactionTraceApdexT;
-
-        [JsonProperty("transaction_tracer.transaction_threshold")]
-        public TimeSpan TransactionTraceThreshold => _configuration.TransactionTraceThreshold;
-
-        [JsonProperty("transaction_tracer.enabled")]
-        public bool TransactionTracerEnabled => _configuration.TransactionTracerEnabled;
-
-        [JsonProperty("transaction_tracer.max_segments")]
-        public int TransactionTracerMaxSegments => _configuration.TransactionTracerMaxSegments;
-
-        [JsonProperty("transaction_tracer.record_sql")]
-        public string TransactionTracerRecordSql => _configuration.TransactionTracerRecordSql;
-
-        [JsonProperty("transaction_tracer.record_sql_source")]
-        public string TransactionTracerRecordSqlSource => _configuration.TransactionTracerRecordSqlSource;
-
-        [JsonProperty("transaction_tracer.max_stack_traces")]
-        public int TransactionTracerMaxStackTraces => _configuration.TransactionTracerMaxStackTraces;
-
-        [JsonProperty("agent.trusted_account_ids")]
-        public IEnumerable<long> TrustedAccountIds => _configuration.TrustedAccountIds;
-
-        [JsonProperty("agent.server_side_config_enabled")]
-        public bool ServerSideConfigurationEnabled => _configuration.ServerSideConfigurationEnabled;
-
-        [JsonProperty("agent.ignore_server_side_config")]
-        public bool IgnoreServerSideConfiguration => _configuration.IgnoreServerSideConfiguration;
-
-        [JsonProperty("agent.url_regex_rules")]
-        public IEnumerable<RegexRule> UrlRegexRules => _configuration.UrlRegexRules;
-
-        [JsonProperty("agent.request_path_exclusion_list")]
-        public IEnumerable<Regex> RequestPathExclusionList => _configuration.RequestPathExclusionList;
-
-        [JsonProperty("agent.web_transactions_apdex")]
-        public IDictionary<string, double> WebTransactionsApdex => _configuration.WebTransactionsApdex;
-
-        [JsonProperty("agent.wrapper_exception_limit")]
-        public int WrapperExceptionLimit => _configuration.WrapperExceptionLimit;
-
-        [JsonProperty("utilization.detect_aws_enabled")]
-        public bool UtilizationDetectAws => _configuration.UtilizationDetectAws;
-
-        [JsonProperty("utilization.detect_azure_enabled")]
-        public bool UtilizationDetectAzure => _configuration.UtilizationDetectAzure;
-
-        [JsonProperty("utilization.detect_gcp_enabled")]
-        public bool UtilizationDetectGcp => _configuration.UtilizationDetectGcp;
-
-        [JsonProperty("utilization.detect_pcf_enabled")]
-        public bool UtilizationDetectPcf => _configuration.UtilizationDetectPcf;
-
-        [JsonProperty("utilization.detect_docker_enabled")]
-        public bool UtilizationDetectDocker => _configuration.UtilizationDetectDocker;
-
-        [JsonProperty("utilization.detect_kubernetes_enabled")]
-        public bool UtilizationDetectKubernetes => _configuration.UtilizationDetectKubernetes;
-
-        [JsonProperty("utilization.detect_azure_function_enabled")]
-        public bool UtilizationDetectAzureFunction => _configuration.UtilizationDetectAzureFunction;
-
-        [JsonProperty("utilization.detect_azure_appservice_enabled")]
-        public bool UtilizationDetectAzureAppService => _configuration.UtilizationDetectAzureAppService;
-
-        [JsonProperty("utilization.logical_processors")]
-        public int? UtilizationLogicalProcessors => _configuration.UtilizationLogicalProcessors;
-
-        [JsonProperty("utilization.total_ram_mib")]
-        public int? UtilizationTotalRamMib => _configuration.UtilizationTotalRamMib;
-
-        [JsonProperty("utilization.billing_host")]
-        public string UtilizationBillingHost => _configuration.UtilizationBillingHost;
-
-        [JsonProperty("utilization.hostname")]
-        public string UtilizationHostName => _configuration.UtilizationHostName;
-
-        [JsonProperty("utilization.full_hostname")]
-        public string UtilizationFullHostName => _configuration.UtilizationFullHostName;
-
-        [JsonProperty("diagnostics.capture_agent_timing_enabled")]
-        public bool DiagnosticsCaptureAgentTiming => _configuration.DiagnosticsCaptureAgentTiming;
-
-        [JsonProperty("diagnostics.capture_agent_timing_frequency")]
-        public int DiagnosticsCaptureAgentTimingFrequency => _configuration.DiagnosticsCaptureAgentTimingFrequency;
-
-        [JsonProperty("agent.use_resource_based_naming_for_wcf_enabled")]
-        public bool UseResourceBasedNamingForWCFEnabled => _configuration.UseResourceBasedNamingForWCFEnabled;
-
-        [JsonProperty("agent.event_listener_samplers_enabled")]
-        public bool EventListenerSamplersEnabled { get => _configuration.EventListenerSamplersEnabled; set { /* nothx */ } }
-
-        [JsonProperty("agent.sampling_target")]
-        public int? SamplingTarget => _configuration.SamplingTarget;
-
-        [JsonProperty("span_events.max_samples_stored")]
-        public int SpanEventsMaxSamplesStored => _configuration.SpanEventsMaxSamplesStored;
-
-        [JsonProperty("agent.sampling_target_period_in_seconds")]
-        public int? SamplingTargetPeriodInSeconds => _configuration.SamplingTargetPeriodInSeconds;
-
-        [JsonProperty("agent.payload_success_metrics_enabled")]
-        public bool PayloadSuccessMetricsEnabled => _configuration.PayloadSuccessMetricsEnabled;
-
-        [JsonProperty("agent.process_host_display_name")]
-        public string ProcessHostDisplayName => _configuration.ProcessHostDisplayName;
-
-        [JsonProperty("transaction_tracer.database_statement_cache_capacity")]
-        public int DatabaseStatementCacheCapacity => _configuration.DatabaseStatementCacheCapacity;
-
-        [JsonProperty("agent.force_synchronous_timing_calculation_for_http_client")]
-        public bool ForceSynchronousTimingCalculationHttpClient => _configuration.ForceSynchronousTimingCalculationHttpClient;
-
-        [JsonProperty("agent.enable_asp_net_core_6plus_browser_injection")]
-        public bool EnableAspNetCore6PlusBrowserInjection => _configuration.EnableAspNetCore6PlusBrowserInjection;
-
-        [JsonProperty("agent.exclude_new_relic_header")]
-        public bool ExcludeNewrelicHeader => _configuration.ExcludeNewrelicHeader;
-
-        [JsonProperty("application_logging.enabled")]
-        public bool ApplicationLoggingEnabled => _configuration.ApplicationLoggingEnabled;
-
-        [JsonProperty("application_logging.metrics.enabled")]
-        public bool LogMetricsCollectorEnabled => _configuration.LogMetricsCollectorEnabled;
-
-        [JsonProperty("application_logging.forwarding.enabled")]
-        public bool LogEventCollectorEnabled => _configuration.LogEventCollectorEnabled;
-
-        [JsonProperty("application_logging.forwarding.max_samples_stored")]
-        public int LogEventsMaxSamplesStored => _configuration.LogEventsMaxSamplesStored;
-
-        [JsonProperty("application_logging.forwarding.log_level_denylist")]
-        public HashSet<string> LogLevelDenyList => _configuration.LogLevelDenyList;
-
-        [JsonProperty("application_logging.harvest_cycle")]
-        public TimeSpan LogEventsHarvestCycle => _configuration.LogEventsHarvestCycle;
-
-        [JsonProperty("application_logging.local_decorating.enabled")]
-        public bool LogDecoratorEnabled => _configuration.LogDecoratorEnabled;
-
-        [JsonProperty("agent.app_domain_caching_disabled")]
-        public bool AppDomainCachingDisabled => _configuration.AppDomainCachingDisabled;
-
-        [JsonProperty("agent.force_new_transaction_on_new_thread_enabled")]
-        public bool ForceNewTransactionOnNewThread => _configuration.ForceNewTransactionOnNewThread;
-
-        [JsonProperty("agent.code_level_metrics_enabled")]
-        public bool CodeLevelMetricsEnabled => _configuration.CodeLevelMetricsEnabled;
-
-        [JsonProperty("agent.app_settings")]
-        public IReadOnlyDictionary<string,string> AppSettings => GetAppSettings();
-
-        [JsonProperty("application_logging.forwarding.context_data.enabled")]
-        public bool ContextDataEnabled => _configuration.ContextDataEnabled;
-
-        [JsonProperty("application_logging.forwarding.context_data.include")]
-        public IEnumerable<string> ContextDataInclude => _configuration.ContextDataInclude;
-
-        [JsonProperty("application_logging.forwarding.context_data.exclude")]
-        public IEnumerable<string> ContextDataExclude => _configuration.ContextDataExclude;
-
-        [JsonProperty("application_logging.forwarding.labels.enabled")]
-        public bool LabelsEnabled => _configuration.LabelsEnabled;
-
-        [JsonProperty("application_logging.forwarding.labels.exclude")]
-        public IEnumerable<string> LabelsExclude => _configuration.LabelsExclude;
-
-        [JsonProperty("metrics.harvest_cycle")]
-        public TimeSpan MetricsHarvestCycle => _configuration.MetricsHarvestCycle;
-
-        [JsonProperty("transaction_traces.harvest_cycle")]
-        public TimeSpan TransactionTracesHarvestCycle => _configuration.TransactionTracesHarvestCycle;
-
-        [JsonProperty("error_traces.harvest_cycle")]
-        public TimeSpan ErrorTracesHarvestCycle => _configuration.ErrorTracesHarvestCycle;
-
-        [JsonProperty("get_agent_commands.cycle")]
-        public TimeSpan GetAgentCommandsCycle => _configuration.GetAgentCommandsCycle;
-
-        [JsonProperty("default.harvest_cycle")]
-        public TimeSpan DefaultHarvestCycle => _configuration.DefaultHarvestCycle;
-
-        [JsonProperty("sql_traces.harvest_cycle")]
-        public TimeSpan SqlTracesHarvestCycle => _configuration.SqlTracesHarvestCycle;
-
-        [JsonProperty("update_loaded_modules.cycle")]
-        public TimeSpan UpdateLoadedModulesCycle => _configuration.UpdateLoadedModulesCycle;
-
-        [JsonProperty("stackexchangeredis_cleanup.cycle")]
-        public TimeSpan StackExchangeRedisCleanupCycle => _configuration.StackExchangeRedisCleanupCycle;
-
-        [JsonProperty("agent.logging_enabled")]
-        public bool LoggingEnabled => _configuration.LoggingEnabled;
-
-        [JsonIgnore]
-        public string LoggingLevel => _configuration.LoggingLevel;
-
-        [JsonProperty("agent.instrumentation.ignore")]
-        public IEnumerable<IDictionary<string, string>> IgnoredInstrumentation => _configuration.IgnoredInstrumentation;
-
-        [JsonProperty("agent.disable_file_system_watcher")]
-        public bool DisableFileSystemWatcher => _configuration.DisableFileSystemWatcher;
-
-        // To support account level disable feature, the name cannot include the "agent" prefix.
-        // The account level disable feature looks for this setting and will only reply with the ServerConfiguration setting if it is present.
-        [JsonProperty("ai_monitoring.enabled")]
-        public bool AiMonitoringEnabled => _configuration.AiMonitoringEnabled;
-
-        [JsonProperty("ai_monitoring.streaming.enabled")]
-        public bool AiMonitoringStreamingEnabled => _configuration.AiMonitoringStreamingEnabled;
-
-        [JsonProperty("ai_monitoring.record_content.enabled")]
-        public bool AiMonitoringRecordContentEnabled => _configuration.AiMonitoringRecordContentEnabled;
-
-        // Serializing this Func doesn't provide us with more information than the supportability metrics
-        [JsonIgnore]
-        public Func<string, string, int> LlmTokenCountingCallback => _configuration.LlmTokenCountingCallback;
-
-        [JsonIgnore]
-        public bool AzureFunctionModeDetected => _configuration.AzureFunctionModeDetected;
-        [JsonIgnore]
-        public bool AzureFunctionModeEnabled => _configuration.AzureFunctionModeEnabled;
-
-        [JsonIgnore]
-        public string AzureFunctionResourceId => _configuration.AzureFunctionResourceId;
-
-        [JsonIgnore]
-        public string AzureFunctionResourceGroupName =>_configuration.AzureFunctionResourceGroupName;
-
-        [JsonIgnore]
-        public string AzureFunctionRegion => _configuration.AzureFunctionRegion;
-
-        [JsonIgnore]
-        public string AzureFunctionSubscriptionId => _configuration.AzureFunctionSubscriptionId;
-
-        [JsonIgnore]
-        public string AzureFunctionAppName => _configuration.AzureFunctionAppName;
-
-        public string AzureFunctionResourceIdWithFunctionName(string functionName) => _configuration.AzureFunctionResourceIdWithFunctionName(functionName);
-
-        [JsonIgnore]
-        public string AwsAccountId => _configuration.AwsAccountId;
-
-        [JsonProperty("gc_sampler_v2.enabled")]
-        public bool GCSamplerV2Enabled => _configuration.GCSamplerV2Enabled;
-
-        public IReadOnlyDictionary<string, string> GetAppSettings()
-        {
-            return _configuration.GetAppSettings();
-        }
-
-        [JsonProperty("agent_control.enabled")]
-        public bool AgentControlEnabled => _configuration.AgentControlEnabled;
-
-        [JsonProperty("agent_control.health.delivery_location")]
-        public string HealthDeliveryLocation => _configuration.HealthDeliveryLocation;
-
-        [JsonProperty("agent_control.health.frequency")]
-        public int HealthFrequency => _configuration.HealthFrequency;
-
-        [JsonIgnore]
-        public bool AwsLambdaApmModeEnabled => _configuration.AwsLambdaApmModeEnabled;
-        
-        [JsonIgnore]
-        public int MaxCustomInstrumentationSupportabilityMetrics { get; }
-
-        // OpenTelemetry Configuration Properties
-        [JsonProperty("opentelemetry.enabled")]
-        public bool OpenTelemetryEnabled => _configuration.OpenTelemetryEnabled;
-
-
-        [JsonProperty("opentelemetry.traces.enabled")]
-        public bool OpenTelemetryTracingEnabled => _configuration.OpenTelemetryTracingEnabled;
-
-        [JsonProperty("opentelemetry.traces.include")]
-        public List<string> OpenTelemetryTracingIncludedActivitySources => _configuration.OpenTelemetryTracingIncludedActivitySources;
-
-        [JsonProperty("opentelemetry.traces.exclude")]
-        public List<string> OpenTelemetryTracingExcludedActivitySources => _configuration.OpenTelemetryTracingExcludedActivitySources;
-
-        [JsonProperty("opentelemetry.traces.default_exclude")]
-        public List<string> OpenTelemetryTracingDefaultExcludedActivitySources =>
-            _configuration.OpenTelemetryTracingDefaultExcludedActivitySources;
-
-        [JsonProperty("opentelemetry.metrics.enabled")]
-        public bool OpenTelemetryMetricsEnabled => _configuration.OpenTelemetryMetricsEnabled;
-
-        [JsonProperty("opentelemetry.metrics.include")]
-        public IEnumerable<string> OpenTelemetryMetricsIncludeFilters => _configuration.OpenTelemetryMetricsIncludeFilters;
-
-        [JsonProperty("opentelemetry.metrics.exclude")]
-        public IEnumerable<string> OpenTelemetryMetricsExcludeFilters => _configuration.OpenTelemetryMetricsExcludeFilters;
-
-        [JsonProperty("opentelemetry.otlp.timeout_seconds")]
-        public int OpenTelemetryOtlpTimeoutSeconds => _configuration.OpenTelemetryOtlpTimeoutSeconds;
-
-        [JsonProperty("opentelemetry.otlp.export_interval_seconds")]
-        public int OpenTelemetryOtlpExportIntervalSeconds => _configuration.OpenTelemetryOtlpExportIntervalSeconds;
-
-        [JsonProperty("hybrid_http_context_storage.enabled")]
-        public bool HybridHttpContextStorageEnabled => _configuration.HybridHttpContextStorageEnabled;
-
-        #endregion
+        _configuration = configuration;
     }
+
+    [JsonProperty("agent.name")]
+    public const string Agent = ".NET Agent";
+
+    #region IConfiguration
+
+    [JsonProperty("agent.run_id")]
+    public object AgentRunId => _configuration.AgentRunId?.ToString();
+
+    [JsonProperty("agent.enabled")]
+    public bool AgentEnabled => _configuration.AgentEnabled;
+
+    [JsonIgnore]
+    public string AgentEnabledAt => _configuration.AgentEnabledAt;
+
+    [JsonIgnore]
+    public bool ServerlessModeEnabled => _configuration.ServerlessModeEnabled;
+
+    [JsonIgnore]
+    public string ServerlessFunctionName => _configuration.ServerlessFunctionName;
+
+    [JsonIgnore]
+    public string ServerlessFunctionVersion => _configuration.ServerlessFunctionVersion;
+
+    [JsonIgnore]
+    public string AgentLicenseKey => _configuration.AgentLicenseKey;
+
+    [JsonProperty("agent.license_key.configured")]
+    public bool AgentLicenseKeyConfigured => !string.IsNullOrWhiteSpace(AgentLicenseKey);
+
+    [JsonProperty("agent.application_names")]
+    public IEnumerable<string> ApplicationNames => _configuration.ApplicationNames;
+
+    public bool TryGetApplicationNames(out IEnumerable<string> names) => _configuration.TryGetApplicationNames(out names);
+
+    [JsonProperty("agent.application_names_source")]
+    public string ApplicationNamesSource => _configuration.ApplicationNamesSource;
+
+    [JsonProperty("agent.auto_start")]
+    public bool AutoStartAgent => _configuration.AutoStartAgent;
+
+    [JsonProperty("browser_monitoring.application_id")]
+    public string BrowserMonitoringApplicationId => _configuration.BrowserMonitoringApplicationId;
+
+    [JsonProperty("browser_monitoring.auto_instrument")]
+    public bool BrowserMonitoringAutoInstrument => _configuration.BrowserMonitoringAutoInstrument;
+
+    [JsonProperty("browser_monitoring.beacon_address")]
+    public string BrowserMonitoringBeaconAddress => _configuration.BrowserMonitoringBeaconAddress;
+
+    [JsonProperty("browser_monitoring.error_beacon_address")]
+    public string BrowserMonitoringErrorBeaconAddress => _configuration.BrowserMonitoringErrorBeaconAddress;
+
+    [JsonIgnore]
+    public string BrowserMonitoringJavaScriptAgent => _configuration.BrowserMonitoringJavaScriptAgent;
+
+    [JsonProperty("browser_monitoring.javascript_agent.populated")]
+    public bool BrowserMonitoringJavaScriptAgentPopulated => !string.IsNullOrWhiteSpace(BrowserMonitoringJavaScriptAgent);
+
+    [JsonProperty("browser_monitoring.javascript_agent_file")]
+    public string BrowserMonitoringJavaScriptAgentFile => _configuration.BrowserMonitoringJavaScriptAgentFile;
+
+    [JsonProperty("browser_monitoring.loader")]
+    public string BrowserMonitoringJavaScriptAgentLoaderType => _configuration.BrowserMonitoringJavaScriptAgentLoaderType;
+
+    // Not an IConfiguration member, but this is here to replicate the behavior of the old 'connect' payload
+    [JsonProperty("browser_monitoring.loader_debug")]
+    public bool LoaderDebug => false;
+
+    [JsonIgnore]
+    public string BrowserMonitoringKey => _configuration.BrowserMonitoringKey;
+
+    [JsonProperty("browser_monitoring.monitoring_key.populated")]
+    public bool BrowserMonitoringKeyPopulated => !string.IsNullOrWhiteSpace(BrowserMonitoringKey);
+
+    [JsonProperty("browser_monitoring.use_ssl")]
+    public bool BrowserMonitoringUseSsl => _configuration.BrowserMonitoringUseSsl;
+
+    [JsonProperty("security.policies_token")]
+    public string SecurityPoliciesToken => _configuration.SecurityPoliciesToken;
+
+    [JsonProperty("security.policies_token_exists")]
+    public bool SecurityPoliciesTokenExists => _configuration.SecurityPoliciesTokenExists;
+
+    [JsonProperty("agent.allow_all_request_headers")]
+    public bool AllowAllRequestHeaders => _configuration.AllowAllRequestHeaders;
+
+    [JsonProperty("agent.attributes_enabled")]
+    public bool CaptureAttributes => _configuration.CaptureAttributes;
+
+    [JsonProperty("agent.can_use_attributes_includes")]
+    public bool CanUseAttributesIncludes => _configuration.CanUseAttributesIncludes;
+
+    [JsonProperty("agent.can_use_attributes_includes_source")]
+    public string CanUseAttributesIncludesSource => _configuration.CanUseAttributesIncludesSource;
+
+    [JsonProperty("agent.attributes_include")]
+    public IEnumerable<string> CaptureAttributesIncludes => _configuration.CaptureAttributesIncludes;
+
+    [JsonProperty("agent.attributes_exclude")]
+    public IEnumerable<string> CaptureAttributesExcludes => _configuration.CaptureAttributesExcludes;
+
+    [JsonProperty("agent.attributes_default_excludes")]
+    public IEnumerable<string> CaptureAttributesDefaultExcludes => _configuration.CaptureAttributesDefaultExcludes;
+
+    [JsonProperty("transaction_events.attributes_enabled")]
+    public bool TransactionEventsAttributesEnabled => _configuration.TransactionEventsAttributesEnabled;
+
+    [JsonProperty("transaction_events.attributes_include")]
+    public HashSet<string> TransactionEventsAttributesInclude => _configuration.TransactionEventsAttributesInclude;
+
+    [JsonProperty("transaction_events.attributes_exclude")]
+    public HashSet<string> TransactionEventsAttributesExclude => _configuration.TransactionEventsAttributesExclude;
+
+    [JsonProperty("transaction_trace.attributes_enabled")]
+    public bool CaptureTransactionTraceAttributes => _configuration.CaptureTransactionTraceAttributes;
+
+    [JsonProperty("transaction_trace.attributes_include")]
+    public IEnumerable<string> CaptureTransactionTraceAttributesIncludes => _configuration.CaptureTransactionTraceAttributesIncludes;
+
+    [JsonProperty("transaction_trace.attributes_exclude")]
+    public IEnumerable<string> CaptureTransactionTraceAttributesExcludes => _configuration.CaptureTransactionTraceAttributesExcludes;
+
+    [JsonProperty("error_collector.attributes_enabled")]
+    public bool CaptureErrorCollectorAttributes => _configuration.CaptureErrorCollectorAttributes;
+
+    [JsonProperty("error_collector.attributes_include")]
+    public IEnumerable<string> CaptureErrorCollectorAttributesIncludes => _configuration.CaptureErrorCollectorAttributesIncludes;
+
+    [JsonProperty("error_collector.attributes_exclude")]
+    public IEnumerable<string> CaptureErrorCollectorAttributesExcludes => _configuration.CaptureErrorCollectorAttributesExcludes;
+
+    [JsonProperty("browser_monitoring.attributes_enabled")]
+    public bool CaptureBrowserMonitoringAttributes => _configuration.CaptureBrowserMonitoringAttributes;
+
+    [JsonProperty("browser_monitoring.attributes_include")]
+    public IEnumerable<string> CaptureBrowserMonitoringAttributesIncludes => _configuration.CaptureBrowserMonitoringAttributesIncludes;
+
+    [JsonProperty("browser_monitoring.attributes_exclude")]
+    public IEnumerable<string> CaptureBrowserMonitoringAttributesExcludes => _configuration.CaptureBrowserMonitoringAttributesExcludes;
+
+    [JsonProperty("custom_parameters.enabled")]
+    public bool CaptureCustomParameters => _configuration.CaptureCustomParameters;
+
+    [JsonProperty("custom_parameters.source")]
+    public string CaptureCustomParametersSource => _configuration.CaptureCustomParametersSource;
+
+    [JsonProperty("collector.host")]
+    public string CollectorHost => _configuration.CollectorHost;
+
+    [JsonProperty("collector.port")]
+    public int CollectorPort => _configuration.CollectorPort;
+
+    [JsonProperty("collector.send_data_on_exit")]
+    public bool CollectorSendDataOnExit => _configuration.CollectorSendDataOnExit;
+
+    [JsonProperty("collector.send_data_on_exit_threshold")]
+    public float CollectorSendDataOnExitThreshold => _configuration.CollectorSendDataOnExitThreshold;
+
+    [JsonProperty("collector.send_environment_info")]
+    public bool CollectorSendEnvironmentInfo => _configuration.CollectorSendEnvironmentInfo;
+
+    [JsonProperty("collector.sync_startup")]
+    public bool CollectorSyncStartup => _configuration.CollectorSyncStartup;
+
+    [JsonProperty("collector.timeout")]
+    public uint CollectorTimeout => _configuration.CollectorTimeout;
+
+    [JsonProperty("collector.max_payload_size_in_bytes")]
+    public int CollectorMaxPayloadSizeInBytes => _configuration.CollectorMaxPayloadSizeInBytes;
+
+    [JsonProperty("agent.complete_transactions_on_thread")]
+    public bool CompleteTransactionsOnThread => _configuration.CompleteTransactionsOnThread;
+
+    [JsonProperty("agent.compressed_content_encoding")]
+    public string CompressedContentEncoding => _configuration.CompressedContentEncoding;
+
+    [JsonProperty("agent.configuration_version")]
+    public long ConfigurationVersion => _configuration.ConfigurationVersion;
+
+    [JsonProperty("cross_application_tracer.cross_process_id")]
+    public string CrossApplicationTracingCrossProcessId => _configuration.CrossApplicationTracingCrossProcessId;
+
+    [JsonProperty("cross_application_tracer.enabled")]
+    public bool CrossApplicationTracingEnabled => _configuration.CrossApplicationTracingEnabled;
+
+    [JsonProperty("distributed_tracing.enabled")]
+    public bool DistributedTracingEnabled => _configuration.DistributedTracingEnabled;
+
+    [JsonProperty("distributed_tracing.sampler.root.sampler_type")]
+    public string RootSamplerName => RootSamplerType.ToSamplerTypeString();
+    [JsonIgnore]
+    public SamplerType RootSamplerType => _configuration.RootSamplerType;
+
+    [JsonProperty("distributed_tracing.sampler.remote_parent_sampled.sampler_type")]
+    public string RemoteParentSampledSamplerName => RemoteParentSampledSamplerType.ToSamplerTypeString();
+    [JsonIgnore]
+    public SamplerType RemoteParentSampledSamplerType => _configuration.RemoteParentSampledSamplerType;
+
+    [JsonProperty("distributed_tracing.sampler.remote_parent_not_sampled.sampler_type")]
+    public string RemoteParentNotSampledSamplerName => RemoteParentNotSampledSamplerType.ToSamplerTypeString();
+    [JsonIgnore]
+    public SamplerType RemoteParentNotSampledSamplerType => _configuration.RemoteParentNotSampledSamplerType;
+
+    [JsonProperty("distributed_tracing.sampler.root.trace_id_ratio_based.ratio")]
+    public float? RootTraceIdRatioSamplerRatio => _configuration.RootTraceIdRatioSamplerRatio;
+    [JsonProperty("distributed_tracing.sampler.remote_parent_sampled.trace_id_ratio_based.ratio")]
+    public float? RemoteParentSampledTraceIdRatioSamplerRatio => _configuration.RemoteParentSampledTraceIdRatioSamplerRatio;
+    [JsonProperty("distributed_tracing.sampler.remote_parent_not_sampled.trace_id_ratio_based.ratio")]
+    public float? RemoteParentNotSampledTraceIdRatioSamplerRatio => _configuration.RemoteParentNotSampledTraceIdRatioSamplerRatio;
+
+    [JsonProperty("span_events.enabled")]
+    public bool SpanEventsEnabled => _configuration.SpanEventsEnabled;
+
+    [JsonProperty("span_events.harvest_cycle")]
+    public TimeSpan SpanEventsHarvestCycle => _configuration.SpanEventsHarvestCycle;
+
+    [JsonProperty("span_events.attributes_enabled")]
+    public bool SpanEventsAttributesEnabled => _configuration.SpanEventsAttributesEnabled;
+
+    [JsonProperty("span_events.attributes_include")]
+    public HashSet<string> SpanEventsAttributesInclude => _configuration.SpanEventsAttributesInclude;
+
+    [JsonProperty("span_events.attributes_exclude")]
+    public HashSet<string> SpanEventsAttributesExclude => _configuration.SpanEventsAttributesExclude;
+
+    [JsonProperty("infinite_tracing.trace_count_consumers")]
+    public int InfiniteTracingTraceCountConsumers => _configuration.InfiniteTracingTraceCountConsumers;
+
+    [JsonProperty("infinite_tracing.trace_observer_host")]
+    public string InfiniteTracingTraceObserverHost => _configuration.InfiniteTracingTraceObserverHost;
+
+    [JsonProperty("infinite_tracing.trace_observer_port")]
+    public string InfiniteTracingTraceObserverPort => _configuration.InfiniteTracingTraceObserverPort;
+
+    [JsonProperty("infinite_tracing.trace_observer_ssl")]
+    public string InfiniteTracingTraceObserverSsl => _configuration.InfiniteTracingTraceObserverSsl;
+
+    [JsonProperty("infinite_tracing.dev.test_flaky")]
+    public float? InfiniteTracingTraceObserverTestFlaky => _configuration.InfiniteTracingTraceObserverTestFlaky;
+
+    [JsonProperty("infinite_tracing.dev.test_flaky_code")]
+    public int? InfiniteTracingTraceObserverTestFlakyCode => _configuration.InfiniteTracingTraceObserverTestFlakyCode;
+
+    [JsonProperty("infinite_tracing.dev.test_delay_ms")]
+    public int? InfiniteTracingTraceObserverTestDelayMs => _configuration.InfiniteTracingTraceObserverTestDelayMs;
+
+    [JsonProperty("infinite_tracing.spans_queue_size")]
+    public int InfiniteTracingQueueSizeSpans => _configuration.InfiniteTracingQueueSizeSpans;
+
+    [JsonProperty("infinite_tracing.spans_partition_count")]
+    public int InfiniteTracingPartitionCountSpans => _configuration.InfiniteTracingPartitionCountSpans;
+
+    [JsonProperty("infinite_tracing.spans_batch_size")]
+    public int InfiniteTracingBatchSizeSpans => _configuration.InfiniteTracingBatchSizeSpans;
+
+    [JsonProperty("infinite_tracing.connect_timeout_ms")]
+    public int InfiniteTracingTraceTimeoutMsConnect => _configuration.InfiniteTracingTraceTimeoutMsConnect;
+
+    [JsonProperty("infinite_tracing.send_data_timeout_ms")]
+    public int InfiniteTracingTraceTimeoutMsSendData => _configuration.InfiniteTracingTraceTimeoutMsSendData;
+
+    [JsonProperty("infinite_tracing.exit_timeout_ms")]
+    public int InfiniteTracingExitTimeoutMs => _configuration.InfiniteTracingExitTimeoutMs;
+
+    [JsonProperty("infinite_tracing.compression")]
+    public bool InfiniteTracingCompression => _configuration.InfiniteTracingCompression;
+
+    [JsonProperty("agent.primary_application_id")]
+    public string PrimaryApplicationId => _configuration.PrimaryApplicationId;
+
+    [JsonProperty("agent.trusted_account_key")]
+    public string TrustedAccountKey => _configuration.TrustedAccountKey;
+
+    [JsonProperty("agent.account_id")]
+    public string AccountId => _configuration.AccountId;
+
+    [JsonProperty("datastore_tracer.name_reporting_enabled")]
+    public bool DatabaseNameReportingEnabled => _configuration.DatabaseNameReportingEnabled;
+
+    [JsonProperty("datastore_tracer.query_parameters_enabled")]
+    public bool DatastoreTracerQueryParametersEnabled => _configuration.DatastoreTracerQueryParametersEnabled;
+
+    [JsonProperty("error_collector.enabled")]
+    public bool ErrorCollectorEnabled => _configuration.ErrorCollectorEnabled;
+
+    [JsonProperty("error_collector.capture_events_enabled")]
+    public bool ErrorCollectorCaptureEvents => _configuration.ErrorCollectorCaptureEvents;
+
+    [JsonProperty("error_collector.max_samples_stored")]
+    public int ErrorCollectorMaxEventSamplesStored => _configuration.ErrorCollectorMaxEventSamplesStored;
+
+    [JsonProperty("error_collector.harvest_cycle")]
+    public TimeSpan ErrorEventsHarvestCycle => _configuration.ErrorEventsHarvestCycle;
+
+    [JsonProperty("error_collector.max_per_period")]
+    public uint ErrorsMaximumPerPeriod => _configuration.ErrorsMaximumPerPeriod;
+
+    [JsonProperty("error_collector.expected_classes")]
+    public IEnumerable<string> ExpectedErrorClassesForAgentSettings => _configuration.ExpectedErrorClassesForAgentSettings;
+
+    [JsonProperty("error_collector.expected_messages")]
+    public IDictionary<string, IEnumerable<string>> ExpectedErrorMessagesForAgentSettings => _configuration.ExpectedErrorMessagesForAgentSettings;
+
+    // The following IConfiguration property `ExpectedErrorStatusCodesForAgentSettings` actually reports the same information in a more friendly way
+    [JsonIgnore]
+    public IEnumerable<MatchRule> ExpectedStatusCodes => _configuration.ExpectedStatusCodes;
+
+    [JsonProperty("error_collector.expected_status_codes")]
+    public IEnumerable<string> ExpectedErrorStatusCodesForAgentSettings => _configuration.ExpectedErrorStatusCodesForAgentSettings;
+
+    [JsonProperty("error_collector.expected_errors_config")]
+    public IDictionary<string, IEnumerable<string>> ExpectedErrorsConfiguration => _configuration.ExpectedErrorsConfiguration;
+
+    [JsonProperty("error_collector.ignore_errors_config")]
+    public IDictionary<string, IEnumerable<string>> IgnoreErrorsConfiguration => _configuration.IgnoreErrorsConfiguration;
+
+    [JsonProperty("error_collector.ignore_classes")]
+    public IEnumerable<string> IgnoreErrorClassesForAgentSettings => _configuration.IgnoreErrorClassesForAgentSettings;
+
+    [JsonProperty("error_collector.ignore_messages")]
+    public IDictionary<string, IEnumerable<string>> IgnoreErrorMessagesForAgentSettings => _configuration.IgnoreErrorMessagesForAgentSettings;
+
+    // Serializing this Func doesn't provide us with more information than the supportability metrics
+    [JsonIgnore]
+    public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback => _configuration.ErrorGroupCallback;
+
+    [JsonProperty("agent.request_headers_map")]
+    public Dictionary<string, string> RequestHeadersMap => _configuration.RequestHeadersMap;
+                
+    [JsonProperty("cross_application_tracer.encoding_key")]
+    public string EncodingKey => _configuration.EncodingKey;
+
+    [JsonProperty("agent.entity_guid")]
+    public string EntityGuid => _configuration.EntityGuid;
+
+    [JsonProperty("agent.high_security_mode_enabled")]
+    public bool HighSecurityModeEnabled => _configuration.HighSecurityModeEnabled;
+
+    [JsonProperty("agent.custom_instrumentation_editor_enabled")]
+    public bool CustomInstrumentationEditorEnabled => _configuration.CustomInstrumentationEditorEnabled;
+
+    [JsonProperty("agent.custom_instrumentation_editor_enabled_source")]
+    public string CustomInstrumentationEditorEnabledSource => _configuration.CustomInstrumentationEditorEnabledSource;
+
+    [JsonProperty("agent.strip_exception_messages")]
+    public bool StripExceptionMessages => _configuration.StripExceptionMessages;
+
+    [JsonProperty("agent.strip_exception_messages_source")]
+    public string StripExceptionMessagesSource => _configuration.StripExceptionMessagesSource;
+
+    [JsonProperty("agent.instance_reporting_enabled")]
+    public bool InstanceReportingEnabled => _configuration.InstanceReportingEnabled;
+
+    [JsonProperty("agent.instrumentation_logging_enabled")]
+    public bool InstrumentationLoggingEnabled => _configuration.InstrumentationLoggingEnabled;
+
+    [JsonProperty("agent.labels")]
+    public string Labels => _configuration.Labels;
+
+    [JsonProperty("agent.metric_name_regex_rules")]
+    public IEnumerable<RegexRule> MetricNameRegexRules => _configuration.MetricNameRegexRules;
+
+    [JsonProperty("agent.new_relic_config_file_path")]
+    public string NewRelicConfigFilePath => _configuration.NewRelicConfigFilePath;
+
+    [JsonProperty("agent.app_settings_config_file_path")]
+    public string AppSettingsConfigFilePath => _configuration.AppSettingsConfigFilePath;
+
+    [JsonIgnore]
+    public string ProxyHost => _configuration.ProxyHost;
+
+    [JsonProperty("proxy.host.configured")]
+    public bool ProxyHostConfigured => !string.IsNullOrWhiteSpace(ProxyHost);
+
+    [JsonIgnore]
+    public string ProxyUriPath => _configuration.ProxyUriPath;
+
+    [JsonProperty("proxy.uri_path.configured")]
+    public bool ProxyUriPathConfigured => !string.IsNullOrWhiteSpace(ProxyUriPath);
+
+    [JsonIgnore]
+    public int ProxyPort => _configuration.ProxyPort;
+
+    [JsonProperty("proxy.port.configured")]
+    public bool ProxyPortConfigured => true; // as this is an integer with a default value, it will always be 'configured'
+
+    [JsonIgnore]
+    public string ProxyUsername => _configuration.ProxyUsername;
+
+    [JsonProperty("proxy.username.configured")]
+    public bool ProxyUsernameConfigured => !string.IsNullOrWhiteSpace(ProxyUsername);
+
+    [JsonIgnore]
+    public string ProxyPassword => _configuration.ProxyPassword;
+
+    [JsonProperty("proxy.password.configured")]
+    public bool ProxyPasswordConfigured => !string.IsNullOrWhiteSpace(ProxyPassword);
+
+    [JsonIgnore]
+    public string ProxyDomain => _configuration.ProxyDomain;
+
+    [JsonProperty("proxy.domain.configured")]
+    public bool ProxyDomainConfigured => !string.IsNullOrWhiteSpace(ProxyDomain);
+
+    [JsonProperty("agent.put_for_data_sent")]
+    public bool PutForDataSend => _configuration.PutForDataSend;
+
+    [JsonProperty("slow_sql.enabled")]
+    public bool SlowSqlEnabled => _configuration.SlowSqlEnabled;
+
+    [JsonProperty("transaction_tracer.explain_threshold")]
+    public TimeSpan SqlExplainPlanThreshold => _configuration.SqlExplainPlanThreshold;
+
+    [JsonProperty("transaction_tracer.explain_enabled")]
+    public bool SqlExplainPlansEnabled => _configuration.SqlExplainPlansEnabled;
+
+    [JsonProperty("transaction_tracer.max_explain_plans")]
+    public int SqlExplainPlansMax => _configuration.SqlExplainPlansMax;
+
+    [JsonProperty("transaction_tracer.max_sql_statements")]
+    public uint SqlStatementsPerTransaction => _configuration.SqlStatementsPerTransaction;
+
+    [JsonProperty("transaction_tracer.sql_traces_per_period")]
+    public int SqlTracesPerPeriod => _configuration.SqlTracesPerPeriod;
+
+    [JsonProperty("transaction_tracer.max_stack_trace_lines")]
+    public int StackTraceMaximumFrames => _configuration.StackTraceMaximumFrames;
+
+    [JsonProperty("error_collector.ignore_status_codes")]
+    public IEnumerable<string> HttpStatusCodesToIgnore => _configuration.HttpStatusCodesToIgnore;
+
+    [JsonProperty("agent.thread_profiling_methods_to_ignore")]
+    public IEnumerable<string> ThreadProfilingIgnoreMethods => _configuration.ThreadProfilingIgnoreMethods;
+
+    [JsonProperty("custom_events.enabled")]
+    public bool CustomEventsEnabled => _configuration.CustomEventsEnabled;
+
+    [JsonProperty("custom_events.enabled_source")]
+    public string CustomEventsEnabledSource => _configuration.CustomEventsEnabledSource;
+
+    [JsonProperty("custom_events.attributes_enabled")]
+    public bool CustomEventsAttributesEnabled => _configuration.CustomEventsAttributesEnabled;
+
+    [JsonProperty("custom_events.attributes_include")]
+    public HashSet<string> CustomEventsAttributesInclude => _configuration.CustomEventsAttributesInclude;
+
+    [JsonProperty("custom_events.attributes_exclude")]
+    public HashSet<string> CustomEventsAttributesExclude => _configuration.CustomEventsAttributesExclude;
+
+    [JsonProperty("custom_events.max_samples_stored")]
+    public int CustomEventsMaximumSamplesStored => _configuration.CustomEventsMaximumSamplesStored;
+
+    [JsonProperty("custom_events.harvest_cycle")]
+    public TimeSpan CustomEventsHarvestCycle => _configuration.CustomEventsHarvestCycle;
+
+    [JsonProperty("agent.disable_samplers")]
+    public bool DisableSamplers => _configuration.DisableSamplers;
+
+    [JsonProperty("thread_profiler.enabled")]
+    public bool ThreadProfilingEnabled => _configuration.ThreadProfilingEnabled;
+
+    [JsonProperty("transaction_events.enabled")]
+    public bool TransactionEventsEnabled => _configuration.TransactionEventsEnabled;
+
+    [JsonProperty("transaction_events.max_samples_stored")]
+    public int TransactionEventsMaximumSamplesStored => _configuration.TransactionEventsMaximumSamplesStored;
+
+    [JsonProperty("transaction_events.harvest_cycle")]
+    public TimeSpan TransactionEventsHarvestCycle => _configuration.TransactionEventsHarvestCycle;
+
+    [JsonProperty("transaction_events.transactions_enabled")]
+    public bool TransactionEventsTransactionsEnabled => _configuration.TransactionEventsTransactionsEnabled;
+
+    [JsonProperty("transaction_name.regex_rules")]
+    public IEnumerable<RegexRule> TransactionNameRegexRules => _configuration.TransactionNameRegexRules;
+
+    [JsonProperty("transaction_name.whitelist_rules")]
+    public IDictionary<string, IEnumerable<string>> TransactionNameWhitelistRules => _configuration.TransactionNameWhitelistRules;
+
+    [JsonProperty("transaction_tracer.apdex_f")]
+    public TimeSpan TransactionTraceApdexF => _configuration.TransactionTraceApdexF;
+
+    [JsonProperty("transaction_tracer.apdex_t")]
+    public TimeSpan TransactionTraceApdexT => _configuration.TransactionTraceApdexT;
+
+    [JsonProperty("transaction_tracer.transaction_threshold")]
+    public TimeSpan TransactionTraceThreshold => _configuration.TransactionTraceThreshold;
+
+    [JsonProperty("transaction_tracer.enabled")]
+    public bool TransactionTracerEnabled => _configuration.TransactionTracerEnabled;
+
+    [JsonProperty("transaction_tracer.max_segments")]
+    public int TransactionTracerMaxSegments => _configuration.TransactionTracerMaxSegments;
+
+    [JsonProperty("transaction_tracer.record_sql")]
+    public string TransactionTracerRecordSql => _configuration.TransactionTracerRecordSql;
+
+    [JsonProperty("transaction_tracer.record_sql_source")]
+    public string TransactionTracerRecordSqlSource => _configuration.TransactionTracerRecordSqlSource;
+
+    [JsonProperty("transaction_tracer.max_stack_traces")]
+    public int TransactionTracerMaxStackTraces => _configuration.TransactionTracerMaxStackTraces;
+
+    [JsonProperty("agent.trusted_account_ids")]
+    public IEnumerable<long> TrustedAccountIds => _configuration.TrustedAccountIds;
+
+    [JsonProperty("agent.server_side_config_enabled")]
+    public bool ServerSideConfigurationEnabled => _configuration.ServerSideConfigurationEnabled;
+
+    [JsonProperty("agent.ignore_server_side_config")]
+    public bool IgnoreServerSideConfiguration => _configuration.IgnoreServerSideConfiguration;
+
+    [JsonProperty("agent.url_regex_rules")]
+    public IEnumerable<RegexRule> UrlRegexRules => _configuration.UrlRegexRules;
+
+    [JsonProperty("agent.request_path_exclusion_list")]
+    public IEnumerable<Regex> RequestPathExclusionList => _configuration.RequestPathExclusionList;
+
+    [JsonProperty("agent.web_transactions_apdex")]
+    public IDictionary<string, double> WebTransactionsApdex => _configuration.WebTransactionsApdex;
+
+    [JsonProperty("agent.wrapper_exception_limit")]
+    public int WrapperExceptionLimit => _configuration.WrapperExceptionLimit;
+
+    [JsonProperty("utilization.detect_aws_enabled")]
+    public bool UtilizationDetectAws => _configuration.UtilizationDetectAws;
+
+    [JsonProperty("utilization.detect_azure_enabled")]
+    public bool UtilizationDetectAzure => _configuration.UtilizationDetectAzure;
+
+    [JsonProperty("utilization.detect_gcp_enabled")]
+    public bool UtilizationDetectGcp => _configuration.UtilizationDetectGcp;
+
+    [JsonProperty("utilization.detect_pcf_enabled")]
+    public bool UtilizationDetectPcf => _configuration.UtilizationDetectPcf;
+
+    [JsonProperty("utilization.detect_docker_enabled")]
+    public bool UtilizationDetectDocker => _configuration.UtilizationDetectDocker;
+
+    [JsonProperty("utilization.detect_kubernetes_enabled")]
+    public bool UtilizationDetectKubernetes => _configuration.UtilizationDetectKubernetes;
+
+    [JsonProperty("utilization.detect_azure_function_enabled")]
+    public bool UtilizationDetectAzureFunction => _configuration.UtilizationDetectAzureFunction;
+
+    [JsonProperty("utilization.detect_azure_appservice_enabled")]
+    public bool UtilizationDetectAzureAppService => _configuration.UtilizationDetectAzureAppService;
+
+    [JsonProperty("utilization.logical_processors")]
+    public int? UtilizationLogicalProcessors => _configuration.UtilizationLogicalProcessors;
+
+    [JsonProperty("utilization.total_ram_mib")]
+    public int? UtilizationTotalRamMib => _configuration.UtilizationTotalRamMib;
+
+    [JsonProperty("utilization.billing_host")]
+    public string UtilizationBillingHost => _configuration.UtilizationBillingHost;
+
+    [JsonProperty("utilization.hostname")]
+    public string UtilizationHostName => _configuration.UtilizationHostName;
+
+    [JsonProperty("utilization.full_hostname")]
+    public string UtilizationFullHostName => _configuration.UtilizationFullHostName;
+
+    [JsonProperty("diagnostics.capture_agent_timing_enabled")]
+    public bool DiagnosticsCaptureAgentTiming => _configuration.DiagnosticsCaptureAgentTiming;
+
+    [JsonProperty("diagnostics.capture_agent_timing_frequency")]
+    public int DiagnosticsCaptureAgentTimingFrequency => _configuration.DiagnosticsCaptureAgentTimingFrequency;
+
+    [JsonProperty("agent.use_resource_based_naming_for_wcf_enabled")]
+    public bool UseResourceBasedNamingForWCFEnabled => _configuration.UseResourceBasedNamingForWCFEnabled;
+
+    [JsonProperty("agent.event_listener_samplers_enabled")]
+    public bool EventListenerSamplersEnabled { get => _configuration.EventListenerSamplersEnabled; set { /* nothx */ } }
+
+    [JsonProperty("agent.sampling_target")]
+    public int? SamplingTarget => _configuration.SamplingTarget;
+
+    [JsonProperty("span_events.max_samples_stored")]
+    public int SpanEventsMaxSamplesStored => _configuration.SpanEventsMaxSamplesStored;
+
+    [JsonProperty("agent.sampling_target_period_in_seconds")]
+    public int? SamplingTargetPeriodInSeconds => _configuration.SamplingTargetPeriodInSeconds;
+
+    [JsonProperty("agent.payload_success_metrics_enabled")]
+    public bool PayloadSuccessMetricsEnabled => _configuration.PayloadSuccessMetricsEnabled;
+
+    [JsonProperty("agent.process_host_display_name")]
+    public string ProcessHostDisplayName => _configuration.ProcessHostDisplayName;
+
+    [JsonProperty("transaction_tracer.database_statement_cache_capacity")]
+    public int DatabaseStatementCacheCapacity => _configuration.DatabaseStatementCacheCapacity;
+
+    [JsonProperty("agent.force_synchronous_timing_calculation_for_http_client")]
+    public bool ForceSynchronousTimingCalculationHttpClient => _configuration.ForceSynchronousTimingCalculationHttpClient;
+
+    [JsonProperty("agent.enable_asp_net_core_6plus_browser_injection")]
+    public bool EnableAspNetCore6PlusBrowserInjection => _configuration.EnableAspNetCore6PlusBrowserInjection;
+
+    [JsonProperty("agent.exclude_new_relic_header")]
+    public bool ExcludeNewrelicHeader => _configuration.ExcludeNewrelicHeader;
+
+    [JsonProperty("application_logging.enabled")]
+    public bool ApplicationLoggingEnabled => _configuration.ApplicationLoggingEnabled;
+
+    [JsonProperty("application_logging.metrics.enabled")]
+    public bool LogMetricsCollectorEnabled => _configuration.LogMetricsCollectorEnabled;
+
+    [JsonProperty("application_logging.forwarding.enabled")]
+    public bool LogEventCollectorEnabled => _configuration.LogEventCollectorEnabled;
+
+    [JsonProperty("application_logging.forwarding.max_samples_stored")]
+    public int LogEventsMaxSamplesStored => _configuration.LogEventsMaxSamplesStored;
+
+    [JsonProperty("application_logging.forwarding.log_level_denylist")]
+    public HashSet<string> LogLevelDenyList => _configuration.LogLevelDenyList;
+
+    [JsonProperty("application_logging.harvest_cycle")]
+    public TimeSpan LogEventsHarvestCycle => _configuration.LogEventsHarvestCycle;
+
+    [JsonProperty("application_logging.local_decorating.enabled")]
+    public bool LogDecoratorEnabled => _configuration.LogDecoratorEnabled;
+
+    [JsonProperty("agent.app_domain_caching_disabled")]
+    public bool AppDomainCachingDisabled => _configuration.AppDomainCachingDisabled;
+
+    [JsonProperty("agent.force_new_transaction_on_new_thread_enabled")]
+    public bool ForceNewTransactionOnNewThread => _configuration.ForceNewTransactionOnNewThread;
+
+    [JsonProperty("agent.code_level_metrics_enabled")]
+    public bool CodeLevelMetricsEnabled => _configuration.CodeLevelMetricsEnabled;
+
+    [JsonProperty("agent.app_settings")]
+    public IReadOnlyDictionary<string,string> AppSettings => GetAppSettings();
+
+    [JsonProperty("application_logging.forwarding.context_data.enabled")]
+    public bool ContextDataEnabled => _configuration.ContextDataEnabled;
+
+    [JsonProperty("application_logging.forwarding.context_data.include")]
+    public IEnumerable<string> ContextDataInclude => _configuration.ContextDataInclude;
+
+    [JsonProperty("application_logging.forwarding.context_data.exclude")]
+    public IEnumerable<string> ContextDataExclude => _configuration.ContextDataExclude;
+
+    [JsonProperty("application_logging.forwarding.labels.enabled")]
+    public bool LabelsEnabled => _configuration.LabelsEnabled;
+
+    [JsonProperty("application_logging.forwarding.labels.exclude")]
+    public IEnumerable<string> LabelsExclude => _configuration.LabelsExclude;
+
+    [JsonProperty("metrics.harvest_cycle")]
+    public TimeSpan MetricsHarvestCycle => _configuration.MetricsHarvestCycle;
+
+    [JsonProperty("transaction_traces.harvest_cycle")]
+    public TimeSpan TransactionTracesHarvestCycle => _configuration.TransactionTracesHarvestCycle;
+
+    [JsonProperty("error_traces.harvest_cycle")]
+    public TimeSpan ErrorTracesHarvestCycle => _configuration.ErrorTracesHarvestCycle;
+
+    [JsonProperty("get_agent_commands.cycle")]
+    public TimeSpan GetAgentCommandsCycle => _configuration.GetAgentCommandsCycle;
+
+    [JsonProperty("default.harvest_cycle")]
+    public TimeSpan DefaultHarvestCycle => _configuration.DefaultHarvestCycle;
+
+    [JsonProperty("sql_traces.harvest_cycle")]
+    public TimeSpan SqlTracesHarvestCycle => _configuration.SqlTracesHarvestCycle;
+
+    [JsonProperty("update_loaded_modules.cycle")]
+    public TimeSpan UpdateLoadedModulesCycle => _configuration.UpdateLoadedModulesCycle;
+
+    [JsonProperty("stackexchangeredis_cleanup.cycle")]
+    public TimeSpan StackExchangeRedisCleanupCycle => _configuration.StackExchangeRedisCleanupCycle;
+
+    [JsonProperty("agent.logging_enabled")]
+    public bool LoggingEnabled => _configuration.LoggingEnabled;
+
+    [JsonIgnore]
+    public string LoggingLevel => _configuration.LoggingLevel;
+
+    [JsonProperty("agent.instrumentation.ignore")]
+    public IEnumerable<IDictionary<string, string>> IgnoredInstrumentation => _configuration.IgnoredInstrumentation;
+
+    [JsonProperty("agent.disable_file_system_watcher")]
+    public bool DisableFileSystemWatcher => _configuration.DisableFileSystemWatcher;
+
+    // To support account level disable feature, the name cannot include the "agent" prefix.
+    // The account level disable feature looks for this setting and will only reply with the ServerConfiguration setting if it is present.
+    [JsonProperty("ai_monitoring.enabled")]
+    public bool AiMonitoringEnabled => _configuration.AiMonitoringEnabled;
+
+    [JsonProperty("ai_monitoring.streaming.enabled")]
+    public bool AiMonitoringStreamingEnabled => _configuration.AiMonitoringStreamingEnabled;
+
+    [JsonProperty("ai_monitoring.record_content.enabled")]
+    public bool AiMonitoringRecordContentEnabled => _configuration.AiMonitoringRecordContentEnabled;
+
+    // Serializing this Func doesn't provide us with more information than the supportability metrics
+    [JsonIgnore]
+    public Func<string, string, int> LlmTokenCountingCallback => _configuration.LlmTokenCountingCallback;
+
+    [JsonIgnore]
+    public bool AzureFunctionModeDetected => _configuration.AzureFunctionModeDetected;
+    [JsonIgnore]
+    public bool AzureFunctionModeEnabled => _configuration.AzureFunctionModeEnabled;
+
+    [JsonIgnore]
+    public string AzureFunctionResourceId => _configuration.AzureFunctionResourceId;
+
+    [JsonIgnore]
+    public string AzureFunctionResourceGroupName =>_configuration.AzureFunctionResourceGroupName;
+
+    [JsonIgnore]
+    public string AzureFunctionRegion => _configuration.AzureFunctionRegion;
+
+    [JsonIgnore]
+    public string AzureFunctionSubscriptionId => _configuration.AzureFunctionSubscriptionId;
+
+    [JsonIgnore]
+    public string AzureFunctionAppName => _configuration.AzureFunctionAppName;
+
+    public string AzureFunctionResourceIdWithFunctionName(string functionName) => _configuration.AzureFunctionResourceIdWithFunctionName(functionName);
+
+    [JsonIgnore]
+    public string AwsAccountId => _configuration.AwsAccountId;
+
+    [JsonProperty("gc_sampler_v2.enabled")]
+    public bool GCSamplerV2Enabled => _configuration.GCSamplerV2Enabled;
+
+    public IReadOnlyDictionary<string, string> GetAppSettings()
+    {
+        return _configuration.GetAppSettings();
+    }
+
+    [JsonProperty("agent_control.enabled")]
+    public bool AgentControlEnabled => _configuration.AgentControlEnabled;
+
+    [JsonProperty("agent_control.health.delivery_location")]
+    public string HealthDeliveryLocation => _configuration.HealthDeliveryLocation;
+
+    [JsonProperty("agent_control.health.frequency")]
+    public int HealthFrequency => _configuration.HealthFrequency;
+
+    [JsonIgnore]
+    public bool AwsLambdaApmModeEnabled => _configuration.AwsLambdaApmModeEnabled;
+        
+    [JsonIgnore]
+    public int MaxCustomInstrumentationSupportabilityMetrics { get; }
+
+    // OpenTelemetry Configuration Properties
+    [JsonProperty("opentelemetry.enabled")]
+    public bool OpenTelemetryEnabled => _configuration.OpenTelemetryEnabled;
+
+
+    [JsonProperty("opentelemetry.traces.enabled")]
+    public bool OpenTelemetryTracingEnabled => _configuration.OpenTelemetryTracingEnabled;
+
+    [JsonProperty("opentelemetry.traces.include")]
+    public List<string> OpenTelemetryTracingIncludedActivitySources => _configuration.OpenTelemetryTracingIncludedActivitySources;
+
+    [JsonProperty("opentelemetry.traces.exclude")]
+    public List<string> OpenTelemetryTracingExcludedActivitySources => _configuration.OpenTelemetryTracingExcludedActivitySources;
+
+    [JsonProperty("opentelemetry.traces.default_exclude")]
+    public List<string> OpenTelemetryTracingDefaultExcludedActivitySources =>
+        _configuration.OpenTelemetryTracingDefaultExcludedActivitySources;
+
+    [JsonProperty("opentelemetry.metrics.enabled")]
+    public bool OpenTelemetryMetricsEnabled => _configuration.OpenTelemetryMetricsEnabled;
+
+    [JsonProperty("opentelemetry.metrics.include")]
+    public IEnumerable<string> OpenTelemetryMetricsIncludeFilters => _configuration.OpenTelemetryMetricsIncludeFilters;
+
+    [JsonProperty("opentelemetry.metrics.exclude")]
+    public IEnumerable<string> OpenTelemetryMetricsExcludeFilters => _configuration.OpenTelemetryMetricsExcludeFilters;
+
+    [JsonProperty("opentelemetry.otlp.timeout_seconds")]
+    public int OpenTelemetryOtlpTimeoutSeconds => _configuration.OpenTelemetryOtlpTimeoutSeconds;
+
+    [JsonProperty("opentelemetry.otlp.export_interval_seconds")]
+    public int OpenTelemetryOtlpExportIntervalSeconds => _configuration.OpenTelemetryOtlpExportIntervalSeconds;
+
+    [JsonProperty("hybrid_http_context_storage.enabled")]
+    public bool HybridHttpContextStorageEnabled => _configuration.HybridHttpContextStorageEnabled;
+
+    #endregion
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/RunTimeConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/RunTimeConfiguration.cs
@@ -5,28 +5,27 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class RunTimeConfiguration
 {
-    public class RunTimeConfiguration
+    public IEnumerable<string> ApplicationNames;
+
+    public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback;
+
+    public Func<string, string, int> LlmTokenCountingCallback;
+
+    public RunTimeConfiguration()
     {
-        public IEnumerable<string> ApplicationNames;
+        ApplicationNames = Enumerable.Empty<string>();
+        ErrorGroupCallback = null;
+        LlmTokenCountingCallback = null;
+    }
 
-        public Func<IReadOnlyDictionary<string, object>, string> ErrorGroupCallback;
-
-        public Func<string, string, int> LlmTokenCountingCallback;
-
-        public RunTimeConfiguration()
-        {
-            ApplicationNames = Enumerable.Empty<string>();
-            ErrorGroupCallback = null;
-            LlmTokenCountingCallback = null;
-        }
-
-        public RunTimeConfiguration(IEnumerable<string> applicationNames, Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback, Func<string, string, int> llmTokenCountingCallback)
-        {
-            ApplicationNames = applicationNames.ToList();
-            ErrorGroupCallback = errorGroupCallback;
-            LlmTokenCountingCallback = llmTokenCountingCallback;
-        }
+    public RunTimeConfiguration(IEnumerable<string> applicationNames, Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback, Func<string, string, int> llmTokenCountingCallback)
+    {
+        ApplicationNames = applicationNames.ToList();
+        ErrorGroupCallback = errorGroupCallback;
+        LlmTokenCountingCallback = llmTokenCountingCallback;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPoliciesConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPoliciesConfiguration.cs
@@ -4,84 +4,83 @@
 using System.Collections.Generic;
 using NewRelic.Agent.Core.DataTransport;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class SecurityPoliciesConfiguration
 {
-    public class SecurityPoliciesConfiguration
+    public const string RecordSqlPolicyName = "record_sql";
+    public const string AttributesIncludePolicyName = "attributes_include";
+    public const string AllowRawExceptionMessagePolicyName = "allow_raw_exception_messages";
+    public const string CustomEventsPolicyName = "custom_events";
+    public const string CustomParametersPolicyName = "custom_parameters";
+    public const string CustomInstrumentationEditorPolicyName = "custom_instrumentation_editor";
+
+    private static readonly List<string> KnownPolicies = new List<string>()
     {
-        public const string RecordSqlPolicyName = "record_sql";
-        public const string AttributesIncludePolicyName = "attributes_include";
-        public const string AllowRawExceptionMessagePolicyName = "allow_raw_exception_messages";
-        public const string CustomEventsPolicyName = "custom_events";
-        public const string CustomParametersPolicyName = "custom_parameters";
-        public const string CustomInstrumentationEditorPolicyName = "custom_instrumentation_editor";
+        RecordSqlPolicyName,
+        AttributesIncludePolicyName,
+        AllowRawExceptionMessagePolicyName,
+        CustomEventsPolicyName,
+        CustomParametersPolicyName,
+        CustomInstrumentationEditorPolicyName
+    };
 
-        private static readonly List<string> KnownPolicies = new List<string>()
+    private readonly Dictionary<string, SecurityPolicy> _policies = new Dictionary<string, SecurityPolicy>();
+
+    public SecurityPolicy RecordSql => _policies.ContainsKey(RecordSqlPolicyName) ? _policies[RecordSqlPolicyName] : null;
+
+    public SecurityPolicy AttributesInclude => _policies.ContainsKey(AttributesIncludePolicyName) ? _policies[AttributesIncludePolicyName] : null;
+
+    public SecurityPolicy AllowRawExceptionMessage => _policies.ContainsKey(AllowRawExceptionMessagePolicyName) ? _policies[AllowRawExceptionMessagePolicyName] : null;
+
+    public SecurityPolicy CustomEvents => _policies.ContainsKey(CustomEventsPolicyName) ? _policies[CustomEventsPolicyName] : null;
+
+    public SecurityPolicy CustomParameters => _policies.ContainsKey(CustomParametersPolicyName) ? _policies[CustomParametersPolicyName] : null;
+
+    public SecurityPolicy CustomInstrumentationEditor => _policies.ContainsKey(CustomInstrumentationEditorPolicyName) ? _policies[CustomInstrumentationEditorPolicyName] : null;
+
+    public SecurityPoliciesConfiguration() { }
+
+    public SecurityPoliciesConfiguration(Dictionary<string, SecurityPolicyState> policies)
+    {
+        foreach (var policy in policies)
         {
-            RecordSqlPolicyName,
-            AttributesIncludePolicyName,
-            AllowRawExceptionMessagePolicyName,
-            CustomEventsPolicyName,
-            CustomParametersPolicyName,
-            CustomInstrumentationEditorPolicyName
-        };
+            _policies.Add(policy.Key, new SecurityPolicy(policy.Key, policy.Value.Enabled));
+        }
+    }
 
-        private readonly Dictionary<string, SecurityPolicy> _policies = new Dictionary<string, SecurityPolicy>();
+    public bool SecurityPolicyExistsFor(string securityPolicyName)
+    {
+        return _policies.ContainsKey(securityPolicyName);
+    }
 
-        public SecurityPolicy RecordSql => _policies.ContainsKey(RecordSqlPolicyName) ? _policies[RecordSqlPolicyName] : null;
+    public static List<string> GetMissingExpectedSeverPolicyNames(Dictionary<string, SecurityPolicyState> policies)
+    {
+        var unknownPolicies = new List<string>();
 
-        public SecurityPolicy AttributesInclude => _policies.ContainsKey(AttributesIncludePolicyName) ? _policies[AttributesIncludePolicyName] : null;
-
-        public SecurityPolicy AllowRawExceptionMessage => _policies.ContainsKey(AllowRawExceptionMessagePolicyName) ? _policies[AllowRawExceptionMessagePolicyName] : null;
-
-        public SecurityPolicy CustomEvents => _policies.ContainsKey(CustomEventsPolicyName) ? _policies[CustomEventsPolicyName] : null;
-
-        public SecurityPolicy CustomParameters => _policies.ContainsKey(CustomParametersPolicyName) ? _policies[CustomParametersPolicyName] : null;
-
-        public SecurityPolicy CustomInstrumentationEditor => _policies.ContainsKey(CustomInstrumentationEditorPolicyName) ? _policies[CustomInstrumentationEditorPolicyName] : null;
-
-        public SecurityPoliciesConfiguration() { }
-
-        public SecurityPoliciesConfiguration(Dictionary<string, SecurityPolicyState> policies)
+        foreach (var policyName in KnownPolicies)
         {
-            foreach (var policy in policies)
+            if (!policies.ContainsKey(policyName))
             {
-                _policies.Add(policy.Key, new SecurityPolicy(policy.Key, policy.Value.Enabled));
+                unknownPolicies.Add(policyName);
             }
         }
 
-        public bool SecurityPolicyExistsFor(string securityPolicyName)
-        {
-            return _policies.ContainsKey(securityPolicyName);
-        }
+        return unknownPolicies;
+    }
 
-        public static List<string> GetMissingExpectedSeverPolicyNames(Dictionary<string, SecurityPolicyState> policies)
-        {
-            var unknownPolicies = new List<string>();
+    public static List<string> GetMissingRequiredPolicies(Dictionary<string, SecurityPolicyState> policies)
+    {
+        var missingRequiredPolicies = new List<string>();
 
-            foreach (var policyName in KnownPolicies)
+        foreach (var policy in policies)
+        {
+            if (policy.Value.Required && !KnownPolicies.Contains(policy.Key))
             {
-                if (!policies.ContainsKey(policyName))
-                {
-                    unknownPolicies.Add(policyName);
-                }
+                missingRequiredPolicies.Add(policy.Key);
             }
-
-            return unknownPolicies;
         }
 
-        public static List<string> GetMissingRequiredPolicies(Dictionary<string, SecurityPolicyState> policies)
-        {
-            var missingRequiredPolicies = new List<string>();
-
-            foreach (var policy in policies)
-            {
-                if (policy.Value.Required && !KnownPolicies.Contains(policy.Key))
-                {
-                    missingRequiredPolicies.Add(policy.Key);
-                }
-            }
-
-            return missingRequiredPolicies;
-        }
+        return missingRequiredPolicies;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPoliciesValidationException.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPoliciesValidationException.cs
@@ -3,20 +3,19 @@
 
 using System;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class SecurityPoliciesValidationException : Exception
 {
-    public class SecurityPoliciesValidationException : Exception
+    public SecurityPoliciesValidationException()
     {
-        public SecurityPoliciesValidationException()
-        {
-        }
+    }
 
-        public SecurityPoliciesValidationException(string message) : base(message)
-        {
-        }
+    public SecurityPoliciesValidationException(string message) : base(message)
+    {
+    }
 
-        public SecurityPoliciesValidationException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    public SecurityPoliciesValidationException(string message, Exception innerException) : base(message, innerException)
+    {
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPolicy.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SecurityPolicy.cs
@@ -1,18 +1,17 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class SecurityPolicy
 {
-    public class SecurityPolicy
+    public string Name { get; private set; }
+
+    public bool Enabled { get; private set; }
+
+    public SecurityPolicy(string name, bool enabled)
     {
-        public string Name { get; private set; }
-
-        public bool Enabled { get; private set; }
-
-        public SecurityPolicy(string name, bool enabled)
-        {
-            Name = name;
-            Enabled = enabled;
-        }
+        Name = name;
+        Enabled = enabled;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
@@ -1,343 +1,339 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Serialization;
-using NewRelic.Agent.Core.JsonConverters;
 using NewRelic.Agent.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+/// <summary>
+/// from collector connectApplicationAgent(RequestContext) return value (https://github.com/newrelic/collector/blob/master/src/main/java/com/nr/collector/methods/Connect.java#L259)
+/// </summary>
+public class ServerConfiguration
 {
-    /// <summary>
-    /// from collector connectApplicationAgent(RequestContext) return value (https://github.com/newrelic/collector/blob/master/src/main/java/com/nr/collector/methods/Connect.java#L259)
-    /// </summary>
-    public class ServerConfiguration
+    [JsonProperty(PropertyName = "agent_run_id", Required = Required.Always)]
+    public object AgentRunId { get; set; }
+
+    [JsonProperty("apdex_t")]
+    public double? ApdexT { get; set; }
+
+    [JsonProperty("collect_error_events")]
+    public bool? ErrorEventCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_analytics_events")]
+    public bool? AnalyticsEventCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_span_events")]
+    public bool? SpanEventCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_custom_events")]
+    public bool? CustomEventCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_errors")]
+    public bool? ErrorCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_traces")]
+    public bool? TraceCollectionEnabled { get; set; }
+
+    [JsonProperty("collect_ai")]
+    public bool? AICollectionEnabled { get; set; }
+
+    [JsonProperty("data_report_period")]
+    public long? DataReportPeriod { get; set; }
+
+    [JsonProperty("max_payload_size_in_bytes")]
+    // Making it int per the agent spec. 
+    public int? MaxPayloadSizeInBytes { get; set; }
+
+    [JsonProperty("encoding_key")]
+    public string EncodingKey { get; set; }
+
+    [JsonProperty("entity_guid")]
+    public string EntityGuid { get; set; }
+
+    [JsonProperty("high_security")]
+    public bool? HighSecurityEnabled { get; set; }
+
+    [JsonProperty("instrumentation")]
+    public IEnumerable<InstrumentationConfig> Instrumentation { get; set; }
+
+    [JsonProperty("messages")]
+    public IEnumerable<Message> Messages { get; set; }
+
+    [JsonProperty("sampling_rate")]
+    public int? SamplingRate { get; set; }
+
+    [JsonProperty("web_transactions_apdex")]
+    public IDictionary<string, double> WebTransactionsApdex { get; set; }
+
+    [JsonProperty("trusted_account_ids")]
+    public IEnumerable<long> TrustedIds { get; set; }
+
+    [JsonProperty("request_headers_map")]
+    public Dictionary<string, string> RequestHeadersMap { get; set; }
+
+
+    // Server Side Config
+
+    public bool ServerSideConfigurationEnabled { get; private set; }
+
+    [JsonProperty("agent_config")]
+    public AgentConfig RpmConfig { get; set; }
+
+
+    // Faster Event Harvest
+
+    [JsonProperty("event_harvest_config")]
+    public EventHarvestConfig EventHarvestConfig { get; set; }
+
+    [JsonProperty("span_event_harvest_config")]
+    public SingleEventHarvestConfig SpanEventHarvestConfig { get; set; }
+
+
+    // CAT
+
+    [JsonProperty("cross_process_id")]
+    public string CatId { get; set; }
+
+
+    // DISTRIBUTED TRACE
+    [JsonProperty("primary_application_id")]
+    public string PrimaryApplicationId { get; set; }
+
+    [JsonProperty("trusted_account_key")]
+    public string TrustedAccountKey { get; set; }
+
+    [JsonProperty("account_id")]
+    public string AccountId { get; set; }
+
+    [JsonProperty("sampling_target")]
+    public int? SamplingTarget { get; set; }
+
+    [JsonProperty("sampling_target_period_in_seconds")]
+    public int? SamplingTargetPeriodInSeconds { get; set; }
+
+
+    // RUM
+
+    [JsonProperty("application_id")]
+    public string RumSettingsApplicationId { get; set; }
+
+    [JsonProperty("beacon")]
+    public string RumSettingsBeacon { get; set; }
+
+    [JsonProperty("browser_key")]
+    public string RumSettingsBrowserKey { get; set; }
+
+    [JsonProperty("browser_monitoring.loader")]
+    public string RumSettingsBrowserMonitoringLoader { get; set; }
+
+    [JsonProperty("browser_monitoring.loader_debug")]
+    public string RumSettingsBrowserMonitoringLoaderDebug { get; set; }
+
+    [JsonProperty("browser_monitoring.loader_version")]
+    public string RumSettingsBrowserMonitoringLoaderVersion { get; set; }
+
+    [JsonProperty("episodes_url")]
+    public string RumSettingsEpisodesUrl { get; set; }
+
+    [JsonProperty("episodes_file")]
+    public string RumSettingsEpisodesFile { get; set; }
+
+    [JsonProperty("error_beacon")]
+    public string RumSettingsErrorBeacon { get; set; }
+
+    [JsonProperty("js_agent_file")]
+    public string RumSettingsJavaScriptAgentFile { get; set; }
+
+    [JsonProperty("js_agent_loader")]
+    public string RumSettingsJavaScriptAgentLoader { get; set; }
+
+    [JsonProperty("js_agent_loader_version")]
+    public string RumSettingsJavaScriptAgentLoaderVersion { get; set; }
+
+    [JsonProperty("js_errors_beta")]
+    public string RumSettingsJavaScriptErrorsBeta { get; set; }
+
+
+    // rules
+
+    [JsonProperty("metric_name_rules")]
+    public IEnumerable<RegexRule> MetricNameRegexRules { get; set; }
+
+    [JsonProperty("transaction_name_rules")]
+    public IEnumerable<RegexRule> TransactionNameRegexRules { get; set; }
+
+    [JsonProperty("url_rules")]
+    public IEnumerable<RegexRule> UrlRegexRules { get; set; }
+
+    [JsonProperty("transaction_segment_terms")]
+    public IEnumerable<WhitelistRule> TransactionNameWhitelistRules { get; set; }
+
+    public ServerConfiguration()
     {
-        [JsonProperty(PropertyName = "agent_run_id", Required = Required.Always)]
-        public object AgentRunId { get; set; }
+        RpmConfig = new AgentConfig();
+    }
 
-        [JsonProperty("apdex_t")]
-        public double? ApdexT { get; set; }
-
-        [JsonProperty("collect_error_events")]
-        public bool? ErrorEventCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_analytics_events")]
-        public bool? AnalyticsEventCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_span_events")]
-        public bool? SpanEventCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_custom_events")]
-        public bool? CustomEventCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_errors")]
-        public bool? ErrorCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_traces")]
-        public bool? TraceCollectionEnabled { get; set; }
-
-        [JsonProperty("collect_ai")]
-        public bool? AICollectionEnabled { get; set; }
-
-        [JsonProperty("data_report_period")]
-        public long? DataReportPeriod { get; set; }
-
-        [JsonProperty("max_payload_size_in_bytes")]
-        // Making it int per the agent spec. 
-        public int? MaxPayloadSizeInBytes { get; set; }
-
-        [JsonProperty("encoding_key")]
-        public string EncodingKey { get; set; }
-
-        [JsonProperty("entity_guid")]
-        public string EntityGuid { get; set; }
-
-        [JsonProperty("high_security")]
-        public bool? HighSecurityEnabled { get; set; }
-
-        [JsonProperty("instrumentation")]
-        public IEnumerable<InstrumentationConfig> Instrumentation { get; set; }
-
-        [JsonProperty("messages")]
-        public IEnumerable<Message> Messages { get; set; }
-
-        [JsonProperty("sampling_rate")]
-        public int? SamplingRate { get; set; }
-
-        [JsonProperty("web_transactions_apdex")]
-        public IDictionary<string, double> WebTransactionsApdex { get; set; }
-
-        [JsonProperty("trusted_account_ids")]
-        public IEnumerable<long> TrustedIds { get; set; }
-
-        [JsonProperty("request_headers_map")]
-        public Dictionary<string, string> RequestHeadersMap { get; set; }
-
-
-        // Server Side Config
-
-        public bool ServerSideConfigurationEnabled { get; private set; }
-
-        [JsonProperty("agent_config")]
-        public AgentConfig RpmConfig { get; set; }
-
-
-        // Faster Event Harvest
-
-        [JsonProperty("event_harvest_config")]
-        public EventHarvestConfig EventHarvestConfig { get; set; }
-
-        [JsonProperty("span_event_harvest_config")]
-        public SingleEventHarvestConfig SpanEventHarvestConfig { get; set; }
-
-
-        // CAT
-
-        [JsonProperty("cross_process_id")]
-        public string CatId { get; set; }
-
-
-        // DISTRIBUTED TRACE
-        [JsonProperty("primary_application_id")]
-        public string PrimaryApplicationId { get; set; }
-
-        [JsonProperty("trusted_account_key")]
-        public string TrustedAccountKey { get; set; }
-
-        [JsonProperty("account_id")]
-        public string AccountId { get; set; }
-
-        [JsonProperty("sampling_target")]
-        public int? SamplingTarget { get; set; }
-
-        [JsonProperty("sampling_target_period_in_seconds")]
-        public int? SamplingTargetPeriodInSeconds { get; set; }
-
-
-        // RUM
-
-        [JsonProperty("application_id")]
-        public string RumSettingsApplicationId { get; set; }
-
-        [JsonProperty("beacon")]
-        public string RumSettingsBeacon { get; set; }
-
-        [JsonProperty("browser_key")]
-        public string RumSettingsBrowserKey { get; set; }
-
-        [JsonProperty("browser_monitoring.loader")]
-        public string RumSettingsBrowserMonitoringLoader { get; set; }
-
-        [JsonProperty("browser_monitoring.loader_debug")]
-        public string RumSettingsBrowserMonitoringLoaderDebug { get; set; }
-
-        [JsonProperty("browser_monitoring.loader_version")]
-        public string RumSettingsBrowserMonitoringLoaderVersion { get; set; }
-
-        [JsonProperty("episodes_url")]
-        public string RumSettingsEpisodesUrl { get; set; }
-
-        [JsonProperty("episodes_file")]
-        public string RumSettingsEpisodesFile { get; set; }
-
-        [JsonProperty("error_beacon")]
-        public string RumSettingsErrorBeacon { get; set; }
-
-        [JsonProperty("js_agent_file")]
-        public string RumSettingsJavaScriptAgentFile { get; set; }
-
-        [JsonProperty("js_agent_loader")]
-        public string RumSettingsJavaScriptAgentLoader { get; set; }
-
-        [JsonProperty("js_agent_loader_version")]
-        public string RumSettingsJavaScriptAgentLoaderVersion { get; set; }
-
-        [JsonProperty("js_errors_beta")]
-        public string RumSettingsJavaScriptErrorsBeta { get; set; }
-
-
-        // rules
-
-        [JsonProperty("metric_name_rules")]
-        public IEnumerable<RegexRule> MetricNameRegexRules { get; set; }
-
-        [JsonProperty("transaction_name_rules")]
-        public IEnumerable<RegexRule> TransactionNameRegexRules { get; set; }
-
-        [JsonProperty("url_rules")]
-        public IEnumerable<RegexRule> UrlRegexRules { get; set; }
-
-        [JsonProperty("transaction_segment_terms")]
-        public IEnumerable<WhitelistRule> TransactionNameWhitelistRules { get; set; }
-
-        public ServerConfiguration()
+    public static ServerConfiguration GetDefault() => new ServerConfiguration
+    {
+        RpmConfig =
         {
-            RpmConfig = new AgentConfig();
+            // CAT should be disabled for empty/default configurations because CAT cannot function without a CrossProcessId.
+            CrossApplicationTracerEnabled = false
+        }
+    };
+
+    /// <summary>
+    /// From server side configuration (https://rpm.newrelic.com/admin/agent_configuration_defaults)
+    /// </summary>
+    public class AgentConfig
+    {
+        [JsonProperty("cross_application_tracer.enabled")]
+        public bool? CrossApplicationTracerEnabled { get; set; }
+
+        [JsonProperty("error_collector.enabled")]
+        public bool? ErrorCollectorEnabled { get; set; }
+
+        [JsonProperty("error_collector.ignore_status_codes")]
+        public IEnumerable<string> ErrorCollectorStatusCodesToIgnore { get; set; }
+
+        [JsonProperty("error_collector.ignore_errors")]
+        public IEnumerable<string> ErrorCollectorErrorsToIgnore { get; set; }
+
+        [JsonProperty("error_collector.ignore_classes")]
+        public IEnumerable<string> ErrorCollectorIgnoreClasses { get; set; }
+
+        [JsonProperty("error_collector.ignore_messages")]
+        public IEnumerable<KeyValuePair<string, IEnumerable<string>>> ErrorCollectorIgnoreMessages { get; set; }
+
+        [JsonProperty("error_collector.expected_classes")]
+        public IEnumerable<string> ErrorCollectorExpectedClasses { get; set; }
+
+        [JsonProperty("error_collector.expected_messages")]
+        public IEnumerable<KeyValuePair<string, IEnumerable<string>>> ErrorCollectorExpectedMessages { get; set; }
+
+        [JsonProperty("error_collector.expected_status_codes")]
+        public IEnumerable<string> ErrorCollectorExpectedStatusCodes { get; set; }
+
+        [JsonProperty("ignored_params")]
+        public IEnumerable<string> ParametersToIgnore { get; set; }
+
+        [JsonProperty("slow_sql.enabled")]
+        public bool? SlowSqlEnabled { get; set; }
+
+        [JsonProperty("transaction_tracer.enabled")]
+        public bool? TransactionTracerEnabled { get; set; }
+
+        [JsonProperty("transaction_tracer.explain_enabled")]
+        public bool? TransactionTracerExplainEnabled { get; set; }
+
+        [JsonProperty("transaction_tracer.explain_threshold")]
+        public double? TransactionTracerExplainThreshold { get; set; }
+
+        [JsonProperty("transaction_tracer.record_sql")]
+        public string TransactionTracerRecordSql { get; set; }
+
+        [JsonProperty("transaction_tracer.stack_trace_threshold")]
+        public double? TransactionTracerStackThreshold { get; set; }
+
+        [JsonProperty("transaction_tracer.transaction_threshold")]
+        public object TransactionTracerThreshold { get; set; }
+
+        [JsonProperty("capture_params")]
+        public bool? CaptureParametersEnabled { get; set; }
+    }
+
+    public class InstrumentationConfig
+    {
+        [JsonProperty("config")]
+        public string Config { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        public InstrumentationConfig()
+        {
+            Name = "live_instrumentation";
+        }
+    }
+
+    public class Message
+    {
+        [JsonProperty("message")]
+        public string Text { get; set; }
+        [JsonProperty("level")]
+        public string Level { get; set; }
+    }
+
+    public class RegexRule
+    {
+        [JsonProperty("match_expression")]
+        public string MatchExpression { get; set; }
+
+        [JsonProperty("replacement")]
+        public string Replacement { get; set; }
+
+        [JsonProperty("ignore")]
+        public bool? Ignore { get; set; }
+
+        [JsonProperty("eval_order")]
+        public long? EvaluationOrder { get; set; }
+
+        [JsonProperty("terminate_chain")]
+        public bool? TerminateChain { get; set; }
+
+        [JsonProperty("each_segment")]
+        public bool? EachSegment { get; set; }
+
+        [JsonProperty("replace_all")]
+        public bool? ReplaceAll { get; set; }
+    }
+
+    public class WhitelistRule
+    {
+        [JsonProperty("prefix")]
+        public string Prefix { get; set; }
+        [JsonProperty("terms")]
+        public IEnumerable<string> Terms { get; set; }
+    }
+
+    public static ServerConfiguration FromJson(string json, bool ignoreServerConfiguration = false)
+    {
+        var serverConfiguration = JsonConvert.DeserializeObject<ServerConfiguration>(json);
+        Debug.Assert(serverConfiguration != null);
+
+        if (ignoreServerConfiguration)
+        {
+            serverConfiguration.RpmConfig = new AgentConfig();
         }
 
-        public static ServerConfiguration GetDefault() => new ServerConfiguration
-        {
-            RpmConfig =
-            {
-				// CAT should be disabled for empty/default configurations because CAT cannot function without a CrossProcessId.
-				CrossApplicationTracerEnabled = false
-            }
-        };
+        serverConfiguration.ServerSideConfigurationEnabled = JsonContainsNonNullProperty(json, "agent_config");
 
-        /// <summary>
-        /// From server side configuration (https://rpm.newrelic.com/admin/agent_configuration_defaults)
-        /// </summary>
-        public class AgentConfig
-        {
-            [JsonProperty("cross_application_tracer.enabled")]
-            public bool? CrossApplicationTracerEnabled { get; set; }
+        return serverConfiguration;
+    }
 
-            [JsonProperty("error_collector.enabled")]
-            public bool? ErrorCollectorEnabled { get; set; }
+    public static bool JsonContainsNonNullProperty(string json, string propertyName)
+    {
+        var dictionary = JsonConvert.DeserializeObject<IDictionary<string, object>>(json);
+        Debug.Assert(dictionary != null);
 
-            [JsonProperty("error_collector.ignore_status_codes")]
-            public IEnumerable<string> ErrorCollectorStatusCodesToIgnore { get; set; }
+        return dictionary.ContainsKey(propertyName)
+               && dictionary[propertyName] != null;
+    }
 
-            [JsonProperty("error_collector.ignore_errors")]
-            public IEnumerable<string> ErrorCollectorErrorsToIgnore { get; set; }
+    public static ServerConfiguration FromDeserializedReturnValue(object deserializedJson, bool ignoreServerConfiguration = false)
+    {
+        var json = JsonConvert.SerializeObject(deserializedJson);
+        return FromJson(json, ignoreServerConfiguration);
+    }
 
-            [JsonProperty("error_collector.ignore_classes")]
-            public IEnumerable<string> ErrorCollectorIgnoreClasses { get; set; }
-
-            [JsonProperty("error_collector.ignore_messages")]
-            public IEnumerable<KeyValuePair<string, IEnumerable<string>>> ErrorCollectorIgnoreMessages { get; set; }
-
-            [JsonProperty("error_collector.expected_classes")]
-            public IEnumerable<string> ErrorCollectorExpectedClasses { get; set; }
-
-            [JsonProperty("error_collector.expected_messages")]
-            public IEnumerable<KeyValuePair<string, IEnumerable<string>>> ErrorCollectorExpectedMessages { get; set; }
-
-            [JsonProperty("error_collector.expected_status_codes")]
-            public IEnumerable<string> ErrorCollectorExpectedStatusCodes { get; set; }
-
-            [JsonProperty("ignored_params")]
-            public IEnumerable<string> ParametersToIgnore { get; set; }
-
-            [JsonProperty("slow_sql.enabled")]
-            public bool? SlowSqlEnabled { get; set; }
-
-            [JsonProperty("transaction_tracer.enabled")]
-            public bool? TransactionTracerEnabled { get; set; }
-
-            [JsonProperty("transaction_tracer.explain_enabled")]
-            public bool? TransactionTracerExplainEnabled { get; set; }
-
-            [JsonProperty("transaction_tracer.explain_threshold")]
-            public double? TransactionTracerExplainThreshold { get; set; }
-
-            [JsonProperty("transaction_tracer.record_sql")]
-            public string TransactionTracerRecordSql { get; set; }
-
-            [JsonProperty("transaction_tracer.stack_trace_threshold")]
-            public double? TransactionTracerStackThreshold { get; set; }
-
-            [JsonProperty("transaction_tracer.transaction_threshold")]
-            public object TransactionTracerThreshold { get; set; }
-
-            [JsonProperty("capture_params")]
-            public bool? CaptureParametersEnabled { get; set; }
-        }
-
-        public class InstrumentationConfig
-        {
-            [JsonProperty("config")]
-            public string Config { get; set; }
-
-            [JsonProperty("name")]
-            public string Name { get; set; }
-
-            public InstrumentationConfig()
-            {
-                Name = "live_instrumentation";
-            }
-        }
-
-        public class Message
-        {
-            [JsonProperty("message")]
-            public string Text { get; set; }
-            [JsonProperty("level")]
-            public string Level { get; set; }
-        }
-
-        public class RegexRule
-        {
-            [JsonProperty("match_expression")]
-            public string MatchExpression { get; set; }
-
-            [JsonProperty("replacement")]
-            public string Replacement { get; set; }
-
-            [JsonProperty("ignore")]
-            public bool? Ignore { get; set; }
-
-            [JsonProperty("eval_order")]
-            public long? EvaluationOrder { get; set; }
-
-            [JsonProperty("terminate_chain")]
-            public bool? TerminateChain { get; set; }
-
-            [JsonProperty("each_segment")]
-            public bool? EachSegment { get; set; }
-
-            [JsonProperty("replace_all")]
-            public bool? ReplaceAll { get; set; }
-        }
-
-        public class WhitelistRule
-        {
-            [JsonProperty("prefix")]
-            public string Prefix { get; set; }
-            [JsonProperty("terms")]
-            public IEnumerable<string> Terms { get; set; }
-        }
-
-        public static ServerConfiguration FromJson(string json, bool ignoreServerConfiguration = false)
-        {
-            var serverConfiguration = JsonConvert.DeserializeObject<ServerConfiguration>(json);
-            Debug.Assert(serverConfiguration != null);
-
-            if (ignoreServerConfiguration)
-            {
-                serverConfiguration.RpmConfig = new AgentConfig();
-            }
-
-            serverConfiguration.ServerSideConfigurationEnabled = JsonContainsNonNullProperty(json, "agent_config");
-
-            return serverConfiguration;
-        }
-
-        public static bool JsonContainsNonNullProperty(string json, string propertyName)
-        {
-            var dictionary = JsonConvert.DeserializeObject<IDictionary<string, object>>(json);
-            Debug.Assert(dictionary != null);
-
-            return dictionary.ContainsKey(propertyName)
-                && dictionary[propertyName] != null;
-        }
-
-        public static ServerConfiguration FromDeserializedReturnValue(object deserializedJson, bool ignoreServerConfiguration = false)
-        {
-            var json = JsonConvert.SerializeObject(deserializedJson);
-            return FromJson(json, ignoreServerConfiguration);
-        }
-
-        [OnError]
-        public void OnError(StreamingContext context, ErrorContext errorContext)
-        {
-            Log.Error(errorContext.Error, "Json serializer context path: {0}", errorContext.Path);
-        }
+    [OnError]
+    public void OnError(StreamingContext context, ErrorContext errorContext)
+    {
+        Log.Error(errorContext.Error, "Json serializer context path: {0}", errorContext.Path);
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/SingleEventHarvestConfig.cs
@@ -3,18 +3,16 @@
 
 using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
-namespace NewRelic.Agent.Core.Configuration
+namespace NewRelic.Agent.Core.Configuration;
+
+public class SingleEventHarvestConfig
 {
-    public class SingleEventHarvestConfig
-    {
-        [JsonProperty("report_period_ms")]
-        public int ReportPeriodMs { get; set; }
+    [JsonProperty("report_period_ms")]
+    public int ReportPeriodMs { get; set; }
 
-        [JsonProperty("harvest_limit")]
-        public int HarvestLimit { get; set; }
+    [JsonProperty("harvest_limit")]
+    public int HarvestLimit { get; set; }
 
-        public TimeSpan? HarvestCycle => TimeSpan.FromMilliseconds(ReportPeriodMs);
-    }
+    public TimeSpan? HarvestCycle => TimeSpan.FromMilliseconds(ReportPeriodMs);
 }


### PR DESCRIPTION
Applies the following refactoring to the Core project, folders starting with A through C, except for the config classes generated by Xsd2Code:
* File-scoped namespace 
* Sort usings
* Remove unused usings

There are no other changes in this PR so it shouldn't be too hard to review (even though there are 91 files...) -- As previously mentioned, it will help if you set the "hide whitespace" setting when you first start reviewing the files in this PR.