### PR TITLE
fix: Agent correctly overwrites files when necessary.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
+++ b/src/Agent/NewRelic/Agent/Core/AgentHealth/AgentHealthReporter.cs
@@ -848,7 +848,7 @@ public class AgentHealthReporter : ConfigurationBasedService, IAgentHealthReport
 
         try
         {
-            using var fs = _fileWrapper.OpenWrite(Path.Combine(_healthCheckPath, _healthCheck.FileName));
+            using var fs = _fileWrapper.CreateOpenOverwrite(Path.Combine(_healthCheckPath, _healthCheck.FileName));
             var payloadBytes = Encoding.UTF8.GetBytes(healthCheckYaml);
             fs.Write(payloadBytes, 0, payloadBytes.Length);
             fs.Flush();

--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
@@ -51,7 +51,7 @@ public class ServerlessModePayloadManager : IServerlessModePayloadManager
                 var payloadBytes = Encoding.UTF8.GetBytes(payloadJson);
                 if (_fileWrapper.Exists(path))
                 {
-                    using (var fs = _fileWrapper.OpenWrite(path))
+                    using (var fs = _fileWrapper.CreateOpenOverwrite(path))
                     {
                         fs.Write(payloadBytes, 0, payloadBytes.Length);
                         fs.Flush(true);

--- a/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
@@ -12,7 +12,7 @@ namespace NewRelic.Agent.Core.Utilities;
 public interface IFileWrapper
 {
     bool Exists(string path);
-    FileStream OpenWrite(string path);
+    FileStream CreateOpenOverwrite(string path);
     bool TryCreateFile(string path, bool deleteOnSuccess = true);
     string ReadAllText(string path);
     string[] ReadAllLines(string path);
@@ -29,9 +29,14 @@ public class FileWrapper : IFileWrapper
 
     }
 
-    public FileStream OpenWrite(string path)
+    /// <summary>
+    /// Creates or opens and overwrites a file and returns the file stream.
+    /// </summary>
+    /// <param name="path"></param>
+    /// <returns></returns>
+    public FileStream CreateOpenOverwrite(string path)
     {
-        return File.OpenWrite(path);
+        return File.Create(path);
     }
 
     public bool TryCreateFile(string path, bool deleteOnSuccess = true)

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTestAgent.cs
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTestAgent.cs
@@ -200,7 +200,7 @@ public class CompositeTestAgent : IDisposable
                 .DoInstead((byte[] content, int offset, int len) => _serverlessPayloadMemoryStream.Write(content, 0, content.Length));
             var fileWrapper = Mock.Create<IFileWrapper>();
             Mock.Arrange(() => fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
-            Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+            Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
             _container.ReplaceInstanceRegistration(fileWrapper);
         }

--- a/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterAgentControlTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/AgentHealth/AgentHealthReporterAgentControlTests.cs
@@ -107,7 +107,7 @@ public class AgentHealthReporterAgentControlTests
 
         var fileWrapper = Mock.Create<IFileWrapper>();
         Mock.Arrange(() => fileWrapper.TryCreateFile(Arg.IsAny<string>(), Arg.IsAny<bool>())).Returns(true);
-        Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+        Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
         var directoryWrapper = Mock.Create<IDirectoryWrapper>();
         Mock.Arrange(() => directoryWrapper.Exists(Arg.IsAny<string>())).Returns(true);
@@ -216,7 +216,7 @@ public class AgentHealthReporterAgentControlTests
 
         var fileWrapper = Mock.Create<IFileWrapper>();
         Mock.Arrange(() => fileWrapper.TryCreateFile(Arg.IsAny<string>(), Arg.IsAny<bool>())).Returns(true);
-        Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Throws(new IOException());
+        Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Throws(new IOException());
 
         var directoryWrapper = Mock.Create<IDirectoryWrapper>();
         Mock.Arrange(() => directoryWrapper.Exists(Arg.IsAny<string>())).Returns(true);
@@ -247,7 +247,7 @@ public class AgentHealthReporterAgentControlTests
 
         var fileWrapper = Mock.Create<IFileWrapper>();
         Mock.Arrange(() => fileWrapper.TryCreateFile(Arg.IsAny<string>(), Arg.IsAny<bool>())).Returns(true);
-        Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+        Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
         var directoryWrapper = Mock.Create<IDirectoryWrapper>();
         Mock.Arrange(() => directoryWrapper.Exists(Arg.IsAny<string>())).Returns(true);
@@ -290,7 +290,7 @@ public class AgentHealthReporterAgentControlTests
 
         var fileWrapper = Mock.Create<IFileWrapper>();
         Mock.Arrange(() => fileWrapper.TryCreateFile(Arg.IsAny<string>(), Arg.IsAny<bool>())).Returns(true);
-        Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+        Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
         var directoryWrapper = Mock.Create<IDirectoryWrapper>();
         Mock.Arrange(() => directoryWrapper.Exists(Arg.IsAny<string>())).Returns(true);
@@ -446,7 +446,7 @@ public class AgentHealthReporterAgentControlTests
 
         var fileWrapper = Mock.Create<IFileWrapper>();
         Mock.Arrange(() => fileWrapper.TryCreateFile(Arg.IsAny<string>(), Arg.IsAny<bool>())).Returns(true);
-        Mock.Arrange(() => fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+        Mock.Arrange(() => fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
         var directoryWrapper = Mock.Create<IDirectoryWrapper>();
         Mock.Arrange(() => directoryWrapper.Exists(Arg.IsAny<string>())).Returns(true);

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ServerlessModePayloadManagerTests.cs
@@ -113,7 +113,7 @@ public class ServerlessModePayloadManagerTests
         Mock.Arrange(() => fs.Write(null, 0, 0)).IgnoreArguments()
             .DoInstead((byte[] content, int offset, int len) => actualMS.Write(content, 0, content.Length));
         Mock.Arrange(() => _fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
-        Mock.Arrange(() => _fileWrapper.OpenWrite(Arg.IsAny<string>())).Returns(fs);
+        Mock.Arrange(() => _fileWrapper.CreateOpenOverwrite(Arg.IsAny<string>())).Returns(fs);
 
         Mock.Arrange(() => _environment.GetEnvironmentVariable("AWS_EXECUTION_ENV")).Returns(testExecutionEnv);
 


### PR DESCRIPTION
## Description

Previously, the agent was using File.OpenWrite when writing out the agent health check report and other payloads (serverless).  The goal was to either create the file or open and overwrite the file, but File.OpenWrite only overwrites individual characters not whole files.  If the data being written is less than the file's current contents, the remainder will still be present in the file.  See: https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openwrite?view=net-10.0#remarks

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
