### PR TITLE
chore: File-Scope namespace refactor, cleaning up a few files that got missed

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilterTrieNode.cs
+++ b/src/Agent/NewRelic/Agent/Core/Attributes/AttributeFilterTrieNode.cs
@@ -3,56 +3,55 @@
 
 using System.Linq;
 
-namespace NewRelic.Agent.Core.Attributes
+namespace NewRelic.Agent.Core.Attributes;
+
+internal static class AttributeFilterTrieNode
 {
-    internal static class AttributeFilterTrieNode
+    public static Clude GetClusion(this TrieNode<AttributeFilterNode> nodeBuilder, string name, AttributeDestinations destination)
     {
-        public static Clude GetClusion(this TrieNode<AttributeFilterNode> nodeBuilder, string name, AttributeDestinations destination)
-        {
-            var childClusion = nodeBuilder.GetClusionFromChildren(name, destination);
-            if (childClusion != Clude.Unknown)
-                return childClusion;
-
-            var exclude = (nodeBuilder.Data.DestinationExcludes & destination) == destination;
-            if (exclude)
-                return Clude.Exclude;
-
-            var include = (nodeBuilder.Data.DestinationIncludes & destination) == destination;
-            if (include)
-                return Clude.Include;
-
-            return Clude.Unknown;
-        }
-
-        private static Clude GetClusionFromChildren(this TrieNode<AttributeFilterNode> nodeBuilder, string name, AttributeDestinations destination)
-        {
-            var child = nodeBuilder.ApplicableChild(name);
-            var childClusion = child.GetChildClusion(name, destination);
+        var childClusion = nodeBuilder.GetClusionFromChildren(name, destination);
+        if (childClusion != Clude.Unknown)
             return childClusion;
-        }
 
-        private static Clude GetChildClusion(this TrieNode<AttributeFilterNode> child, string name, AttributeDestinations destination)
-        {
-            if (child == null)
-                return Clude.Unknown;
+        var exclude = (nodeBuilder.Data.DestinationExcludes & destination) == destination;
+        if (exclude)
+            return Clude.Exclude;
 
-            return child.GetClusion(name, destination);
-        }
+        var include = (nodeBuilder.Data.DestinationIncludes & destination) == destination;
+        if (include)
+            return Clude.Include;
 
-        private static bool NodeAppliesToAttribute(this TrieNode<AttributeFilterNode> nodeBuilder, string name)
-        {
-            if (nodeBuilder.Data.Wildcard)
-                return name.StartsWith(nodeBuilder.Data.Key);
-            else
-                return name == nodeBuilder.Data.Key;
-        }
+        return Clude.Unknown;
+    }
 
-        private static TrieNode<AttributeFilterNode> ApplicableChild(this TrieNode<AttributeFilterNode> nodeBuilder, string name)
-        {
-            return nodeBuilder.Children
+    private static Clude GetClusionFromChildren(this TrieNode<AttributeFilterNode> nodeBuilder, string name, AttributeDestinations destination)
+    {
+        var child = nodeBuilder.ApplicableChild(name);
+        var childClusion = child.GetChildClusion(name, destination);
+        return childClusion;
+    }
+
+    private static Clude GetChildClusion(this TrieNode<AttributeFilterNode> child, string name, AttributeDestinations destination)
+    {
+        if (child == null)
+            return Clude.Unknown;
+
+        return child.GetClusion(name, destination);
+    }
+
+    private static bool NodeAppliesToAttribute(this TrieNode<AttributeFilterNode> nodeBuilder, string name)
+    {
+        if (nodeBuilder.Data.Wildcard)
+            return name.StartsWith(nodeBuilder.Data.Key);
+        else
+            return name == nodeBuilder.Data.Key;
+    }
+
+    private static TrieNode<AttributeFilterNode> ApplicableChild(this TrieNode<AttributeFilterNode> nodeBuilder, string name)
+    {
+        return nodeBuilder.Children
             .Where(child => child != null)
             .Where(child => child.NodeAppliesToAttribute(name))
             .FirstOrDefault();
-        }
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/CallStack/CallStackManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/CallStack/CallStackManager.cs
@@ -1,11 +1,11 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Extensions.Providers;
-using NewRelic.Agent.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Extensions.Logging;
+using NewRelic.Agent.Extensions.Providers;
 
 namespace NewRelic.Agent.Core.CallStack;
 

--- a/src/Agent/NewRelic/Agent/Core/Commands/StartThreadProfilerCommand.cs
+++ b/src/Agent/NewRelic/Agent/Core/Commands/StartThreadProfilerCommand.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.ThreadProfiling;
 using NewRelic.Agent.Extensions.Logging;
 

--- a/src/Agent/NewRelic/Agent/Core/Events/ManualHarvestEvent.cs
+++ b/src/Agent/NewRelic/Agent/Core/Events/ManualHarvestEvent.cs
@@ -1,8 +1,6 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-
 namespace NewRelic.Agent.Core.Events;
 
 public class ManualHarvestEvent

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/ITransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/ITransactionCollector.cs
@@ -4,24 +4,23 @@
 using System.Collections.Generic;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 
-namespace NewRelic.Agent.Core.TransactionTraces
-{
-    public interface ITransactionCollector
-    {
-        /// <summary>
-        /// Informs a transaction collector of a new transaction trace allowing it to collect it.
-        /// Note that this method may be called by multiple threads so the trace storage method should
-        /// be thread safe.
-        /// 
-        /// Transaction collectors must be able to decide whether or not they want to keep a transaction 
-        /// without calling the WireModel method.
-        /// </summary>
-        /// <param name="transactionTraceWireModelComponents"></param>
-        void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents);
+namespace NewRelic.Agent.Core.TransactionTraces;
 
-        /// <summary>
-        /// Returns an immutable enumerable of samples and clears the sample storage.
-        /// </summary>
-        IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples();
-    }
+public interface ITransactionCollector
+{
+    /// <summary>
+    /// Informs a transaction collector of a new transaction trace allowing it to collect it.
+    /// Note that this method may be called by multiple threads so the trace storage method should
+    /// be thread safe.
+    /// 
+    /// Transaction collectors must be able to decide whether or not they want to keep a transaction 
+    /// without calling the WireModel method.
+    /// </summary>
+    /// <param name="transactionTraceWireModelComponents"></param>
+    void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents);
+
+    /// <summary>
+    /// Returns an immutable enumerable of samples and clears the sample storage.
+    /// </summary>
+    IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples();
 }

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/KeyTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/KeyTransactionCollector.cs
@@ -9,61 +9,60 @@ using System.Threading;
 using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
 
-namespace NewRelic.Agent.Core.TransactionTraces
+namespace NewRelic.Agent.Core.TransactionTraces;
+
+public class KeyTransactionCollector : ITransactionCollector, IDisposable
 {
-    public class KeyTransactionCollector : ITransactionCollector, IDisposable
+    private volatile ConcurrentDictionary<double, TransactionTraceWireModelComponents> _keyTransactions =
+        new ConcurrentDictionary<double, TransactionTraceWireModelComponents>();
+
+    protected ConfigurationSubscriber ConfigurationSubscription = new ConfigurationSubscriber();
+
+    public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
     {
-        private volatile ConcurrentDictionary<double, TransactionTraceWireModelComponents> _keyTransactions =
-            new ConcurrentDictionary<double, TransactionTraceWireModelComponents>();
-
-        protected ConfigurationSubscriber ConfigurationSubscription = new ConfigurationSubscriber();
-
-        public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
+        if (transactionTraceWireModelComponents == null)
         {
-            if (transactionTraceWireModelComponents == null)
-            {
-                return;
-            }
-
-            var isKeyTransaction = ConfigurationSubscription.Configuration.WebTransactionsApdex.TryGetValue(transactionTraceWireModelComponents.TransactionMetricName.ToString(), out double apdexT);
-            if (!isKeyTransaction)
-            {
-                return;
-            }
-
-            var apdexTime = TimeSpan.FromSeconds(apdexT);
-            if (transactionTraceWireModelComponents.Duration <= apdexTime)
-            {
-                return;
-            }
-
-            // larger the score, the larger the diff. A low score indicates a better performing transaction (golf rules).
-            var score = 100.0 * (transactionTraceWireModelComponents.Duration.TotalMilliseconds / apdexTime.TotalMilliseconds);
-
-            // If there aren't any higher scores than what we currently encountered, add this one to the collection
-            if (!_keyTransactions.Any(x => x.Key > score))
-            {
-                _keyTransactions[score] = transactionTraceWireModelComponents;
-            }
+            return;
         }
 
-        public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+        var isKeyTransaction = ConfigurationSubscription.Configuration.WebTransactionsApdex.TryGetValue(transactionTraceWireModelComponents.TransactionMetricName.ToString(), out double apdexT);
+        if (!isKeyTransaction)
         {
-            var harvestedKeyTransactions = Interlocked.Exchange(ref _keyTransactions,
-                new ConcurrentDictionary<double, TransactionTraceWireModelComponents>());
-
-            if (harvestedKeyTransactions.Count == 0)
-            {
-                return Enumerable.Empty<TransactionTraceWireModelComponents>();
-            }
-
-            var worstScoredTransaction = harvestedKeyTransactions.Aggregate((x, y) => x.Key > y.Key ? x : y).Value;
-            return new TransactionTraceWireModelComponents[] { worstScoredTransaction };
+            return;
         }
 
-        public void Dispose()
+        var apdexTime = TimeSpan.FromSeconds(apdexT);
+        if (transactionTraceWireModelComponents.Duration <= apdexTime)
         {
-            ConfigurationSubscription.Dispose();
+            return;
         }
+
+        // larger the score, the larger the diff. A low score indicates a better performing transaction (golf rules).
+        var score = 100.0 * (transactionTraceWireModelComponents.Duration.TotalMilliseconds / apdexTime.TotalMilliseconds);
+
+        // If there aren't any higher scores than what we currently encountered, add this one to the collection
+        if (!_keyTransactions.Any(x => x.Key > score))
+        {
+            _keyTransactions[score] = transactionTraceWireModelComponents;
+        }
+    }
+
+    public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+    {
+        var harvestedKeyTransactions = Interlocked.Exchange(ref _keyTransactions,
+            new ConcurrentDictionary<double, TransactionTraceWireModelComponents>());
+
+        if (harvestedKeyTransactions.Count == 0)
+        {
+            return Enumerable.Empty<TransactionTraceWireModelComponents>();
+        }
+
+        var worstScoredTransaction = harvestedKeyTransactions.Aggregate((x, y) => x.Key > y.Key ? x : y).Value;
+        return new TransactionTraceWireModelComponents[] { worstScoredTransaction };
+    }
+
+    public void Dispose()
+    {
+        ConfigurationSubscription.Dispose();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SlowestTransactionCollector.cs
@@ -2,57 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
-using System.Linq;
-using System.Collections.Concurrent;
-using System.Threading;
 
-namespace NewRelic.Agent.Core.TransactionTraces
+namespace NewRelic.Agent.Core.TransactionTraces;
+
+public class SlowestTransactionCollector : ITransactionCollector, IDisposable
 {
-    public class SlowestTransactionCollector : ITransactionCollector, IDisposable
+    private volatile ConcurrentBag<TransactionTraceWireModelComponents> _slowTransactions = new ConcurrentBag<TransactionTraceWireModelComponents>();
+
+    protected ConfigurationSubscriber ConfigurationSubscription = new ConfigurationSubscriber();
+
+    public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
     {
-        private volatile ConcurrentBag<TransactionTraceWireModelComponents> _slowTransactions = new ConcurrentBag<TransactionTraceWireModelComponents>();
-
-        protected ConfigurationSubscriber ConfigurationSubscription = new ConfigurationSubscriber();
-
-        public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
+        if (transactionTraceWireModelComponents == null)
         {
-            if (transactionTraceWireModelComponents == null)
-            {
-                return;
-            }
-
-            if (transactionTraceWireModelComponents.Duration <= ConfigurationSubscription.Configuration.TransactionTraceThreshold)
-            {
-                return;
-            }
-
-            // If this is the slowest transaction so far, save it!
-            if (!_slowTransactions.Any(x => x.Duration > transactionTraceWireModelComponents.Duration))
-            {
-                _slowTransactions.Add(transactionTraceWireModelComponents);
-            }
+            return;
         }
 
-        public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+        if (transactionTraceWireModelComponents.Duration <= ConfigurationSubscription.Configuration.TransactionTraceThreshold)
         {
-            var harvestedSlowTransactions = Interlocked.Exchange(ref _slowTransactions,
-                new ConcurrentBag<TransactionTraceWireModelComponents>());
-
-            if (harvestedSlowTransactions.Count == 0)
-            {
-                return Enumerable.Empty<TransactionTraceWireModelComponents>();
-            }
-
-            var slowestTransaction = harvestedSlowTransactions.Aggregate((x, y) => x.Duration > y.Duration ? x : y);
-            return new TransactionTraceWireModelComponents[] { slowestTransaction };
+            return;
         }
 
-        public void Dispose()
+        // If this is the slowest transaction so far, save it!
+        if (!_slowTransactions.Any(x => x.Duration > transactionTraceWireModelComponents.Duration))
         {
-            ConfigurationSubscription.Dispose();
+            _slowTransactions.Add(transactionTraceWireModelComponents);
         }
+    }
+
+    public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+    {
+        var harvestedSlowTransactions = Interlocked.Exchange(ref _slowTransactions,
+            new ConcurrentBag<TransactionTraceWireModelComponents>());
+
+        if (harvestedSlowTransactions.Count == 0)
+        {
+            return Enumerable.Empty<TransactionTraceWireModelComponents>();
+        }
+
+        var slowestTransaction = harvestedSlowTransactions.Aggregate((x, y) => x.Duration > y.Duration ? x : y);
+        return new TransactionTraceWireModelComponents[] { slowestTransaction };
+    }
+
+    public void Dispose()
+    {
+        ConfigurationSubscription.Dispose();
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/TransactionTraces/SyntheticsTransactionCollector.cs
+++ b/src/Agent/NewRelic/Agent/Core/TransactionTraces/SyntheticsTransactionCollector.cs
@@ -6,46 +6,43 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using NewRelic.Agent.Core.Configuration;
 using NewRelic.Agent.Core.Transactions;
 using NewRelic.Agent.Core.Transformers.TransactionTransformer;
-using NewRelic.Agent.Extensions.Collections;
 
-namespace NewRelic.Agent.Core.TransactionTraces
+namespace NewRelic.Agent.Core.TransactionTraces;
+
+public class SyntheticsTransactionCollector : ITransactionCollector, IDisposable
 {
-    public class SyntheticsTransactionCollector : ITransactionCollector, IDisposable
+    private volatile ConcurrentBag<TransactionTraceWireModelComponents> _collectedSamples = new ConcurrentBag<TransactionTraceWireModelComponents>();
+
+    public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
     {
-        private volatile ConcurrentBag<TransactionTraceWireModelComponents> _collectedSamples = new ConcurrentBag<TransactionTraceWireModelComponents>();
-
-        public void Collect(TransactionTraceWireModelComponents transactionTraceWireModelComponents)
+        if (transactionTraceWireModelComponents == null)
         {
-            if (transactionTraceWireModelComponents == null)
-            {
-                return;
-            }
-
-            if (!transactionTraceWireModelComponents.IsSynthetics)
-            {
-                return;
-            }
-
-            if (_collectedSamples.Count >= SyntheticsHeader.MaxTraceCount)
-            {
-                return;
-            }
-
-            _collectedSamples.Add(transactionTraceWireModelComponents);
+            return;
         }
 
-        public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+        if (!transactionTraceWireModelComponents.IsSynthetics)
         {
-            var harvestedTransactions = Interlocked.Exchange(ref _collectedSamples,
-                new ConcurrentBag<TransactionTraceWireModelComponents>());
-
-            // Due to race conditions in Collect, make sure we only return the MaxTraceCount
-            return harvestedTransactions.Take(SyntheticsHeader.MaxTraceCount);
+            return;
         }
 
-        public void Dispose() { }
+        if (_collectedSamples.Count >= SyntheticsHeader.MaxTraceCount)
+        {
+            return;
+        }
+
+        _collectedSamples.Add(transactionTraceWireModelComponents);
     }
+
+    public IEnumerable<TransactionTraceWireModelComponents> GetCollectedSamples()
+    {
+        var harvestedTransactions = Interlocked.Exchange(ref _collectedSamples,
+            new ConcurrentBag<TransactionTraceWireModelComponents>());
+
+        // Due to race conditions in Collect, make sure we only return the MaxTraceCount
+        return harvestedTransactions.Take(SyntheticsHeader.MaxTraceCount);
+    }
+
+    public void Dispose() { }
 }

--- a/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/UtilizationStore.cs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Generic;
-using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Utilities;
 using NewRelic.Agent.Extensions.Logging;
 
 namespace NewRelic.Agent.Core.Utilization;

--- a/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilization/VendorInfo.cs
@@ -1,18 +1,18 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.Configuration;
-using NewRelic.Agent.Core.AgentHealth;
-using NewRelic.Agent.Core.Utilities;
-using NewRelic.Agent.Helpers;
-using NewRelic.Agent.Extensions.Logging;
-using NewRelic.Agent.Core.SharedInterfaces;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using NewRelic.Agent.Configuration;
+using NewRelic.Agent.Core.AgentHealth;
+using NewRelic.Agent.Core.SharedInterfaces;
+using NewRelic.Agent.Core.Utilities;
+using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.SystemExtensions.Collections.Generic;
+using NewRelic.Agent.Helpers;
+using Newtonsoft.Json.Linq;
 
 namespace NewRelic.Agent.Core.Utilization;
 


### PR DESCRIPTION
A few stragglers from the Core project. I ran a different ReSharper "remove unused usings" command and I think that's where most of these changes came from. But there were also a couple that didn't get the file-scope namespace refactor also. 