### PR TITLE
chore: File-Scoped Namespace refactor, phase 12 (Unbounded tests)

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/App_Start/FilterConfig.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/App_Start/FilterConfig.cs
@@ -4,13 +4,12 @@
 
 using System.Web.Mvc;
 
-namespace BasicMvcApplication
+namespace BasicMvcApplication;
+
+public class FilterConfig
 {
-    public class FilterConfig
+    public static void RegisterGlobalFilters(GlobalFilterCollection filters)
     {
-        public static void RegisterGlobalFilters(GlobalFilterCollection filters)
-        {
-            filters.Add(new HandleErrorAttribute());
-        }
+        filters.Add(new HandleErrorAttribute());
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/App_Start/RouteConfig.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/App_Start/RouteConfig.cs
@@ -5,21 +5,20 @@
 using System.Web.Mvc;
 using System.Web.Routing;
 
-namespace BasicMvcApplication
+namespace BasicMvcApplication;
+
+public class RouteConfig
 {
-    public class RouteConfig
+    public static void RegisterRoutes(RouteCollection routes)
     {
-        public static void RegisterRoutes(RouteCollection routes)
-        {
-            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+        routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
-            routes.MapMvcAttributeRoutes();
+        routes.MapMvcAttributeRoutes();
 
-            routes.MapRoute(
-                name: "Default",
-                url: "{controller}/{action}/{id}",
-                defaults: new { action = "Index", id = UrlParameter.Optional }
-            );
-        }
+        routes.MapRoute(
+            name: "Default",
+            url: "{controller}/{action}/{id}",
+            defaults: new { action = "Index", id = UrlParameter.Optional }
+        );
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/OracleController.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Controllers/OracleController.cs
@@ -2,105 +2,103 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using Microsoft.Practices.EnterpriseLibrary.Data;
-using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
-using NewRelic.Agent.IntegrationTests.Shared;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Web.Mvc;
-using NewRelic.Api.Agent;
+using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
+using Microsoft.Practices.EnterpriseLibrary.Data;
+using NewRelic.Agent.IntegrationTests.Shared;
 using Oracle.ManagedDataAccess.Client;
 
-namespace BasicMvcApplication.Controllers
+namespace BasicMvcApplication.Controllers;
+
+public class OracleController : Controller
 {
-    public class OracleController : Controller
+    private const string InsertHotelOracleSql = "INSERT INTO {0} (HOTEL_ID, BOOKING_DATE) VALUES (1, SYSDATE)";
+    private const string DeleteHotelOracleSql = "DELETE FROM {0} WHERE HOTEL_ID = 1";
+    private const string CountHotelOracleSql = "SELECT COUNT(*) FROM {0}";
+
+    private const string CreateHotelTableOracleSql = "CREATE TABLE {0} (HOTEL_ID INT NOT NULL, BOOKING_DATE DATE NOT NULL, " +
+                                                     "ROOMS_TAKEN INT DEFAULT 0, PRIMARY KEY (HOTEL_ID, BOOKING_DATE))";
+    private const string DropHotelTableOracleSql = "DROP TABLE {0}";
+
+
+    [HttpGet]
+    public string EnterpriseLibraryOracle(string tableName)
     {
-        private const string InsertHotelOracleSql = "INSERT INTO {0} (HOTEL_ID, BOOKING_DATE) VALUES (1, SYSDATE)";
-        private const string DeleteHotelOracleSql = "DELETE FROM {0} WHERE HOTEL_ID = 1";
-        private const string CountHotelOracleSql = "SELECT COUNT(*) FROM {0}";
+        var teamMembers = new List<string>();
 
-        private const string CreateHotelTableOracleSql = "CREATE TABLE {0} (HOTEL_ID INT NOT NULL, BOOKING_DATE DATE NOT NULL, " +
-                                                         "ROOMS_TAKEN INT DEFAULT 0, PRIMARY KEY (HOTEL_ID, BOOKING_DATE))";
-        private const string DropHotelTableOracleSql = "DROP TABLE {0}";
+        var connectionStringSettings = new ConnectionStringSettings("OracleConnection", OracleConfiguration.OracleConnectionString, "Oracle.ManagedDataAccess.Client");
+        var connectionStringsSection = new ConnectionStringsSection();
+        connectionStringsSection.ConnectionStrings.Add(connectionStringSettings);
+        var dictionaryConfigSource = new DictionaryConfigurationSource();
+        dictionaryConfigSource.Add("connectionStrings", connectionStringsSection);
+        var dbProviderFactory = new DatabaseProviderFactory(dictionaryConfigSource);
+        var oracleDatabase = dbProviderFactory.Create("OracleConnection");
 
-
-        [HttpGet]
-        public string EnterpriseLibraryOracle(string tableName)
+        using (var reader = oracleDatabase.ExecuteReader(CommandType.Text, "SELECT DEGREE FROM user_tables WHERE ROWNUM <= 1"))
         {
-            var teamMembers = new List<string>();
-
-            var connectionStringSettings = new ConnectionStringSettings("OracleConnection", OracleConfiguration.OracleConnectionString, "Oracle.ManagedDataAccess.Client");
-            var connectionStringsSection = new ConnectionStringsSection();
-            connectionStringsSection.ConnectionStrings.Add(connectionStringSettings);
-            var dictionaryConfigSource = new DictionaryConfigurationSource();
-            dictionaryConfigSource.Add("connectionStrings", connectionStringsSection);
-            var dbProviderFactory = new DatabaseProviderFactory(dictionaryConfigSource);
-            var oracleDatabase = dbProviderFactory.Create("OracleConnection");
-
-            using (var reader = oracleDatabase.ExecuteReader(CommandType.Text, "SELECT DEGREE FROM user_tables WHERE ROWNUM <= 1"))
+            while (reader.Read())
             {
-                while (reader.Read())
-                {
-                    teamMembers.Add(reader.GetString(reader.GetOrdinal("DEGREE")));
-                }
-            }
-
-            var insertSql = string.Format(InsertHotelOracleSql, tableName);
-            var countSql = string.Format(CountHotelOracleSql, tableName);
-            var deleteSql = string.Format(DeleteHotelOracleSql, tableName);
-
-            var insertCount = oracleDatabase.ExecuteNonQuery(CommandType.Text, insertSql);
-            var hotelCount = oracleDatabase.ExecuteScalar(CommandType.Text, countSql);
-            var deleteCount = oracleDatabase.ExecuteNonQuery(CommandType.Text, deleteSql);
-
-            return string.Join(",", teamMembers);
-        }
-
-        [HttpGet]
-        public void CreateTable(string tableName)
-        {
-            NewRelic.Api.Agent.NewRelic.IgnoreTransaction(); // this is a setup method, don't need a transaction for it
-
-            CreateTableInternal(tableName);
-        }
-
-        [HttpGet]
-        public void DropTable(string tableName)
-        {
-            NewRelic.Api.Agent.NewRelic.IgnoreTransaction(); // this is a teardown method, don't need a transaction for it
-
-            DropTableInternal(tableName);
-        }
-
-        private void CreateTableInternal(string tableName)
-        {
-            var createTable = string.Format(CreateHotelTableOracleSql, tableName);
-            using (var connection = new OracleConnection(OracleConfiguration.OracleConnectionString))
-            {
-                connection.Open();
-
-                using (var command = new OracleCommand(createTable, connection))
-                {
-                    command.ExecuteNonQuery();
-                }
+                teamMembers.Add(reader.GetString(reader.GetOrdinal("DEGREE")));
             }
         }
 
-        private void DropTableInternal(string tableName)
-        {
-            var dropTableSql = string.Format(DropHotelTableOracleSql, tableName);
+        var insertSql = string.Format(InsertHotelOracleSql, tableName);
+        var countSql = string.Format(CountHotelOracleSql, tableName);
+        var deleteSql = string.Format(DeleteHotelOracleSql, tableName);
 
-            using (var connection = new OracleConnection(OracleConfiguration.OracleConnectionString))
-            {
-                connection.Open();
+        var insertCount = oracleDatabase.ExecuteNonQuery(CommandType.Text, insertSql);
+        var hotelCount = oracleDatabase.ExecuteScalar(CommandType.Text, countSql);
+        var deleteCount = oracleDatabase.ExecuteNonQuery(CommandType.Text, deleteSql);
 
-                using (var command = new OracleCommand(dropTableSql, connection))
-                {
-                    command.ExecuteNonQuery();
-                }
-            }
-        }
-
+        return string.Join(",", teamMembers);
     }
+
+    [HttpGet]
+    public void CreateTable(string tableName)
+    {
+        NewRelic.Api.Agent.NewRelic.IgnoreTransaction(); // this is a setup method, don't need a transaction for it
+
+        CreateTableInternal(tableName);
+    }
+
+    [HttpGet]
+    public void DropTable(string tableName)
+    {
+        NewRelic.Api.Agent.NewRelic.IgnoreTransaction(); // this is a teardown method, don't need a transaction for it
+
+        DropTableInternal(tableName);
+    }
+
+    private void CreateTableInternal(string tableName)
+    {
+        var createTable = string.Format(CreateHotelTableOracleSql, tableName);
+        using (var connection = new OracleConnection(OracleConfiguration.OracleConnectionString))
+        {
+            connection.Open();
+
+            using (var command = new OracleCommand(createTable, connection))
+            {
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private void DropTableInternal(string tableName)
+    {
+        var dropTableSql = string.Format(DropHotelTableOracleSql, tableName);
+
+        using (var connection = new OracleConnection(OracleConfiguration.OracleConnectionString))
+        {
+            connection.Open();
+
+            using (var command = new OracleCommand(dropTableSql, connection))
+            {
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
 }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Global.asax.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Global.asax.cs
@@ -5,15 +5,14 @@
 using System.Web.Mvc;
 using System.Web.Routing;
 
-namespace BasicMvcApplication
+namespace BasicMvcApplication;
+
+public class MvcApplication : System.Web.HttpApplication
 {
-    public class MvcApplication : System.Web.HttpApplication
+    protected void Application_Start()
     {
-        protected void Application_Start()
-        {
-            AreaRegistration.RegisterAllAreas();
-            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
-            RouteConfig.RegisterRoutes(RouteTable.Routes);
-        }
+        AreaRegistration.RegisterAllAreas();
+        FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
+        RouteConfig.RegisterRoutes(RouteTable.Routes);
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Properties/AssemblyInfo.cs
+++ b/tests/Agent/IntegrationTests/UnboundedApplications/BasicMvcApplication/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
@@ -8,254 +8,252 @@ using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
+
+public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly TFixture _fixture;
+    private readonly string _queueOrTopicName;
+    private readonly string _destinationType;
+
+    private readonly string _processMetricNameBase;
+    private readonly string _settleMetricNameBase;
+    private readonly string _transactionNameBase;
+    private readonly string _topicScopeSuffix;
+    private readonly string _onProcessMessageMethodSegmentMetricName;
+
+    protected AzureServiceBusProcessorTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) : base(fixture)
     {
-        private readonly TFixture _fixture;
-        private readonly string _queueOrTopicName;
-        private readonly string _destinationType;
+        _fixture = fixture;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+        _fixture.TestLogger = output;
 
-        private readonly string _processMetricNameBase;
-        private readonly string _settleMetricNameBase;
-        private readonly string _transactionNameBase;
-        private readonly string _topicScopeSuffix;
-        private readonly string _onProcessMessageMethodSegmentMetricName;
+        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
+        _destinationType = destinationType;
 
-        protected AzureServiceBusProcessorTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) : base(fixture)
+        _topicScopeSuffix = null;
+        if (_destinationType == "Topic")
         {
-            _fixture = fixture;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(1));
-            _fixture.TestLogger = output;
+            _topicScopeSuffix = "/Subscriptions/test";
+        }
 
-            _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
-            _destinationType = destinationType;
+        _processMetricNameBase = $"MessageBroker/ServiceBus/{_destinationType}/Process/Named";
+        _onProcessMessageMethodSegmentMetricName = "DotNet/ServiceBusProcessor/OnProcessMessageAsync";
+        _settleMetricNameBase = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named";
+        _transactionNameBase = $"OtherTransaction/Message/ServiceBus/{_destinationType}/Named";
 
-            _topicScopeSuffix = null;
-            if (_destinationType == "Topic")
+        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_SendMessagesFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_ReceiveMessagesFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                _topicScopeSuffix = "/Subscriptions/test";
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                configModifier
+                    .SetLogLevel("finest")
+                    .EnableDistributedTrace()
+                    .ForceTransactionTraces()
+                    .ConfigureFasterMetricsHarvestCycle(20)
+                    .ConfigureFasterSpanEventsHarvestCycle(20)
+                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex,
+                    TimeSpan.FromMinutes(1));
             }
+        );
 
-            _processMetricNameBase = $"MessageBroker/ServiceBus/{_destinationType}/Process/Named";
-            _onProcessMessageMethodSegmentMetricName = "DotNet/ServiceBusProcessor/OnProcessMessageAsync";
-            _settleMetricNameBase = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named";
-            _transactionNameBase = $"OtherTransaction/Message/ServiceBus/{_destinationType}/Named";
+        _fixture.Initialize();
+    }
 
-            _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_SendMessagesFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser ExerciseServiceBusProcessor_ReceiveMessagesFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-
-                    configModifier
-                        .SetLogLevel("finest")
-                        .EnableDistributedTrace()
-                        .ForceTransactionTraces()
-                        .ConfigureFasterMetricsHarvestCycle(20)
-                        .ConfigureFasterSpanEventsHarvestCycle(20)
-                        .ConfigureFasterTransactionTracesHarvestCycle(25);
-
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex,
-                        TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
+    [Fact]
+    public void Test()
+    {
+        // Local helper to trim priority to max 7 chars
+        string TrimPriority(object val)
+        {
+            var s = val?.ToString();
+            return string.IsNullOrEmpty(s) ? s : (s.Length > 7 ? s.Substring(0, 7) : s);
         }
 
-        [Fact]
-        public void Test()
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        // 2 messages, 1 process segment, 1 method segment, 1 settle segment per message
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            // Local helper to trim priority to max 7 chars
-            string TrimPriority(object val)
+            new()
             {
-                var s = val?.ToString();
-                return string.IsNullOrEmpty(s) ? s : (s.Length > 7 ? s.Substring(0, 7) : s);
-            }
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            // 2 messages, 1 process segment, 1 method segment, 1 settle segment per message
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                metricName = $"{_processMetricNameBase}/{_queueOrTopicName}",
+                callCount = 2,
+                metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
+            },
+            new()
             {
-                new()
-                {
-                    metricName = $"{_processMetricNameBase}/{_queueOrTopicName}",
-                    callCount = 2,
-                    metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
-                },
-                new()
-                {
-                    metricName = _onProcessMessageMethodSegmentMetricName,
-                    callCount = 2,
-                    metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
-                },
-                new()
-                {
-                    metricName = $"{_settleMetricNameBase}/{_queueOrTopicName}",
-                    callCount = 2,
-                    metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
-                },
-                new() { metricName = "Supportability/TraceContext/Accept/Success"},
-            };
-
-            // get the send transaction events to retrieve the expected DT attributes
-            var expectedSendTransactionEvent =
-                _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser/ExerciseServiceBusProcessor_SendMessagesFor{_destinationType}");
-
-            Assert.NotNull(expectedSendTransactionEvent);
-
-            var expectedTraceId = expectedSendTransactionEvent.IntrinsicAttributes["traceId"].ToString();
-            var expectedPriority = TrimPriority(expectedSendTransactionEvent.IntrinsicAttributes["priority"]);
-            var expectedSampled = expectedSendTransactionEvent.IntrinsicAttributes["sampled"];
-
-            // there should be two processor transactions (one for each message processed)
-            var processorTransactionEvents =
-                _fixture.AgentLog.GetTransactionEvents()
-                    .Where(te => te.IntrinsicAttributes["name"].ToString() ==
-                                          $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}").ToList();
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
-
-            var expectedTransactionTraceSegments = new List<string>
+                metricName = _onProcessMessageMethodSegmentMetricName,
+                callCount = 2,
+                metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
+            },
+            new()
             {
-                $"{_processMetricNameBase}/{_queueOrTopicName}",
-                _onProcessMessageMethodSegmentMetricName,
-                $"{_settleMetricNameBase}/{_queueOrTopicName}",
-            };
+                metricName = $"{_settleMetricNameBase}/{_queueOrTopicName}",
+                callCount = 2,
+                metricScope = $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}"
+            },
+            new() { metricName = "Supportability/TraceContext/Accept/Success"},
+        };
 
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample($"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}");
-            var queueProcessSpanEvent = _fixture.AgentLog.TryGetSpanEvent($"{_processMetricNameBase}/{_queueOrTopicName}");
+        // get the send transaction events to retrieve the expected DT attributes
+        var expectedSendTransactionEvent =
+            _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser/ExerciseServiceBusProcessor_SendMessagesFor{_destinationType}");
 
+        Assert.NotNull(expectedSendTransactionEvent);
 
-            Assert.Multiple(
-                () => Assert.Equal(2, processorTransactionEvents.Count),
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(queueProcessSpanEvent),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assert.NotEmpty(spanEvents));
+        var expectedTraceId = expectedSendTransactionEvent.IntrinsicAttributes["traceId"].ToString();
+        var expectedPriority = TrimPriority(expectedSendTransactionEvent.IntrinsicAttributes["priority"]);
+        var expectedSampled = expectedSendTransactionEvent.IntrinsicAttributes["sampled"];
 
-            // verify processor transaction events have the expected DT attributes
-            Assert.All(processorTransactionEvents, transactionEvent =>
-            {
-                Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("traceId", out var actualTraceId));
-                Assert.Equal(expectedTraceId, actualTraceId);
+        // there should be two processor transactions (one for each message processed)
+        var processorTransactionEvents =
+            _fixture.AgentLog.GetTransactionEvents()
+                .Where(te => te.IntrinsicAttributes["name"].ToString() ==
+                             $"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}").ToList();
 
-                Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("priority", out var actualPriority));
-                Assert.Equal(expectedPriority, TrimPriority(actualPriority));
+        var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
 
-                Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("sampled", out var actualSampled));
-                Assert.Equal(expectedSampled, actualSampled);
-            });
-
-            // verify span events have the expected DT attributes
-            Assert.All(spanEvents, spanEvent =>
-            {
-                Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("traceId", out var actualTraceId));
-                Assert.Equal(expectedTraceId, actualTraceId);
-
-                Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("priority", out var actualPriority));
-                Assert.Equal(expectedPriority, TrimPriority(actualPriority));
-
-                Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("sampled", out var actualSampled));
-                Assert.Equal(expectedSampled, actualSampled);
-            });
-        }
-    }
-
-    #region Queue Tests
-
-    public class
-        AzureServiceBusProcessorQueueTestsFWLatest : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusProcessorQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
+        var expectedTransactionTraceSegments = new List<string>
         {
-        }
-    }
+            $"{_processMetricNameBase}/{_queueOrTopicName}",
+            _onProcessMessageMethodSegmentMetricName,
+            $"{_settleMetricNameBase}/{_queueOrTopicName}",
+        };
 
-    public class
-        AzureServiceBusProcessorQueueTestsFW462 : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusProcessorQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
-            base(fixture, "Queue", output)
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample($"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}");
+        var queueProcessSpanEvent = _fixture.AgentLog.TryGetSpanEvent($"{_processMetricNameBase}/{_queueOrTopicName}");
+
+
+        Assert.Multiple(
+            () => Assert.Equal(2, processorTransactionEvents.Count),
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(queueProcessSpanEvent),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assert.NotEmpty(spanEvents));
+
+        // verify processor transaction events have the expected DT attributes
+        Assert.All(processorTransactionEvents, transactionEvent =>
         {
-        }
-    }
+            Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("traceId", out var actualTraceId));
+            Assert.Equal(expectedTraceId, actualTraceId);
 
-    public class
-        AzureServiceBusProcessorQueueTestsCoreOldest : AzureServiceBusProcessorTestsBase<
-        ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusProcessorQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
+            Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("priority", out var actualPriority));
+            Assert.Equal(expectedPriority, TrimPriority(actualPriority));
+
+            Assert.True(transactionEvent.IntrinsicAttributes.TryGetValue("sampled", out var actualSampled));
+            Assert.Equal(expectedSampled, actualSampled);
+        });
+
+        // verify span events have the expected DT attributes
+        Assert.All(spanEvents, spanEvent =>
         {
-        }
+            Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("traceId", out var actualTraceId));
+            Assert.Equal(expectedTraceId, actualTraceId);
+
+            Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("priority", out var actualPriority));
+            Assert.Equal(expectedPriority, TrimPriority(actualPriority));
+
+            Assert.True(spanEvent.IntrinsicAttributes.TryGetValue("sampled", out var actualSampled));
+            Assert.Equal(expectedSampled, actualSampled);
+        });
     }
-
-    public class
-        AzureServiceBusProcessorQueueTestsCoreLatest : AzureServiceBusProcessorTestsBase<
-        ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusProcessorQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    #endregion Queue Tests
-
-    #region Topic Tests
-
-    public class
-        AzureServiceBusProcessorTopicTestsFWLatest : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusProcessorTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusProcessorTopicTestsFW462 : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusProcessorTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
-            base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusProcessorTopicTestsCoreOldest : AzureServiceBusProcessorTestsBase<
-        ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusProcessorTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusProcessorTopicTestsCoreLatest : AzureServiceBusProcessorTestsBase<
-        ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusProcessorTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    #endregion Topic Tests
-
 }
+
+#region Queue Tests
+
+public class
+    AzureServiceBusProcessorQueueTestsFWLatest : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusProcessorQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorQueueTestsFW462 : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusProcessorQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+        base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorQueueTestsCoreOldest : AzureServiceBusProcessorTestsBase<
+    ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusProcessorQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorQueueTestsCoreLatest : AzureServiceBusProcessorTestsBase<
+    ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusProcessorQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+#endregion Queue Tests
+
+#region Topic Tests
+
+public class
+    AzureServiceBusProcessorTopicTestsFWLatest : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusProcessorTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorTopicTestsFW462 : AzureServiceBusProcessorTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusProcessorTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+        base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorTopicTestsCoreOldest : AzureServiceBusProcessorTestsBase<
+    ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusProcessorTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusProcessorTopicTestsCoreLatest : AzureServiceBusProcessorTestsBase<
+    ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusProcessorTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+#endregion Topic Tests

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
@@ -9,321 +9,319 @@ using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
+
+public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly TFixture _fixture;
+    private readonly string _queueOrTopicName;
+    private readonly string _destinationType;
+
+    protected AzureServiceBusTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
+        base(fixture)
     {
-        private readonly TFixture _fixture;
-        private readonly string _queueOrTopicName;
-        private readonly string _destinationType;
+        _fixture = fixture;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+        _fixture.TestLogger = output;
 
-        protected AzureServiceBusTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
-            base(fixture)
+        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
+        _destinationType = destinationType;
+
+        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ScheduleAndCancelAMessage {_queueOrTopicName}");
+        if (_destinationType == "Queue")
         {
-            _fixture = fixture;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(1));
-            _fixture.TestLogger = output;
-
-            _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
-            _destinationType = destinationType;
-
-            _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser ScheduleAndCancelAMessage {_queueOrTopicName}");
-            if (_destinationType == "Queue")
-            {
-                _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndDeadLetterAMessageForQueue {_queueOrTopicName}");
-            }
-            
-            _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndAbandonAMessageFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-
-                    configModifier
-                        .SetLogLevel("finest")
-                        .EnableDistributedTrace()
-                        .ForceTransactionTraces()
-                        .ConfigureFasterMetricsHarvestCycle(20)
-                        .ConfigureFasterSpanEventsHarvestCycle(20)
-                        .ConfigureFasterTransactionTracesHarvestCycle(25)
-                        ;
-                }
-            );
-
-            _fixture.Initialize();
+            _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndDeadLetterAMessageForQueue {_queueOrTopicName}");
         }
+            
+        _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAndAbandonAMessageFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
-        private readonly string _metricScopeBase =
-            "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
-
-        [Fact]
-        public void Test()
-        {
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                configModifier
+                    .SetLogLevel("finest")
+                    .EnableDistributedTrace()
+                    .ForceTransactionTraces()
+                    .ConfigureFasterMetricsHarvestCycle(20)
+                    .ConfigureFasterSpanEventsHarvestCycle(20)
+                    .ConfigureFasterTransactionTracesHarvestCycle(25)
+                    ;
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    private readonly string _metricScopeBase =
+        "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
+
+    [Fact]
+    public void Test()
+    {
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}", callCount = _destinationType == "Queue" ? 4 : 3
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
+                callCount = 1,
+                metricScope =
+                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
+                callCount = 1,
+                metricScope = $"{_metricScopeBase}/ScheduleAndCancelAMessage"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
+                callCount = 1,
+                metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
+                callCount = _destinationType == "Queue" ? 6 : 5
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
+                callCount = 3,
+                metricScope =
+                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
+                callCount = 2,
+                metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}",
+                callCount = 1
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}",
+                callCount = 1,
+                metricScope =
+                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
+                callCount = _destinationType == "Queue" ? 5 : 4
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
+                callCount = 2,
+                metricScope =
+                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
+            },
+            new()
+            {
+                metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
+                callCount = 2,
+                metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
+            },
+        };
+
+        if (_destinationType == "Queue")
+        {
+            expectedMetrics.Add(
                 new()
                 {
-                    metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}", callCount = _destinationType == "Queue" ? 4 : 3
-                },
+                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
+                    callCount = 1,
+                    metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
+                });
+            expectedMetrics.Add(
+                new()
+                {
+                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
+                    callCount = 1,
+                    metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
+                });
+            expectedMetrics.Add(
                 new()
                 {
                     metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
                     callCount = 1,
-                    metricScope =
-                        $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
-                },
+                    metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
+                });
+            expectedMetrics.Add(
                 new()
                 {
-                    metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
+                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}",
+                    callCount = 1
+                });
+            expectedMetrics.Add(
+                new()
+                {
+                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}",
                     callCount = 1,
                     metricScope = $"{_metricScopeBase}/ScheduleAndCancelAMessage"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
-                    callCount = 1,
-                    metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
-                    callCount = _destinationType == "Queue" ? 6 : 5
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
-                    callCount = 3,
-                    metricScope =
-                        $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
-                    callCount = 2,
-                    metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}",
-                    callCount = 1
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}",
-                    callCount = 1,
-                    metricScope =
-                        $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
-                    callCount = _destinationType == "Queue" ? 5 : 4
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
-                    callCount = 2,
-                    metricScope =
-                        $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}"
-                },
-                new()
-                {
-                    metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
-                    callCount = 2,
-                    metricScope = $"{_metricScopeBase}/ReceiveAndAbandonAMessageFor{_destinationType}"
-                },
-            };
-
-            if (_destinationType == "Queue")
-            {
-                expectedMetrics.Add(
-                    new()
-                    {
-                        metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
-                        callCount = 1,
-                        metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
-                    });
-                expectedMetrics.Add(
-                    new()
-                    {
-                        metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
-                        callCount = 1,
-                        metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
-                    });
-                expectedMetrics.Add(
-                    new()
-                    {
-                        metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}",
-                        callCount = 1,
-                        metricScope = $"{_metricScopeBase}/ReceiveAndDeadLetterAMessageFor{_destinationType}"
-                    });
-                expectedMetrics.Add(
-                    new()
-                    {
-                        metricName = $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}",
-                        callCount = 1
-                    });
-                expectedMetrics.Add(
-                    new()
-                    {
-                        metricName = $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}",
-                        callCount = 1,
-                        metricScope = $"{_metricScopeBase}/ScheduleAndCancelAMessage"
-                    });
-            }
-
-            var exerciseMultipleReceiveOperationsOnAMessageTransactionEvent =
-                _fixture.AgentLog.TryGetTransactionEvent(
-                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
-
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}"
-            };
-
-            var transactionSample =
-                _fixture.AgentLog.TryGetTransactionSample(
-                    $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
-
-            var queueProduceSpanEvents =
-                _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}");
-            var queueConsumeSpanEvents =
-                _fixture.AgentLog.TryGetSpanEvent(
-                    $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}");
-            var queuePeekSpanEvents =
-                _fixture.AgentLog.TryGetSpanEvent(
-                    $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}");
-            var queueSettleSpanEvents =
-                _fixture.AgentLog.TryGetSpanEvent(
-                    $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}");
-            var queueCancelSpanEvents =
-                _fixture.AgentLog.TryGetSpanEvent(
-                    $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}");
-
-            var expectedProduceAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
-
-            var expectedConsumeAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
-
-
-            var expectedPeekAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
-
-            var expectedSettleAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
-
-            var expectedCancelAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
-
-            var expectedIntrinsicAttributes = new List<string> { "span.kind", };
-
-            Assertions.MetricsExist(expectedMetrics, metrics);
-
-            NrAssert.Multiple(
-                () => Assert.True(exerciseMultipleReceiveOperationsOnAMessageTransactionEvent != null,
-                    "ExerciseMultipleReceiveOperationsOnAMessageTransactionEvent should not be null"),
-                () => Assert.True(transactionSample != null, "transactionSample should not be null"),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueProduceSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrinsicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueProduceSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedConsumeAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueConsumeSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrinsicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueConsumeSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedPeekAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queuePeekSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedSettleAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueSettleSpanEvents)
-            );
-
-            if (_destinationType == "Queue")
-            {
-                Assertions.SpanEventHasAttributes(expectedCancelAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueCancelSpanEvents);
-            }
+                });
         }
-    }
 
-    #region Queue Tests
+        var exerciseMultipleReceiveOperationsOnAMessageTransactionEvent =
+            _fixture.AgentLog.TryGetTransactionEvent(
+                $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
 
-    public class AzureServiceBusQueueTestsFWLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) :
-            base(fixture, "Queue", output)
+        var expectedTransactionTraceSegments = new List<string>
         {
-        }
-    }
+            $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}"
+        };
 
-    public class AzureServiceBusQueueTestsFW462 : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(
-            fixture, "Queue", output)
+        var transactionSample =
+            _fixture.AgentLog.TryGetTransactionSample(
+                $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
+
+        var queueProduceSpanEvents =
+            _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}");
+        var queueConsumeSpanEvents =
+            _fixture.AgentLog.TryGetSpanEvent(
+                $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}");
+        var queuePeekSpanEvents =
+            _fixture.AgentLog.TryGetSpanEvent(
+                $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}");
+        var queueSettleSpanEvents =
+            _fixture.AgentLog.TryGetSpanEvent(
+                $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}");
+        var queueCancelSpanEvents =
+            _fixture.AgentLog.TryGetSpanEvent(
+                $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}");
+
+        var expectedProduceAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
+
+        var expectedConsumeAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
+
+
+        var expectedPeekAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
+
+        var expectedSettleAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
+
+        var expectedCancelAgentAttributes = new List<string> { "server.address", "messaging.destination.name", };
+
+        var expectedIntrinsicAttributes = new List<string> { "span.kind", };
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+
+        NrAssert.Multiple(
+            () => Assert.True(exerciseMultipleReceiveOperationsOnAMessageTransactionEvent != null,
+                "ExerciseMultipleReceiveOperationsOnAMessageTransactionEvent should not be null"),
+            () => Assert.True(transactionSample != null, "transactionSample should not be null"),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+
+            () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueProduceSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrinsicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueProduceSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedConsumeAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueConsumeSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrinsicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueConsumeSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedPeekAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queuePeekSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedSettleAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueSettleSpanEvents)
+        );
+
+        if (_destinationType == "Queue")
         {
+            Assertions.SpanEventHasAttributes(expectedCancelAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueCancelSpanEvents);
         }
     }
-
-    public class AzureServiceBusQueueTestsCoreOldest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) :
-            base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusQueueTestsCoreLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) :
-            base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    #endregion Queue Tests
-
-    #region Topic Tests
-
-    public class AzureServiceBusTopicTestsFWLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) :
-            base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusTopicTestsFW462 : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(
-            fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusTopicTestsCoreOldest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) :
-            base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusTopicTestsCoreLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) :
-            base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    #endregion Topic Tests
-
 }
+
+#region Queue Tests
+
+public class AzureServiceBusQueueTestsFWLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) :
+        base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class AzureServiceBusQueueTestsFW462 : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(
+        fixture, "Queue", output)
+    {
+    }
+}
+
+public class AzureServiceBusQueueTestsCoreOldest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) :
+        base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class AzureServiceBusQueueTestsCoreLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) :
+        base(fixture, "Queue", output)
+    {
+    }
+}
+
+#endregion Queue Tests
+
+#region Topic Tests
+
+public class AzureServiceBusTopicTestsFWLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) :
+        base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class AzureServiceBusTopicTestsFW462 : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(
+        fixture, "Topic", output)
+    {
+    }
+}
+
+public class AzureServiceBusTopicTestsCoreOldest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) :
+        base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class AzureServiceBusTopicTestsCoreLatest : AzureServiceBusTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) :
+        base(fixture, "Topic", output)
+    {
+    }
+}
+
+#endregion Topic Tests

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
@@ -6,216 +6,213 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.AzureServiceBus;
+
+public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly TFixture _fixture;
+    private readonly string _queueOrTopicName;
+    private readonly string _destinationType;
+
+    protected AzureServiceBusW3CTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
+        base(fixture)
     {
-        private readonly TFixture _fixture;
-        private readonly string _queueOrTopicName;
-        private readonly string _destinationType;
+        _fixture = fixture;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+        _fixture.TestLogger = output;
 
-        protected AzureServiceBusW3CTestsBase(TFixture fixture, string destinationType, ITestOutputHelper output) :
-            base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(1));
-            _fixture.TestLogger = output;
-
-            _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
-            _destinationType = destinationType;
+        _queueOrTopicName = $"test-queue-{Guid.NewGuid()}";
+        _destinationType = destinationType;
 
 
-            _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
-            // send and receive on separate transactions to validate DT propagation
-            _fixture.AddCommand($"AzureServiceBusExerciser SendAMessageFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAMessageFor{_destinationType} {_queueOrTopicName}");
-            _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser Initialize{_destinationType} {_queueOrTopicName}");
+        // send and receive on separate transactions to validate DT propagation
+        _fixture.AddCommand($"AzureServiceBusExerciser SendAMessageFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAMessageFor{_destinationType} {_queueOrTopicName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser Delete{_destinationType} {_queueOrTopicName}");
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-
-                    configModifier
-                        .EnableDistributedTrace()
-                        .ForceTransactionTraces()
-                        .SetOrDeleteDistributedTraceEnabled(true)
-                        .SetOrDeleteSpanEventsEnabled(true)
-                        .ConfigureFasterMetricsHarvestCycle(20)
-                        .ConfigureFasterSpanEventsHarvestCycle(20)
-                        .ConfigureFasterTransactionTracesHarvestCycle(25);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        private readonly string _metricScopeBase =
-            "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
-
-        [Fact]
-        public void Test()
-        {
-            // attributes
-
-            var sendTx =
-                _fixture.AgentLog.TryGetTransactionEvent(
-                    $"{_metricScopeBase}/SendAMessageFor{_destinationType}");
-
-            var receiveTx=
-                _fixture.AgentLog.TryGetTransactionEvent(
-                    $"{_metricScopeBase}/ReceiveAMessageFor{_destinationType}");
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
-
-            // produce is always queue.
-            var produceSpans = spanEvents
-                .Where(@event => @event.IntrinsicAttributes["name"].ToString()!
-                    .Contains("MessageBroker/ServiceBus/Queue/Produce/Named/")).ToList();
-
-            var consumeSpans = spanEvents
-                .Where(@event => @event.IntrinsicAttributes["name"].ToString()!
-                    .Contains($"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/")).ToList();
-
-            Assert.NotNull(sendTx);
-            Assert.NotNull(receiveTx);
-            Assert.NotNull(produceSpans);
-            Assert.NotNull(consumeSpans);
-
-            // DT propagation validation
-            Assert.True(sendTx.IntrinsicAttributes.TryGetValue("traceId", out var sendTraceId));
-            Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("traceId", out var receiveTraceId));
-            Assert.Equal(receiveTraceId, sendTraceId);
-
-            Assert.True(sendTx.IntrinsicAttributes.TryGetValue("priority", out var sendPriority));
-            Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("priority", out var receivePriority));
-            Assert.Equal(receivePriority.ToString().Substring(0, 7), sendPriority.ToString().Substring(0, 7)); // keep the values the same length
-
-            Assert.True(sendTx.IntrinsicAttributes.TryGetValue("sampled", out var sendSampled));
-            Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("sampled", out var receiveSampled));
-            Assert.Equal(receiveSampled, sendSampled);
-
-            // validate spans have the same trace / priority / sampled values
-            foreach (var produceSpan in produceSpans)
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                Assert.Equal(sendTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
-                Assert.Equal(sendTx.IntrinsicAttributes["traceId"], produceSpan.IntrinsicAttributes["traceId"]);
-                Assert.True(
-                    sendTx.IntrinsicAttributes["priority"].IsEqualTo(produceSpan.IntrinsicAttributes["priority"]),
-                    $"priority: expected: {sendTx.IntrinsicAttributes["priority"]}, actual: {produceSpan.IntrinsicAttributes["priority"]}");
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                configModifier
+                    .EnableDistributedTrace()
+                    .ForceTransactionTraces()
+                    .SetOrDeleteDistributedTraceEnabled(true)
+                    .SetOrDeleteSpanEventsEnabled(true)
+                    .ConfigureFasterMetricsHarvestCycle(20)
+                    .ConfigureFasterSpanEventsHarvestCycle(20)
+                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(1));
             }
+        );
 
-            foreach (var consumeSpan in consumeSpans)
+        _fixture.Initialize();
+    }
+
+    private readonly string _metricScopeBase =
+        "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.AzureServiceBus.AzureServiceBusExerciser";
+
+    [Fact]
+    public void Test()
+    {
+        // attributes
+
+        var sendTx =
+            _fixture.AgentLog.TryGetTransactionEvent(
+                $"{_metricScopeBase}/SendAMessageFor{_destinationType}");
+
+        var receiveTx=
+            _fixture.AgentLog.TryGetTransactionEvent(
+                $"{_metricScopeBase}/ReceiveAMessageFor{_destinationType}");
+
+        var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
+
+        // produce is always queue.
+        var produceSpans = spanEvents
+            .Where(@event => @event.IntrinsicAttributes["name"].ToString()!
+                .Contains("MessageBroker/ServiceBus/Queue/Produce/Named/")).ToList();
+
+        var consumeSpans = spanEvents
+            .Where(@event => @event.IntrinsicAttributes["name"].ToString()!
+                .Contains($"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/")).ToList();
+
+        Assert.NotNull(sendTx);
+        Assert.NotNull(receiveTx);
+        Assert.NotNull(produceSpans);
+        Assert.NotNull(consumeSpans);
+
+        // DT propagation validation
+        Assert.True(sendTx.IntrinsicAttributes.TryGetValue("traceId", out var sendTraceId));
+        Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("traceId", out var receiveTraceId));
+        Assert.Equal(receiveTraceId, sendTraceId);
+
+        Assert.True(sendTx.IntrinsicAttributes.TryGetValue("priority", out var sendPriority));
+        Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("priority", out var receivePriority));
+        Assert.Equal(receivePriority.ToString().Substring(0, 7), sendPriority.ToString().Substring(0, 7)); // keep the values the same length
+
+        Assert.True(sendTx.IntrinsicAttributes.TryGetValue("sampled", out var sendSampled));
+        Assert.True(receiveTx.IntrinsicAttributes.TryGetValue("sampled", out var receiveSampled));
+        Assert.Equal(receiveSampled, sendSampled);
+
+        // validate spans have the same trace / priority / sampled values
+        foreach (var produceSpan in produceSpans)
+        {
+            Assert.Equal(sendTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
+            Assert.Equal(sendTx.IntrinsicAttributes["traceId"], produceSpan.IntrinsicAttributes["traceId"]);
+            Assert.True(
+                sendTx.IntrinsicAttributes["priority"].IsEqualTo(produceSpan.IntrinsicAttributes["priority"]),
+                $"priority: expected: {sendTx.IntrinsicAttributes["priority"]}, actual: {produceSpan.IntrinsicAttributes["priority"]}");
+        }
+
+        foreach (var consumeSpan in consumeSpans)
+        {
+            Assert.Equal(receiveTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
+            Assert.Equal(receiveTx.IntrinsicAttributes["traceId"], consumeSpan.IntrinsicAttributes["traceId"]);
+            Assert.True(
+                receiveTx.IntrinsicAttributes["priority"].IsEqualTo(consumeSpan.IntrinsicAttributes["priority"]),
+                $"priority: expected: {receiveTx.IntrinsicAttributes["priority"]}, actual: {consumeSpan.IntrinsicAttributes["priority"]}");
+        }
+
+        // metrics
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric
             {
-                Assert.Equal(receiveTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
-                Assert.Equal(receiveTx.IntrinsicAttributes["traceId"], consumeSpan.IntrinsicAttributes["traceId"]);
-                Assert.True(
-                    receiveTx.IntrinsicAttributes["priority"].IsEqualTo(consumeSpan.IntrinsicAttributes["priority"]),
-                    $"priority: expected: {receiveTx.IntrinsicAttributes["priority"]}, actual: {consumeSpan.IntrinsicAttributes["priority"]}");
-            }
-
-            // metrics
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1
+            },
+            new Assertions.ExpectedMetric
             {
-                new Assertions.ExpectedMetric
-                {
-                    metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1
-                },
-                new Assertions.ExpectedMetric
-                {
-                    metricName = $"Supportability/TraceContext/Create/Success", callCount = 1
-                },
-            };
+                metricName = $"Supportability/TraceContext/Create/Success", callCount = 1
+            },
+        };
 
-            var metrics = _fixture.AgentLog.GetMetrics();
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
+        var metrics = _fixture.AgentLog.GetMetrics();
+        Assertions.MetricsExist(expectedMetrics, metrics);
     }
-
-    #region Queue Tests
-
-    public class AzureServiceBusW3CQueueTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusW3CQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusW3CQueueTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusW3CQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
-            base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusW3CQueueTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusW3CQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusW3CQueueTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusW3CQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Queue", output)
-        {
-        }
-    }
-
-    #endregion Queue Tests
-
-    #region Topic Tests
-
-    public class AzureServiceBusW3CTopicTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public AzureServiceBusW3CTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class AzureServiceBusW3CTopicTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public AzureServiceBusW3CTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
-            base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusW3CTopicTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public AzureServiceBusW3CTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    public class
-        AzureServiceBusW3CTopicTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public AzureServiceBusW3CTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
-            ITestOutputHelper output) : base(fixture, "Topic", output)
-        {
-        }
-    }
-
-    #endregion Topic Tests
-
 }
+
+#region Queue Tests
+
+public class AzureServiceBusW3CQueueTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusW3CQueueTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class AzureServiceBusW3CQueueTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusW3CQueueTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+        base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusW3CQueueTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusW3CQueueTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusW3CQueueTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusW3CQueueTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Queue", output)
+    {
+    }
+}
+
+#endregion Queue Tests
+
+#region Topic Tests
+
+public class AzureServiceBusW3CTopicTestsFWLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public AzureServiceBusW3CTopicTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class AzureServiceBusW3CTopicTestsFW462 : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public AzureServiceBusW3CTopicTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) :
+        base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusW3CTopicTestsCoreOldest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public AzureServiceBusW3CTopicTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+public class
+    AzureServiceBusW3CTopicTestsCoreLatest : AzureServiceBusW3CTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusW3CTopicTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+        ITestOutputHelper output) : base(fixture, "Topic", output)
+    {
+    }
+}
+
+#endregion Topic Tests

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/CosmosDB/CosmosDBTests.cs
@@ -2,282 +2,276 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
-using System;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Net.NetworkInformation;
-using System.Net.PeerToPeer.Collaboration;
-using System.Reflection;
 using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.CosmosDB;
+
+public abstract class CosmosDBTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class CosmosDBTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    private string UniqueDbName => "test_db_" + Guid.NewGuid().ToString("n").Substring(0, 4);
+    private string _testContainerName = "testContainer";
+
+    protected CosmosDBTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        private string UniqueDbName => "test_db_" + Guid.NewGuid().ToString("n").Substring(0, 4);
-        private string _testContainerName = "testContainer";
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
-        protected CosmosDBTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"CosmosDBExerciser StartAgent");
+        _fixture.AddCommand($"CosmosDBExerciser CreateReadAndDeleteDatabase {UniqueDbName}");
+        _fixture.AddCommand($"CosmosDBExerciser CreateReadAndDeleteContainers {UniqueDbName} {_testContainerName}");
+        _fixture.AddCommand($"CosmosDBExerciser CreateAndReadItems {UniqueDbName} {_testContainerName}");
+        _fixture.AddCommand($"CosmosDBExerciser CreateAndQueryItems {UniqueDbName} {_testContainerName}");
 
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+        var itemsToCreate = 20;
+        _fixture.AddCommand($"CosmosDBExerciser CreateItemsConcurrentlyAsync {UniqueDbName} {_testContainerName} {itemsToCreate}");
+        _fixture.AddCommand($"CosmosDBExerciser CreateAndExecuteStoredProc {UniqueDbName} {_testContainerName}");
 
-            _fixture.AddCommand($"CosmosDBExerciser StartAgent");
-            _fixture.AddCommand($"CosmosDBExerciser CreateReadAndDeleteDatabase {UniqueDbName}");
-            _fixture.AddCommand($"CosmosDBExerciser CreateReadAndDeleteContainers {UniqueDbName} {_testContainerName}");
-            _fixture.AddCommand($"CosmosDBExerciser CreateAndReadItems {UniqueDbName} {_testContainerName}");
-            _fixture.AddCommand($"CosmosDBExerciser CreateAndQueryItems {UniqueDbName} {_testContainerName}");
-
-            var itemsToCreate = 20;
-            _fixture.AddCommand($"CosmosDBExerciser CreateItemsConcurrentlyAsync {UniqueDbName} {_testContainerName} {itemsToCreate}");
-            _fixture.AddCommand($"CosmosDBExerciser CreateAndExecuteStoredProc {UniqueDbName} {_testContainerName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void CreateReadAndDeleteDatabaseTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadFeedDatabase", metricScope = expectedTransactionName, callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-            };
-            var expectedAgentAttributes = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
+
+                configModifier.ForceTransactionTraces();
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+            },
+            exerciseApplication: () =>
             {
-                "db.system",
-                "db.operation",
-                "db.instance",
-                "peer.address",
-                "peer.hostname",
-                "server.address",
-                "server.port"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var spanEvents = _fixture.AgentLog.GetSpanEvents();
-            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
-            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/operation/CosmosDB"));
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Equal(6, operationDatastoreSpans.Count()),
-                () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
-
-            );
-        }
-
-        [Fact]
-        public void CreateReadAndDeleteContainersTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteContainers";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/DeleteCollection", metricScope = expectedTransactionName, callCount = 1 }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics)
-            );
-        }
-
-        [Fact]
-        public void CreateAndReadItemsTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndReadItems";
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
-
-                //From calling Container.CreateItemStreamAsync() and Container.CreateItemAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateDocument", metricScope = expectedTransactionName, callCount = 2 },
-
-                //From calling Container.UpsertItemStreamAsync() and Container.UpsertItemAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/UpsertDocument", metricScope = expectedTransactionName, callCount = 2 },
-
-                //From calling FeedIterator.ReadNextAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadFeedDocument", metricScope = expectedTransactionName, callCount = 1 },
-
-                //From calling Container.ReadManyItemsStreamAsync() and Container.ReadManyItemsAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument", metricScope = expectedTransactionName, callCount = 2 }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics)
-            );
-        }
-
-        [Fact]
-        public void CreateAndQueryItemsTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndQueryItems";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
-
-                //From calling Container.CreateItemStreamAsync() and Container.CreateItemAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateDocument", metricScope = expectedTransactionName, callCount = 2 },
-
-                //From calling Container.UpsertItemStreamAsync() and Container.UpsertItemAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/UpsertDocument", metricScope = expectedTransactionName, callCount = 2 },
-
-                //From calling Container.GetItemQueryIterator() and Container.GetItemQueryStreamIterator()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument", metricScope = expectedTransactionName, callCount = 2 }
-            };
-
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = "SELECT * FROM SalesOrders s WHERE s.AccountNumber = ? AND s.TotalDue > ?",
-                    DatastoreMetricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument"
-                },
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().Where(st => st.TransactionName == expectedTransactionName);
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
-
-        [Fact]
-        public void BulkCreatingItemsTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateItemsConcurrentlyAsync";
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
-
-        [Fact]
-        public void CreateAndExecuteStoredProcTests()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndExecuteStoredProc";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
-
-                //From calling Scripts.CreateStoredProcedureAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateStoredProcedure", metricScope = expectedTransactionName, callCount = 1 },
-
-                //From calling Scripts.ExecuteStoredProcedureAsync()
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ExecuteJavaScriptStoredProcedure", metricScope = expectedTransactionName, callCount = 1 }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
+        _fixture.Initialize();
     }
 
-    public class CosmosDBTestsFW462 : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void CreateReadAndDeleteDatabaseTests()
     {
-        public CosmosDBTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteDatabase";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadFeedDatabase", metricScope = expectedTransactionName, callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+        };
+        var expectedAgentAttributes = new List<string>
+        {
+            "db.system",
+            "db.operation",
+            "db.instance",
+            "peer.address",
+            "peer.hostname",
+            "server.address",
+            "server.port"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var spanEvents = _fixture.AgentLog.GetSpanEvents();
+        var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+        var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/operation/CosmosDB"));
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assert.Equal(6, operationDatastoreSpans.Count()),
+            () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
+
+        );
     }
 
-    public class CosmosDBTestsFWLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void CreateReadAndDeleteContainersTests()
     {
-        public CosmosDBTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateReadAndDeleteContainers";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/DeleteCollection", metricScope = expectedTransactionName, callCount = 1 }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics)
+        );
     }
 
-
-    public class CosmosDBTestsCoreOldest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    [Fact]
+    public void CreateAndReadItemsTests()
     {
-        public CosmosDBTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndReadItems";
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
+
+            //From calling Container.CreateItemStreamAsync() and Container.CreateItemAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateDocument", metricScope = expectedTransactionName, callCount = 2 },
+
+            //From calling Container.UpsertItemStreamAsync() and Container.UpsertItemAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/UpsertDocument", metricScope = expectedTransactionName, callCount = 2 },
+
+            //From calling FeedIterator.ReadNextAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadFeedDocument", metricScope = expectedTransactionName, callCount = 1 },
+
+            //From calling Container.ReadManyItemsStreamAsync() and Container.ReadManyItemsAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument", metricScope = expectedTransactionName, callCount = 2 }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics)
+        );
     }
 
-    public class CosmosDBTestsCoreLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    [Fact]
+    public void CreateAndQueryItemsTests()
     {
-        public CosmosDBTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndQueryItems";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
+
+            //From calling Container.CreateItemStreamAsync() and Container.CreateItemAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateDocument", metricScope = expectedTransactionName, callCount = 2 },
+
+            //From calling Container.UpsertItemStreamAsync() and Container.UpsertItemAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/UpsertDocument", metricScope = expectedTransactionName, callCount = 2 },
+
+            //From calling Container.GetItemQueryIterator() and Container.GetItemQueryStreamIterator()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument", metricScope = expectedTransactionName, callCount = 2 }
+        };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = expectedTransactionName,
+                Sql = "SELECT * FROM SalesOrders s WHERE s.AccountNumber = ? AND s.TotalDue > ?",
+                DatastoreMetricName = $"Datastore/statement/CosmosDB/{_testContainerName}/QueryDocument"
+            },
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().Where(st => st.TransactionName == expectedTransactionName);
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
+    }
+
+    [Fact]
+    public void BulkCreatingItemsTests()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateItemsConcurrentlyAsync";
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateCollection", metricScope = expectedTransactionName, callCount = 1 },
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+    }
+
+    [Fact]
+    public void CreateAndExecuteStoredProcTests()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.CosmosDB.CosmosDBExerciser/CreateAndExecuteStoredProc";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/CreateDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/ReadDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/operation/CosmosDB/DeleteDatabase", metricScope = expectedTransactionName, callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ReadCollection", metricScope = expectedTransactionName, callCount = 1 },
+
+            //From calling Scripts.CreateStoredProcedureAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/CreateStoredProcedure", metricScope = expectedTransactionName, callCount = 1 },
+
+            //From calling Scripts.ExecuteStoredProcedureAsync()
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/CosmosDB/{_testContainerName}/ExecuteJavaScriptStoredProcedure", metricScope = expectedTransactionName, callCount = 1 }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+    }
+}
+
+public class CosmosDBTestsFW462 : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public CosmosDBTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class CosmosDBTestsFWLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public CosmosDBTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+
+public class CosmosDBTestsCoreOldest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public CosmosDBTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class CosmosDBTestsCoreLatest : CosmosDBTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public CosmosDBTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/Couchbase3Tests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Couchbase/Couchbase3Tests.cs
@@ -3,15 +3,12 @@
 
 
 using System;
-using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Agent.IntegrationTests.Shared;
 using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
-using NewRelic.Testing.Assertions;
 using Xunit;
 
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Elasticsearch/ElasticsearchTests.cs
@@ -13,359 +13,358 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch
+namespace NewRelic.Agent.UnboundedIntegrationTests.Elasticsearch;
+
+public abstract class ElasticsearchTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class ElasticsearchTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    protected enum ClientType
     {
-        protected enum ClientType
+        ElasticsearchNet,
+        NEST,
+        ElasticClients
+    }
+
+    protected readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected readonly string _host;
+
+    protected readonly ClientType _clientType;
+
+    const string IndexName = "flights";
+
+    protected readonly bool _syncMethodsOk;
+    const string SyncMethodSkipReason = "Synchronous methods are deprecated in latest Elastic.Clients.Elasticsearch";
+
+
+    protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, ClientType clientType,
+        bool syncMethodsOk = true, bool enableOTelBridge = false) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _clientType = clientType;
+        _syncMethodsOk = syncMethodsOk;
+
+        _host = GetHostFromElasticServer(_clientType);
+
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+
+        _fixture.AddCommand($"ElasticsearchExerciser SetClient {clientType}");
+
+        // Async operations
+        _fixture.AddCommand($"ElasticsearchExerciser IndexAsync");
+        _fixture.AddCommand($"ElasticsearchExerciser SearchAsync");
+        _fixture.AddCommand($"ElasticsearchExerciser IndexManyAsync");
+        _fixture.AddCommand($"ElasticsearchExerciser MultiSearchAsync");
+        _fixture.AddCommand($"ElasticsearchExerciser GenerateErrorAsync");
+
+        // Sync operations
+        if (_syncMethodsOk)
         {
-            ElasticsearchNet,
-            NEST,
-            ElasticClients
+            _fixture.AddCommand($"ElasticsearchExerciser Index");
+            _fixture.AddCommand($"ElasticsearchExerciser Search");
+            _fixture.AddCommand($"ElasticsearchExerciser IndexMany");
+            _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
+
         }
 
-        protected readonly ConsoleDynamicMethodFixture _fixture;
-
-        protected readonly string _host;
-
-        protected readonly ClientType _clientType;
-
-        const string IndexName = "flights";
-
-        protected readonly bool _syncMethodsOk;
-        const string SyncMethodSkipReason = "Synchronous methods are deprecated in latest Elastic.Clients.Elasticsearch";
-
-
-        protected ElasticsearchTestsBase(TFixture fixture, ITestOutputHelper output, ClientType clientType,
-            bool syncMethodsOk = true, bool enableOTelBridge = false) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _clientType = clientType;
-            _syncMethodsOk = syncMethodsOk;
-
-            _host = GetHostFromElasticServer(_clientType);
-
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
-
-            _fixture.AddCommand($"ElasticsearchExerciser SetClient {clientType}");
-
-            // Async operations
-            _fixture.AddCommand($"ElasticsearchExerciser IndexAsync");
-            _fixture.AddCommand($"ElasticsearchExerciser SearchAsync");
-            _fixture.AddCommand($"ElasticsearchExerciser IndexManyAsync");
-            _fixture.AddCommand($"ElasticsearchExerciser MultiSearchAsync");
-            _fixture.AddCommand($"ElasticsearchExerciser GenerateErrorAsync");
-
-            // Sync operations
-            if (_syncMethodsOk)
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                _fixture.AddCommand($"ElasticsearchExerciser Index");
-                _fixture.AddCommand($"ElasticsearchExerciser Search");
-                _fixture.AddCommand($"ElasticsearchExerciser IndexMany");
-                _fixture.AddCommand($"ElasticsearchExerciser MultiSearch");
-
-            }
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath)
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath)
                     .SetLogLevel("finest")
                     .ConfigureFasterMetricsHarvestCycle(15)
                     .ConfigureFasterErrorTracesHarvestCycle(15)
                     .ConfigureFasterSpanEventsHarvestCycle(15)
                     .ForceTransactionTraces();
 
-                    if (enableOTelBridge)
-                    {
-                        configModifier
-                            .EnableOpenTelemetry(true)
-                            .EnableOpenTelemetryTracing(true)
-                            .IncludeActivitySource("Elastic.Transport");
-                    }
-                },
-                exerciseApplication: () =>
+                if (enableOTelBridge)
                 {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                    configModifier
+                        .EnableOpenTelemetry(true)
+                        .EnableOpenTelemetryTracing(true)
+                        .IncludeActivitySource("Elastic.Transport");
                 }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Index()
-        {
-            Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
-            ValidateOperation("Index");
-        }
-
-        [Fact]
-        public void Search()
-        {
-            Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
-            ValidateOperation("Search");
-        }
-
-        [Fact]
-        public void IndexMany()
-        {
-            Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
-            ValidateOperation("IndexMany");
-        }
-
-        [Fact]
-        public void MultiSearch()
-        {
-            Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
-            ValidateOperation("MultiSearch");
-        }
-
-        [Fact]
-        public void IndexAsync()
-        {
-            ValidateOperation("IndexAsync");
-        }
-
-        [Fact]
-        public void SearchAsync()
-        {
-            ValidateOperation("SearchAsync");
-        }
-
-        [Fact]
-        public void IndexManyAsync()
-        {
-            ValidateOperation("IndexAsync");
-        }
-
-        [Fact]
-        public void MultiSearchAsync()
-        {
-            ValidateOperation("SearchAsync");
-        }
-
-        [Fact]
-        public void ErrorAsync()
-        {
-            if (_fixture is not ConsoleDynamicMethodFixtureFWLatest)
-                ValidateError("GenerateErrorAsync");
-            else
-                Assert.Skip("Not supported in Framework OTelBridge (FWLatest).");
-
-        }
-
-        private void ValidateError(string operationName)
-        {
-            var errorTrace =
-                _fixture.AgentLog.TryGetErrorTrace(
-                    $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/{operationName}");
-            Assert.NotNull(errorTrace);
-        }
-
-
-        private void ValidateOperation(string operationName)
-        {
-            var expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/{operationName}";
-
-            var expectedIndexName = GetExpectedIndexName(operationName, _clientType);
-            var expectedOperationName = GetExpectedOperationName(operationName);
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/Elasticsearch/{expectedIndexName}/{expectedOperationName}", metricScope = expectedTransactionName, callCount = 1 },
-            };
-            var expectedAgentAttributes = new List<string>
-            {
-                "db.system",
-                "db.operation",
-                "db.instance",
-                "peer.address",
-                "peer.hostname",
-                "server.address",
-                "server.port"
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents();
-
-            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
-
-            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/Elasticsearch"));
-
-            var operationDatastoreAgentAttributes = operationDatastoreSpans.FirstOrDefault()?.AgentAttributes;
-
-            var uri = operationDatastoreAgentAttributes?.Where(x => x.Key == "peer.address").FirstOrDefault().Value;
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Single(operationDatastoreSpans),
-                () => Assert.Equal(_host, uri),
-                () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
-            );
-        }
-
-        private string GetHostFromElasticServer(ClientType clientType)
-        {
-            // core latest fixture tests elasticsearch 9, which requires a different server configuration
-            string elasticServer;
-            if (_fixture is ConsoleDynamicMethodFixtureCoreLatest)
-                elasticServer = clientType == ClientType.ElasticClients ? ElasticSearch9Configuration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
-            else
-                elasticServer = clientType == ClientType.ElasticClients ? ElasticSearch8Configuration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
-
-            if (elasticServer.StartsWith("https://"))
-            {
-                return elasticServer.Remove(0, "https://".Length);
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
             }
-            else if (elasticServer.StartsWith("http://"))
-            {
-                return elasticServer.Remove(0, "http://".Length);
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
+        );
 
-        private static string GetExpectedIndexName(string operationName, ClientType clientType)
-        {
-            if (clientType != ClientType.ElasticsearchNet && operationName.StartsWith("MultiSearch"))
-            {
-                return "Unknown";
-            }
-            else if (clientType != ClientType.ElasticClients && operationName.StartsWith("IndexMany"))
-            {
-                return "Unknown";
-            }
-            else
-            {
-                return IndexName;
-            }
-        }
-        private static string GetExpectedOperationName(string operationName)
-        {
-            if (operationName.StartsWith("IndexMany"))
-            {
-                return "Bulk";
-            }
-            else
-            {
-                return operationName.Replace("Async", "");
-            }
-        }
-
+        _fixture.Initialize();
     }
 
-    #region NEST
-    public class ElasticsearchNestTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void Index()
     {
-        public ElasticsearchNestTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST)
-        {
-        }
+        Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
+        ValidateOperation("Index");
     }
 
-    public class ElasticsearchNestTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Search()
     {
-        public ElasticsearchNestTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST)
-        {
-        }
+        Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
+        ValidateOperation("Search");
     }
 
-    public class ElasticsearchNestTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    [Fact]
+    public void IndexMany()
     {
-        public ElasticsearchNestTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST)
-        {
-        }
+        Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
+        ValidateOperation("IndexMany");
     }
 
-    public class ElasticsearchNestTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+    [Fact]
+    public void MultiSearch()
     {
-        public ElasticsearchNestTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.NEST)
-        {
-        }
+        Assert.SkipUnless(_syncMethodsOk, SyncMethodSkipReason);
+        ValidateOperation("MultiSearch");
     }
 
-    #endregion NEST
-
-    #region ElasticsearchNet
-    public class ElasticsearchNetTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void IndexAsync()
     {
-        public ElasticsearchNetTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticsearchNet)
+        ValidateOperation("IndexAsync");
+    }
+
+    [Fact]
+    public void SearchAsync()
+    {
+        ValidateOperation("SearchAsync");
+    }
+
+    [Fact]
+    public void IndexManyAsync()
+    {
+        ValidateOperation("IndexAsync");
+    }
+
+    [Fact]
+    public void MultiSearchAsync()
+    {
+        ValidateOperation("SearchAsync");
+    }
+
+    [Fact]
+    public void ErrorAsync()
+    {
+        if (_fixture is not ConsoleDynamicMethodFixtureFWLatest)
+            ValidateError("GenerateErrorAsync");
+        else
+            Assert.Skip("Not supported in Framework OTelBridge (FWLatest).");
+
+    }
+
+    private void ValidateError(string operationName)
+    {
+        var errorTrace =
+            _fixture.AgentLog.TryGetErrorTrace(
+                $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/{operationName}");
+        Assert.NotNull(errorTrace);
+    }
+
+
+    private void ValidateOperation(string operationName)
+    {
+        var expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Elasticsearch.ElasticsearchExerciser/{operationName}";
+
+        var expectedIndexName = GetExpectedIndexName(operationName, _clientType);
+        var expectedOperationName = GetExpectedOperationName(operationName);
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/Elasticsearch/{expectedIndexName}/{expectedOperationName}", metricScope = expectedTransactionName, callCount = 1 },
+        };
+        var expectedAgentAttributes = new List<string>
+        {
+            "db.system",
+            "db.operation",
+            "db.instance",
+            "peer.address",
+            "peer.hostname",
+            "server.address",
+            "server.port"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+        var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+
+        var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/Elasticsearch"));
+
+        var operationDatastoreAgentAttributes = operationDatastoreSpans.FirstOrDefault()?.AgentAttributes;
+
+        var uri = operationDatastoreAgentAttributes?.Where(x => x.Key == "peer.address").FirstOrDefault().Value;
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assert.Single(operationDatastoreSpans),
+            () => Assert.Equal(_host, uri),
+            () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
+        );
+    }
+
+    private string GetHostFromElasticServer(ClientType clientType)
+    {
+        // core latest fixture tests elasticsearch 9, which requires a different server configuration
+        string elasticServer;
+        if (_fixture is ConsoleDynamicMethodFixtureCoreLatest)
+            elasticServer = clientType == ClientType.ElasticClients ? ElasticSearch9Configuration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
+        else
+            elasticServer = clientType == ClientType.ElasticClients ? ElasticSearch8Configuration.ElasticServer : ElasticSearch7Configuration.ElasticServer;
+
+        if (elasticServer.StartsWith("https://"))
+        {
+            return elasticServer.Remove(0, "https://".Length);
+        }
+        else if (elasticServer.StartsWith("http://"))
+        {
+            return elasticServer.Remove(0, "http://".Length);
+        }
+        else
+        {
+            return string.Empty;
         }
     }
 
-    public class ElasticsearchNetTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+    private static string GetExpectedIndexName(string operationName, ClientType clientType)
     {
-        public ElasticsearchNetTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
-            : base(fixture, output, ClientType.ElasticsearchNet)
+        if (clientType != ClientType.ElasticsearchNet && operationName.StartsWith("MultiSearch"))
         {
+            return "Unknown";
+        }
+        else if (clientType != ClientType.ElasticClients && operationName.StartsWith("IndexMany"))
+        {
+            return "Unknown";
+        }
+        else
+        {
+            return IndexName;
+        }
+    }
+    private static string GetExpectedOperationName(string operationName)
+    {
+        if (operationName.StartsWith("IndexMany"))
+        {
+            return "Bulk";
+        }
+        else
+        {
+            return operationName.Replace("Async", "");
         }
     }
 
-    public class ElasticsearchNetTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public ElasticsearchNetTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticsearchNet)
-        {
-        }
-    }
-
-    public class ElasticsearchNetTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public ElasticsearchNetTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticsearchNet)
-        {
-        }
-    }
-    #endregion ElasticsearchNet
-
-    #region ElasticClients
-    public class ElasticsearchElasticClientTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public ElasticsearchElasticClientTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticClients, syncMethodsOk: false, enableOTelBridge: true)
-        {
-        }
-    }
-
-    public class ElasticsearchElasticClientTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public ElasticsearchElasticClientTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticClients)
-        {
-        }
-    }
-
-    public class ElasticsearchElasticClientTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public ElasticsearchElasticClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticClients, syncMethodsOk: false, enableOTelBridge: true)
-        {
-        }
-    }
-
-    public class ElasticsearchElasticClientTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public ElasticsearchElasticClientTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, ClientType.ElasticClients)
-        {
-        }
-    }
-    #endregion ElasticClients
 }
+
+#region NEST
+public class ElasticsearchNestTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public ElasticsearchNestTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.NEST)
+    {
+    }
+}
+
+public class ElasticsearchNestTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public ElasticsearchNestTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.NEST)
+    {
+    }
+}
+
+public class ElasticsearchNestTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public ElasticsearchNestTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.NEST)
+    {
+    }
+}
+
+public class ElasticsearchNestTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public ElasticsearchNestTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.NEST)
+    {
+    }
+}
+
+#endregion NEST
+
+#region ElasticsearchNet
+public class ElasticsearchNetTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public ElasticsearchNetTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticsearchNet)
+    {
+    }
+}
+
+public class ElasticsearchNetTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public ElasticsearchNetTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        // FW462 is testing MongoDB.Driver version 2.3, which needs to connect to the 3.2 server
+        : base(fixture, output, ClientType.ElasticsearchNet)
+    {
+    }
+}
+
+public class ElasticsearchNetTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public ElasticsearchNetTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticsearchNet)
+    {
+    }
+}
+
+public class ElasticsearchNetTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public ElasticsearchNetTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticsearchNet)
+    {
+    }
+}
+#endregion ElasticsearchNet
+
+#region ElasticClients
+public class ElasticsearchElasticClientTestsFWLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public ElasticsearchElasticClientTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticClients, syncMethodsOk: false, enableOTelBridge: true)
+    {
+    }
+}
+
+public class ElasticsearchElasticClientTestsFW462 : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public ElasticsearchElasticClientTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticClients)
+    {
+    }
+}
+
+public class ElasticsearchElasticClientTestsCoreLatest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public ElasticsearchElasticClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticClients, syncMethodsOk: false, enableOTelBridge: true)
+    {
+    }
+}
+
+public class ElasticsearchElasticClientTestsCoreOldest : ElasticsearchTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public ElasticsearchElasticClientTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, ClientType.ElasticClients)
+    {
+    }
+}
+#endregion ElasticClients

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverCollectionTests.cs
@@ -2,215 +2,213 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+using System;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
-using System;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB;
+
+public abstract class MongoDBDriverCollectionTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MongoDBDriverCollectionTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    private MongoDBDriverVersion _driverVersion;
+
+    private string _mongoUrl;
+
+    private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
+
+    public MongoDBDriverCollectionTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _mongoUrl = mongoUrl;
+        _driverVersion = driverVersion;
 
-        private MongoDBDriverVersion _driverVersion;
+        _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
+        // Async methods first
+        _fixture.AddCommand("MongoDbDriverExerciser AggregateAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser CountAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser DeleteManyAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser DeleteOneAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser DistinctAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser FindAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDeleteAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplaceAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdateAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser InsertManyAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser InsertOneAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser MapReduceAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser ReplaceOneAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser UpdateManyAsync");
+        _fixture.AddCommand("MongoDbDriverExerciser UpdateOneAsync");
+        // Then sync methods
+        _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
+        _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
+        _fixture.AddCommand("MongoDbDriverExerciser Count");
+        _fixture.AddCommand("MongoDbDriverExerciser DeleteMany");
+        _fixture.AddCommand("MongoDbDriverExerciser DeleteOne");
+        _fixture.AddCommand("MongoDbDriverExerciser Distinct");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDelete");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplace");
+        _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdate");
+        _fixture.AddCommand("MongoDbDriverExerciser FindSync");
+        _fixture.AddCommand("MongoDbDriverExerciser MapReduce");
+        _fixture.AddCommand("MongoDbDriverExerciser InsertMany");
+        _fixture.AddCommand("MongoDbDriverExerciser InsertOne");
+        _fixture.AddCommand("MongoDbDriverExerciser ReplaceOne");
+        _fixture.AddCommand("MongoDbDriverExerciser UpdateMany");
+        _fixture.AddCommand("MongoDbDriverExerciser UpdateOne");
 
-        private string _mongoUrl;
-
-        private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
-
-        public MongoDBDriverCollectionTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion) : base(fixture)
+        // the following commands are unavailable in MongoDB.Driver version 2.3
+        if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
         {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _mongoUrl = mongoUrl;
-            _driverVersion = driverVersion;
+            _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
+            _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCount");
+            _fixture.AddCommand("MongoDbDriverExerciser Watch");
+        }
 
-            _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            // Async methods first
-            _fixture.AddCommand("MongoDbDriverExerciser AggregateAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser BulkWriteAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser CountAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser DistinctAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDeleteAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplaceAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdateAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser MapReduceAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOneAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateManyAsync");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateOneAsync");
-             // Then sync methods
-            _fixture.AddCommand("MongoDbDriverExerciser Aggregate");
-            _fixture.AddCommand("MongoDbDriverExerciser BulkWrite");
-            _fixture.AddCommand("MongoDbDriverExerciser Count");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteMany");
-            _fixture.AddCommand("MongoDbDriverExerciser DeleteOne");
-            _fixture.AddCommand("MongoDbDriverExerciser Distinct");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndDelete");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndReplace");
-            _fixture.AddCommand("MongoDbDriverExerciser FindOneAndUpdate");
-            _fixture.AddCommand("MongoDbDriverExerciser FindSync");
-            _fixture.AddCommand("MongoDbDriverExerciser MapReduce");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertMany");
-            _fixture.AddCommand("MongoDbDriverExerciser InsertOne");
-            _fixture.AddCommand("MongoDbDriverExerciser ReplaceOne");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateMany");
-            _fixture.AddCommand("MongoDbDriverExerciser UpdateOne");
+        // the following commands are unavailable in MongoDB.Driver versions <2.11
+        if (_driverVersion >= MongoDBDriverVersion.AtLeast2_11)
+        {
+            _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollectionAsync");
+            _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
+        }
 
-            // the following commands are unavailable in MongoDB.Driver version 2.3
-            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                _fixture.AddCommand("MongoDbDriverExerciser CountDocumentsAsync");
-                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCountAsync");
-                _fixture.AddCommand("MongoDbDriverExerciser WatchAsync");
-                _fixture.AddCommand("MongoDbDriverExerciser CountDocuments");
-                _fixture.AddCommand("MongoDbDriverExerciser EstimatedDocumentCount");
-                _fixture.AddCommand("MongoDbDriverExerciser Watch");
-            }
-
-            // the following commands are unavailable in MongoDB.Driver versions <2.11
-            if (_driverVersion >= MongoDBDriverVersion.AtLeast2_11)
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+            },
+            exerciseApplication: () =>
             {
-                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollectionAsync");
-                _fixture.AddCommand("MongoDbDriverExerciser AggregateToCollection");
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
             }
+        );
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void CheckForDatastoreInstanceMetrics()
-        {
-            var mongoUri = new UriBuilder(_mongoUrl);
-            var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
-            Assert.NotNull(m);
-        }
-
-        [Theory]
-        [InlineData("Count", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("CountAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("Distinct", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("DistinctAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("MapReduce", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("MapReduceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("InsertOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("InsertOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("InsertMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("InsertManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("ReplaceOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("ReplaceOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("UpdateOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("UpdateOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("UpdateMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("UpdateManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("DeleteOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("DeleteOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("DeleteMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("DeleteManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindSync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndDelete", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndDeleteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndReplace", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndReplaceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndUpdate", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("FindOneAndUpdateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("BulkWrite", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("BulkWriteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("Aggregate", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("AggregateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-
-        // Methods unavailable in driver version 2.3
-        [InlineData("CountDocuments", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("CountDocumentsAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("EstimatedDocumentCount", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("EstimatedDocumentCountAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
-
-        //Methods availabile in driver versions >= 2.11
-        [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
-        [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
-
-        public void CheckForMethodMetrics(string methodName, MongoDBDriverVersion minVersion)
-        {
-            if (_driverVersion >= minVersion)
-            {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{methodName}");
-                Assert.True(m != null, $"Did not find metric for db operation named {methodName}");
-            }
-        }
-
+        _fixture.Initialize();
     }
 
-    public class MongoDBDriverCollectionTestsFWLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void CheckForDatastoreInstanceMetrics()
     {
-        public MongoDBDriverCollectionTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
+        var mongoUri = new UriBuilder(_mongoUrl);
+        var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
+        var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
+        Assert.NotNull(m);
+    }
+
+    [Theory]
+    [InlineData("Count", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("CountAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("Distinct", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("DistinctAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("MapReduce", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("MapReduceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("InsertOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("InsertOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("InsertMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("InsertManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("ReplaceOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("ReplaceOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("UpdateOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("UpdateOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("UpdateMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("UpdateManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("DeleteOne", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("DeleteOneAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("DeleteMany", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("DeleteManyAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindSync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndDelete", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndDeleteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndReplace", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndReplaceAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndUpdate", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("FindOneAndUpdateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("BulkWrite", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("BulkWriteAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("Aggregate", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("AggregateAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+
+    // Methods unavailable in driver version 2.3
+    [InlineData("CountDocuments", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("CountDocumentsAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("EstimatedDocumentCount", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("EstimatedDocumentCountAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+
+    //Methods availabile in driver versions >= 2.11
+    [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
+    [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
+
+    public void CheckForMethodMetrics(string methodName, MongoDBDriverVersion minVersion)
+    {
+        if (_driverVersion >= minVersion)
         {
+            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{methodName}");
+            Assert.True(m != null, $"Did not find metric for db operation named {methodName}");
         }
     }
 
-    public class MongoDBDriverCollectionTestsFW48 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public MongoDBDriverCollectionTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
-        {
-        }
-    }
+}
 
-    public class MongoDBDriverCollectionTestsFW471 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MongoDBDriverCollectionTestsFWLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MongoDBDriverCollectionTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        public MongoDBDriverCollectionTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverCollectionTestsCoreLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MongoDBDriverCollectionTestsFW48 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MongoDBDriverCollectionTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        public MongoDBDriverCollectionTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverCollectionTestsCoreOldest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MongoDBDriverCollectionTestsFW471 : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MongoDBDriverCollectionTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
     {
-        public MongoDBDriverCollectionTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
-        {
-        }
     }
+}
 
-    public enum MongoDBDriverVersion
+public class MongoDBDriverCollectionTestsCoreLatest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MongoDBDriverCollectionTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        OldestSupportedOnFramework, // 2.3
-        OldestSupportedOnCore, // 2.8.1
-        AtLeast2_11 // 2.11 or greater
     }
+}
 
+public class MongoDBDriverCollectionTestsCoreOldest : MongoDBDriverCollectionTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MongoDBDriverCollectionTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
+    {
+    }
+}
+
+public enum MongoDBDriverVersion
+{
+    OldestSupportedOnFramework, // 2.3
+    OldestSupportedOnCore, // 2.8.1
+    AtLeast2_11 // 2.11 or greater
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverDatabaseTests.cs
@@ -8,158 +8,156 @@ using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB;
+
+public abstract class MongoDBDriverDatabaseTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MongoDBDriverDatabaseTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private string _mongoUrl;
+    private MongoDBDriverVersion _driverVersion;
+
+    private readonly string DatastoreStatementPathBase = "Datastore/statement/MongoDB";
+    private readonly string DatastoreOperationPathBase = "Datastore/operation/MongoDB";
+
+    public MongoDBDriverDatabaseTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion)  : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private string _mongoUrl;
-        private MongoDBDriverVersion _driverVersion;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _mongoUrl = mongoUrl;
+        _driverVersion = driverVersion;
 
-        private readonly string DatastoreStatementPathBase = "Datastore/statement/MongoDB";
-        private readonly string DatastoreOperationPathBase = "Datastore/operation/MongoDB";
+        _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
+        // Async methods first
+        _fixture.AddCommand("MongoDBDriverExerciser CreateCollectionAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser DropCollectionAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser ListCollectionsAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser RenameCollectionAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser RunCommandAsync");
+        // Then sync methods
+        _fixture.AddCommand("MongoDBDriverExerciser CreateCollection");
+        _fixture.AddCommand("MongoDBDriverExerciser DropCollection");
+        _fixture.AddCommand("MongoDBDriverExerciser ListCollections");
+        _fixture.AddCommand("MongoDBDriverExerciser RenameCollection");
+        _fixture.AddCommand("MongoDBDriverExerciser RunCommand");
 
-        public MongoDBDriverDatabaseTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl, MongoDBDriverVersion driverVersion)  : base(fixture)
+        if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
         {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _mongoUrl = mongoUrl;
-            _driverVersion = driverVersion;
-
-            _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-             // Async methods first
-            _fixture.AddCommand("MongoDBDriverExerciser CreateCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser ListCollectionsAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser RenameCollectionAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser RunCommandAsync");
-            // Then sync methods
-            _fixture.AddCommand("MongoDBDriverExerciser CreateCollection");
-            _fixture.AddCommand("MongoDBDriverExerciser DropCollection");
-            _fixture.AddCommand("MongoDBDriverExerciser ListCollections");
-            _fixture.AddCommand("MongoDBDriverExerciser RenameCollection");
-            _fixture.AddCommand("MongoDBDriverExerciser RunCommand");
-
-            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnFramework)
-            {
-                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser WatchDBAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
-                _fixture.AddCommand("MongoDBDriverExerciser WatchDB");
-            }
-
-            if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnCore)
-            {
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollectionAsync");
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
-                _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
-            }
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
+            _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNamesAsync");
+            _fixture.AddCommand("MongoDBDriverExerciser WatchDBAsync");
+            _fixture.AddCommand("MongoDBDriverExerciser ListCollectionNames");
+            _fixture.AddCommand("MongoDBDriverExerciser WatchDB");
         }
 
-        [Fact]
-        public void CheckForDatastoreInstanceMetrics()
+        if (_driverVersion > MongoDBDriverVersion.OldestSupportedOnCore)
         {
-            var mongoUri = new UriBuilder(_mongoUrl);
-            var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
+            _fixture.AddCommand("MongoDBDriverExerciser AggregateDBAsync");
+            _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollectionAsync");
+            _fixture.AddCommand("MongoDBDriverExerciser AggregateDB");
+            _fixture.AddCommand("MongoDBDriverExerciser AggregateDBToCollection");
+        }
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void CheckForDatastoreInstanceMetrics()
+    {
+        var mongoUri = new UriBuilder(_mongoUrl);
+        var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
+        var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
+        Assert.NotNull(m);
+    }
+
+    [Theory]
+    [InlineData("createTestCollection", "CreateCollection")]
+    [InlineData("createTestCollectionAsync", "CreateCollectionAsync")]
+    [InlineData("dropTestCollection", "DropCollection")]
+    [InlineData("dropTestCollectionAsync", "DropCollectionAsync")]
+    public void CheckForStatementMetrics(string collectionName, string operationName)
+    {
+        var m = _fixture.AgentLog.GetMetricByName($"{DatastoreStatementPathBase}/{collectionName}/{operationName}");
+        Assert.NotNull(m);
+    }
+
+    [Theory]
+    [InlineData("ListCollections", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("ListCollectionsAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("RenameCollection", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("RenameCollectionAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("RunCommand", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    [InlineData("RunCommandAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
+    // Methods not available in driver version 2.3
+    [InlineData("ListCollectionNames", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("ListCollectionNamesAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
+    [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
+    // Methods not available in driver version 2.8
+    [InlineData("Aggregate", MongoDBDriverVersion.AtLeast2_11)]
+    [InlineData("AggregateAsync", MongoDBDriverVersion.AtLeast2_11)]
+    [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
+    [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
+    public void CheckForOperationMetrics(string operationName, MongoDBDriverVersion minVersion)
+    {
+        if (_driverVersion >= minVersion)
+        {
+            var m = _fixture.AgentLog.GetMetricByName($"{DatastoreOperationPathBase}/{operationName}");
             Assert.NotNull(m);
         }
-
-        [Theory]
-        [InlineData("createTestCollection", "CreateCollection")]
-        [InlineData("createTestCollectionAsync", "CreateCollectionAsync")]
-        [InlineData("dropTestCollection", "DropCollection")]
-        [InlineData("dropTestCollectionAsync", "DropCollectionAsync")]
-        public void CheckForStatementMetrics(string collectionName, string operationName)
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastoreStatementPathBase}/{collectionName}/{operationName}");
-            Assert.NotNull(m);
-        }
-
-        [Theory]
-        [InlineData("ListCollections", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("ListCollectionsAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("RenameCollection", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("RenameCollectionAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("RunCommand", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        [InlineData("RunCommandAsync", MongoDBDriverVersion.OldestSupportedOnFramework)]
-        // Methods not available in driver version 2.3
-        [InlineData("ListCollectionNames", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("ListCollectionNamesAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("Watch", MongoDBDriverVersion.OldestSupportedOnCore)]
-        [InlineData("WatchAsync", MongoDBDriverVersion.OldestSupportedOnCore)]
-        // Methods not available in driver version 2.8
-        [InlineData("Aggregate", MongoDBDriverVersion.AtLeast2_11)]
-        [InlineData("AggregateAsync", MongoDBDriverVersion.AtLeast2_11)]
-        [InlineData("AggregateToCollection", MongoDBDriverVersion.AtLeast2_11)]
-        [InlineData("AggregateToCollectionAsync", MongoDBDriverVersion.AtLeast2_11)]
-        public void CheckForOperationMetrics(string operationName, MongoDBDriverVersion minVersion)
-        {
-            if (_driverVersion >= minVersion)
-            {
-                var m = _fixture.AgentLog.GetMetricByName($"{DatastoreOperationPathBase}/{operationName}");
-                Assert.NotNull(m);
-            }
-        }
-
     }
 
-    public class MongoDBDriverDatabaseTestsFWLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+}
+
+public class MongoDBDriverDatabaseTestsFWLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MongoDBDriverDatabaseTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        public MongoDBDriverDatabaseTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverDatabaseTestsFW48 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MongoDBDriverDatabaseTestsFW48 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MongoDBDriverDatabaseTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        public MongoDBDriverDatabaseTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverDatabaseTestsFW471 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MongoDBDriverDatabaseTestsFW471 : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MongoDBDriverDatabaseTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
     {
-        public MongoDBDriverDatabaseTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString, MongoDBDriverVersion.OldestSupportedOnFramework)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverDatabaseTestsCoreLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MongoDBDriverDatabaseTestsCoreLatest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MongoDBDriverDatabaseTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
     {
-        public MongoDBDriverDatabaseTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.AtLeast2_11)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverDatabaseTestsCoreOldest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MongoDBDriverDatabaseTestsCoreOldest : MongoDBDriverDatabaseTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MongoDBDriverDatabaseTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
     {
-        public MongoDBDriverDatabaseTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString, MongoDBDriverVersion.OldestSupportedOnCore)
-        {
-        }
     }
-
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverIndexManagerTests.cs
@@ -8,119 +8,117 @@ using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB;
+
+public abstract class MongoDBDriverIndexManagerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MongoDBDriverIndexManagerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private string _mongoUrl;
+
+    private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
+
+    public MongoDBDriverIndexManagerTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private string _mongoUrl;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _mongoUrl = mongoUrl;
 
-        private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
+        _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
+        // Async methods first
+        _fixture.AddCommand("MongoDBDriverExerciser CreateManyAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser CreateOneAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser DropAllAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser DropOneAsync");
+        _fixture.AddCommand("MongoDBDriverExerciser ListAsync");
+        // Then sync
+        _fixture.AddCommand("MongoDBDriverExerciser CreateMany");
+        _fixture.AddCommand("MongoDBDriverExerciser CreateOne");
+        _fixture.AddCommand("MongoDBDriverExerciser DropAll");
+        _fixture.AddCommand("MongoDBDriverExerciser DropOne");
+        _fixture.AddCommand("MongoDBDriverExerciser List");
 
-        public MongoDBDriverIndexManagerTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _mongoUrl = mongoUrl;
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            // Async methods first
-            _fixture.AddCommand("MongoDBDriverExerciser CreateManyAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateOneAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropAllAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser DropOneAsync");
-            _fixture.AddCommand("MongoDBDriverExerciser ListAsync");
-            // Then sync
-            _fixture.AddCommand("MongoDBDriverExerciser CreateMany");
-            _fixture.AddCommand("MongoDBDriverExerciser CreateOne");
-            _fixture.AddCommand("MongoDBDriverExerciser DropAll");
-            _fixture.AddCommand("MongoDBDriverExerciser DropOne");
-            _fixture.AddCommand("MongoDBDriverExerciser List");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void CheckForDatastoreInstanceMetrics()
-        {
-            var mongoUri = new UriBuilder(_mongoUrl);
-            var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
-            Assert.NotNull(m);
-        }
-
-        [Theory]
-        [InlineData("CreateOne")]
-        [InlineData("CreateOneAsync")]
-        [InlineData("CreateMany")]
-        [InlineData("CreateManyAsync")]
-        [InlineData("DropAll")]
-        [InlineData("DropAllAsync")]
-        [InlineData("DropOne")]
-        [InlineData("DropOneAsync")]
-        [InlineData("List")]
-        [InlineData("ListAsync")]
-        public void CheckForOperationMetrics(string operationName)
-        {
-            var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{operationName}");
-            Assert.NotNull(m);
-        }
-
+        _fixture.Initialize();
     }
 
-    public class MongoDBDriverIndexManagerTestsFWLatest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void CheckForDatastoreInstanceMetrics()
     {
-        public MongoDBDriverIndexManagerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
+        var mongoUri = new UriBuilder(_mongoUrl);
+        var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
+        var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
+        Assert.NotNull(m);
     }
 
-    public class MongoDBDriverIndexManagerTestsFW48 : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFW48>
+    [Theory]
+    [InlineData("CreateOne")]
+    [InlineData("CreateOneAsync")]
+    [InlineData("CreateMany")]
+    [InlineData("CreateManyAsync")]
+    [InlineData("DropAll")]
+    [InlineData("DropAllAsync")]
+    [InlineData("DropOne")]
+    [InlineData("DropOneAsync")]
+    [InlineData("List")]
+    [InlineData("ListAsync")]
+    public void CheckForOperationMetrics(string operationName)
     {
-        public MongoDBDriverIndexManagerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
+        var m = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/{operationName}");
+        Assert.NotNull(m);
     }
 
-    public class MongoDBDriverIndexManagerTestsFW471 : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public MongoDBDriverIndexManagerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString)
-        {
-        }
-    }
+}
 
-    public class MongoDBDriverIndexManagerTestsCoreLatest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MongoDBDriverIndexManagerTestsFWLatest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MongoDBDriverIndexManagerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
     {
-        public MongoDBDriverIndexManagerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
     }
+}
 
-    public class MongoDBDriverIndexManagerTestsCoreOldest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MongoDBDriverIndexManagerTestsFW48 : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MongoDBDriverIndexManagerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
     {
-        public MongoDBDriverIndexManagerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
     }
+}
 
+public class MongoDBDriverIndexManagerTestsFW471 : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MongoDBDriverIndexManagerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString)
+    {
+    }
+}
+
+public class MongoDBDriverIndexManagerTestsCoreLatest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MongoDBDriverIndexManagerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+    {
+    }
+}
+
+public class MongoDBDriverIndexManagerTestsCoreOldest : MongoDBDriverIndexManagerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MongoDBDriverIndexManagerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+    {
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBDriverQueryProviderTests.cs
@@ -8,116 +8,114 @@ using NewRelic.Agent.IntegrationTests.Shared;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB;
+
+public abstract class MongoDBDriverQueryProviderTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MongoDBDriverQueryProviderTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    private string _mongoUrl;
+
+    private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
+
+    public MongoDBDriverQueryProviderTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl)  : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _mongoUrl = mongoUrl;
 
-        private string _mongoUrl;
+        _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
+        _fixture.AddCommand("MongoDBDriverExerciser ExecuteModel");
+        _fixture.AddCommand("MongoDBDriverExerciser ExecuteModelAsync");
 
-        private readonly string DatastorePath = "Datastore/statement/MongoDB/myCollection";
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-        public MongoDBDriverQueryProviderTestsBase(TFixture fixture, ITestOutputHelper output, string mongoUrl)  : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _mongoUrl = mongoUrl;
-
-            _fixture.AddCommand($"MongoDbDriverExerciser SetMongoUrl {_mongoUrl}");
-            _fixture.AddCommand("MongoDBDriverExerciser ExecuteModel");
-            _fixture.AddCommand("MongoDBDriverExerciser ExecuteModelAsync");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void CheckForDatastoreInstanceMetrics()
-        {
-            var mongoUri = new UriBuilder(_mongoUrl);
-            var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
-            var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
-            Assert.NotNull(m);
-        }
-
-        [Fact]
-        public void ExecuteModel()
-        {
-            // Starting with driver version 2.14.0, the operation name we generate for
-            // "Collection.AsQueryable()" changed from LinqQuery to Aggregate
-            // TODO: figure out if this is a bug
-            // TODO: figure out a cleaner way of handling this difference
-            var linqQueryMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/LinqQuery");
-            var aggregateMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Aggregate");
-
-            Assert.True(linqQueryMetric != null || aggregateMetric != null);
-        }
-
-        [Fact]
-        public void ExecuteModelAsync()
-        {
-            // See comments for ExecuteModel above
-            var linqQueryMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/LinqQueryAsync");
-            var aggregateMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/AggregateAsync");
-
-            Assert.True(linqQueryMetric != null || aggregateMetric != null);
-        }
-
+        _fixture.Initialize();
     }
 
-    public class MongoDBDriverQueryProviderTestsFWLatest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void CheckForDatastoreInstanceMetrics()
     {
-        public MongoDBDriverQueryProviderTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
+        var mongoUri = new UriBuilder(_mongoUrl);
+        var serverHost = CommonUtils.NormalizeHostname(mongoUri.Host);
+        var m = _fixture.AgentLog.GetMetricByName($"Datastore/instance/MongoDB/{serverHost}/{mongoUri.Port}");
+        Assert.NotNull(m);
     }
 
-    public class MongoDBDriverQueryProviderTestsFW48 : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFW48>
+    [Fact]
+    public void ExecuteModel()
     {
-        public MongoDBDriverQueryProviderTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
+        // Starting with driver version 2.14.0, the operation name we generate for
+        // "Collection.AsQueryable()" changed from LinqQuery to Aggregate
+        // TODO: figure out if this is a bug
+        // TODO: figure out a cleaner way of handling this difference
+        var linqQueryMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/LinqQuery");
+        var aggregateMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/Aggregate");
+
+        Assert.True(linqQueryMetric != null || aggregateMetric != null);
     }
 
-    public class MongoDBDriverQueryProviderTestsFW471 : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void ExecuteModelAsync()
     {
-        public MongoDBDriverQueryProviderTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString)
-        {
-        }
+        // See comments for ExecuteModel above
+        var linqQueryMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/LinqQueryAsync");
+        var aggregateMetric = _fixture.AgentLog.GetMetricByName($"{DatastorePath}/AggregateAsync");
+
+        Assert.True(linqQueryMetric != null || aggregateMetric != null);
     }
 
-    public class MongoDBDriverQueryProviderTestsCoreLatest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MongoDBDriverQueryProviderTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
-    }
+}
 
-    public class MongoDBDriverQueryProviderTestsCoreOldest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MongoDBDriverQueryProviderTestsFWLatest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MongoDBDriverQueryProviderTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
     {
-        public MongoDBDriverQueryProviderTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
-        {
-        }
     }
+}
 
+public class MongoDBDriverQueryProviderTestsFW48 : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MongoDBDriverQueryProviderTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+    {
+    }
+}
+
+public class MongoDBDriverQueryProviderTestsFW471 : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MongoDBDriverQueryProviderTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb3_2ConnectionString)
+    {
+    }
+}
+
+public class MongoDBDriverQueryProviderTestsCoreLatest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MongoDBDriverQueryProviderTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+    {
+    }
+}
+
+public class MongoDBDriverQueryProviderTestsCoreOldest : MongoDBDriverQueryProviderTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MongoDBDriverQueryProviderTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, MongoDbConfiguration.MongoDb6_0ConnectionString)
+    {
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MongoDB/MongoDBLegacyTests.cs
@@ -10,130 +10,129 @@ using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB
+namespace NewRelic.Agent.UnboundedIntegrationTests.MongoDB;
+
+public class MongoDBLegacyTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW462>
 {
-    public class MongoDBLegacyTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW462>
+    private const string CollectionName = "myCollection";
+    private const string StatementRoot = "Datastore/statement/MongoDB/" + CollectionName;
+    private const string OperationRoot = "Datastore/operation/MongoDB";
+    private const string TransactionRoot = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB.MongoDBLegacyExerciser";
+
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public MongoDBLegacyTests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture)
     {
-        private const string CollectionName = "myCollection";
-        private const string StatementRoot = "Datastore/statement/MongoDB/" + CollectionName;
-        private const string OperationRoot = "Datastore/operation/MongoDB";
-        private const string TransactionRoot = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MongoDB.MongoDBLegacyExerciser";
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture.AddCommand($"MongoDBLegacyExerciser SetupClient");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Insert");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Find");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindOne");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindOneById");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindOneAs");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindAll");
+        _fixture.AddCommand($"MongoDBLegacyExerciser GenericFind");
+        _fixture.AddCommand($"MongoDBLegacyExerciser GenericFindAs");
+        _fixture.AddCommand($"MongoDBLegacyExerciser CursorGetEnumerator");
+        _fixture.AddCommand($"MongoDBLegacyExerciser OrderedBulkInsert");
+        _fixture.AddCommand($"MongoDBLegacyExerciser UnorderedBulkInsert");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Update");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Remove");
+        _fixture.AddCommand($"MongoDBLegacyExerciser RemoveAll");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindAndModify");
+        _fixture.AddCommand($"MongoDBLegacyExerciser FindAndRemove");
+        _fixture.AddCommand($"MongoDBLegacyExerciser CreateIndex");
+        _fixture.AddCommand($"MongoDBLegacyExerciser GetIndexes");
+        _fixture.AddCommand($"MongoDBLegacyExerciser IndexExistsByName");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Aggregate");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Validate");
+        _fixture.AddCommand($"MongoDBLegacyExerciser ParallelScanAs");
+        _fixture.AddCommand($"MongoDBLegacyExerciser Drop");
+        _fixture.AddCommand($"MongoDBLegacyExerciser CleanupClient");
 
-        public MongoDBLegacyTests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-
-            _fixture.AddCommand($"MongoDBLegacyExerciser SetupClient");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Insert");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Find");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindOne");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindOneById");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindOneAs");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindAll");
-            _fixture.AddCommand($"MongoDBLegacyExerciser GenericFind");
-            _fixture.AddCommand($"MongoDBLegacyExerciser GenericFindAs");
-            _fixture.AddCommand($"MongoDBLegacyExerciser CursorGetEnumerator");
-            _fixture.AddCommand($"MongoDBLegacyExerciser OrderedBulkInsert");
-            _fixture.AddCommand($"MongoDBLegacyExerciser UnorderedBulkInsert");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Update");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Remove");
-            _fixture.AddCommand($"MongoDBLegacyExerciser RemoveAll");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindAndModify");
-            _fixture.AddCommand($"MongoDBLegacyExerciser FindAndRemove");
-            _fixture.AddCommand($"MongoDBLegacyExerciser CreateIndex");
-            _fixture.AddCommand($"MongoDBLegacyExerciser GetIndexes");
-            _fixture.AddCommand($"MongoDBLegacyExerciser IndexExistsByName");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Aggregate");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Validate");
-            _fixture.AddCommand($"MongoDBLegacyExerciser ParallelScanAs");
-            _fixture.AddCommand($"MongoDBLegacyExerciser Drop");
-            _fixture.AddCommand($"MongoDBLegacyExerciser CleanupClient");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedDatastoreCallCount = 55;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/allOther", callCount = expectedDatastoreCallCount },
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
+    }
 
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/CreateCollection", metricScope = $"{TransactionRoot}/SetupClient" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Insert", metricScope = $"{TransactionRoot}/Insert" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/Find" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOne" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOneById" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOneAs" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAll", metricScope = $"{TransactionRoot}/FindAll" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/GenericFind" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/GenericFindAs" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/GetEnumerator", metricScope = $"{TransactionRoot}/CursorGetEnumerator" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/InitializeOrderedBulkOperation", metricScope = $"{TransactionRoot}/OrderedBulkInsert" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/InitializeUnorderedBulkOperation", metricScope = $"{TransactionRoot}/UnorderedBulkInsert" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Update", metricScope = $"{TransactionRoot}/Update" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Remove", metricScope = $"{TransactionRoot}/Remove" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/RemoveAll", metricScope = $"{TransactionRoot}/RemoveAll" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAndModify", metricScope = $"{TransactionRoot}/FindAndModify" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAndRemove", metricScope = $"{TransactionRoot}/FindAndRemove" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/CreateIndex", metricScope = $"{TransactionRoot}/CreateIndex" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/GetIndexes", metricScope = $"{TransactionRoot}/GetIndexes" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/IndexExistsByName", metricScope = $"{TransactionRoot}/IndexExistsByName" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Aggregate", metricScope = $"{TransactionRoot}/Aggregate" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Validate", metricScope = $"{TransactionRoot}/Validate" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/ParallelScanAs", metricScope = $"{TransactionRoot}/ParallelScanAs" },
-                new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Drop", metricScope = $"{TransactionRoot}/Drop" },
+    [Fact]
+    public void Test()
+    {
+        var expectedDatastoreCallCount = 55;
 
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/CreateCollection" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Insert" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Find" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindOne" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/GetEnumerator" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAll" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/InitializeOrderedBulkOperation" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/BulkWriteOperation Insert" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/BulkWriteOperation Execute" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/InitializeUnorderedBulkOperation" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Update" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Remove" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/RemoveAll" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAndModify" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAndRemove" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/CreateIndex" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/GetIndexes" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/IndexExistsByName" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Aggregate" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Validate" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/ParallelScanAs" },
-                new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Drop" },
-            };
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/allOther", callCount = expectedDatastoreCallCount },
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/CreateCollection", metricScope = $"{TransactionRoot}/SetupClient" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Insert", metricScope = $"{TransactionRoot}/Insert" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/Find" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOne" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOneById" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindOne", metricScope = $"{TransactionRoot}/FindOneAs" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAll", metricScope = $"{TransactionRoot}/FindAll" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/GenericFind" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Find", metricScope = $"{TransactionRoot}/GenericFindAs" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/GetEnumerator", metricScope = $"{TransactionRoot}/CursorGetEnumerator" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/InitializeOrderedBulkOperation", metricScope = $"{TransactionRoot}/OrderedBulkInsert" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/InitializeUnorderedBulkOperation", metricScope = $"{TransactionRoot}/UnorderedBulkInsert" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Update", metricScope = $"{TransactionRoot}/Update" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Remove", metricScope = $"{TransactionRoot}/Remove" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/RemoveAll", metricScope = $"{TransactionRoot}/RemoveAll" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAndModify", metricScope = $"{TransactionRoot}/FindAndModify" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/FindAndRemove", metricScope = $"{TransactionRoot}/FindAndRemove" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/CreateIndex", metricScope = $"{TransactionRoot}/CreateIndex" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/GetIndexes", metricScope = $"{TransactionRoot}/GetIndexes" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/IndexExistsByName", metricScope = $"{TransactionRoot}/IndexExistsByName" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Aggregate", metricScope = $"{TransactionRoot}/Aggregate" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Validate", metricScope = $"{TransactionRoot}/Validate" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/ParallelScanAs", metricScope = $"{TransactionRoot}/ParallelScanAs" },
+            new Assertions.ExpectedMetric { metricName = $@"{StatementRoot}/Drop", metricScope = $"{TransactionRoot}/Drop" },
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics)
-            );
-        }
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/CreateCollection" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Insert" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Find" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindOne" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/GetEnumerator" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAll" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/InitializeOrderedBulkOperation" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/BulkWriteOperation Insert" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/BulkWriteOperation Execute" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/InitializeUnorderedBulkOperation" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Update" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Remove" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/RemoveAll" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAndModify" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/FindAndRemove" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/CreateIndex" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/GetIndexes" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/IndexExistsByName" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Aggregate" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Validate" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/ParallelScanAs" },
+            new Assertions.ExpectedMetric { metricName = $@"{OperationRoot}/Drop" },
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics)
+        );
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/EnterpriseLibraryMsSqlTests.cs
@@ -13,177 +13,176 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public class EnterpriseLibraryMsSqlTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW462>
 {
-    public class EnterpriseLibraryMsSqlTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW462>
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _tableName;
+
+    public EnterpriseLibraryMsSqlTests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _tableName;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.EnterpriseLibraryClientExerciser/MsSql";
 
-        public EnterpriseLibraryMsSqlTests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture)
+        _tableName = Utilities.GenerateTableName();
+
+        _fixture.AddCommand($"EnterpriseLibraryClientExerciser CreateTable {_tableName}");
+        _fixture.AddCommand($"EnterpriseLibraryClientExerciser MsSql {_tableName}");
+        _fixture.AddCommand($"EnterpriseLibraryClientExerciser Wait 5000"); // TBD if this is really necessary
+        _fixture.AddCommand($"EnterpriseLibraryClientExerciser DropTable {_tableName}");
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+
+                configModifier.ForceTransactionTraces();
+
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedDatastoreCallCount = 4;
+
+        //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+        //This results in a call to Read which succeeds followed by a call to NextResult and then another call to Read that doesn't succeed. Therefore
+        //the call count for the Iterate metric should be 3.
+
+        var expectedIterateCallCount = 3;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.EnterpriseLibraryClientExerciser/MsSql";
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = _expectedTransactionName}
+        };
 
-            _tableName = Utilities.GenerateTableName();
-
-            _fixture.AddCommand($"EnterpriseLibraryClientExerciser CreateTable {_tableName}");
-            _fixture.AddCommand($"EnterpriseLibraryClientExerciser MsSql {_tableName}");
-            _fixture.AddCommand($"EnterpriseLibraryClientExerciser Wait 5000"); // TBD if this is really necessary
-            _fixture.AddCommand($"EnterpriseLibraryClientExerciser DropTable {_tableName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            var expectedDatastoreCallCount = 4;
+            // The datastore operation happened outside a web transaction so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allWeb", callCount = expectedDatastoreCallCount },
 
-            //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-            //This results in a call to Read which succeeds followed by a call to NextResult and then another call to Read that doesn't succeed. Therefore
-            //the call count for the Iterate metric should be 3.
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2, metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 1, metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1, metricScope = _expectedTransactionName }
+        };
 
-            var expectedIterateCallCount = 3;
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/MSSQL/teammembers/select"
+        };
 
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        {
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" },
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)
+            },
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"}
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = _expectedTransactionName}
-            };
+                TransactionName = _expectedTransactionName,
+                Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = ?",
+                DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
 
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                HasExplainPlan = true
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                // The datastore operation happened outside a web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allWeb", callCount = expectedDatastoreCallCount },
+                TransactionName = _expectedTransactionName,
+                Sql = $"SELECT COUNT(*) FROM {_tableName} WITH(nolock)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/select",
 
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2, metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 1, metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 1, metricScope = _expectedTransactionName }
-            };
-
-            var expectedTransactionTraceSegments = new List<string>
+                HasExplainPlan = true
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                "Datastore/statement/MSSQL/teammembers/select"
-            };
+                TransactionName = _expectedTransactionName,
+                Sql = $"INSERT INTO {_tableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/insert",
 
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+                HasExplainPlan = true
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" },
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)
-                },
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"}
-            };
+                TransactionName = _expectedTransactionName,
+                Sql = $"DELETE FROM {_tableName} WHERE Email = ?",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/delete",
 
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
+                HasExplainPlan = true
+            }
+        };
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = ?",
-                    DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-                    HasExplainPlan = true
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = $"SELECT COUNT(*) FROM {_tableName} WITH(nolock)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/select",
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-                    HasExplainPlan = true
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = $"INSERT INTO {_tableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/insert",
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
 
-                    HasExplainPlan = true
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = $"DELETE FROM {_tableName} WHERE Email = ?",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/delete",
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample),
 
-                    HasExplainPlan = true
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample),
-
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlFailedExplainPlanTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlFailedExplainPlanTests.cs
@@ -2,68 +2,62 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public class MsSqlFailedExplainPlanTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureCoreLatest>
 {
-    public class MsSqlFailedExplainPlanTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureCoreLatest>
+    private readonly ConsoleDynamicMethodFixtureCoreLatest _fixture;
+
+    public MsSqlFailedExplainPlanTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper outputHelper) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixtureCoreLatest _fixture;
+        var exerciserName = "MicrosoftDataSqlClientExerciser";
 
-        public MsSqlFailedExplainPlanTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper outputHelper) : base(fixture)
-        {
-            var exerciserName = "MicrosoftDataSqlClientExerciser";
+        _fixture = fixture;
+        _fixture.TestLogger = outputHelper;
 
-            _fixture = fixture;
-            _fixture.TestLogger = outputHelper;
+        var procedureName = Utilities.GenerateProcedureName();
 
-            var procedureName = Utilities.GenerateProcedureName();
+        _fixture.AddCommand($"{exerciserName} MsSqlCreateStoredProcWithTempTable {procedureName}");
+        _fixture.AddCommand($"{exerciserName} MsSqlStoredProcWithTempTable {procedureName}");
+        _fixture.AddCommand($"{exerciserName} MsSqlStoredProcWithTempTable {procedureName}");
+        _fixture.AddCommand($"{exerciserName} MsSqlDropStoredProcWithTempTable {procedureName}");
 
-            _fixture.AddCommand($"{exerciserName} MsSqlCreateStoredProcWithTempTable {procedureName}");
-            _fixture.AddCommand($"{exerciserName} MsSqlStoredProcWithTempTable {procedureName}");
-            _fixture.AddCommand($"{exerciserName} MsSqlStoredProcWithTempTable {procedureName}");
-            _fixture.AddCommand($"{exerciserName} MsSqlDropStoredProcWithTempTable {procedureName}");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
 
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ExplainPlainFailureLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.ExplainPlainFailureLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
+        _fixture.Initialize();
 
-            _fixture.Initialize();
+    }
 
-        }
-
-        [Fact]
-        public void Test()
-        {
-            // verify that the log contains one explain plan failure log line - second call to the stored proc doesn't try to generate an explain plan
-            Assert.Single(_fixture.AgentLog.TryGetLogLines(AgentLogBase.ExplainPlainFailureLogLineRegex));
-        }
+    [Fact]
+    public void Test()
+    {
+        // verify that the log contains one explain plan failure log line - second call to the stored proc doesn't try to generate an explain plan
+        Assert.Single(_fixture.AgentLog.TryGetLogLines(AgentLogBase.ExplainPlainFailureLogLineRegex));
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
@@ -6,299 +6,298 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlQueryParamTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsSqlQueryParamTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _expectedAsyncTransactionName;
+    private readonly bool _paramsWithAtSigns;
+
+    public MsSqlQueryParamTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _expectedAsyncTransactionName;
-        private readonly bool _paramsWithAtSigns;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlWithParameterizedQuery";
+        _expectedAsyncTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlAsync_WithParameterizedQuery";
 
-        public MsSqlQueryParamTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, bool paramsWithAtSign) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlWithParameterizedQuery";
-            _expectedAsyncTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlAsync_WithParameterizedQuery";
+        _fixture.AddCommand($"{excerciserName} MsSqlWithParameterizedQuery {paramsWithAtSign}");
+        _fixture.AddCommand($"{excerciserName} MsSqlAsync_WithParameterizedQuery {paramsWithAtSign}");
 
-            _fixture.AddCommand($"{excerciserName} MsSqlWithParameterizedQuery {paramsWithAtSign}");
-            _fixture.AddCommand($"{excerciserName} MsSqlAsync_WithParameterizedQuery {paramsWithAtSign}");
+        _paramsWithAtSigns = paramsWithAtSign;
 
-            _paramsWithAtSigns = paramsWithAtSign;
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
-
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = 2},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
+
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
+
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedAsyncTransactionName },
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedTransactionTraceSegments = new List<string>
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = 2},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedAsyncTransactionName },
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/MSSQL/teammembers/select"
+        };
+
+
+        var expectedQueryParameters = _paramsWithAtSigns
+            ? new Dictionary<string, object> { { "@FN", "O'Keefe" } }
+            : new Dictionary<string, object> { { "FN", "O'Keefe" } };
+        var expectedAsyncQueryParameters = _paramsWithAtSigns
+            ? new Dictionary<string, object> { { "@LN", "Lee" } }
+            : new Dictionary<string, object> { { "LN", "Lee" } };
+
+        var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/teammembers/select", QueryParameters = expectedQueryParameters };
+        var expectedAsyncTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/teammembers/select", QueryParameters = expectedAsyncQueryParameters };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                $"Datastore/statement/MSSQL/teammembers/select"
-            };
-
-
-            var expectedQueryParameters = _paramsWithAtSigns
-                ? new Dictionary<string, object> { { "@FN", "O'Keefe" } }
-                : new Dictionary<string, object> { { "FN", "O'Keefe" } };
-            var expectedAsyncQueryParameters = _paramsWithAtSigns
-                ? new Dictionary<string, object> { { "@LN", "Lee" } }
-                : new Dictionary<string, object> { { "LN", "Lee" } };
-
-            var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/teammembers/select", QueryParameters = expectedQueryParameters };
-            var expectedAsyncTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/teammembers/select", QueryParameters = expectedAsyncQueryParameters };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
+                TransactionName = _expectedTransactionName,
+                Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN",
+                DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+                QueryParameters = expectedQueryParameters,
+                HasExplainPlan = true
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                "databaseDuration"
-            };
+                TransactionName = _expectedAsyncTransactionName,
+                Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE LastName = @LN",
+                DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+                QueryParameters = expectedAsyncQueryParameters,
+                HasExplainPlan = true
+            },
+        };
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = @FN",
-                    DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
-                    QueryParameters = expectedQueryParameters,
-                    HasExplainPlan = true
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedAsyncTransactionName,
-                    Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE LastName = @LN",
-                    DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
-                    QueryParameters = expectedAsyncQueryParameters,
-                    HasExplainPlan = true
-                },
-            };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var syncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var asyncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedAsyncTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var asyncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedAsyncTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var logEntries = _fixture.AgentLog.GetFileLines();
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var syncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var asyncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedAsyncTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var asyncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedAsyncTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-            var logEntries = _fixture.AgentLog.GetFileLines();
-
-            // some variable expectations based on which transaction was sampled
-            var asyncSampled = asyncTransactionSample != null;
-            var transactionSample = asyncSampled ? asyncTransactionSample : syncTransactionSample;
-            var whereClause = asyncSampled ? "LastName = @LN" : "FirstName = @FN";
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
-            {
-                new Assertions.ExpectedSegmentParameter { segmentName = $"Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" },
-                new Assertions.ExpectedSegmentParameter { segmentName = $"Datastore/statement/MSSQL/teammembers/select", parameterName = "sql", parameterValue = $"SELECT * FROM NewRelic.dbo.TeamMembers WHERE {whereClause}"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"},
-            };
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent),
-                () => Assert.NotNull(asyncTransactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(asyncSampled ? expectedAsyncTransactionTraceQueryParameters: expectedTransactionTraceQueryParameters, transactionSample),
-
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
-            );
-        }
-    }
-
-    #region System.Data (.NET Framework only)
-    public class MsSqlQueryParamTests_SystemData_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlQueryParamTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser",
-                  paramsWithAtSign: true)
+        // some variable expectations based on which transaction was sampled
+        var asyncSampled = asyncTransactionSample != null;
+        var transactionSample = asyncSampled ? asyncTransactionSample : syncTransactionSample;
+        var whereClause = asyncSampled ? "LastName = @LN" : "FirstName = @FN";
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
         {
-        }
+            new Assertions.ExpectedSegmentParameter { segmentName = $"Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" },
+            new Assertions.ExpectedSegmentParameter { segmentName = $"Datastore/statement/MSSQL/teammembers/select", parameterName = "sql", parameterValue = $"SELECT * FROM NewRelic.dbo.TeamMembers WHERE {whereClause}"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"},
+        };
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent),
+            () => Assert.NotNull(asyncTransactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(asyncSampled ? expectedAsyncTransactionTraceQueryParameters: expectedTransactionTraceQueryParameters, transactionSample),
+
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
+        );
     }
-
-    public class MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
-    #endregion
-
-    #region Microsoft.Data.SqlClient (FW and Core/5+)
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreOldest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: true)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
-
-    public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  paramsWithAtSign: false)
-        {
-        }
-    }
-    #endregion
 }
+
+#region System.Data (.NET Framework only)
+public class MsSqlQueryParamTests_SystemData_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlQueryParamTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataExerciser",
+            paramsWithAtSign: true)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlQueryParamTests_SystemData_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataExerciser",
+            paramsWithAtSign: false)
+    {
+    }
+}
+#endregion
+
+#region Microsoft.Data.SqlClient (FW and Core/5+)
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: true)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: false)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: true)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462 : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: false)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: true)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreOldest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: true)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: false)
+    {
+    }
+}
+
+public class MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest : MsSqlQueryParamTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlQueryParamTests_MicrosoftDataSqlClient_NoAtSigns_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            paramsWithAtSign: false)
+    {
+    }
+}
+#endregion

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureTests.cs
@@ -11,188 +11,187 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _tableName;
+    private readonly string _procNameWith;
+    private readonly string _procNameWithout;
+
+    public MsSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _tableName;
-        private readonly string _procNameWith;
-        private readonly string _procNameWithout;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedure";
 
-        public MsSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedure";
+        _tableName = Utilities.GenerateTableName();
+        var procedureName = Utilities.GenerateProcedureName();
+        _procNameWith = $"{procedureName}_with";
+        _procNameWithout = $"{procedureName}_without";
 
-            _tableName = Utilities.GenerateTableName();
-            var procedureName = Utilities.GenerateProcedureName();
-            _procNameWith = $"{procedureName}_with";
-            _procNameWithout = $"{procedureName}_without";
-
-            _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
-            _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
+        _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
 
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
-            };
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            var expectedTransactionTraceSegments = new List<string>
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");       //This has to stay at finest to ensure parameter check security
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
-                $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedQueryParametersWith = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        _fixture.Initialize();
+    }
 
-            var expectedQueryParametersWithout = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
+    [Fact]
+    public void Test()
+    {
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName }
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+            $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure"
+        };
+
+        var expectedQueryParametersWith = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+
+        var expectedQueryParametersWithout = DbParameterData.MsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
 
 
-            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
-            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
+        var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
+        var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = _procNameWith,
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWith,
-                    HasExplainPlan = true
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = _procNameWithout,
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWithout,
-                    HasExplainPlan = true
-                }
-            };
+                TransactionName = _expectedTransactionName,
+                Sql = _procNameWith,
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWith,
+                HasExplainPlan = true
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName,
+                Sql = _procNameWithout,
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWithout,
+                HasExplainPlan = true
+            }
+        };
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-            var logEntries = _fixture.AgentLog.GetFileLines().ToList();
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var logEntries = _fixture.AgentLog.GetFileLines().ToList();
 
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
-            );
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
+        );
     }
-
-    #region System.Data (.NET Framework only)
-    public class MsSqlStoredProcedureTests_SystemData_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlStoredProcedureTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser")
-        {
-        }
-    }
-
-    #endregion
-
-    #region Microsoft.Data.SqlClient (FW and Core/5+)
-
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
-        {
-        }
-    }
-
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
-        {
-        }
-    }
-
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
-        {
-        }
-    }
-
-    public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreOldest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser")
-        {
-        }
-    }
-
-    #endregion
 }
+
+#region System.Data (.NET Framework only)
+public class MsSqlStoredProcedureTests_SystemData_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlStoredProcedureTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataExerciser")
+    {
+    }
+}
+
+#endregion
+
+#region Microsoft.Data.SqlClient (FW and Core/5+)
+
+public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462 : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+public class MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreOldest : MsSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlStoredProcedureTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+#endregion

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOdbcDriverTests.cs
@@ -11,150 +11,148 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlStoredProcedureUsingOdbcDriverTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _tableName;
+    private readonly string _procNameWith;
+    private readonly string _procNameWithout;
 
-    public abstract class MsSqlStoredProcedureUsingOdbcDriverTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    public MsSqlStoredProcedureUsingOdbcDriverTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _tableName;
-        private readonly string _procNameWith;
-        private readonly string _procNameWithout;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/OdbcParameterizedStoredProcedure";
 
-        public MsSqlStoredProcedureUsingOdbcDriverTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/OdbcParameterizedStoredProcedure";
-
-            _tableName = Utilities.GenerateTableName();
-            var procedureName = Utilities.GenerateProcedureName();
-            _procNameWith = $"{procedureName}_with";
-            _procNameWithout = $"{procedureName}_without";
+        _tableName = Utilities.GenerateTableName();
+        var procedureName = Utilities.GenerateProcedureName();
+        _procNameWith = $"{procedureName}_with";
+        _procNameWithout = $"{procedureName}_without";
 
 
-            _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} OdbcParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
-            _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} OdbcParameterizedStoredProcedure {_procNameWith} {_procNameWithout}");
+        _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
-            var expectedSqlStatementWith = $"{{call {_procNameWith.ToLower()}({parameterPlaceholder})}}";
-            var expectedSqlStatementWithout = $"{{call {_procNameWithout.ToLower()}({parameterPlaceholder})}}";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
-            };
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            var expectedTransactionTraceSegments = new List<string>
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
-                $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedQueryParametersWith = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
-            var expectedQueryParametersWithout = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
-
-            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
-            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
-
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = $"{{call {_procNameWith}({parameterPlaceholder})}}",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWith
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = $"{{call {_procNameWithout}({parameterPlaceholder})}}",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWithout
-                }
-
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-            var logEntries = _fixture.AgentLog.GetFileLines().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void Test()
     {
-        public MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser")
-        {
-        }
-    }
+        var parameterPlaceholder = string.Join(",", DbParameterData.OdbcMsSqlParameters.Select(_ => "?"));
+        var expectedSqlStatementWith = $"{{call {_procNameWith.ToLower()}({parameterPlaceholder})}}";
+        var expectedSqlStatementWithout = $"{{call {_procNameWithout.ToLower()}({parameterPlaceholder})}}";
 
-    public class MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser")
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
+            $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure"
+        };
+
+        var expectedQueryParametersWith = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        var expectedQueryParametersWithout = DbParameterData.OdbcMsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
+        var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName,
+                Sql = $"{{call {_procNameWith}({parameterPlaceholder})}}",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWith}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWith
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName,
+                Sql = $"{{call {_procNameWithout}({parameterPlaceholder})}}",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{expectedSqlStatementWithout}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWithout
+            }
+
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var logEntries = _fixture.AgentLog.GetFileLines().ToList();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
+        );
+    }
+}
+
+public class MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlStoredProcedureUsingOdbcDriverTests_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser")
+    {
+    }
+}
+
+public class MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest : MsSqlStoredProcedureUsingOdbcDriverTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlStoredProcedureUsingOdbcDriverTests_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser")
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlStoredProcedureUsingOleDbDriverTests.cs
@@ -12,133 +12,132 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlStoredProcedureUsingOleDbDriverTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsSqlStoredProcedureUsingOleDbDriverTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _tableName;
+    private readonly string _procNameWith;
+    private readonly string _procNameWithout;
+
+    public MsSqlStoredProcedureUsingOleDbDriverTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _tableName;
-        private readonly string _procNameWith;
-        private readonly string _procNameWithout;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedureUsingOleDbDriver";
 
-        public MsSqlStoredProcedureUsingOleDbDriverTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlParameterizedStoredProcedureUsingOleDbDriver";
+        _tableName = Utilities.GenerateTableName();
+        var procedureName = Utilities.GenerateProcedureName();
+        _procNameWith = $"{procedureName}_with";
+        _procNameWithout = $"{procedureName}_without";
 
-            _tableName = Utilities.GenerateTableName();
-            var procedureName = Utilities.GenerateProcedureName();
-            _procNameWith = $"{procedureName}_with";
-            _procNameWithout = $"{procedureName}_without";
+        _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedureUsingOleDbDriver {_procNameWith} {_procNameWithout}");
+        _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
 
-            _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} MsSqlParameterizedStoredProcedureUsingOleDbDriver {_procNameWith} {_procNameWithout}");
-            _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
-            };
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            var expectedTransactionTraceSegments = new List<string>
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure",
-                $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure"
-            };
-
-            var expectedQueryParametersWith = DbParameterData.OleDbMsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
-            var expectedQueryParametersWithout = DbParameterData.OleDbMsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
-
-            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
-            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters {segmentName = $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
-
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = _procNameWith,
-                    DatastoreMetricName = $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWith
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName,
-                    Sql = _procNameWithout,
-                    DatastoreMetricName = $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWithout
-                }
-
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-            var logEntries = _fixture.AgentLog.GetFileLines().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
-            );
-        }
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    // Only tests for System.Data in .NET Framework for OleDb, since the OleDbCommandWrapper is .NET Framework only,
-    // and the instrumentation.xml only matches System.Data as of 2022-10-20
-    public class MsSqlStoredProcedureUsingOleDbDriverTests : MsSqlStoredProcedureUsingOleDbDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void Test()
     {
-        public MsSqlStoredProcedureUsingOleDbDriverTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser")
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = _expectedTransactionName}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure",
+            $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure"
+        };
+
+        var expectedQueryParametersWith = DbParameterData.OleDbMsSqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        var expectedQueryParametersWithout = DbParameterData.OleDbMsSqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWith };
+        var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters {segmentName = $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParametersWithout };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName,
+                Sql = _procNameWith,
+                DatastoreMetricName = $"Datastore/statement/Other/{_procNameWith.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWith
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName,
+                Sql = _procNameWithout,
+                DatastoreMetricName = $"Datastore/statement/Other/{_procNameWithout.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWithout
+            }
+
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var logEntries = _fixture.AgentLog.GetFileLines().ToList();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.LogLinesNotExist(new[] { AgentLogFile.ErrorLogLinePrefixRegex }, logEntries)
+        );
+    }
+}
+
+// Only tests for System.Data in .NET Framework for OleDb, since the OleDbCommandWrapper is .NET Framework only,
+// and the instrumentation.xml only matches System.Data as of 2022-10-20
+public class MsSqlStoredProcedureUsingOleDbDriverTests : MsSqlStoredProcedureUsingOleDbDriverTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlStoredProcedureUsingOleDbDriverTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataExerciser")
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTests.cs
@@ -6,382 +6,380 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsSqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _expectedTransactionName;
+    private readonly string _expectedAsyncTransactionName;
+    private readonly string _tableName;
+    private readonly string _asyncTableName;
+    private readonly string _libraryName;
+
+    private readonly bool _isOdbc;
+
+    public MsSqlTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, string libraryName) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _expectedTransactionName;
-        private readonly string _expectedAsyncTransactionName;
-        private readonly string _tableName;
-        private readonly string _asyncTableName;
-        private readonly string _libraryName;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSql";
+        _expectedAsyncTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlAsync";
 
-        private readonly bool _isOdbc;
+        //Using different table names for the sync and async calls prevents sql traces from being merged
+        _tableName = Utilities.GenerateTableName();
+        _asyncTableName = Utilities.GenerateTableName();
+        _libraryName = libraryName;
 
-        public MsSqlTestsBase(TFixture fixture, ITestOutputHelper output, string excerciserName, string libraryName) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSql";
-            _expectedAsyncTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MsSql.{excerciserName}/MsSqlAsync";
+        //Some metrics (connection open and iteration) aren't available in the ODBC instrumentation
+        _isOdbc = excerciserName.Contains("Odbc");
 
-            //Using different table names for the sync and async calls prevents sql traces from being merged
-            _tableName = Utilities.GenerateTableName();
-            _asyncTableName = Utilities.GenerateTableName();
-            _libraryName = libraryName;
+        _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} CreateTable {_asyncTableName}");
+        _fixture.AddCommand($"{excerciserName} MsSql {_tableName}");
+        _fixture.AddCommand($"{excerciserName} MsSqlAsync {_asyncTableName}");
+        _fixture.AddCommand($"{excerciserName} Wait 5000"); // TBD if this is really necessary
 
-            //Some metrics (connection open and iteration) aren't available in the ODBC instrumentation
-            _isOdbc = excerciserName.Contains("Odbc");
+        _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
+        _fixture.AddCommand($"{excerciserName} DropTable {_asyncTableName}");
 
-            _fixture.AddCommand($"{excerciserName} CreateTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} CreateTable {_asyncTableName}");
-            _fixture.AddCommand($"{excerciserName} MsSql {_tableName}");
-            _fixture.AddCommand($"{excerciserName} MsSqlAsync {_asyncTableName}");
-            _fixture.AddCommand($"{excerciserName} Wait 5000"); // TBD if this is really necessary
-
-            _fixture.AddCommand($"{excerciserName} DropTable {_tableName}");
-            _fixture.AddCommand($"{excerciserName} DropTable {_asyncTableName}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedDatastoreCallCount = 8;
-            //This value is dictated by the queries that are being run as part of this test. In this case, we're running two queries that each return a single row.
-            //This results in a call to Read, NextResult and then a final Read. Therefore the overall call count for the Iterate metric should be 6.
-            var expectedIterateCallCount = 6;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = expectedDatastoreCallCount },
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 4 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/insert", callCount = 1, metricScope = _expectedAsyncTransactionName},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1, metricScope = _expectedTransactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/delete", callCount = 1, metricScope = _expectedAsyncTransactionName},
-            };
+                configModifier.ForceTransactionTraces();
 
-            // The ODBC instrumentation does not instrument connection calls or iterations
-            if (! _isOdbc)
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/Open", callCount = 1 });
-                expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/OpenAsync", callCount = 1 });
-                expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount });
-                expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount / 2, metricScope = _expectedTransactionName });
-                expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount / 2, metricScope = _expectedAsyncTransactionName });
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
             }
+        );
+        _fixture.Initialize();
+    }
 
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+    [Fact]
+    public void Test()
+    {
+        var expectedDatastoreCallCount = 8;
+        //This value is dictated by the queries that are being run as part of this test. In this case, we're running two queries that each return a single row.
+        //This results in a call to Read, NextResult and then a final Read. Therefore the overall call count for the Iterate metric should be 6.
+        var expectedIterateCallCount = 6;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MSSQL/allOther", callCount = expectedDatastoreCallCount },
+
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MSSQL/{CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)}/default", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", callCount = 4 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MSSQL/teammembers/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/select", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/select", callCount = 1, metricScope = _expectedAsyncTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/insert", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/insert", callCount = 1, metricScope = _expectedAsyncTransactionName},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_tableName}/delete", callCount = 1, metricScope = _expectedTransactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MSSQL/{_asyncTableName}/delete", callCount = 1, metricScope = _expectedAsyncTransactionName},
+        };
+
+        // The ODBC instrumentation does not instrument connection calls or iterations
+        if (! _isOdbc)
+        {
+            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/Open", callCount = 1 });
+            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = $"DotNet/{_libraryName}.SqlConnection/OpenAsync", callCount = 1 });
+            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount });
+            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount / 2, metricScope = _expectedTransactionName });
+            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount / 2, metricScope = _expectedAsyncTransactionName });
+        }
+
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", metricScope = _expectedTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedAsyncTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", metricScope = _expectedAsyncTransactionName },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", metricScope = _expectedAsyncTransactionName }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/MSSQL/teammembers/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var syncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
+        var syncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
+        var asyncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedAsyncTransactionName);
+        var asyncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedAsyncTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        // Some variable expectations based on which transaction was sampled
+        var sampledTransactionSample = syncTransactionSample != null ? syncTransactionSample : asyncTransactionSample;
+        var firstOrLastNameQueried = syncTransactionSample != null ? "FirstName" : "LastName";
+
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        {
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "sql", parameterValue = $"SELECT * FROM NewRelic.dbo.TeamMembers WHERE {firstOrLastNameQueried} = ?"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"}
+
+        };
+
+        // The ODBC instrumentation doesn't do explain plans
+        var sqlTracesShouldHaveExplainPlans = false;
+        if (!_isOdbc)
+        {
+            expectedTransactionTraceSegmentParameters.Add(new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" });
+            sqlTracesShouldHaveExplainPlans = true;
+        }
+
+
+        // There should be a total of 8 traces: 4 for the sync methods and 4 for the async methods.
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", metricScope = _expectedTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/select", metricScope = _expectedAsyncTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/insert", metricScope = _expectedAsyncTransactionName },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MSSQL/delete", metricScope = _expectedAsyncTransactionName }
-            };
-            var expectedTransactionTraceSegments = new List<string>
+                TransactionName = _expectedTransactionName, //sync select
+                Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = ?",
+                DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                "Datastore/statement/MSSQL/teammembers/select"
-            };
+                TransactionName = _expectedAsyncTransactionName, //async select - note querying LastName
+                Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE LastName = ?",
+                DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
 
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                "databaseDuration"
-            };
+                TransactionName = _expectedTransactionName, //sync count
+                Sql = $"SELECT COUNT(*) FROM {_tableName} WITH(nolock)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/select",
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var syncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedTransactionName);
-            var syncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedTransactionName);
-            var asyncTransactionSample = _fixture.AgentLog.TryGetTransactionSample(_expectedAsyncTransactionName);
-            var asyncTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_expectedAsyncTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            // Some variable expectations based on which transaction was sampled
-            var sampledTransactionSample = syncTransactionSample != null ? syncTransactionSample : asyncTransactionSample;
-            var firstOrLastNameQueried = syncTransactionSample != null ? "FirstName" : "LastName";
-
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "sql", parameterValue = $"SELECT * FROM NewRelic.dbo.TeamMembers WHERE {firstOrLastNameQueried} = ?"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MsSqlConfiguration.MsSqlServer)},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "port_path_or_id", parameterValue = "default"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "database_name", parameterValue = "NewRelic"}
+                TransactionName = _expectedAsyncTransactionName, //async count
+                Sql = $"SELECT COUNT(*) FROM {_asyncTableName} WITH(nolock)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/select",
 
-            };
-
-            // The ODBC instrumentation doesn't do explain plans
-            var sqlTracesShouldHaveExplainPlans = false;
-            if (!_isOdbc)
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
             {
-                expectedTransactionTraceSegmentParameters.Add(new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MSSQL/teammembers/select", parameterName = "explain_plan" });
-                sqlTracesShouldHaveExplainPlans = true;
+                TransactionName = _expectedTransactionName, //sync insert
+                Sql = $"INSERT INTO {_tableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/insert",
+
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedAsyncTransactionName, //async insert
+                Sql = $"INSERT INTO {_asyncTableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/insert",
+
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedTransactionName, //sync delete
+                Sql = $"DELETE FROM {_tableName} WHERE Email = ?",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/delete",
+
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans,
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = _expectedAsyncTransactionName, //async delete
+                Sql = $"DELETE FROM {_asyncTableName} WHERE Email = ?",
+                DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/delete",
+
+                HasExplainPlan = sqlTracesShouldHaveExplainPlans
             }
+        };
 
+        NrAssert.Multiple(
+            () => Assert.NotNull(sampledTransactionSample),
+            () => Assert.NotNull(syncTransactionEvent),
+            () => Assert.NotNull(asyncTransactionEvent)
+        );
 
-            // There should be a total of 8 traces: 4 for the sync methods and 4 for the async methods.
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName, //sync select
-                    Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE FirstName = ?",
-                    DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, sampledTransactionSample),
 
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedAsyncTransactionName, //async select - note querying LastName
-                    Sql = "SELECT * FROM NewRelic.dbo.TeamMembers WHERE LastName = ?",
-                    DatastoreMetricName = "Datastore/statement/MSSQL/teammembers/select",
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, sampledTransactionSample),
 
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName, //sync count
-                    Sql = $"SELECT COUNT(*) FROM {_tableName} WITH(nolock)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/select",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedAsyncTransactionName, //async count
-                    Sql = $"SELECT COUNT(*) FROM {_asyncTableName} WITH(nolock)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/select",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName, //sync insert
-                    Sql = $"INSERT INTO {_tableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/insert",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedAsyncTransactionName, //async insert
-                    Sql = $"INSERT INTO {_asyncTableName} (FirstName, LastName, Email) VALUES(?, ?, ?)",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/insert",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedTransactionName, //sync delete
-                    Sql = $"DELETE FROM {_tableName} WHERE Email = ?",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_tableName}/delete",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans,
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = _expectedAsyncTransactionName, //async delete
-                    Sql = $"DELETE FROM {_asyncTableName} WHERE Email = ?",
-                    DatastoreMetricName = $"Datastore/statement/MSSQL/{_asyncTableName}/delete",
-
-                    HasExplainPlan = sqlTracesShouldHaveExplainPlans
-                }
-            };
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(sampledTransactionSample),
-                () => Assert.NotNull(syncTransactionEvent),
-                () => Assert.NotNull(asyncTransactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, sampledTransactionSample),
-
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, sampledTransactionSample),
-
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, syncTransactionEvent),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, asyncTransactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, syncTransactionEvent),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, asyncTransactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
-
-
-    #region System.Data.SqlClient
-    public class MsSqlTests_SystemData_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataExerciser",
-                  libraryName: "System.Data.SqlClient")
-        {
-        }
-    }
-    #endregion
-
-    #region Microsoft.Data.SqlClient
-
-    public class MsSqlTests_MicrosoftDataSqlClient_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  libraryName: "Microsoft.Data.SqlClient")
-        {
-        }
-    }
-
-    public class MsSqlTests_MicrosoftDataSqlClient_FW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  libraryName: "Microsoft.Data.SqlClient")
-        {
-        }
-    }
-
-    public class MsSqlTests_MicrosoftDataSqlClient_CoreOldest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  libraryName: "Microsoft.Data.SqlClient")
-        {
-        }
-    }
-
-    public class MsSqlTests_MicrosoftDataSqlClient_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "MicrosoftDataSqlClientExerciser",
-                  libraryName: "Microsoft.Data.SqlClient")
-        {
-        }
-    }
-
-    #endregion
-
-    #region System.Data.Odbc
-
-    public class MsSqlTests_SystemDataOdbc_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public MsSqlTests_SystemDataOdbc_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser",
-                  libraryName: "System.Data.Odbc")
-        {
-        }
-    }
-
-    public class MsSqlTests_SystemDataOdbc_FW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsSqlTests_SystemDataOdbc_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser",
-                  libraryName: "System.Data.Odbc")
-        {
-        }
-    }
-
-    public class MsSqlTests_SystemDataOdbc_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public MsSqlTests_SystemDataOdbc_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser",
-                  libraryName: "System.Data.Odbc")
-        {
-        }
-    }
-
-    public class MsSqlTests_SystemDataOdbc_CoreOldest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public MsSqlTests_SystemDataOdbc_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  excerciserName: "SystemDataOdbcExerciser",
-                  libraryName: "System.Data.Odbc")
-        {
-        }
-    }
-
-    #endregion
-
 }
+
+
+#region System.Data.SqlClient
+public class MsSqlTests_SystemData_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlTests_SystemData_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataExerciser",
+            libraryName: "System.Data.SqlClient")
+    {
+    }
+}
+#endregion
+
+#region Microsoft.Data.SqlClient
+
+public class MsSqlTests_MicrosoftDataSqlClient_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlTests_MicrosoftDataSqlClient_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            libraryName: "Microsoft.Data.SqlClient")
+    {
+    }
+}
+
+public class MsSqlTests_MicrosoftDataSqlClient_FW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlTests_MicrosoftDataSqlClient_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            libraryName: "Microsoft.Data.SqlClient")
+    {
+    }
+}
+
+public class MsSqlTests_MicrosoftDataSqlClient_CoreOldest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlTests_MicrosoftDataSqlClient_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            libraryName: "Microsoft.Data.SqlClient")
+    {
+    }
+}
+
+public class MsSqlTests_MicrosoftDataSqlClient_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "MicrosoftDataSqlClientExerciser",
+            libraryName: "Microsoft.Data.SqlClient")
+    {
+    }
+}
+
+#endregion
+
+#region System.Data.Odbc
+
+public class MsSqlTests_SystemDataOdbc_FWLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsSqlTests_SystemDataOdbc_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser",
+            libraryName: "System.Data.Odbc")
+    {
+    }
+}
+
+public class MsSqlTests_SystemDataOdbc_FW462 : MsSqlTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsSqlTests_SystemDataOdbc_FW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser",
+            libraryName: "System.Data.Odbc")
+    {
+    }
+}
+
+public class MsSqlTests_SystemDataOdbc_CoreLatest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlTests_SystemDataOdbc_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser",
+            libraryName: "System.Data.Odbc")
+    {
+    }
+}
+
+public class MsSqlTests_SystemDataOdbc_CoreOldest : MsSqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MsSqlTests_SystemDataOdbc_CoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            excerciserName: "SystemDataOdbcExerciser",
+            libraryName: "System.Data.Odbc")
+    {
+    }
+}
+
+#endregion

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTruncationTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlTruncationTests.cs
@@ -9,80 +9,79 @@ using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MsSql;
+
+public abstract class MsSqlTruncationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsSqlTruncationTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    // SQL statement maximum length is 4096 bytes, including 3-character ellipsis ("...") if truncation occurs
+    private const int MaxSqlLength = 4096;
+    private const string Ellipsis = "...";
+
+    public MsSqlTruncationTestsBase(TFixture fixture, ITestOutputHelper output, string exerciserName) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        // SQL statement maximum length is 4096 bytes, including 3-character ellipsis ("...") if truncation occurs
-        private const int MaxSqlLength = 4096;
-        private const string Ellipsis = "...";
+        _fixture.BaselinePayloadBytes = 61446; // Baseline payload size for Core Latest agent with Microsoft.Data.SqlClient
 
-        public MsSqlTruncationTestsBase(TFixture fixture, ITestOutputHelper output, string exerciserName) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"{exerciserName} MsSqlWithLongQuery");
+        _fixture.AddCommand($"{exerciserName} Wait 5000");
 
-            _fixture.BaselinePayloadBytes = 61446; // Baseline payload size for Core Latest agent with Microsoft.Data.SqlClient
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
 
-            _fixture.AddCommand($"{exerciserName} MsSqlWithLongQuery");
-            _fixture.AddCommand($"{exerciserName} Wait 5000");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
-
-                    configModifier.SetLogLevel("finest");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            // find the Datastore/statement/MSSQL/teammembers/select span
-            var sqlSpan = _fixture.AgentLog.TryGetSpanEvent("Datastore/statement/MSSQL/teammembers/select");
-            Assert.NotNull(sqlSpan);
-
-            // get the db.statement attribute
-            Assert.True(sqlSpan.AgentAttributes.ContainsKey("db.statement"), "Span should have 'db.statement' attribute");
-            var sqlStatement = sqlSpan.AgentAttributes["db.statement"] as string;
-
-            Assert.NotNull(sqlStatement);
-
-            // Verify the SQL statement is truncated to exactly 4096 bytes
-            var sqlStatementBytes = Encoding.UTF8.GetBytes(sqlStatement);
-            Assert.Equal(MaxSqlLength, sqlStatementBytes.Length);
-
-            // Verify the SQL statement ends with the ellipsis
-            Assert.EndsWith(Ellipsis, sqlStatement);
-        }
+                configModifier.SetLogLevel("finest");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    #region System.Data.SqlClient
-
-    public class MsSqlTruncationTests_MicrosoftDataSqlClient_CoreLatest : MsSqlTruncationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+    [Fact]
+    public void Test()
     {
-        public MsSqlTruncationTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(
-                  fixture: fixture,
-                  output: output,
-                  exerciserName: "MicrosoftDataSqlClientExerciser")
-        {
-        }
-    }
+        // find the Datastore/statement/MSSQL/teammembers/select span
+        var sqlSpan = _fixture.AgentLog.TryGetSpanEvent("Datastore/statement/MSSQL/teammembers/select");
+        Assert.NotNull(sqlSpan);
 
-    #endregion
+        // get the db.statement attribute
+        Assert.True(sqlSpan.AgentAttributes.ContainsKey("db.statement"), "Span should have 'db.statement' attribute");
+        var sqlStatement = sqlSpan.AgentAttributes["db.statement"] as string;
+
+        Assert.NotNull(sqlStatement);
+
+        // Verify the SQL statement is truncated to exactly 4096 bytes
+        var sqlStatementBytes = Encoding.UTF8.GetBytes(sqlStatement);
+        Assert.Equal(MaxSqlLength, sqlStatementBytes.Length);
+
+        // Verify the SQL statement ends with the ellipsis
+        Assert.EndsWith(Ellipsis, sqlStatement);
+    }
 }
+
+#region System.Data.SqlClient
+
+public class MsSqlTruncationTests_MicrosoftDataSqlClient_CoreLatest : MsSqlTruncationTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MsSqlTruncationTests_MicrosoftDataSqlClient_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(
+            fixture: fixture,
+            output: output,
+            exerciserName: "MicrosoftDataSqlClientExerciser")
+    {
+    }
+}
+
+#endregion

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqConsumeTests.cs
@@ -10,108 +10,107 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
+namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq;
+
+/// <summary>
+/// Integration Test for MSMQ Consume message.
+/// </summary>
+/// <remarks>
+/// Although this test also uses the MSMQ Send endpoint, it is important to keep the Send and Consume tests as separate fixtures
+/// in order to separately test the existence of a Consume segment in the transaction trace. Only a single TT is being saved per test.
+/// </remarks>
+public abstract class MsmqConsumeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    /// <summary>
-    /// Integration Test for MSMQ Consume message.
-    /// </summary>
-    /// <remarks>
-    /// Although this test also uses the MSMQ Send endpoint, it is important to keep the Send and Consume tests as separate fixtures
-    /// in order to separately test the existence of a Consume segment in the transaction trace. Only a single TT is being saved per test.
-    /// </remarks>
-    public abstract class MsmqConsumeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+
+    public MsmqConsumeTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MsmqConsumeTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
+        _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
+        _fixture.AddCommand($"MSMQExerciser Receive {_queueNum}");
 
-            _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
-            _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
-            _fixture.AddCommand($"MSMQExerciser Receive {_queueNum}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces()
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Receive";
-            string metricName = @"MessageBroker/Msmq/Queue/Consume/Named/private$\nrtestqueue" + _queueNum.ToString();
-            string segmentName = @"MessageBroker/Msmq/Queue/Consume/Named/private$\nrtestqueue" + _queueNum.ToString();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName}
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                segmentName
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    public class MsmqConsumeTestsFW462 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MsmqConsumeTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Receive";
+        string metricName = @"MessageBroker/Msmq/Queue/Consume/Named/private$\nrtestqueue" + _queueNum.ToString();
+        string segmentName = @"MessageBroker/Msmq/Queue/Consume/Named/private$\nrtestqueue" + _queueNum.ToString();
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName}
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            segmentName
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
     }
+}
 
-    public class MsmqConsumeTestsFW471 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MsmqConsumeTestsFW462 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsmqConsumeTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqConsumeTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqConsumeTestsFW48 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MsmqConsumeTestsFW471 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MsmqConsumeTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqConsumeTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqConsumeTestsFWLatest : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MsmqConsumeTestsFW48 : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MsmqConsumeTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqConsumeTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class MsmqConsumeTestsFWLatest : MsmqConsumeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsmqConsumeTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqHelper.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqHelper.cs
@@ -1,22 +1,21 @@
 ﻿// Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
-{
-    internal static class MsmqHelper
-    {
-        private static int _queueNum = 0;
-        private static object _lock = new object();
+namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq;
 
-        // Because the MSMQ tests modify the queue, we can run into concurrency issues if more than one test
-        // is running at the same time. To prevent this, give each test a unique queue name based on a number
-        internal static int GetNextQueueNum()
+internal static class MsmqHelper
+{
+    private static int _queueNum = 0;
+    private static object _lock = new object();
+
+    // Because the MSMQ tests modify the queue, we can run into concurrency issues if more than one test
+    // is running at the same time. To prevent this, give each test a unique queue name based on a number
+    internal static int GetNextQueueNum()
+    {
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                _queueNum++;
-                return _queueNum;
-            }
+            _queueNum++;
+            return _queueNum;
         }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPeekTests.cs
@@ -11,103 +11,101 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
+namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq;
+
+public abstract class MsmqPeekTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsmqPeekTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+
+    public MsmqPeekTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MsmqPeekTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
+        _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
+        _fixture.AddCommand($"MSMQExerciser Peek {_queueNum}");
 
-            _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
-            _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
-            _fixture.AddCommand($"MSMQExerciser Peek {_queueNum}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces()
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Peek";
-            string metricName = @"MessageBroker/Msmq/Queue/Peek/Named/private$\nrtestqueue" + _queueNum.ToString();
-            string segmentName = @"MessageBroker/Msmq/Queue/Peek/Named/private$\nrtestqueue" + _queueNum.ToString();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName}
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                segmentName
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
-
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    public class MsmqPeekTestsFW462 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MsmqPeekTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Peek";
+        string metricName = @"MessageBroker/Msmq/Queue/Peek/Named/private$\nrtestqueue" + _queueNum.ToString();
+        string segmentName = @"MessageBroker/Msmq/Queue/Peek/Named/private$\nrtestqueue" + _queueNum.ToString();
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName}
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            segmentName
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
     }
 
-    public class MsmqPeekTestsFW471 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW471>
+}
+
+public class MsmqPeekTestsFW462 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsmqPeekTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPeekTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqPeekTestsFW48 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MsmqPeekTestsFW471 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MsmqPeekTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPeekTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqPeekTestsFWLatest : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MsmqPeekTestsFW48 : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MsmqPeekTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPeekTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
+public class MsmqPeekTestsFWLatest : MsmqPeekTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsmqPeekTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqPurgeTests.cs
@@ -11,103 +11,101 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
+namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq;
+
+public abstract class MsmqPurgeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsmqPurgeTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+
+    public MsmqPurgeTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MsmqPurgeTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
+        _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
+        _fixture.AddCommand($"MSMQExerciser Purge {_queueNum}");
 
-            _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
-            _fixture.AddCommand($"MSMQExerciser Send {_queueNum} true");
-            _fixture.AddCommand($"MSMQExerciser Purge {_queueNum}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces()
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Purge";
-            string metricName = @"MessageBroker/Msmq/Queue/Purge/Named/private$\nrtestqueue" + _queueNum.ToString();
-            string segmentName = @"MessageBroker/Msmq/Queue/Purge/Named/private$\nrtestqueue" + _queueNum.ToString();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName},
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                segmentName
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
-
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    public class MsmqPurgeTestsFW462 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MsmqPurgeTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Purge";
+        string metricName = @"MessageBroker/Msmq/Queue/Purge/Named/private$\nrtestqueue" + _queueNum.ToString();
+        string segmentName = @"MessageBroker/Msmq/Queue/Purge/Named/private$\nrtestqueue" + _queueNum.ToString();
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName},
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            segmentName
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
     }
 
-    public class MsmqPurgeTestsFW471 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW471>
+}
+
+public class MsmqPurgeTestsFW462 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsmqPurgeTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPurgeTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqPurgeTestsFW48 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MsmqPurgeTestsFW471 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MsmqPurgeTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPurgeTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqPurgeTestsFWLatest : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MsmqPurgeTestsFW48 : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MsmqPurgeTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqPurgeTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
+public class MsmqPurgeTestsFWLatest : MsmqPurgeTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsmqPurgeTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Msmq/MsmqSendTests.cs
@@ -1,109 +1,107 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
-using System;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Msmq
+public abstract class MsmqSendTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MsmqSendTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+
+    public MsmqSendTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly int _queueNum = MsmqHelper.GetNextQueueNum();
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MsmqSendTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
+        _fixture.AddCommand($"MSMQExerciser Send {_queueNum} false");
 
-            _fixture.AddCommand($"MSMQExerciser Create {_queueNum}");
-            _fixture.AddCommand($"MSMQExerciser Send {_queueNum} false");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces()
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                }
-            );
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Send";
-            string metricName = @"MessageBroker/Msmq/Queue/Produce/Named/private$\nrtestqueue" + _queueNum.ToString();
-            string segmentName = @"MessageBroker/Msmq/Queue/Produce/Named/private$\nrtestqueue" + _queueNum.ToString();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
-                new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName},
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                segmentName
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
-    }
-    public class MsmqSendTestsFW462 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MsmqSendTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-
-        }
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+            }
+        );
+        _fixture.Initialize();
     }
 
-    public class MsmqSendTestsFW471 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void Test()
     {
-        public MsmqSendTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        string transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MSMQExerciser/Send";
+        string metricName = @"MessageBroker/Msmq/Queue/Produce/Named/private$\nrtestqueue" + _queueNum.ToString();
+        string segmentName = @"MessageBroker/Msmq/Queue/Produce/Named/private$\nrtestqueue" + _queueNum.ToString();
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1},
+            new Assertions.ExpectedMetric { metricName = metricName, callCount = 1, metricScope = transactionName},
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            segmentName
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
     }
-
-    public class MsmqSendTestsFW48 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW48>
+}
+public class MsmqSendTestsFW462 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MsmqSendTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqSendTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MsmqSendTestsFWLatest : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MsmqSendTestsFW471 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MsmqSendTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MsmqSendTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class MsmqSendTestsFW48 : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MsmqSendTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
+    }
+}
+
+public class MsmqSendTestsFWLatest : MsmqSendTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MsmqSendTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlAsyncTests.cs
@@ -6,189 +6,188 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MySql;
+
+public abstract class MySqlAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MySqlAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public MySqlAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MySqlAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MySqlExerciser SingleDateQueryAsync");
 
-            _fixture.AddCommand($"MySqlExerciser SingleDateQueryAsync");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
 
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/SingleDateQueryAsync";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1, metricScope = transactionName },
-            };
-
-            expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/MySql.Data.MySqlClient.MySqlConnection/OpenAsync", callCount = 1 });
-
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                // The datastore operation happened inside a console app so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", callCount = 1 },
-
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1, metricScope = transactionName }
-            };
-
-            // Don't double count the Open
-            unexpectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/MySql.Data.MySqlClient.MySqlConnection/Open", callCount = 1 });
-
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/MySQL/dates/select"
-            };
-
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = transactionName,
-                    Sql = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?",
-                    DatastoreMetricName = "Datastore/statement/MySQL/dates/select",
-
-                    HasExplainPlan = true
-                }
-            };
-
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
-            {
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "sql", parameterValue = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "port_path_or_id", parameterValue = MySqlTestConfiguration.MySqlPort},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "database_name", parameterValue = MySqlTestConfiguration.MySqlDbName}
-
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class MySqlAsyncTestsFW462 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MySqlAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/SingleDateQueryAsync";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
 
-        }
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1, metricScope = transactionName },
+        };
+
+        expectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/MySql.Data.MySqlClient.MySqlConnection/OpenAsync", callCount = 1 });
+
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a console app so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", callCount = 1 },
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1, metricScope = transactionName }
+        };
+
+        // Don't double count the Open
+        unexpectedMetrics.Add(new Assertions.ExpectedMetric { metricName = @"DotNet/MySql.Data.MySqlClient.MySqlConnection/Open", callCount = 1 });
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/MySQL/dates/select"
+        };
+
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = transactionName,
+                Sql = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?",
+                DatastoreMetricName = "Datastore/statement/MySQL/dates/select",
+
+                HasExplainPlan = true
+            }
+        };
+
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        {
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "sql", parameterValue = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "port_path_or_id", parameterValue = MySqlTestConfiguration.MySqlPort},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "database_name", parameterValue = MySqlTestConfiguration.MySqlDbName}
+
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
+        );
     }
+}
 
-    public class MySqlAsyncTestsFW471 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MySqlAsyncTestsFW462 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MySqlAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlAsyncTestsFW48 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MySqlAsyncTestsFW471 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MySqlAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlAsyncTestsFWLatest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MySqlAsyncTestsFW48 : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MySqlAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlAsyncTestsCoreOldest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MySqlAsyncTestsFWLatest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MySqlAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlAsyncTestsCoreLatest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MySqlAsyncTestsCoreOldest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MySqlAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class MySqlAsyncTestsCoreLatest : MySqlAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MySqlAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlConnectorTests.cs
@@ -7,262 +7,261 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.Collections.Generic;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
-{
-    public abstract class MySqlConnectorTestBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
-    {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+namespace NewRelic.Agent.UnboundedIntegrationTests.MySql;
 
-        private readonly List<string> commandList = new List<string>()
+public abstract class MySqlConnectorTestBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
+{
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    private readonly List<string> commandList = new List<string>()
+    {
+        "ExecuteReaderWithDelay",
+        "ExecuteScalar",
+        "ExecuteNonQuery",
+        "ExecuteReaderAsync",
+        "ExecuteScalarAsync",
+        "ExecuteNonQueryAsync",
+        "DbCommandExecuteReader",
+        "DbCommandExecuteScalar",
+        "DbCommandExecuteNonQuery",
+        "DbCommandExecuteReaderAsync",
+        "DbCommandExecuteScalarAsync",
+        "DbCommandExecuteNonQueryAsync"
+    };
+
+    protected MySqlConnectorTestBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        foreach (var command in commandList)
+            _fixture.AddCommand($"MySqlConnectorExerciser {command}");
+
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+
+                configModifier
+                    .ConfigureFasterMetricsHarvestCycle(30)
+                    .ConfigureFasterTransactionTracesHarvestCycle(30)
+                    .ConfigureFasterSqlTracesHarvestCycle(30)
+                    .ForceTransactionTraces()
+                    .SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath,
+                    new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath,
+                    new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "",
+                    "enabled", "true");
+            },
+            exerciseApplication: () =>
+            {
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            "ExecuteReaderWithDelay",
-            "ExecuteScalar",
-            "ExecuteNonQuery",
-            "ExecuteReaderAsync",
-            "ExecuteScalarAsync",
-            "ExecuteNonQueryAsync",
-            "DbCommandExecuteReader",
-            "DbCommandExecuteScalar",
-            "DbCommandExecuteNonQuery",
-            "DbCommandExecuteReaderAsync",
-            "DbCommandExecuteScalarAsync",
-            "DbCommandExecuteNonQueryAsync"
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", CallCountAllHarvests = commandList.Count },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", CallCountAllHarvests = commandList.Count },
         };
 
-        protected MySqlConnectorTestBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
         {
+            // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", CallCountAllHarvests = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", CallCountAllHarvests = 1 },
+        };
 
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-
-            foreach (var command in commandList)
-                _fixture.AddCommand($"MySqlConnectorExerciser {command}");
-
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-
-                    configModifier
-                        .ConfigureFasterMetricsHarvestCycle(30)
-                        .ConfigureFasterTransactionTracesHarvestCycle(30)
-                        .ConfigureFasterSqlTracesHarvestCycle(30)
-                        .ForceTransactionTraces()
-                        .SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath,
-                        new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath,
-                        new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "",
-                        "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
+        foreach (var command in commandList)
         {
+            var transactionName = GetTransactionName(command);
 
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+            expectedMetrics.Add(new Assertions.ExpectedMetric
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", CallCountAllHarvests = commandList.Count },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", CallCountAllHarvests = commandList.Count },
-            };
+                metricName = @"Datastore/statement/MySQL/dates/select",
+                CallCountAllHarvests = 1,
+                metricScope = transactionName
+            });
 
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+            // only check "Iterate" metrics for ExecuteReader calls
+            if (transactionName.IndexOf("Reader", StringComparison.Ordinal) != -1)
             {
-                // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", CallCountAllHarvests = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", CallCountAllHarvests = 1 },
-            };
-
-            foreach (var command in commandList)
-            {
-                var transactionName = GetTransactionName(command);
+                //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+                //This results in two calls to Read followed by a call to NextResult.
+                //Therefore the call count for the Iterate metric should be 3. The unscoped Iterate metric should have a count of commandList.Count (3 x 4)
 
                 expectedMetrics.Add(new Assertions.ExpectedMetric
                 {
-                    metricName = @"Datastore/statement/MySQL/dates/select",
+                    metricName = @"DotNet/DatabaseResult/Iterate",
+                    CallCountAllHarvests = commandList.Count
+                });
+                expectedMetrics.Add(new Assertions.ExpectedMetric
+                {
+                    metricName = @"DotNet/DatabaseResult/Iterate",
+                    CallCountAllHarvests = 3,
+                    metricScope = transactionName
+                });
+            }
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            unexpectedMetrics.Add(
+                new Assertions.ExpectedMetric
+                {
+                    metricName = @"Datastore/operation/MySQL/select",
                     CallCountAllHarvests = 1,
                     metricScope = transactionName
                 });
+        }
 
-                // only check "Iterate" metrics for ExecuteReader calls
-                if (transactionName.IndexOf("Reader", StringComparison.Ordinal) != -1)
-                {
-                    //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-                    //This results in two calls to Read followed by a call to NextResult.
-                    //Therefore the call count for the Iterate metric should be 3. The unscoped Iterate metric should have a count of commandList.Count (3 x 4)
+        var queryWithDelay = "SELECT SLEEP(?), _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?";
 
-                    expectedMetrics.Add(new Assertions.ExpectedMetric
-                    {
-                        metricName = @"DotNet/DatabaseResult/Iterate",
-                        CallCountAllHarvests = commandList.Count
-                    });
-                    expectedMetrics.Add(new Assertions.ExpectedMetric
-                    {
-                        metricName = @"DotNet/DatabaseResult/Iterate",
-                        CallCountAllHarvests = 3,
-                        metricScope = transactionName
-                    });
-                }
+        var expectedTransactionTraceSegments = new List<string> { "Datastore/statement/MySQL/dates/select" };
 
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                unexpectedMetrics.Add(
-                    new Assertions.ExpectedMetric
-                    {
-                        metricName = @"Datastore/operation/MySQL/select",
-                        CallCountAllHarvests = 1,
-                        metricScope = transactionName
-                    });
-            }
+        var expectedTransactionEventIntrinsicAttributes = new List<string> { "databaseDuration" };
 
-            var queryWithDelay = "SELECT SLEEP(?), _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?";
-
-            var expectedTransactionTraceSegments = new List<string> { "Datastore/statement/MySQL/dates/select" };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string> { "databaseDuration" };
-
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        {
+            new Assertions.ExpectedSegmentParameter
             {
-                new Assertions.ExpectedSegmentParameter
-                {
-                    segmentName = "Datastore/statement/MySQL/dates/select",
-                    parameterName = "sql",
-                    parameterValue = queryWithDelay
-                },
-                new Assertions.ExpectedSegmentParameter
-                {
-                    segmentName = "Datastore/statement/MySQL/dates/select",
-                    parameterName = "host",
-                    parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)
-                },
-                new Assertions.ExpectedSegmentParameter
-                {
-                    segmentName = "Datastore/statement/MySQL/dates/select",
-                    parameterName = "port_path_or_id",
-                    parameterValue = MySqlTestConfiguration.MySqlPort
-                },
-                new Assertions.ExpectedSegmentParameter
-                {
-                    segmentName = "Datastore/statement/MySQL/dates/select",
-                    parameterName = "database_name",
-                    parameterValue = MySqlTestConfiguration.MySqlDbName
-                },
-                new Assertions.ExpectedSegmentParameter
-                {
-                    segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"
-                }
-            };
+                segmentName = "Datastore/statement/MySQL/dates/select",
+                parameterName = "sql",
+                parameterValue = queryWithDelay
+            },
+            new Assertions.ExpectedSegmentParameter
+            {
+                segmentName = "Datastore/statement/MySQL/dates/select",
+                parameterName = "host",
+                parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)
+            },
+            new Assertions.ExpectedSegmentParameter
+            {
+                segmentName = "Datastore/statement/MySQL/dates/select",
+                parameterName = "port_path_or_id",
+                parameterValue = MySqlTestConfiguration.MySqlPort
+            },
+            new Assertions.ExpectedSegmentParameter
+            {
+                segmentName = "Datastore/statement/MySQL/dates/select",
+                parameterName = "database_name",
+                parameterValue = MySqlTestConfiguration.MySqlDbName
+            },
+            new Assertions.ExpectedSegmentParameter
+            {
+                segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"
+            }
+        };
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
-            // there may be multiple traces, but we want the slowest one (by total call time) which is always the result of ExecuteReaderWithDelay
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-            var sqlTrace = sqlTraces.OrderByDescending(t => t.TotalCallTime).First();
+        // there may be multiple traces, but we want the slowest one (by total call time) which is always the result of ExecuteReaderWithDelay
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var sqlTrace = sqlTraces.OrderByDescending(t => t.TotalCallTime).First();
 
-            Assert.Equal( queryWithDelay, sqlTrace.Sql );
-            Assert.Equal("Datastore/statement/MySQL/dates/select", sqlTrace.DatastoreMetricName);
-            Assert.True(sqlTrace.ParameterData.GetValueOrDefault("explain_plan") != null);
+        Assert.Equal( queryWithDelay, sqlTrace.Sql );
+        Assert.Equal("Datastore/statement/MySQL/dates/select", sqlTrace.DatastoreMetricName);
+        Assert.True(sqlTrace.ParameterData.GetValueOrDefault("explain_plan") != null);
             
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
-            );
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
+        );
 
-            // only a single transaction trace is expected - it will be the command that was slowest, which is always the first command
-            var sampledTransactionName = GetTransactionName(commandList.First());
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(sampledTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(sampledTransactionName);
+        // only a single transaction trace is expected - it will be the command that was slowest, which is always the first command
+        var sampledTransactionName = GetTransactionName(commandList.First());
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(sampledTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(sampledTransactionName);
 
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-            NrAssert.Multiple
-            (
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
-            );
-        }
-
-        private static string GetTransactionName(string command) => $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlConnectorExerciser/{command}";
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+        NrAssert.Multiple
+        (
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
+        );
     }
 
-    public class MySqlConnectorTestFW462 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public MySqlConnectorTestFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+    private static string GetTransactionName(string command) => $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlConnectorExerciser/{command}";
+}
 
-    public class MySqlConnectorTestFW471 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW471>
+public class MySqlConnectorTestFW462 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MySqlConnectorTestFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public MySqlConnectorTestFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class MySqlConnectorTestFW48 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW48>
+public class MySqlConnectorTestFW471 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MySqlConnectorTestFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public MySqlConnectorTestFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class MySqlConnectorTestFWLatest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MySqlConnectorTestFW48 : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MySqlConnectorTestFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public MySqlConnectorTestFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class MySqlConnectorTestCoreOldest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MySqlConnectorTestFWLatest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MySqlConnectorTestFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public MySqlConnectorTestCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class MySqlConnectorTestCoreLatest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MySqlConnectorTestCoreOldest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MySqlConnectorTestCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public MySqlConnectorTestCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class MySqlConnectorTestCoreLatest : MySqlConnectorTestBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MySqlConnectorTestCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlStoredProcedureTests.cs
@@ -12,179 +12,178 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MySql;
+
+public abstract class MySqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MySqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _procNameWith;
+    private readonly string _procNameWithout;
+
+    protected MySqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _procNameWith;
-        private readonly string _procNameWithout;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        protected MySqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        string procedureName = "testProcedure" + Guid.NewGuid().ToString("n").Substring(0, 4);
+        _procNameWith = $"{procedureName}_with";
+        _procNameWithout = $"{procedureName}_without";
+        _fixture.AddCommand($"MySqlExerciser CreateAndExecuteStoredProcedures {_procNameWith} {_procNameWithout}");
 
-            string procedureName = "testProcedure" + Guid.NewGuid().ToString("n").Substring(0, 4);
-            _procNameWith = $"{procedureName}_with";
-            _procNameWithout = $"{procedureName}_without";
-            _fixture.AddCommand($"MySqlExerciser CreateAndExecuteStoredProcedures {_procNameWith} {_procNameWithout}");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/CreateAndExecuteStoredProcedures";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = transactionName},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = transactionName}
-            };
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
 
-            var expectedTransactionTraceSegments = new List<string>
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
-                $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure"
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            };
-
-            var expectedQueryParametersWith = DbParameterData.MySqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
-            var expectedQueryParametersWithout = DbParameterData.MySqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
-
-            var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters
-            {
-                segmentName = $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
-                QueryParameters = expectedQueryParametersWith
-            };
-
-            var expectedSqlTracesWith = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = transactionName,
-                    Sql = _procNameWith,
-                    DatastoreMetricName = $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWith,
-                    HasExplainPlan = false
-                }
-            };
-            var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters
-            {
-                segmentName = $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
-                QueryParameters = expectedQueryParametersWithout
-            };
-
-            var expectedSqlTracesWithout = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = transactionName,
-                    Sql = _procNameWithout,
-                    DatastoreMetricName = $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParametersWithout,
-                    HasExplainPlan = false
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTracesWith, sqlTraces),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTracesWithout, sqlTraces)
-            );
-
-        }
+        _fixture.Initialize();
     }
 
-    public class MySqlStoredProcedureTestsFW462 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MySqlStoredProcedureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/CreateAndExecuteStoredProcedures";
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = transactionName},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = transactionName}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+            $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure"
+
+        };
+
+        var expectedQueryParametersWith = DbParameterData.MySqlParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        var expectedQueryParametersWithout = DbParameterData.MySqlParameters.ToDictionary(p => p.ParameterName.TrimStart('@'), p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParametersWith = new Assertions.ExpectedSegmentQueryParameters
+        {
+            segmentName = $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+            QueryParameters = expectedQueryParametersWith
+        };
+
+        var expectedSqlTracesWith = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = transactionName,
+                Sql = _procNameWith,
+                DatastoreMetricName = $"Datastore/statement/MySQL/{_procNameWith.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWith,
+                HasExplainPlan = false
+            }
+        };
+        var expectedTransactionTraceQueryParametersWithout = new Assertions.ExpectedSegmentQueryParameters
+        {
+            segmentName = $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
+            QueryParameters = expectedQueryParametersWithout
+        };
+
+        var expectedSqlTracesWithout = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = transactionName,
+                Sql = _procNameWithout,
+                DatastoreMetricName = $"Datastore/statement/MySQL/{_procNameWithout.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParametersWithout,
+                HasExplainPlan = false
+            }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWith, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTracesWith, sqlTraces),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParametersWithout, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTracesWithout, sqlTraces)
+        );
+
     }
+}
 
-    public class MySqlStoredProcedureTestsFW471 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MySqlStoredProcedureTestsFW462 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MySqlStoredProcedureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlStoredProcedureTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlStoredProcedureTestsFW48 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MySqlStoredProcedureTestsFW471 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MySqlStoredProcedureTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlStoredProcedureTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlStoredProcedureTestsFWLatest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MySqlStoredProcedureTestsFW48 : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MySqlStoredProcedureTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlStoredProcedureTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlStoredProcedureTestsCoreOldest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MySqlStoredProcedureTestsFWLatest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MySqlStoredProcedureTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlStoredProcedureTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlStoredProcedureTestsCoreLatest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MySqlStoredProcedureTestsCoreOldest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MySqlStoredProcedureTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class MySqlStoredProcedureTestsCoreLatest : MySqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MySqlStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MySql/MySqlTests.cs
@@ -6,186 +6,185 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.MySql
+namespace NewRelic.Agent.UnboundedIntegrationTests.MySql;
+
+public abstract class MySqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class MySqlTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public MySqlTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public MySqlTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"MySqlExerciser SingleDateQuery");
 
-            _fixture.AddCommand($"MySqlExerciser SingleDateQuery");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(10);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(10);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(10);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
 
-                    var instrumentationFilePath = string.Format(@"{0}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml", fixture.DestinationNewRelicExtensionsDirectoryPath);
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-            //This results in two calls to Read followed by a call to NextResult. Therefore the call count for the Iterate metric should be 3.
-            var expectedIterateCallCount = 3;
-
-            var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/SingleDateQuery";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                var instrumentationFilePath = string.Format(@"{0}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml", fixture.DestinationNewRelicExtensionsDirectoryPath);
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1, metricScope = transactionName},
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = transactionName}
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                // The datastore operation happened inside a console app so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", callCount = 1 },
-
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1, metricScope = transactionName }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/MySQL/dates/select"
-            };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = transactionName,
-                    Sql = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?",
-                    DatastoreMetricName = "Datastore/statement/MySQL/dates/select",
-
-                    HasExplainPlan = true
-                }
-            };
-
-            var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
-            {
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "sql", parameterValue = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?"},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "port_path_or_id", parameterValue = MySqlTestConfiguration.MySqlPort},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "database_name", parameterValue = MySqlTestConfiguration.MySqlDbName},
-                new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"}
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple
-            (
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
-                () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class MySqlTestsFW462 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public MySqlTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+        //This results in two calls to Read followed by a call to NextResult. Therefore the call count for the Iterate metric should be 3.
+        var expectedIterateCallCount = 3;
 
-        }
+        var transactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.MySql.MySqlExerciser/SingleDateQuery";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/all", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/MySQL/{CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)}/{MySqlTestConfiguration.MySqlPort}", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/MySQL/dates/select", callCount = 1, metricScope = transactionName},
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = transactionName}
+
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a console app so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/MySQL/allWeb", callCount = 1 },
+
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/MySQL/select", callCount = 1, metricScope = transactionName }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/MySQL/dates/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = transactionName,
+                Sql = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?",
+                DatastoreMetricName = "Datastore/statement/MySQL/dates/select",
+
+                HasExplainPlan = true
+            }
+        };
+
+        var expectedTransactionTraceSegmentParameters = new List<Assertions.ExpectedSegmentParameter>
+        {
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "sql", parameterValue = "SELECT _date FROM dates WHERE _date LIKE ? ORDER BY _date DESC LIMIT ?"},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "host", parameterValue = CommonUtils.NormalizeHostname(MySqlTestConfiguration.MySqlServer)},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "port_path_or_id", parameterValue = MySqlTestConfiguration.MySqlPort},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "database_name", parameterValue = MySqlTestConfiguration.MySqlDbName},
+            new Assertions.ExpectedSegmentParameter { segmentName = "Datastore/statement/MySQL/dates/select", parameterName = "explain_plan"}
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(transactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces),
+            () => Assertions.TransactionTraceSegmentParametersExist(expectedTransactionTraceSegmentParameters, transactionSample)
+        );
     }
+}
 
-    public class MySqlTestsFW471 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class MySqlTestsFW462 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public MySqlTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlTestsFW48 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class MySqlTestsFW471 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public MySqlTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlTestsFWLatest : MySqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class MySqlTestsFW48 : MySqlTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public MySqlTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlTestsCoreOldest : MySqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class MySqlTestsFWLatest : MySqlTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MySqlTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class MySqlTestsCoreLatest : MySqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class MySqlTestsCoreOldest : MySqlTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MySqlTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public MySqlTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class MySqlTestsCoreLatest : MySqlTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MySqlTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbCmdHandlerTests.cs
@@ -2,124 +2,123 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus;
+
+public abstract class NsbCmdHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class NsbCmdHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected NsbCmdHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
 
-        protected NsbCmdHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+        _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
+        _fixture.AddCommand("NServiceBusDriver SendCommand");
 
-            _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithCommandHandler");
-            _fixture.AddCommand("NServiceBusDriver SendCommand");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
-                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command",
-                                                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
-                new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"}
-            };
-
-            var expectedTransactionTraceSegments = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+                configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+            },
+            exerciseApplication: () =>
             {
-                @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-
-            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
-        }
+        _fixture.Initialize();
     }
 
-    public class NsbCmdHandlerTestsFW471 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void Test()
     {
-        public NsbCmdHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command",
+                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
+            new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"}
+        };
 
-    public class NsbCmdHandlerTestsFW48 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public NsbCmdHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionTraceSegments = new List<string>
         {
-        }
-    }
+            @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
+        };
 
-    public class NsbCmdHandlerTestsFWLatest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public NsbCmdHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
-    public class NsbCmdHandlerTestsCoreOldest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public NsbCmdHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
 
-    public class NsbCmdHandlerTestsCoreLatest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
+
+        Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
+    }
+}
+
+public class NsbCmdHandlerTestsFW471 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public NsbCmdHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbCmdHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class NsbCmdHandlerTestsFW48 : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public NsbCmdHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbCmdHandlerTestsFWLatest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public NsbCmdHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbCmdHandlerTestsCoreOldest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public NsbCmdHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbCmdHandlerTestsCoreLatest : NsbCmdHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public NsbCmdHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbEventHandlerTests.cs
@@ -2,124 +2,123 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus;
+
+public abstract class NsbEventHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class NsbEventHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected NsbEventHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
 
-        protected NsbEventHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+        _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
+        _fixture.AddCommand("NServiceBusDriver PublishEvent");
 
-            _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithEventHandler");
-            _fixture.AddCommand("NServiceBusDriver PublishEvent");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
-                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event",
-                                                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"},
-                new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"}
-            };
-
-            var expectedTransactionTraceSegments = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+                configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+            },
+            exerciseApplication: () =>
             {
-                @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event");
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-
-            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
-        }
+        _fixture.Initialize();
     }
 
-    public class NsbEventHandlerTestsFW471 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void Test()
     {
-        public NsbEventHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event",
+                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"},
+            new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"}
+        };
 
-    public class NsbEventHandlerTestsFW48 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public NsbEventHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedTransactionTraceSegments = new List<string>
         {
-        }
-    }
+            @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event"
+        };
 
-    public class NsbEventHandlerTestsFWLatest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public NsbEventHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
-    public class NsbEventHandlerTestsCoreOldest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public NsbEventHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Event");
 
-    public class NsbEventHandlerTestsCoreLatest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
+
+        Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
+    }
+}
+
+public class NsbEventHandlerTestsFW471 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public NsbEventHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbEventHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class NsbEventHandlerTestsFW48 : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public NsbEventHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbEventHandlerTestsFWLatest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public NsbEventHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbEventHandlerTestsCoreOldest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public NsbEventHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbEventHandlerTestsCoreLatest : NsbEventHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public NsbEventHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbSendTests.cs
@@ -2,118 +2,117 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus;
+
+public abstract class NsbSendTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class NsbSendTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected NsbSendTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
 
-        protected NsbSendTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+        _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
+        _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
 
-            _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithoutHandlers");
-            _fixture.AddCommand("NServiceBusDriver SendCommandInTransaction");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
-                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction"}
-            };
-            var expectedTransactionTraceSegments = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+                configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+            },
+            exerciseApplication: () =>
             {
-                @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction");
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class NsbSendTestsFW471 : NsbSendTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void Test()
     {
-        public NsbSendTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction"}
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            @"MessageBroker/NServiceBus/Queue/Produce/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
+        };
 
-    public class NsbSendTestsFW48 : NsbSendTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public NsbSendTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.NServiceBusDriver/SendCommandInTransaction");
 
-    public class NsbSendTestsFWLatest : NsbSendTestsBase<ConsoleDynamicMethodFixtureFWLatest>
-    {
-        public NsbSendTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-    public class NsbSendTestsCoreOldest : NsbSendTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public NsbSendTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
     }
+}
 
-    public class NsbSendTestsCoreLatest : NsbSendTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class NsbSendTestsFW471 : NsbSendTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public NsbSendTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbSendTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class NsbSendTestsFW48 : NsbSendTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public NsbSendTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbSendTestsFWLatest : NsbSendTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public NsbSendTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbSendTestsCoreOldest : NsbSendTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public NsbSendTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class NsbSendTestsCoreLatest : NsbSendTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public NsbSendTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus/NsbThrowingHandlerTests.cs
@@ -2,135 +2,134 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus
+namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus;
+
+public abstract class NsbThrowingHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class NsbThrowingHandlerTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected NsbThrowingHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
 
-        protected NsbThrowingHandlerTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+        _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
+        _fixture.AddCommand("NServiceBusDriver SendCommand");
 
-            _fixture.AddCommand("NServiceBusDriver StartNServiceBusWithThrowingCommandHandler");
-            _fixture.AddCommand("NServiceBusDriver SendCommand");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-                    configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
-                    _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command",
-                                                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
-                new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"}
-            };
-
-            var expectedTransactionTraceSegments = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+                configModifier.DisableEventListenerSamplers(); // Required for .NET 8 to pass.
+            },
+            exerciseApplication: () =>
             {
-                @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30));
+                _fixture.SendCommand("NServiceBusDriver StopNServiceBus");
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
-            var errorTrace =
-                _fixture.AgentLog.TryGetErrorTrace(
-                    "OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent),
-                () => Assert.NotNull(errorTrace)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-
-            Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
-        }
+        _fixture.Initialize();
     }
 
-
-    /// <summary>
-    /// This harness targets to NServiceBus 6.5.10
-    /// </summary>
-    public class NsbThrowingHandlerTestsFW471 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+    [Fact]
+    public void Test()
     {
-        public NsbThrowingHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command",
+                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"},
+            new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
+        var errorTrace =
+            _fixture.AgentLog.TryGetErrorTrace(
+                "OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus.Models.Command");
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent),
+            () => Assert.NotNull(errorTrace)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
+
+        Assert.DoesNotContain("Transaction was garbage collected without ever ending", _fixture.AgentLog.GetFullLogAsString());
     }
+}
 
-    /// <summary>
-    /// This harness, and all the others, target to NServiceBus 7.5
-    /// </summary>
-    public class NsbThrowingHandlerTestsFW48 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
+
+/// <summary>
+/// This harness targets to NServiceBus 6.5.10
+/// </summary>
+public class NsbThrowingHandlerTestsFW471 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public NsbThrowingHandlerTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbThrowingHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class NsbThrowingHandlerTestsFWLatest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+/// <summary>
+/// This harness, and all the others, target to NServiceBus 7.5
+/// </summary>
+public class NsbThrowingHandlerTestsFW48 : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public NsbThrowingHandlerTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbThrowingHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class NsbThrowingHandlerTestsCoreOldest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class NsbThrowingHandlerTestsFWLatest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public NsbThrowingHandlerTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbThrowingHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class NsbThrowingHandlerTestsCoreLatest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class NsbThrowingHandlerTestsCoreOldest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public NsbThrowingHandlerTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public NsbThrowingHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class NsbThrowingHandlerTestsCoreLatest : NsbThrowingHandlerTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public NsbThrowingHandlerTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5ReceiveTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/NServiceBus5/NServiceBus5ReceiveTests.cs
@@ -2,99 +2,97 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
-
 using Assert = Xunit.Assert;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus5
+namespace NewRelic.Agent.UnboundedIntegrationTests.NServiceBus5;
+
+public abstract class NServiceBus5ReceiveTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class NServiceBus5ReceiveTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected NServiceBus5ReceiveTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        protected NServiceBus5ReceiveTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand("NServiceBusSetup Setup");
+        _fixture.AddCommand("NServiceBusReceiverHost Start");
+        _fixture.AddCommand("NServiceBusService Start");
+        _fixture.AddCommand("NServiceBusService SendValid");
+        _fixture.AddCommand("NServiceBusService SendInvalid");
 
-            _fixture.AddCommand("NServiceBusSetup Setup");
-            _fixture.AddCommand("NServiceBusReceiverHost Start");
-            _fixture.AddCommand("NServiceBusService Start");
-            _fixture.AddCommand("NServiceBusService SendValid");
-            _fixture.AddCommand("NServiceBusService SendInvalid");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-                },
-                exerciseApplication: () =>
-                {
-                    // There will be two transactions created by the reciever, one for the valid message and one for the invalid message
-                    _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30), 2);
-                    _fixture.SendCommand("NServiceBusService Stop");
-                    _fixture.SendCommand("NServiceBusReceiverHost Stop");
-                }
-            );
-
-            _fixture.Initialize();
-            // _fixture.AgentLog.WaitForLogLine(AgentLogFile.ErrorTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
-        }
-
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2",
-                                                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
-                new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
-                new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"}
-            };
-
-            var expectedTransactionTraceSegments = new List<string>
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+            },
+            exerciseApplication: () =>
             {
-                @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"
-            };
+                // There will be two transactions created by the reciever, one for the valid message and one for the invalid message
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromSeconds(30), 2);
+                _fixture.SendCommand("NServiceBusService Stop");
+                _fixture.SendCommand("NServiceBusReceiverHost Stop");
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
-            var errorTrace =
-                _fixture.AgentLog.TryGetErrorTrace(
-                    "OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent),
-                () => Assert.NotNull(errorTrace)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
-            );
-        }
+        _fixture.Initialize();
+        // _fixture.AgentLog.WaitForLogLine(AgentLogFile.ErrorTraceDataLogLineRegex, TimeSpan.FromMinutes(2));
     }
 
-    public class NServiceBus5ReceiveOnFW462Tests : NServiceBus5ReceiveTestsBase<ConsoleDynamicMethodFixtureFW462>
+
+    [Fact]
+    public void Test()
     {
-        public NServiceBus5ReceiveOnFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2",
+                metricScope = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
+            new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"},
+            new Assertions.ExpectedMetric { metricName = @"OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            @"MessageBroker/NServiceBus/Queue/Consume/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
+        var errorTrace =
+            _fixture.AgentLog.TryGetErrorTrace(
+                "OtherTransaction/Message/NServiceBus/Queue/Named/MultiFunctionApplicationHelpers.NetStandardLibraries.NServiceBus5.SampleNServiceBusMessage2");
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent),
+            () => Assert.NotNull(errorTrace)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample)
+        );
+    }
+}
+
+public class NServiceBus5ReceiveOnFW462Tests : NServiceBus5ReceiveTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public NServiceBus5ReceiveOnFW462Tests(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/OpenSearch/OpenSearchTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/OpenSearch/OpenSearchTests.cs
@@ -13,234 +13,233 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.OpenSearch
+namespace NewRelic.Agent.UnboundedIntegrationTests.OpenSearch;
+
+public abstract class OpenSearchTestsTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class OpenSearchTestsTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    protected readonly ConsoleDynamicMethodFixture _fixture;
+
+    protected readonly string _host;
+
+    const string IndexName = "flights";
+
+    protected OpenSearchTestsTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        protected readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        protected readonly string _host;
+        _host = GetHostFromElasticServer();
 
-        const string IndexName = "flights";
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
 
-        protected OpenSearchTestsTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        // Required to set up the connection to the OpenSearch server
+        _fixture.AddCommand($"OpenSearchExerciser ConnectAsync");
 
-            _host = GetHostFromElasticServer();
+        // Async operations
+        _fixture.AddCommand($"OpenSearchExerciser IndexAsync");
+        _fixture.AddCommand($"OpenSearchExerciser SearchAsync");
+        _fixture.AddCommand($"OpenSearchExerciser IndexManyAsync");
+        _fixture.AddCommand($"OpenSearchExerciser MultiSearchAsync");
+        _fixture.AddCommand($"OpenSearchExerciser GenerateErrorAsync");
 
-            _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+        // Sync operations
+        _fixture.AddCommand($"OpenSearchExerciser Index");
+        _fixture.AddCommand($"OpenSearchExerciser Search");
+        _fixture.AddCommand($"OpenSearchExerciser IndexMany");
+        _fixture.AddCommand($"OpenSearchExerciser MultiSearch");
 
-            // Required to set up the connection to the OpenSearch server
-            _fixture.AddCommand($"OpenSearchExerciser ConnectAsync");
-
-            // Async operations
-            _fixture.AddCommand($"OpenSearchExerciser IndexAsync");
-            _fixture.AddCommand($"OpenSearchExerciser SearchAsync");
-            _fixture.AddCommand($"OpenSearchExerciser IndexManyAsync");
-            _fixture.AddCommand($"OpenSearchExerciser MultiSearchAsync");
-            _fixture.AddCommand($"OpenSearchExerciser GenerateErrorAsync");
-
-            // Sync operations
-            _fixture.AddCommand($"OpenSearchExerciser Index");
-            _fixture.AddCommand($"OpenSearchExerciser Search");
-            _fixture.AddCommand($"OpenSearchExerciser IndexMany");
-            _fixture.AddCommand($"OpenSearchExerciser MultiSearch");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterErrorTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Index()
-        {
-            ValidateOperation("Index");
-        }
-
-        [Fact]
-        public void Search()
-        {
-            ValidateOperation("Search");
-        }
-
-        [Fact]
-        public void IndexMany()
-        {
-            ValidateOperation("IndexMany");
-        }
-
-        [Fact]
-        public void MultiSearch()
-        {
-            ValidateOperation("MultiSearch");
-        }
-
-        [Fact]
-        public void IndexAsync()
-        {
-            ValidateOperation("IndexAsync");
-        }
-
-        [Fact]
-        public void SearchAsync()
-        {
-            ValidateOperation("SearchAsync");
-        }
-
-        [Fact]
-        public void IndexManyAsync()
-        {
-            ValidateOperation("IndexManyAsync");
-        }
-
-        [Fact]
-        public void MultiSearchAsync()
-        {
-            ValidateOperation("MultiSearchAsync");
-        }
-
-        [Fact]
-        public void ErrorAsync()
-        {
-            ValidateError("GenerateErrorAsync");
-        }
-
-        private void ValidateError(string operationName)
-        {
-            var errorTrace =
-                _fixture.AgentLog.TryGetErrorTrace(
-                    $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.OpenSearch.OpenSearchExerciser/{operationName}");
-            Assert.NotNull(errorTrace);
-        }
-
-
-        private void ValidateOperation(string operationName)
-        {
-            var expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.OpenSearch.OpenSearchExerciser/{operationName}";
-
-            var expectedIndexName = IndexName;
-            var expectedOperationName = GetExpectedOperationName(operationName);
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $"Datastore/statement/OpenSearch/{expectedIndexName}/{expectedOperationName}", metricScope = expectedTransactionName, callCount = 1 },
-            };
-            var expectedAgentAttributes = new List<string>
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterErrorTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(15);
+
+                configModifier.ForceTransactionTraces();
+            },
+            exerciseApplication: () =>
             {
-                "db.system",
-                "db.operation",
-                "db.instance",
-                "peer.address",
-                "peer.hostname",
-                "server.address",
-                "server.port"
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents();
-
-            var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
-
-            var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/OpenSearch"));
-
-            var operationDatastoreAgentAttributes = operationDatastoreSpans.FirstOrDefault()?.AgentAttributes;
-
-            var uri = operationDatastoreAgentAttributes?.Where(x => x.Key == "peer.address").FirstOrDefault().Value;
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assert.Single(operationDatastoreSpans),
-                () => Assert.Equal(_host, uri),
-                () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
-            );
-        }
-
-        // Using the Elasticsearch server credentials since it OpenSearch supports it.
-        private static string GetHostFromElasticServer()
-        {
-            var elasticServer = ElasticSearch8Configuration.ElasticServer;
-
-            if (elasticServer.StartsWith("https://"))
-            {
-                return elasticServer.Remove(0, "https://".Length);
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
             }
-            else if (elasticServer.StartsWith("http://"))
-            {
-                return elasticServer.Remove(0, "http://".Length);
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
+        );
 
-        private static string GetExpectedOperationName(string operationName)
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Index()
+    {
+        ValidateOperation("Index");
+    }
+
+    [Fact]
+    public void Search()
+    {
+        ValidateOperation("Search");
+    }
+
+    [Fact]
+    public void IndexMany()
+    {
+        ValidateOperation("IndexMany");
+    }
+
+    [Fact]
+    public void MultiSearch()
+    {
+        ValidateOperation("MultiSearch");
+    }
+
+    [Fact]
+    public void IndexAsync()
+    {
+        ValidateOperation("IndexAsync");
+    }
+
+    [Fact]
+    public void SearchAsync()
+    {
+        ValidateOperation("SearchAsync");
+    }
+
+    [Fact]
+    public void IndexManyAsync()
+    {
+        ValidateOperation("IndexManyAsync");
+    }
+
+    [Fact]
+    public void MultiSearchAsync()
+    {
+        ValidateOperation("MultiSearchAsync");
+    }
+
+    [Fact]
+    public void ErrorAsync()
+    {
+        ValidateError("GenerateErrorAsync");
+    }
+
+    private void ValidateError(string operationName)
+    {
+        var errorTrace =
+            _fixture.AgentLog.TryGetErrorTrace(
+                $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.OpenSearch.OpenSearchExerciser/{operationName}");
+        Assert.NotNull(errorTrace);
+    }
+
+
+    private void ValidateOperation(string operationName)
+    {
+        var expectedTransactionName = $"OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.OpenSearch.OpenSearchExerciser/{operationName}";
+
+        var expectedIndexName = IndexName;
+        var expectedOperationName = GetExpectedOperationName(operationName);
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            if (operationName.StartsWith("IndexMany"))
-            {
-                return "Bulk";
-            }
-            else
-            {
-                return operationName.Replace("Async", "");
-            }
+            new Assertions.ExpectedMetric { metricName = $"Datastore/statement/OpenSearch/{expectedIndexName}/{expectedOperationName}", metricScope = expectedTransactionName, callCount = 1 },
+        };
+        var expectedAgentAttributes = new List<string>
+        {
+            "db.system",
+            "db.operation",
+            "db.instance",
+            "peer.address",
+            "peer.hostname",
+            "server.address",
+            "server.port"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+        var traceId = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Equals(expectedTransactionName)).FirstOrDefault().IntrinsicAttributes["traceId"];
+
+        var operationDatastoreSpans = spanEvents.Where(@event => @event.IntrinsicAttributes["traceId"].ToString().Equals(traceId) && @event.IntrinsicAttributes["name"].ToString().Contains("Datastore/statement/OpenSearch"));
+
+        var operationDatastoreAgentAttributes = operationDatastoreSpans.FirstOrDefault()?.AgentAttributes;
+
+        var uri = operationDatastoreAgentAttributes?.Where(x => x.Key == "peer.address").FirstOrDefault().Value;
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assert.Single(operationDatastoreSpans),
+            () => Assert.Equal(_host, uri),
+            () => Assertions.SpanEventHasAttributes(expectedAgentAttributes, SpanEventAttributeType.Agent, operationDatastoreSpans.FirstOrDefault())
+        );
+    }
+
+    // Using the Elasticsearch server credentials since it OpenSearch supports it.
+    private static string GetHostFromElasticServer()
+    {
+        var elasticServer = ElasticSearch8Configuration.ElasticServer;
+
+        if (elasticServer.StartsWith("https://"))
+        {
+            return elasticServer.Remove(0, "https://".Length);
+        }
+        else if (elasticServer.StartsWith("http://"))
+        {
+            return elasticServer.Remove(0, "http://".Length);
+        }
+        else
+        {
+            return string.Empty;
         }
     }
 
-    #region OpenSearchClient
-    public class OpenSearchClientTestsFWLatest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    private static string GetExpectedOperationName(string operationName)
     {
-        public OpenSearchClientTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        if (operationName.StartsWith("IndexMany"))
         {
+            return "Bulk";
+        }
+        else
+        {
+            return operationName.Replace("Async", "");
         }
     }
-
-    public class OpenSearchClientTestsFW462 : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public OpenSearchClientTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    public class OpenSearchClientTestsCoreLatest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
-    {
-        public OpenSearchClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-
-    public class OpenSearchClientTestsCoreOldest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public OpenSearchClientTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
-    #endregion Clients
 }
+
+#region OpenSearchClient
+public class OpenSearchClientTestsFWLatest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public OpenSearchClientTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class OpenSearchClientTestsFW462 : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public OpenSearchClientTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class OpenSearchClientTestsCoreLatest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public OpenSearchClientTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class OpenSearchClientTestsCoreOldest : OpenSearchTestsTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public OpenSearchClientTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+#endregion Clients

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/EnterpriseLibraryOracleTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/EnterpriseLibraryOracleTests.cs
@@ -6,169 +6,168 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
+namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle;
+
+public class EnterpriseLibraryOracleTests : NewRelicIntegrationTest<RemoteServiceFixtures.OracleBasicMvcFixture>
 {
-    public class EnterpriseLibraryOracleTests : NewRelicIntegrationTest<RemoteServiceFixtures.OracleBasicMvcFixture>
+    private readonly RemoteServiceFixtures.OracleBasicMvcFixture _fixture;
+
+    public EnterpriseLibraryOracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly RemoteServiceFixtures.OracleBasicMvcFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public EnterpriseLibraryOracleTests(RemoteServiceFixtures.OracleBasicMvcFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
+                configModifier.ForceTransactionTraces();
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.CreateTable();
+
+                try
                 {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.CreateTable();
-
-                    try
-                    {
-                        _fixture.GetEnterpriseLibraryOracle();
-                        _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex,
-                            TimeSpan.FromMinutes(1));
-                        _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex,
-                            TimeSpan.FromMinutes(1));
-                    }
-                    finally
-                    {
-                        _fixture.DropTable();
-                    }
+                    _fixture.GetEnterpriseLibraryOracle();
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex,
+                        TimeSpan.FromMinutes(1));
+                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex,
+                        TimeSpan.FromMinutes(1));
                 }
-            );
-
-            _fixture.Initialize();
-
-        }
-        [Fact]
-        public void Test()
-        {
-            var expectedDatastoreCallCount = 4;
-
-            //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-            //This results in a call to Read which succeeds followed by a call that doesn't as there is only one result. Therefore
-            //the call count for the Iterate metric should be 2.
-            var expectedIterateCallCount = 2;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/allWeb", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/select", callCount = 2},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/select", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/insert", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/insert", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/delete", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/delete", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
-
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"}
-            };
-
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-				// The datastore operation happened inside a web transaction so there should be no allOther metrics
-				new Assertions.ExpectedMetric { metricName = @"Datastore/allOther"},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/allOther"},
-
-				// The operation metric should not be scoped because the statement metric is scoped instead
-				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/select", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/insert", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/delete", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Oracle/user_tables/select"
-            };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
+                finally
                 {
-                    TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
-                    Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
-                    DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
-                    HasExplainPlan = false
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
-                    Sql = $"SELECT COUNT(*) FROM {_fixture.TableName}",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/select",
-
-                    HasExplainPlan = false
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
-                    Sql = $"INSERT INTO {_fixture.TableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/insert",
-
-                    HasExplainPlan = false
-                },
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
-                    Sql = $"DELETE FROM {_fixture.TableName} WHERE HOTEL_ID = ?",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/delete",
-
-                    HasExplainPlan = false
+                    _fixture.DropTable();
                 }
-            };
+            }
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("WebTransaction/MVC/OracleController/EnterpriseLibraryOracle");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("WebTransaction/MVC/OracleController/EnterpriseLibraryOracle");
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        _fixture.Initialize();
 
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
+    }
+    [Fact]
+    public void Test()
+    {
+        var expectedDatastoreCallCount = 4;
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+        //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+        //This results in a call to Read which succeeds followed by a call that doesn't as there is only one result. Therefore
+        //the call count for the Iterate metric should be 2.
+        var expectedIterateCallCount = 2;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/allWeb", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/select", callCount = 2},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/select", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/insert", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/insert", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/delete", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Oracle/{_fixture.TableName}/delete", callCount = 1, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"},
+
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle"}
+        };
+
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a web transaction so there should be no allOther metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther"},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Oracle/allOther"},
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/select", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/insert", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Oracle/delete", metricScope = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle" }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Oracle/user_tables/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
+                Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
+                DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
+                HasExplainPlan = false
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
+                Sql = $"SELECT COUNT(*) FROM {_fixture.TableName}",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/select",
+
+                HasExplainPlan = false
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
+                Sql = $"INSERT INTO {_fixture.TableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/insert",
+
+                HasExplainPlan = false
+            },
+            new Assertions.ExpectedSqlTrace
+            {
+                TransactionName = "WebTransaction/MVC/OracleController/EnterpriseLibraryOracle",
+                Sql = $"DELETE FROM {_fixture.TableName} WHERE HOTEL_ID = ?",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_fixture.TableName}/delete",
+
+                HasExplainPlan = false
+            }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("WebTransaction/MVC/OracleController/EnterpriseLibraryOracle");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("WebTransaction/MVC/OracleController/EnterpriseLibraryOracle");
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleAsyncTests.cs
@@ -11,190 +11,189 @@ using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
+namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle;
+
+public abstract class OracleAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class OracleAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _tableName;
+
+    protected OracleAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _tableName;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _tableName = GenerateTableName();
 
-        protected OracleAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _tableName = GenerateTableName();
+        _fixture.AddCommand($"OracleExerciser InitializeTable {_tableName}"); // creates a new table. The table gets dropped automatically when the exerciser goes out of scope
+        _fixture.AddCommand($"OracleExerciser ExerciseAsync");
 
-            _fixture.AddCommand($"OracleExerciser InitializeTable {_tableName}"); // creates a new table. The table gets dropped automatically when the exerciser goes out of scope
-            _fixture.AddCommand($"OracleExerciser ExerciseAsync");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedDatastoreCallCount = 4; // SELECT, INSERT, COUNT, and DELETE from GetOracle() above
-
-            //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-            //This results in two calls to read. Therefore the call count for the Iterate metric should be 2.
-            var expectedIterateCallCount = 2;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new() { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/Oracle/allOther", callCount = expectedDatastoreCallCount },
-                new() { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
-                new() { metricName = @"Datastore/operation/Oracle/select", callCount = 2 },
-                new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
-                new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
-                new() { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
-                new() { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-                new() { metricName = @"DotNet/DatabaseResult/Iterate" , callCount = expectedIterateCallCount },
-                new() { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"}
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                configModifier.ForceTransactionTraces();
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
-                new() { metricName = @"Datastore/allWeb" },
-                new() { metricName = @"Datastore/Oracle/allWeb"},
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new() { metricName = @"Datastore/operation/Oracle/select", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" },
-                new() { metricName = @"Datastore/operation/Oracle/insert", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" },
-                new() { metricName = @"Datastore/operation/Oracle/delete", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Oracle/user_tables/select"
-            };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
-                    Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
-                    DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
-                    Sql = $"SELECT COUNT(*) FROM {_tableName}",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/select",
-
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
-                    Sql = $"INSERT INTO {_tableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/insert",
-
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
-                    Sql = $"DELETE FROM {_tableName} WHERE HOTEL_ID = ?",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/delete",
-
-                    HasExplainPlan = false
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync");
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            Assert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            Assert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
-
-        private static string GenerateTableName()
-        {
-            //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
-            var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
-            return $"h{tableId}";
-        }
+        _fixture.Initialize();
     }
 
-    public class OracleAsyncTestsFramework462 : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public OracleAsyncTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var expectedDatastoreCallCount = 4; // SELECT, INSERT, COUNT, and DELETE from GetOracle() above
+
+        //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+        //This results in two calls to read. Therefore the call count for the Iterate metric should be 2.
+        var expectedIterateCallCount = 2;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new() { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/Oracle/allOther", callCount = expectedDatastoreCallCount },
+            new() { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
+            new() { metricName = @"Datastore/operation/Oracle/select", callCount = 2 },
+            new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
+            new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
+            new() { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
+            new() { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"},
+
+            new() { metricName = @"DotNet/DatabaseResult/Iterate" , callCount = expectedIterateCallCount },
+            new() { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync"}
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
+            new() { metricName = @"Datastore/allWeb" },
+            new() { metricName = @"Datastore/Oracle/allWeb"},
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new() { metricName = @"Datastore/operation/Oracle/select", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" },
+            new() { metricName = @"Datastore/operation/Oracle/insert", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" },
+            new() { metricName = @"Datastore/operation/Oracle/delete", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync" }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Oracle/user_tables/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
+                Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
+                DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
+                Sql = $"SELECT COUNT(*) FROM {_tableName}",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/select",
+
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
+                Sql = $"INSERT INTO {_tableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/insert",
+
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync",
+                Sql = $"DELETE FROM {_tableName} WHERE HOTEL_ID = ?",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/delete",
+
+                HasExplainPlan = false
+            }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseAsync");
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        Assert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        Assert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
 
-    public class OracleAsyncTestsFramework471 : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    private static string GenerateTableName()
     {
-        public OracleAsyncTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
+        //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
+        var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
+        return $"h{tableId}";
     }
+}
 
-    public class OracleAsyncTestsFrameworkLatest : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class OracleAsyncTestsFramework462 : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public OracleAsyncTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleAsyncTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class OracleAsyncTestsCoreLatest : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class OracleAsyncTestsFramework471 : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public OracleAsyncTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class OracleAsyncTestsFrameworkLatest : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public OracleAsyncTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+    }
+}
+
+public class OracleAsyncTestsCoreLatest : OracleAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public OracleAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleStoredProcedureTests.cs
@@ -7,137 +7,135 @@ using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
+namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle;
+
+public abstract class OracleStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class OracleStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _storedProcedureName;
+
+    protected OracleStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _storedProcedureName;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        protected OracleStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _storedProcedureName = GenerateStoredProcedureName();
 
-            _storedProcedureName = GenerateStoredProcedureName();
+        _fixture.AddCommand($"OracleExerciser InitializeStoredProcedure {_storedProcedureName}"); // creates a new stored procedure. The stored procedure gets dropped automatically when the exerciser goes out of scope)
+        _fixture.AddCommand($"OracleExerciser ExerciseStoredProcedure"); 
 
-            _fixture.AddCommand($"OracleExerciser InitializeStoredProcedure {_storedProcedureName}"); // creates a new stored procedure. The stored procedure gets dropped automatically when the exerciser goes out of scope)
-            _fixture.AddCommand($"OracleExerciser ExerciseStoredProcedure"); 
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-                    configModifier.SetLogLevel("finest");
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new() { metricName = $@"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure"}
-            };
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            var expectedTransactionTraceSegments = new List<string>
+                configModifier.ForceTransactionTraces();
+                configModifier.SetLogLevel("finest");
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedQueryParameters = DbParameterData.OracleParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        _fixture.Initialize();
+    }
 
-            var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+    [Fact]
+    public void Test()
+    {
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = $@"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure"}
+        };
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure"
+        };
+
+        var expectedQueryParameters = DbParameterData.OracleParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new()
             {
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure",
-                    Sql = _storedProcedureName,
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParameters,
-                    HasExplainPlan = false
-                }
-            };
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure",
+                Sql = _storedProcedureName,
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_storedProcedureName.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParameters,
+                HasExplainPlan = false
+            }
+        };
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure");
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseStoredProcedure");
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            Assert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
+        Assert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            Assert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
-
-        private string GenerateStoredProcedureName()
-        {
-            return $"OracleStoredProcedureTest{Guid.NewGuid():N}".Substring(0, 30);
-        }
+        Assert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
 
-    public class OracleStoredProcedureTestsFramework462 : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+    private string GenerateStoredProcedureName()
     {
-        public OracleStoredProcedureTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
+        return $"OracleStoredProcedureTest{Guid.NewGuid():N}".Substring(0, 30);
     }
+}
+
+public class OracleStoredProcedureTestsFramework462 : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public OracleStoredProcedureTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+    }
+}
 
 
-    public class OracleStoredProcedureTestsFramework471 : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class OracleStoredProcedureTestsFramework471 : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public OracleStoredProcedureTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleStoredProcedureTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
     }
-    public class OracleStoredProcedureTestsFrameworkLatest : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+}
+public class OracleStoredProcedureTestsFrameworkLatest : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public OracleStoredProcedureTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleStoredProcedureTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class OracleStoredProcedureTestsCoreLatest : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class OracleStoredProcedureTestsCoreLatest : OracleStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public OracleStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleSyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Oracle/OracleSyncTests.cs
@@ -11,190 +11,189 @@ using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle
+namespace NewRelic.Agent.UnboundedIntegrationTests.Oracle;
+
+public abstract class OracleSyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class OracleSyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _tableName;
+
+    protected OracleSyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _tableName;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _tableName = GenerateTableName();
 
-        protected OracleSyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
-            _tableName = GenerateTableName();
+        _fixture.AddCommand($"OracleExerciser InitializeTable {_tableName}"); // creates a new table. The table gets dropped automatically when the exerciser goes out of scope
+        _fixture.AddCommand($"OracleExerciser ExerciseSync");
 
-            _fixture.AddCommand($"OracleExerciser InitializeTable {_tableName}"); // creates a new table. The table gets dropped automatically when the exerciser goes out of scope
-            _fixture.AddCommand($"OracleExerciser ExerciseSync");
-
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces();
-
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedDatastoreCallCount = 4; // SELECT, INSERT, COUNT, and DELETE from GetOracle() above
-
-            //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
-            //This results in two calls to read. Therefore the call count for the Iterate metric should be 2.
-            var expectedIterateCallCount = 2;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new() { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
-                new() { metricName = @"Datastore/Oracle/allOther", callCount = expectedDatastoreCallCount },
-                new() { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
-                new() { metricName = @"Datastore/operation/Oracle/select", callCount = 2 },
-                new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
-                new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
-                new() { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
-                new() { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1 },
-                new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-                new() { metricName = @"DotNet/DatabaseResult/Iterate" , callCount = expectedIterateCallCount },
-                new() { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"}
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                configModifier.ForceTransactionTraces();
+
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
-                new() { metricName = @"Datastore/allWeb" },
-                new() { metricName = @"Datastore/Oracle/allWeb"},
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.ShutdownLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new() { metricName = @"Datastore/operation/Oracle/select", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" },
-                new() { metricName = @"Datastore/operation/Oracle/insert", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" },
-                new() { metricName = @"Datastore/operation/Oracle/delete", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Oracle/user_tables/select"
-            };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
-                    Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
-                    DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
-                    Sql = $"SELECT COUNT(*) FROM {_tableName}",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/select",
-
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
-                    Sql = $"INSERT INTO {_tableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/insert",
-
-                    HasExplainPlan = false
-                },
-                new()
-                {
-                    TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
-                    Sql = $"DELETE FROM {_tableName} WHERE HOTEL_ID = ?",
-                    DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/delete",
-
-                    HasExplainPlan = false
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync");
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync");
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            Assert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            Assert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
-
-        private static string GenerateTableName()
-        {
-            //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
-            var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
-            return $"h{tableId}";
-        }
+        _fixture.Initialize();
     }
 
-    public class OracleSyncTestsFramework462 : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public OracleSyncTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var expectedDatastoreCallCount = 4; // SELECT, INSERT, COUNT, and DELETE from GetOracle() above
+
+        //This value is dictated by the query that is being run as part of this test. In this case, we're running a query that returns a single row.
+        //This results in two calls to read. Therefore the call count for the Iterate metric should be 2.
+        var expectedIterateCallCount = 2;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
+            new() { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/Oracle/all", callCount = expectedDatastoreCallCount },
+            new() { metricName = @"Datastore/Oracle/allOther", callCount = expectedDatastoreCallCount },
+            new() { metricName = $@"Datastore/instance/Oracle/{OracleConfiguration.OracleServer}/{OracleConfiguration.OraclePort}", callCount = expectedDatastoreCallCount},
+            new() { metricName = @"Datastore/operation/Oracle/select", callCount = 2 },
+            new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1 },
+            new() { metricName = @"Datastore/statement/Oracle/user_tables/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/select", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
+            new() { metricName = @"Datastore/operation/Oracle/insert", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/insert", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
+            new() { metricName = @"Datastore/operation/Oracle/delete", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1 },
+            new() { metricName = $@"Datastore/statement/Oracle/{_tableName}/delete", callCount = 1, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"},
+
+            new() { metricName = @"DotNet/DatabaseResult/Iterate" , callCount = expectedIterateCallCount },
+            new() { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterateCallCount, metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync"}
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a non-web transaction so there should be no allWeb metrics
+            new() { metricName = @"Datastore/allWeb" },
+            new() { metricName = @"Datastore/Oracle/allWeb"},
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new() { metricName = @"Datastore/operation/Oracle/select", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" },
+            new() { metricName = @"Datastore/operation/Oracle/insert", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" },
+            new() { metricName = @"Datastore/operation/Oracle/delete", metricScope = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync" }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Oracle/user_tables/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
+                Sql = "SELECT DEGREE FROM user_tables WHERE ROWNUM <= ?",
+                DatastoreMetricName = "Datastore/statement/Oracle/user_tables/select",
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
+                Sql = $"SELECT COUNT(*) FROM {_tableName}",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/select",
+
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
+                Sql = $"INSERT INTO {_tableName} (HOTEL_ID, BOOKING_DATE) VALUES (?, SYSDATE)",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/insert",
+
+                HasExplainPlan = false
+            },
+            new()
+            {
+                TransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync",
+                Sql = $"DELETE FROM {_tableName} WHERE HOTEL_ID = ?",
+                DatastoreMetricName = $"Datastore/statement/Oracle/{_tableName}/delete",
+
+                HasExplainPlan = false
+            }
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync");
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent("OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.Oracle.OracleExerciser/ExerciseSync");
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+
+        Assert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
+
+        Assert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
 
-    public class OracleSyncTestsFramework471 : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+    private static string GenerateTableName()
     {
-        public OracleSyncTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
+        //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
+        var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
+        return $"h{tableId}";
     }
+}
 
-    public class OracleSyncTestsFrameworkLatest : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class OracleSyncTestsFramework462 : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public OracleSyncTestsFramework462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleSyncTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class OracleSyncTestsCoreLatest : OracleSyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class OracleSyncTestsFramework471 : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public OracleSyncTestsFramework471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public OracleSyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
-        }
+    }
+}
+
+public class OracleSyncTestsFrameworkLatest : OracleSyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public OracleSyncTestsFrameworkLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+    }
+}
+
+public class OracleSyncTestsCoreLatest : OracleSyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public OracleSyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresExecuteScalarAsyncTests.cs
@@ -6,169 +6,167 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlExecuteScalarAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlExecuteScalarAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public PostgresSqlExecuteScalarAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlExecuteScalarAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser ExecuteScalarAsync");
 
-            _fixture.AddCommand($"PostgresSqlExerciser ExecuteScalarAsync");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ExecuteScalarAsync";
-            var expectedDatastoreCallCount = 1;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ExecuteScalarAsync";
+        var expectedDatastoreCallCount = 1;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened outside a web transaction so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+            // Don't double count the Open
+            new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName },
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Postgres/teammembers/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-				// The datastore operation happened outside a web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-                // Don't double count the Open
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
-				// The operation metric should not be scoped because the statement metric is scoped instead
-				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName },
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Postgres/teammembers/select"
-            };
+                TransactionName = expectedTransactionName,
+                Sql = "SELECT firstname FROM newrelic.teammembers WHERE lastname = ?",
+                DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
+                HasExplainPlan = false
+            }
+        };
 
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = "SELECT firstname FROM newrelic.teammembers WHERE lastname = ?",
-                    DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
-                    HasExplainPlan = false
-                }
-            };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent),
+            () => Assert.NotNull(sqlTraces),
+            () => Assert.Single(sqlTraces)
+        );
 
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent),
-                () => Assert.NotNull(sqlTraces),
-                () => Assert.Single(sqlTraces)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsFW462 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class PostgresSqlExecuteScalarAsyncTestsFW462 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlExecuteScalarAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsFW471 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlExecuteScalarAsyncTestsFW471 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlExecuteScalarAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsFW48 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlExecuteScalarAsyncTestsFW48 : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlExecuteScalarAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsFWLatest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlExecuteScalarAsyncTestsFWLatest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlExecuteScalarAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsCoreOldest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlExecuteScalarAsyncTestsCoreOldest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlExecuteScalarAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlExecuteScalarAsyncTestsCoreLatest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlExecuteScalarAsyncTestsCoreLatest : PostgresSqlExecuteScalarAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlExecuteScalarAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlExecuteScalarAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
-
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorAsyncTests.cs
@@ -12,138 +12,136 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlIteratorAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlIteratorAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public PostgresSqlIteratorAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlIteratorAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser AsyncIteratorTest");
 
-            _fixture.AddCommand($"PostgresSqlExerciser AsyncIteratorTest");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
 
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "DataReaderTracerAsync", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/AsyncIteratorTest";
-            var expectedDatastoreCallCount = 1;
-
-            //These values are dictated by the queries that are being run as part of this test.
-            //The typical pattern in this case is for there to be a call to Read(), followed by a call to NextResult(), followed by a final call to
-            //Read() which returns false to exit the loop.  Each of these roll up to Iterate for a total of 3
-            var expectedIterationCount = 3;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "DataReaderTracerAsync", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                // NpgsqlDataReader methods Read/ReadAsync and NextResult/NextResultAsync result in Iterate metrics.
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount, metricScope = expectedTransactionName}
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", metricScope = expectedTransactionName }
-            };
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class PostgresSqlIteratorAsyncTestsFW462 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public PostgresSqlIteratorAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/AsyncIteratorTest";
+        var expectedDatastoreCallCount = 1;
+
+        //These values are dictated by the queries that are being run as part of this test.
+        //The typical pattern in this case is for there to be a call to Read(), followed by a call to NextResult(), followed by a final call to
+        //Read() which returns false to exit the loop.  Each of these roll up to Iterate for a total of 3
+        var expectedIterationCount = 3;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
 
-        }
+            // NpgsqlDataReader methods Read/ReadAsync and NextResult/NextResultAsync result in Iterate metrics.
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount, metricScope = expectedTransactionName}
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", metricScope = expectedTransactionName }
+        };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
+        );
     }
+}
 
-    public class PostgresSqlIteratorAsyncTestsFW471 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlIteratorAsyncTestsFW462 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlIteratorAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorAsyncTestsFW48 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlIteratorAsyncTestsFW471 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlIteratorAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorAsyncTestsFWLatest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlIteratorAsyncTestsFW48 : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlIteratorAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorAsyncTestsCoreOldest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlIteratorAsyncTestsFWLatest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlIteratorAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorAsyncTestsCoreLatest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlIteratorAsyncTestsCoreOldest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlIteratorAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
+public class PostgresSqlIteratorAsyncTestsCoreLatest : PostgresSqlIteratorAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlIteratorAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresIteratorTests.cs
@@ -12,138 +12,136 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlIteratorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlIteratorTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public PostgresSqlIteratorTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlIteratorTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser IteratorTest");
 
-            _fixture.AddCommand($"PostgresSqlExerciser IteratorTest");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
 
-                    var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
-                    CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "DataReaderTracer", "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/IteratorTest";
-            var expectedDatastoreCallCount = 1;
-
-            //These values are dictated by the queries that are being run as part of this test.
-            //The typical pattern in this case is for there to be a call to Read(), followed by a call to NextResult(), followed by a final call to
-            //Read() which returns false to exit the loop.  Each of these roll up to Iterate for a total of 3
-            var expectedIterationCount = 3;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                var instrumentationFilePath = $@"{fixture.DestinationNewRelicExtensionsDirectoryPath}\NewRelic.Providers.Wrapper.Sql.Instrumentation.xml";
+                CommonUtils.SetAttributeOnTracerFactoryInNewRelicInstrumentation(instrumentationFilePath, "DataReaderTracer", "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-                // NpgsqlDataReader methods Read/ReadAsync and NextResult/NextResultAsync result in Iterate metrics.
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount, metricScope = expectedTransactionName}
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-
-                // The operation metric should not be scoped because the statement metric is scoped instead
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", metricScope = expectedTransactionName }
-            };
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class PostgresSqlIteratorTestsFW462 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public PostgresSqlIteratorTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/IteratorTest";
+        var expectedDatastoreCallCount = 1;
+
+        //These values are dictated by the queries that are being run as part of this test.
+        //The typical pattern in this case is for there to be a call to Read(), followed by a call to NextResult(), followed by a final call to
+        //Read() which returns false to exit the loop.  Each of these roll up to Iterate for a total of 3
+        var expectedIterationCount = 3;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
 
-        }
+            // NpgsqlDataReader methods Read/ReadAsync and NextResult/NextResultAsync result in Iterate metrics.
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/DatabaseResult/Iterate", callCount = expectedIterationCount, metricScope = expectedTransactionName}
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", metricScope = expectedTransactionName }
+        };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics)
+        );
     }
+}
 
-    public class PostgresSqlIteratorTestsFW471 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlIteratorTestsFW462 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlIteratorTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorTestsFW48 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlIteratorTestsFW471 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlIteratorTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorTestsFWLatest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlIteratorTestsFW48 : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlIteratorTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorTestsCoreOldest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlIteratorTestsFWLatest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlIteratorTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlIteratorTestsCoreLatest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlIteratorTestsCoreOldest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlIteratorTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlIteratorTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
+public class PostgresSqlIteratorTestsCoreLatest : PostgresSqlIteratorTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlIteratorTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryAsyncTests.cs
@@ -6,167 +6,166 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlSimpleQueryAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlSimpleQueryAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public PostgresSqlSimpleQueryAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlSimpleQueryAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser SimpleQueryAsync");
 
-            _fixture.AddCommand($"PostgresSqlExerciser SimpleQueryAsync");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/SimpleQueryAsync";
-            var expectedDatastoreCallCount = 1;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/SimpleQueryAsync";
+        var expectedDatastoreCallCount = 1;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/OpenAsync", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = 1, metricScope = expectedTransactionName},
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened outside a web transaction so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+            // Don't double count the Open
+            new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Postgres/teammembers/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-				// The datastore operation happened outside a web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
-                // Don't double count the Open
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open" },
-				// The operation metric should not be scoped because the statement metric is scoped instead
-				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Postgres/teammembers/select"
-            };
+                TransactionName = expectedTransactionName,
+                Sql = "SELECT * FROM newrelic.teammembers WHERE firstname = ?",
+                DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
+                HasExplainPlan = false
+            }
+        };
 
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = "SELECT * FROM newrelic.teammembers WHERE firstname = ?",
-                    DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
-                    HasExplainPlan = false
-                }
-            };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
 
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsFW462 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class PostgresSqlSimpleQueryAsyncTestsFW462 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlSimpleQueryAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsFW471 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlSimpleQueryAsyncTestsFW471 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlSimpleQueryAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsFW48 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlSimpleQueryAsyncTestsFW48 : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlSimpleQueryAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsFWLatest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlSimpleQueryAsyncTestsFWLatest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlSimpleQueryAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsCoreOldest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlSimpleQueryAsyncTestsCoreOldest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlSimpleQueryAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryAsyncTestsCoreLatest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlSimpleQueryAsyncTestsCoreLatest : PostgresSqlSimpleQueryAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlSimpleQueryAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresSimpleQueryTests.cs
@@ -6,166 +6,164 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using NewRelic.Agent.IntegrationTests.Shared;
-using NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
 using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlSimpleQueryTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlSimpleQueryTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public PostgresSqlSimpleQueryTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlSimpleQueryTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser SimpleQuery");
 
-            _fixture.AddCommand($"PostgresSqlExerciser SimpleQuery");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/SimpleQuery";
-            var expectedDatastoreCallCount = 1;
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
-                new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount, metricScope = expectedTransactionName},
-            };
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/SimpleQuery";
+        var expectedDatastoreCallCount = 1;
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = @"Datastore/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/all", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allOther", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"DotNet/Npgsql.NpgsqlConnection/Open", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/instance/Postgres/{CommonUtils.NormalizeHostname(PostgresConfiguration.PostgresServer)}/{PostgresConfiguration.PostgresPort}", callCount = expectedDatastoreCallCount},
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/statement/Postgres/teammembers/select", callCount = expectedDatastoreCallCount, metricScope = expectedTransactionName},
+        };
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened outside a web transaction so there should be no allWeb metrics
+            new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
+            new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+
+            // The operation metric should not be scoped because the statement metric is scoped instead
+            new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName }
+        };
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            "Datastore/statement/Postgres/teammembers/select"
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-				// The datastore operation happened outside a web transaction so there should be no allWeb metrics
-                new Assertions.ExpectedMetric { metricName = @"Datastore/allWeb" },
-                new Assertions.ExpectedMetric { metricName = @"Datastore/Postgres/allWeb" },
+                TransactionName = expectedTransactionName,
+                Sql = "SELECT * FROM newrelic.teammembers WHERE firstname = ?",
+                DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
+                HasExplainPlan = false
+            }
+        };
 
-				// The operation metric should not be scoped because the statement metric is scoped instead
-				new Assertions.ExpectedMetric { metricName = @"Datastore/operation/Postgres/select", callCount = 1, metricScope = expectedTransactionName }
-            };
-            var expectedTransactionTraceSegments = new List<string>
-            {
-                "Datastore/statement/Postgres/teammembers/select"
-            };
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = "SELECT * FROM newrelic.teammembers WHERE firstname = ?",
-                    DatastoreMetricName = "Datastore/statement/Postgres/teammembers/select",
-                    HasExplainPlan = false
-                }
-            };
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-                );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsFW462 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class PostgresSqlSimpleQueryTestsFW462 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlSimpleQueryTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsFW471 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlSimpleQueryTestsFW471 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlSimpleQueryTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsFW48 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlSimpleQueryTestsFW48 : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlSimpleQueryTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsFWLatest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlSimpleQueryTestsFWLatest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlSimpleQueryTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsCoreOldest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlSimpleQueryTestsCoreOldest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlSimpleQueryTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlSimpleQueryTestsCoreLatest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlSimpleQueryTestsCoreLatest : PostgresSqlSimpleQueryTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlSimpleQueryTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlSimpleQueryTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureAsyncTests.cs
@@ -12,146 +12,145 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlStoredProcedureAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlStoredProcedureAsyncTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
+
+    public PostgresSqlStoredProcedureAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlStoredProcedureAsyncTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser ParameterizedStoredProcedureAsync {_procedureName}");
 
-            _fixture.AddCommand($"PostgresSqlExerciser ParameterizedStoredProcedureAsync {_procedureName}");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ParameterizedStoredProcedureAsync";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = expectedTransactionName}
-            };
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedTransactionTraceSegments = new List<string>
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ParameterizedStoredProcedureAsync";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = expectedTransactionName}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure"
+        };
+
+        var expectedQueryParameters = DbParameterData.PostgresParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure"
-            };
+                TransactionName = expectedTransactionName,
+                Sql = _procedureName,
+                DatastoreMetricName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParameters,
+                HasExplainPlan = false
+            }
+        };
 
-            var expectedQueryParameters = DbParameterData.PostgresParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = _procedureName,
-                    DatastoreMetricName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParameters,
-                    HasExplainPlan = false
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsFW462 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class PostgresSqlStoredProcedureAsyncTestsFW462 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlStoredProcedureAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsFW471 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlStoredProcedureAsyncTestsFW471 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlStoredProcedureAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsFW48 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlStoredProcedureAsyncTestsFW48 : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlStoredProcedureAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsFWLatest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlStoredProcedureAsyncTestsFWLatest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlStoredProcedureAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsCoreOldest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlStoredProcedureAsyncTestsCoreOldest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlStoredProcedureAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureAsyncTestsCoreLatest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlStoredProcedureAsyncTestsCoreLatest : PostgresSqlStoredProcedureAsyncTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlStoredProcedureAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureAsyncTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Postgres/PostgresStoredProcedureTests.cs
@@ -12,146 +12,145 @@ using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres
+namespace NewRelic.Agent.UnboundedIntegrationTests.Postgres;
+
+public abstract class PostgresSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class PostgresSqlStoredProcedureTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+    private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
+
+    public PostgresSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-        private readonly string _procedureName = $"PostgresTestStoredProc{Guid.NewGuid():N}";
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public PostgresSqlStoredProcedureTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"PostgresSqlExerciser ParameterizedStoredProcedure {_procedureName}");
 
-            _fixture.AddCommand($"PostgresSqlExerciser ParameterizedStoredProcedure {_procedureName}");
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
+                configModifier.ConfigureFasterMetricsHarvestCycle(15);
+                configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
+                configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
 
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-                    configModifier.ConfigureFasterMetricsHarvestCycle(15);
-                    configModifier.ConfigureFasterTransactionTracesHarvestCycle(15);
-                    configModifier.ConfigureFasterSqlTracesHarvestCycle(15);
-
-                    configModifier.ForceTransactionTraces()
+                configModifier.ForceTransactionTraces()
                     .SetLogLevel("finest");
 
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
-                    CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
-                },
-                exerciseApplication: () =>
-                {
-                    // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ParameterizedStoredProcedure";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainEnabled", "true");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "recordSql", "raw");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "transactionTracer" }, "explainThreshold", "1");
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(configPath, new[] { "configuration", "datastoreTracer", "queryParameters" }, "enabled", "true");
+            },
+            exerciseApplication: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = expectedTransactionName}
-            };
+                // Confirm transaction transform has completed before moving on to host application shutdown, and final sendDataOnExit harvest
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2)); // must be 2 minutes since this can take a while.
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
 
-            var expectedTransactionTraceSegments = new List<string>
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void Test()
+    {
+        var expectedTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.PostgresSql.PostgresSqlExerciser/ParameterizedStoredProcedure";
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $@"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", callCount = 1, metricScope = expectedTransactionName}
+        };
+
+        var expectedTransactionTraceSegments = new List<string>
+        {
+            $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure"
+        };
+
+        var expectedQueryParameters = DbParameterData.PostgresParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+
+        var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+
+        var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
+        {
+            new Assertions.ExpectedSqlTrace
             {
-                $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure"
-            };
+                TransactionName = expectedTransactionName,
+                Sql = _procedureName,
+                DatastoreMetricName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure",
+                QueryParameters = expectedQueryParameters,
+                HasExplainPlan = false
+            }
+        };
 
-            var expectedQueryParameters = DbParameterData.PostgresParameters.ToDictionary(p => p.ParameterName, p => p.ExpectedValue);
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
+        var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
 
-            var expectedTransactionTraceQueryParameters = new Assertions.ExpectedSegmentQueryParameters { segmentName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure", QueryParameters = expectedQueryParameters };
+        NrAssert.Multiple(
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent)
+        );
 
-            var expectedSqlTraces = new List<Assertions.ExpectedSqlTrace>
-            {
-                new Assertions.ExpectedSqlTrace
-                {
-                    TransactionName = expectedTransactionName,
-                    Sql = _procedureName,
-                    DatastoreMetricName = $"Datastore/statement/Postgres/{_procedureName.ToLower()}/ExecuteProcedure",
-                    QueryParameters = expectedQueryParameters,
-                    HasExplainPlan = false
-                }
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(expectedTransactionName);
-            var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(expectedTransactionName);
-            var sqlTraces = _fixture.AgentLog.GetSqlTraces().ToList();
-
-            NrAssert.Multiple(
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-                () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
-                () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
-            );
-        }
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+            () => Assertions.TransactionTraceSegmentQueryParametersExist(expectedTransactionTraceQueryParameters, transactionSample),
+            () => Assertions.SqlTraceExists(expectedSqlTraces, sqlTraces)
+        );
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsFW462 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class PostgresSqlStoredProcedureTestsFW462 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public PostgresSqlStoredProcedureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsFW471 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class PostgresSqlStoredProcedureTestsFW471 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public PostgresSqlStoredProcedureTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsFW48 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class PostgresSqlStoredProcedureTestsFW48 : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public PostgresSqlStoredProcedureTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsFWLatest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class PostgresSqlStoredProcedureTestsFWLatest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public PostgresSqlStoredProcedureTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsCoreOldest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class PostgresSqlStoredProcedureTestsCoreOldest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public PostgresSqlStoredProcedureTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class PostgresSqlStoredProcedureTestsCoreLatest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class PostgresSqlStoredProcedureTestsCoreLatest : PostgresSqlStoredProcedureTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public PostgresSqlStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public PostgresSqlStoredProcedureTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyDistributedTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyDistributedTracingTests.cs
@@ -2,106 +2,104 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using System;
 using System.Collections.Generic;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
 using Xunit;
 
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy
+namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy;
+
+public abstract class RabbitMqLegacyDistributedTracingTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class RabbitMqLegacyDistributedTracingTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+    private ConsoleDynamicMethodFixture _fixture;
+
+    public RabbitMqLegacyDistributedTracingTestsBase(TFixture fixture, ITestOutputHelper output)  : base(fixture)
     {
-        private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
-        private ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        fixture.TestLogger = output;
 
-        public RabbitMqLegacyDistributedTracingTestsBase(TFixture fixture, ITestOutputHelper output)  : base(fixture)
-        {
-            _fixture = fixture;
-            fixture.TestLogger = output;
+        // RabbitMQ SendRecieve uses the BasicGet method to receive, which does not process incoming tracing payloads
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
+        // RabbitMQ SendRecieveWithEventingConsumer uses the HandleBasicDeliverWrapper on the receiving side, which does process incoming tracing headers
+        // We execute the method twice to make sure this issue stays fixed: https://github.com/newrelic/newrelic-dotnet-agent/issues/464
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} EventingConsumerTestMessageOne");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} EventingConsumerTestMessageTwo");
+        // This is needed to avoid a hang on shutdown in the test app
+        _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
 
-            // RabbitMQ SendRecieve uses the BasicGet method to receive, which does not process incoming tracing payloads
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
-            // RabbitMQ SendRecieveWithEventingConsumer uses the HandleBasicDeliverWrapper on the receiving side, which does process incoming tracing headers
-            // We execute the method twice to make sure this issue stays fixed: https://github.com/newrelic/newrelic-dotnet-agent/issues/464
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} EventingConsumerTestMessageOne");
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} EventingConsumerTestMessageTwo");
-            // This is needed to avoid a hang on shutdown in the test app
-            _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
-
-            fixture.Actions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces();
-
-                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
-                    configModifier.SetOrDeleteSpanEventsEnabled(true);
-                }
-            );
-            fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        fixture.Actions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = "Supportability/DistributedTrace/CreatePayload/Success", callCount = 3 },
-                new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Create/Success", callCount = 3 },
-                new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Accept/Success", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = "DotNet/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser/InstrumentedChildMethod"} ,
-                new Assertions.ExpectedMetric { metricName = "DotNet/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser/InstrumentedChildMethod", metricScope = "OtherTransaction/Message/RabbitMQ/Queue/Named/integrationTestQueue.*", IsRegexScope = true}
-            };
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces();
 
-            var metrics = _fixture.AgentLog.GetMetrics();
-
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
+                configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                configModifier.SetOrDeleteSpanEventsEnabled(true);
+            }
+        );
+        fixture.Initialize();
     }
 
-    public class RabbitMqLegacyDistributedTracingTestsFWLatest : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void Test()
     {
-        public RabbitMqLegacyDistributedTracingTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = "Supportability/DistributedTrace/CreatePayload/Success", callCount = 3 },
+            new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Create/Success", callCount = 3 },
+            new Assertions.ExpectedMetric { metricName = "Supportability/TraceContext/Accept/Success", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = "DotNet/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser/InstrumentedChildMethod"} ,
+            new Assertions.ExpectedMetric { metricName = "DotNet/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser/InstrumentedChildMethod", metricScope = "OtherTransaction/Message/RabbitMQ/Queue/Named/integrationTestQueue.*", IsRegexScope = true}
+        };
 
-    public class RabbitMqLegacyDistributedTracingTestsFW48 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW48>
+        var metrics = _fixture.AgentLog.GetMetrics();
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+    }
+}
+
+public class RabbitMqLegacyDistributedTracingTestsFWLatest : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public RabbitMqLegacyDistributedTracingTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public RabbitMqLegacyDistributedTracingTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class RabbitMqLegacyDistributedTracingTestsFW471 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class RabbitMqLegacyDistributedTracingTestsFW48 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public RabbitMqLegacyDistributedTracingTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public RabbitMqLegacyDistributedTracingTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class RabbitMqLegacyDistributedTracingTestsFW462 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW462>
+public class RabbitMqLegacyDistributedTracingTestsFW471 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public RabbitMqLegacyDistributedTracingTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public RabbitMqLegacyDistributedTracingTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
-    public class RabbitMqLegacyDistributedTracingTestsCoreOldest : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class RabbitMqLegacyDistributedTracingTestsFW462 : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public RabbitMqLegacyDistributedTracingTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output)
     {
-        public RabbitMqLegacyDistributedTracingTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
     }
+}
 
+public class RabbitMqLegacyDistributedTracingTestsCoreOldest : RabbitMqLegacyDistributedTracingTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public RabbitMqLegacyDistributedTracingTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyTests.cs
@@ -2,224 +2,223 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy
+namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy;
+
+public abstract class RabbitMqLegacyTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class RabbitMqLegacyTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
-        where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+    private readonly string _purgeQueue = $"integrationPurgeTestQueue-{Guid.NewGuid()}";
+    private readonly string _testExchangeName = $"integrationTestExchange-{Guid.NewGuid()}";
+    // The topic name has to contain a '.' character.  See https://www.rabbitmq.com/tutorials/tutorial-five-dotnet.html
+    private readonly string _sendReceiveTopic = "SendReceiveTopic.Topic";
+
+    private readonly string _metricScopeBase = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser";
+
+    protected RabbitMqLegacyTestsBase(TFixture fixture, ITestOutputHelper output)  : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
-
-        private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
-        private readonly string _purgeQueue = $"integrationPurgeTestQueue-{Guid.NewGuid()}";
-        private readonly string _testExchangeName = $"integrationTestExchange-{Guid.NewGuid()}";
-        // The topic name has to contain a '.' character.  See https://www.rabbitmq.com/tutorials/tutorial-five-dotnet.html
-        private readonly string _sendReceiveTopic = "SendReceiveTopic.Topic";
-
-        private readonly string _metricScopeBase = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser";
-
-        protected RabbitMqLegacyTestsBase(TFixture fixture, ITestOutputHelper output)  : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
 
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveTempQueue TempQueueTestMessage");
-            _fixture.AddCommand($"RabbitMQLegacyExerciser QueuePurge {_purgeQueue}");
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveTopic {_testExchangeName} {_sendReceiveTopic} TopicTestMessage");
-            // This is needed to avoid a hang on shutdown in the test app
-            _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveTempQueue TempQueueTestMessage");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser QueuePurge {_purgeQueue}");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveTopic {_testExchangeName} {_sendReceiveTopic} TopicTestMessage");
+        // This is needed to avoid a hang on shutdown in the test app
+        _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
 
-            // AddActions() executes the applied actions after actions defined by the base.
-            // In this case the base defines an exerciseApplication action we want to wait after.
-            _fixture.AddActions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces();
-                },
-                exerciseApplication: () =>
-                {
-                    _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
-                }
-            );
-
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
+        // AddActions() executes the applied actions after actions defined by the base.
+        // In this case the base defines an exerciseApplication action we want to wait after.
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
             {
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceive"},
-
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceive"},
-
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/QueuePurge" },
-
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Purge/Named/{_purgeQueue}", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Purge/Named/{_purgeQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/QueuePurge" },
-
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Produce/Temp", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Produce/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTempQueue"},
-
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}", callCount = 1 },
-                new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTopic" },
-
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 2 },
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTempQueue"},
-                new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTopic" },
-            };
-
-            var sendReceiveTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceive");
-            var sendReceiveTempQueueTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveTempQueue");
-            var queuePurgeTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/QueuePurge");
-            var sendReceiveTopicTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveTopic");
-
-            var expectedTransactionTraceSegments = new List<string>
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces();
+            },
+            exerciseApplication: () =>
             {
-                $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}"
-            };
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
+            }
+        );
 
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample($"{_metricScopeBase}/SendReceive");
-
-            var queueProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}");
-            var queueConsumeSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}");
-            var purgeProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}");
-            var tempProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent(@"MessageBroker/RabbitMQ/Queue/Produce/Temp");
-            var tempConsumeSpanEvents = _fixture.AgentLog.TryGetSpanEvent(@"MessageBroker/RabbitMQ/Queue/Consume/Temp");
-            var topicProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}");
-
-            var expectedProduceAgentAttributes = new List<string>
-            {
-                "server.address",
-                "server.port",
-                "messaging.destination.name",
-                "message.routingKey",
-                "messaging.rabbitmq.destination.routing_key"
-            };
-
-            var expectedTempProduceAgentAttributes = new List<string>
-            {
-                "server.address",
-                "server.port",
-                "message.routingKey",
-                "messaging.rabbitmq.destination.routing_key"
-            };
-
-            var expectedConsumeAgentAttributes = new List<string>
-            {
-                "server.address",
-                "server.port",
-                "messaging.destination.name",
-                "message.queueName",
-                "messaging.destination_publish.name",
-            };
-
-            var expectedTempConsumeAgentAttributes = new List<string>
-            {
-                "server.address",
-                "server.port",
-            };
-
-            var expectedIntrisicAttributes = new List<string> { "span.kind", };
-
-            Assertions.MetricsExist(expectedMetrics, metrics);
-
-            NrAssert.Multiple(
-                () => Assert.True(sendReceiveTransactionEvent != null, "sendReceiveTransactionEvent should not be null"),
-                () => Assert.True(sendReceiveTempQueueTransactionEvent != null, "sendReceiveTempQueueTransactionEvent should not be null"),
-                () => Assert.True(queuePurgeTransactionEvent != null, "queuePurgeTransactionEvent should not be null"),
-                () => Assert.True(sendReceiveTopicTransactionEvent != null, "sendReceiveTopicTransactionEvent should not be null"),
-                () => Assert.True(transactionSample != null, "transactionSample should not be null"),
-                () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
-
-                () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueProduceSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueProduceSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedConsumeAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueConsumeSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueConsumeSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, purgeProduceSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, purgeProduceSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedTempProduceAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, tempProduceSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, tempProduceSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedTempConsumeAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, tempConsumeSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, tempConsumeSpanEvents),
-
-                () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, topicProduceSpanEvents),
-                () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
-                    Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, topicProduceSpanEvents)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class RabbitMqLegacyTestsFWLatest : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+    [Fact]
+    public void Test()
     {
-        public RabbitMqLegacyTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
 
-    public class RabbitMqLegacyTestsFW48 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW48>
-    {
-        public RabbitMqLegacyTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
-            : base(fixture, output)
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceive"},
 
-    public class RabbitMqLegacyTestsFW471 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW471>
-    {
-        public RabbitMqLegacyTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceive"},
 
-    public class RabbitMqLegacyTestsFW462 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW462>
-    {
-        public RabbitMqLegacyTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
-            : base(fixture, output)
-        {
-        }
-    }
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/QueuePurge" },
 
-    public class RabbitMqLegacyTestsCoreOldest : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
-    {
-        public RabbitMqLegacyTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
-            : base(fixture, output)
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Purge/Named/{_purgeQueue}", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Queue/Purge/Named/{_purgeQueue}", callCount = 1, metricScope = $"{_metricScopeBase}/QueuePurge" },
+
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Produce/Temp", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Produce/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTempQueue"},
+
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}", callCount = 1 },
+            new Assertions.ExpectedMetric { metricName = $"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTopic" },
+
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 2 },
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTempQueue"},
+            new Assertions.ExpectedMetric { metricName = @"MessageBroker/RabbitMQ/Queue/Consume/Temp", callCount = 1, metricScope = $"{_metricScopeBase}/SendReceiveTopic" },
+        };
+
+        var sendReceiveTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceive");
+        var sendReceiveTempQueueTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveTempQueue");
+        var queuePurgeTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/QueuePurge");
+        var sendReceiveTopicTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveTopic");
+
+        var expectedTransactionTraceSegments = new List<string>
         {
-        }
+            $"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}"
+        };
+
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample($"{_metricScopeBase}/SendReceive");
+
+        var queueProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}");
+        var queueConsumeSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}");
+        var purgeProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_purgeQueue}");
+        var tempProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent(@"MessageBroker/RabbitMQ/Queue/Produce/Temp");
+        var tempConsumeSpanEvents = _fixture.AgentLog.TryGetSpanEvent(@"MessageBroker/RabbitMQ/Queue/Consume/Temp");
+        var topicProduceSpanEvents = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Topic/Produce/Named/{_sendReceiveTopic}");
+
+        var expectedProduceAgentAttributes = new List<string>
+        {
+            "server.address",
+            "server.port",
+            "messaging.destination.name",
+            "message.routingKey",
+            "messaging.rabbitmq.destination.routing_key"
+        };
+
+        var expectedTempProduceAgentAttributes = new List<string>
+        {
+            "server.address",
+            "server.port",
+            "message.routingKey",
+            "messaging.rabbitmq.destination.routing_key"
+        };
+
+        var expectedConsumeAgentAttributes = new List<string>
+        {
+            "server.address",
+            "server.port",
+            "messaging.destination.name",
+            "message.queueName",
+            "messaging.destination_publish.name",
+        };
+
+        var expectedTempConsumeAgentAttributes = new List<string>
+        {
+            "server.address",
+            "server.port",
+        };
+
+        var expectedIntrisicAttributes = new List<string> { "span.kind", };
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+
+        NrAssert.Multiple(
+            () => Assert.True(sendReceiveTransactionEvent != null, "sendReceiveTransactionEvent should not be null"),
+            () => Assert.True(sendReceiveTempQueueTransactionEvent != null, "sendReceiveTempQueueTransactionEvent should not be null"),
+            () => Assert.True(queuePurgeTransactionEvent != null, "queuePurgeTransactionEvent should not be null"),
+            () => Assert.True(sendReceiveTopicTransactionEvent != null, "sendReceiveTopicTransactionEvent should not be null"),
+            () => Assert.True(transactionSample != null, "transactionSample should not be null"),
+            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
+
+            () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueProduceSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueProduceSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedConsumeAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueConsumeSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, queueConsumeSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, purgeProduceSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, purgeProduceSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedTempProduceAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, tempProduceSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, tempProduceSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedTempConsumeAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, tempConsumeSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, tempConsumeSpanEvents),
+
+            () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, topicProduceSpanEvents),
+            () => Assertions.SpanEventHasAttributes(expectedIntrisicAttributes,
+                Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Intrinsic, topicProduceSpanEvents)
+        );
+    }
+}
+
+public class RabbitMqLegacyTestsFWLatest : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public RabbitMqLegacyTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class RabbitMqLegacyTestsFW48 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public RabbitMqLegacyTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class RabbitMqLegacyTestsFW471 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public RabbitMqLegacyTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class RabbitMqLegacyTestsFW462 : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public RabbitMqLegacyTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class RabbitMqLegacyTestsCoreOldest : RabbitMqLegacyTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public RabbitMqLegacyTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyW3cTracingTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/Legacy/RabbitMqLegacyW3cTracingTests.cs
@@ -2,164 +2,163 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy
+namespace NewRelic.Agent.UnboundedIntegrationTests.RabbitMq.Legacy;
+
+public abstract class RabbitMqLegacyW3cTracingTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW471>
 {
-    public abstract class RabbitMqLegacyW3cTracingTests : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFW471>
+    protected readonly string _metricScopeBase = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser";
+
+    public RabbitMqLegacyW3cTracingTests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)  : base(fixture)
     {
-        protected readonly string _metricScopeBase = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.RabbitMQ.RabbitMQLegacyExerciser";
+        fixture.TestLogger = output;
+        fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+                configModifier.ForceTransactionTraces();
 
-        public RabbitMqLegacyW3cTracingTests(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)  : base(fixture)
-        {
-            fixture.TestLogger = output;
-            fixture.Actions
-            (
-                setupConfiguration: () =>
-                {
-                    var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
-                    configModifier.ForceTransactionTraces();
+                configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                configModifier.SetOrDeleteSpanEventsEnabled(true);
+            }
+        );
+    }
+}
 
-                    configModifier.SetOrDeleteDistributedTraceEnabled(true);
-                    configModifier.SetOrDeleteSpanEventsEnabled(true);
-                }
-            );
-        }
+public class RabbitMqLegacyW3cTracingBasicTest : RabbitMqLegacyW3cTracingTests
+{
+    private ConsoleDynamicMethodFixtureFW471 _fixture;
+
+    private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+
+    public RabbitMqLegacyW3cTracingBasicTest(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+        _fixture = fixture;
+
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
+        // This is needed to avoid a hang on shutdown in the test app
+        _fixture.AddCommand("RabbitMQ Shutdown");
+
+        fixture.Initialize();
     }
 
-    public class RabbitMqLegacyW3cTracingBasicTest : RabbitMqLegacyW3cTracingTests
+    [Fact]
+    public void Test()
     {
-        private ConsoleDynamicMethodFixtureFW471 _fixture;
+        // attributes
 
-        private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+        var headerValueTx = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceive");
 
-        public RabbitMqLegacyW3cTracingBasicTest(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
+        var spanEvents = _fixture.AgentLog.GetSpanEvents();
+
+        var produceSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/RabbitMQ/Queue/Produce/Named/"))
+            .FirstOrDefault();
+
+        var consumeSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/RabbitMQ/Queue/Consume/Named/"))
+            .FirstOrDefault();
+
+        Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
+        Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], produceSpan.IntrinsicAttributes["traceId"]);
+        Assert.True(headerValueTx.IntrinsicAttributes["priority"].IsEqualTo(produceSpan.IntrinsicAttributes["priority"]),
+            $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {produceSpan.IntrinsicAttributes["priority"]}");
+
+        Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
+        Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], consumeSpan.IntrinsicAttributes["traceId"]);
+        Assert.True(headerValueTx.IntrinsicAttributes["priority"].IsEqualTo(consumeSpan.IntrinsicAttributes["priority"]),
+            $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {consumeSpan.IntrinsicAttributes["priority"]}");
+
+        // metrics
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new Assertions.ExpectedMetric { metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Create/Success", callCount = 1},
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics();
+        Assertions.MetricsExist(expectedMetrics, metrics);
+    }
+}
+
+public class RabbitMqLegacyW3cTracingEventingConsumerTest : RabbitMqLegacyW3cTracingTests
+{
+    private ConsoleDynamicMethodFixtureFW471 _fixture;
+
+    private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+
+    public RabbitMqLegacyW3cTracingEventingConsumerTest(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
         : base(fixture, output)
-        {
-            _fixture = fixture;
+    {
+        _fixture = fixture;
 
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceive {_sendReceiveQueue} TestMessage");
-            // This is needed to avoid a hang on shutdown in the test app
-            _fixture.AddCommand("RabbitMQ Shutdown");
+        _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} TestMessage");
+        // This is needed to avoid a hang on shutdown in the test app
+        _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
 
-            fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            // attributes
-
-            var headerValueTx = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceive");
-
-            var spanEvents = _fixture.AgentLog.GetSpanEvents();
-
-            var produceSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/RabbitMQ/Queue/Produce/Named/"))
-                .FirstOrDefault();
-
-            var consumeSpan = spanEvents.Where(@event => @event.IntrinsicAttributes["name"].ToString().Contains("MessageBroker/RabbitMQ/Queue/Consume/Named/"))
-                .FirstOrDefault();
-
-            Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
-            Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], produceSpan.IntrinsicAttributes["traceId"]);
-            Assert.True(headerValueTx.IntrinsicAttributes["priority"].IsEqualTo(produceSpan.IntrinsicAttributes["priority"]),
-                $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {produceSpan.IntrinsicAttributes["priority"]}");
-
-            Assert.Equal(headerValueTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
-            Assert.Equal(headerValueTx.IntrinsicAttributes["traceId"], consumeSpan.IntrinsicAttributes["traceId"]);
-            Assert.True(headerValueTx.IntrinsicAttributes["priority"].IsEqualTo(consumeSpan.IntrinsicAttributes["priority"]),
-                $"priority: expected: {headerValueTx.IntrinsicAttributes["priority"]}, actual: {consumeSpan.IntrinsicAttributes["priority"]}");
-
-            // metrics
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Create/Success", callCount = 1},
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics();
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
+        fixture.Initialize();
     }
 
-    public class RabbitMqLegacyW3cTracingEventingConsumerTest : RabbitMqLegacyW3cTracingTests
+    [Fact]
+    public void Test()
     {
-        private ConsoleDynamicMethodFixtureFW471 _fixture;
+        // transaction attributes
 
-        private readonly string _sendReceiveQueue = $"integrationTestQueue-{Guid.NewGuid()}";
+        var produceTx = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveWithEventingConsumer");
+        var consumeTx = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Message/RabbitMQ/Queue/Named/{_sendReceiveQueue}");
 
-        public RabbitMqLegacyW3cTracingEventingConsumerTest(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output)
-        : base(fixture, output)
+        Assert.Equal(consumeTx.IntrinsicAttributes["traceId"], produceTx.IntrinsicAttributes["traceId"]);
+        Assert.True(produceTx.IntrinsicAttributes["priority"].IsEqualTo(consumeTx.IntrinsicAttributes["priority"]),
+            $"priority: expected: {produceTx.IntrinsicAttributes["priority"]}, actual: {consumeTx.IntrinsicAttributes["priority"]}");
+        Assert.Equal(consumeTx.IntrinsicAttributes["parentId"], produceTx.IntrinsicAttributes["guid"]);
+        Assert.Equal("AMQP", consumeTx.IntrinsicAttributes["parent.transportType"]);
+
+        // span attributes
+
+        _fixture.AgentLog.GetSpanEvents().ToList().ForEach
+        (span =>
         {
-            _fixture = fixture;
+            Assert.Equal(produceTx.IntrinsicAttributes["traceId"], span.IntrinsicAttributes["traceId"]);
+            Assert.True(produceTx.IntrinsicAttributes["priority"].IsEqualTo(span.IntrinsicAttributes["priority"]),
+                $"priority: expected: {produceTx.IntrinsicAttributes["priority"]}, actual: {span.IntrinsicAttributes["priority"]}");
+        });
 
-            _fixture.AddCommand($"RabbitMQLegacyExerciser SendReceiveWithEventingConsumer {_sendReceiveQueue} TestMessage");
-            // This is needed to avoid a hang on shutdown in the test app
-            _fixture.AddCommand("RabbitMQLegacyExerciser Shutdown");
+        var produceSpan = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}");
+        var consumeSpan = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}");
 
-            fixture.Initialize();
-        }
+        Assert.Equal(produceTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
+        Assert.Equal(consumeTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
 
-        [Fact]
-        public void Test()
+        Assert.Equal(consumeTx.IntrinsicAttributes["parentSpanId"], produceSpan.IntrinsicAttributes["guid"]);
+
+        // metrics
+        var acctId = _fixture.AgentLog.GetAccountId();
+        var appId = _fixture.AgentLog.GetApplicationId();
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            // transaction attributes
+            new Assertions.ExpectedMetric { metricName = $"DurationByCaller/App/{acctId}/{appId}/AMQP/all", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"DurationByCaller/App/{acctId}/{appId}/AMQP/allOther", callCount = 1},
 
-            var produceTx = _fixture.AgentLog.TryGetTransactionEvent($"{_metricScopeBase}/SendReceiveWithEventingConsumer");
-            var consumeTx = _fixture.AgentLog.TryGetTransactionEvent($"OtherTransaction/Message/RabbitMQ/Queue/Named/{_sendReceiveQueue}");
+            new Assertions.ExpectedMetric { metricName = $"TransportDuration/App/{acctId}/{appId}/AMQP/all", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"TransportDuration/App/{acctId}/{appId}/AMQP/allOther", callCount = 1},
 
-            Assert.Equal(consumeTx.IntrinsicAttributes["traceId"], produceTx.IntrinsicAttributes["traceId"]);
-            Assert.True(produceTx.IntrinsicAttributes["priority"].IsEqualTo(consumeTx.IntrinsicAttributes["priority"]),
-                $"priority: expected: {produceTx.IntrinsicAttributes["priority"]}, actual: {consumeTx.IntrinsicAttributes["priority"]}");
-            Assert.Equal(consumeTx.IntrinsicAttributes["parentId"], produceTx.IntrinsicAttributes["guid"]);
-            Assert.Equal("AMQP", consumeTx.IntrinsicAttributes["parent.transportType"]);
+            new Assertions.ExpectedMetric { metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Create/Success", callCount = 1},
+            new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Accept/Success", callCount = 1}
+        };
 
-            // span attributes
-
-            _fixture.AgentLog.GetSpanEvents().ToList().ForEach
-                (span =>
-                {
-                    Assert.Equal(produceTx.IntrinsicAttributes["traceId"], span.IntrinsicAttributes["traceId"]);
-                    Assert.True(produceTx.IntrinsicAttributes["priority"].IsEqualTo(span.IntrinsicAttributes["priority"]),
-                        $"priority: expected: {produceTx.IntrinsicAttributes["priority"]}, actual: {span.IntrinsicAttributes["priority"]}");
-                });
-
-            var produceSpan = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Produce/Named/{_sendReceiveQueue}");
-            var consumeSpan = _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/RabbitMQ/Queue/Consume/Named/{_sendReceiveQueue}");
-
-            Assert.Equal(produceTx.IntrinsicAttributes["guid"], produceSpan.IntrinsicAttributes["transactionId"]);
-            Assert.Equal(consumeTx.IntrinsicAttributes["guid"], consumeSpan.IntrinsicAttributes["transactionId"]);
-
-            Assert.Equal(consumeTx.IntrinsicAttributes["parentSpanId"], produceSpan.IntrinsicAttributes["guid"]);
-
-            // metrics
-            var acctId = _fixture.AgentLog.GetAccountId();
-            var appId = _fixture.AgentLog.GetApplicationId();
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new Assertions.ExpectedMetric { metricName = $"DurationByCaller/App/{acctId}/{appId}/AMQP/all", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"DurationByCaller/App/{acctId}/{appId}/AMQP/allOther", callCount = 1},
-
-                new Assertions.ExpectedMetric { metricName = $"TransportDuration/App/{acctId}/{appId}/AMQP/all", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"TransportDuration/App/{acctId}/{appId}/AMQP/allOther", callCount = 1},
-
-                new Assertions.ExpectedMetric { metricName = $"Supportability/DistributedTrace/CreatePayload/Success", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Create/Success", callCount = 1},
-                new Assertions.ExpectedMetric { metricName = $"Supportability/TraceContext/Accept/Success", callCount = 1}
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics();
-            Assertions.MetricsExist(expectedMetrics, metrics);
-        }
+        var metrics = _fixture.AgentLog.GetMetrics();
+        Assertions.MetricsExist(expectedMetrics, metrics);
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RabbitMq/RabbitMqTests.cs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
-using NewRelic.Agent.UnboundedIntegrationTests.RabbitMq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/Redis/StackExchangeRedisTests.cs
@@ -1,174 +1,173 @@
 // Copyright 2020 New Relic, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using NewRelic.Agent.IntegrationTestHelpers;
-using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
-using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Agent.IntegrationTests.Shared;
-using NewRelic.Testing.Assertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.IntegrationTests.Shared;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using NewRelic.Testing.Assertions;
 using Xunit;
 
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.Redis
+namespace NewRelic.Agent.UnboundedIntegrationTests.Redis;
+
+public abstract class StackExchangeRedisTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
 {
-    public abstract class StackExchangeRedisTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+    private readonly ConsoleDynamicMethodFixture _fixture;
+
+    public StackExchangeRedisTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
     {
-        private readonly ConsoleDynamicMethodFixture _fixture;
+        _fixture = fixture;
+        _fixture.TestLogger = output;
 
-        public StackExchangeRedisTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
-        {
-            _fixture = fixture;
-            _fixture.TestLogger = output;
+        _fixture.AddCommand($"StackExchangeRedisExerciser DoSomeWork");
+        _fixture.AddCommand($"StackExchangeRedisExerciser DoSomeWorkAsync");
 
-            _fixture.AddCommand($"StackExchangeRedisExerciser DoSomeWork");
-            _fixture.AddCommand($"StackExchangeRedisExerciser DoSomeWorkAsync");
+        // Confirm both transaction transforms have completed before moving on to host application shutdown, and final sendDataOnExit harvest
+        _fixture.AddActions(setupConfiguration: () =>
+            {
+                var configPath = fixture.DestinationNewRelicConfigFilePath;
+                var configModifier = new NewRelicConfigModifier(configPath);
 
-            // Confirm both transaction transforms have completed before moving on to host application shutdown, and final sendDataOnExit harvest
-            _fixture.AddActions(setupConfiguration: () =>
-                {
-                    var configPath = fixture.DestinationNewRelicConfigFilePath;
-                    var configModifier = new NewRelicConfigModifier(configPath);
-
-                    configModifier.ForceTransactionTraces().DisableEventListenerSamplers()
+                configModifier.ForceTransactionTraces().DisableEventListenerSamplers()
                     .SetLogLevel("finest");
 
-                },
-                exerciseApplication: () => _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2), 2)
-            );
+            },
+            exerciseApplication: () => _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2), 2)
+        );
 
-            _fixture.Initialize();
-        }
-
-        [Fact]
-        public void Test()
-        {
-            var syncTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedis.StackExchangeRedisExerciser/DoSomeWork";
-            var asyncTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedis.StackExchangeRedisExerciser/DoSomeWorkAsync";
-
-            var expectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                new() { metricName = @"Datastore/all", callCount = 66 },
-                new() { metricName = @"Datastore/allOther", callCount = 66 },
-                new() { metricName = @"Datastore/Redis/all", callCount = 66 },
-                new() { metricName = @"Datastore/Redis/allOther", callCount = 66 },
-                new() { metricName = $@"Datastore/instance/Redis/{CommonUtils.NormalizeHostname(StackExchangeRedisConfiguration.StackExchangeRedisServer)}/{StackExchangeRedisConfiguration.StackExchangeRedisPort}", callCount = 66},
-                new() { metricName = @"Datastore/operation/Redis/SET", callCount = 4 },
-                new() { metricName = @"Datastore/operation/Redis/GET", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/APPEND", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/GETRANGE", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SETRANGE", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/STRLEN", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/DECR", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/INCR", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/HMSET", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/HINCRBY", callCount = 4 }, // increment and decrement
-                new() { metricName = @"Datastore/operation/Redis/HEXISTS", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/HVALS", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/EXISTS", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/RANDOMKEY", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/RENAME", callCount = 2 },
-                // Delete can resolve to DEL or UNLINK depending on Redis version
-                new() { metricName = @"Datastore/operation/Redis/(DEL|UNLINK)", IsRegexName = true, callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/PING", callCount = 4 }, //ping and identifyendpoint
-                new() { metricName = @"Datastore/operation/Redis/SADD", callCount = 4 },
-                new() { metricName = @"Datastore/operation/Redis/SUNION", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SISMEMBER", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SCARD", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SMEMBERS", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SMOVE", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SRANDMEMBER", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SPOP", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/SREM", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/PUBLISH", callCount = 2 },
-                new() { metricName = @"Datastore/operation/Redis/EXEC", callCount = 2}
-            };
-
-            var unexpectedMetrics = new List<Assertions.ExpectedMetric>
-            {
-                // The datastore operation happened inside a console app so there should be no allWeb metrics
-                new() {metricName = @"Datastore/allWeb", callCount = 1},
-                new() {metricName = @"Datastore/Redis/allWeb", callCount = 1}
-            };
-
-            var expectedTransactionEventIntrinsicAttributes = new List<string>
-            {
-                "databaseDuration"
-            };
-
-            var metrics = _fixture.AgentLog.GetMetrics().ToList();
-            // The previous version of this test cheated a bit by naming both transactions the same. Since either one might be the slowest,
-            // let's allow for either one
-            var transactionSample = _fixture.AgentLog.TryGetTransactionSample(syncTransactionName) ?? _fixture.AgentLog.TryGetTransactionSample(asyncTransactionName);
-            var transactionEvent1 = _fixture.AgentLog.TryGetTransactionEvent(syncTransactionName);
-            var transactionEvent2 = _fixture.AgentLog.TryGetTransactionEvent(asyncTransactionName);
-
-            NrAssert.Multiple
-            (
-                () => Assert.NotNull(transactionSample),
-                () => Assert.NotNull(transactionEvent1),
-                () => Assert.NotNull(transactionEvent2)
-            );
-
-            NrAssert.Multiple
-            (
-                () => Assertions.MetricsExist(expectedMetrics, metrics),
-                () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent1),
-                () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent2)
-            );
-        }
+        _fixture.Initialize();
     }
 
-    public class StackExchangeRedisTestsFW462 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW462>
+    [Fact]
+    public void Test()
     {
-        public StackExchangeRedisTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
+        var syncTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedis.StackExchangeRedisExerciser/DoSomeWork";
+        var asyncTransactionName = "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.StackExchangeRedis.StackExchangeRedisExerciser/DoSomeWorkAsync";
 
-        }
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = @"Datastore/all", callCount = 66 },
+            new() { metricName = @"Datastore/allOther", callCount = 66 },
+            new() { metricName = @"Datastore/Redis/all", callCount = 66 },
+            new() { metricName = @"Datastore/Redis/allOther", callCount = 66 },
+            new() { metricName = $@"Datastore/instance/Redis/{CommonUtils.NormalizeHostname(StackExchangeRedisConfiguration.StackExchangeRedisServer)}/{StackExchangeRedisConfiguration.StackExchangeRedisPort}", callCount = 66},
+            new() { metricName = @"Datastore/operation/Redis/SET", callCount = 4 },
+            new() { metricName = @"Datastore/operation/Redis/GET", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/APPEND", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/GETRANGE", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SETRANGE", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/STRLEN", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/DECR", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/INCR", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/HMSET", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/HINCRBY", callCount = 4 }, // increment and decrement
+            new() { metricName = @"Datastore/operation/Redis/HEXISTS", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/HVALS", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/HLEN", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/EXISTS", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/RANDOMKEY", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/RENAME", callCount = 2 },
+            // Delete can resolve to DEL or UNLINK depending on Redis version
+            new() { metricName = @"Datastore/operation/Redis/(DEL|UNLINK)", IsRegexName = true, callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/PING", callCount = 4 }, //ping and identifyendpoint
+            new() { metricName = @"Datastore/operation/Redis/SADD", callCount = 4 },
+            new() { metricName = @"Datastore/operation/Redis/SUNION", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SISMEMBER", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SCARD", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SMEMBERS", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SMOVE", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SRANDMEMBER", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SPOP", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/SREM", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/PUBLISH", callCount = 2 },
+            new() { metricName = @"Datastore/operation/Redis/EXEC", callCount = 2}
+        };
+
+        var unexpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            // The datastore operation happened inside a console app so there should be no allWeb metrics
+            new() {metricName = @"Datastore/allWeb", callCount = 1},
+            new() {metricName = @"Datastore/Redis/allWeb", callCount = 1}
+        };
+
+        var expectedTransactionEventIntrinsicAttributes = new List<string>
+        {
+            "databaseDuration"
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        // The previous version of this test cheated a bit by naming both transactions the same. Since either one might be the slowest,
+        // let's allow for either one
+        var transactionSample = _fixture.AgentLog.TryGetTransactionSample(syncTransactionName) ?? _fixture.AgentLog.TryGetTransactionSample(asyncTransactionName);
+        var transactionEvent1 = _fixture.AgentLog.TryGetTransactionEvent(syncTransactionName);
+        var transactionEvent2 = _fixture.AgentLog.TryGetTransactionEvent(asyncTransactionName);
+
+        NrAssert.Multiple
+        (
+            () => Assert.NotNull(transactionSample),
+            () => Assert.NotNull(transactionEvent1),
+            () => Assert.NotNull(transactionEvent2)
+        );
+
+        NrAssert.Multiple
+        (
+            () => Assertions.MetricsExist(expectedMetrics, metrics),
+            () => Assertions.MetricsDoNotExist(unexpectedMetrics, metrics),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent1),
+            () => Assertions.TransactionEventHasAttributes(expectedTransactionEventIntrinsicAttributes, TransactionEventAttributeType.Intrinsic, transactionEvent2)
+        );
     }
+}
 
-    public class StackExchangeRedisTestsFW471 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW471>
+public class StackExchangeRedisTestsFW462 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW462>
+{
+    public StackExchangeRedisTestsFW462(ConsoleDynamicMethodFixtureFW462 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public StackExchangeRedisTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class StackExchangeRedisTestsFW48 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW48>
+public class StackExchangeRedisTestsFW471 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW471>
+{
+    public StackExchangeRedisTestsFW471(ConsoleDynamicMethodFixtureFW471 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public StackExchangeRedisTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class StackExchangeRedisTestsFWLatest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+public class StackExchangeRedisTestsFW48 : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFW48>
+{
+    public StackExchangeRedisTestsFW48(ConsoleDynamicMethodFixtureFW48 fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public StackExchangeRedisTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class StackExchangeRedisTestsCoreOldest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+public class StackExchangeRedisTestsFWLatest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public StackExchangeRedisTestsFWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public StackExchangeRedisTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
     }
+}
 
-    public class StackExchangeRedisTestsCoreLatest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+public class StackExchangeRedisTestsCoreOldest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public StackExchangeRedisTestsCoreOldest(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output) : base(fixture, output)
     {
-        public StackExchangeRedisTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
-        {
 
-        }
+    }
+}
+
+public class StackExchangeRedisTestsCoreLatest : StackExchangeRedisTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public StackExchangeRedisTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/BasicMvcApplication.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/BasicMvcApplication.cs
@@ -2,49 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
-using System.Net;
-using System.Net.Http;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
+namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
+
+public class BasicMvcApplication : RemoteApplicationFixture
 {
-    public class BasicMvcApplication : RemoteApplicationFixture
+    public const string ExpectedTransactionName = @"WebTransaction/MVC/DefaultController/Index";
+
+    public BasicMvcApplication() : base(new RemoteWebApplication("BasicMvcApplication", ApplicationType.Unbounded))
     {
-        public const string ExpectedTransactionName = @"WebTransaction/MVC/DefaultController/Index";
+    }
 
-        public BasicMvcApplication() : base(new RemoteWebApplication("BasicMvcApplication", ApplicationType.Unbounded))
-        {
-        }
+    public void GetStackExchangeRedis()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedis";
 
-        public void GetStackExchangeRedis()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedis";
+        GetStringAndAssertIsNotNull(address);
+    }
 
-            GetStringAndAssertIsNotNull(address);
-        }
+    public void GetStackExchangeRedisStrongName()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisStrongName";
 
-        public void GetStackExchangeRedisStrongName()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisStrongName";
-
-            GetStringAndAssertIsNotNull(address);
-        }
+        GetStringAndAssertIsNotNull(address);
+    }
 
 
-        public void GetStackExchangeRedisAsync()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisAsync";
+    public void GetStackExchangeRedisAsync()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisAsync";
 
-            GetStringAndAssertIsNotNull(address);
-        }
+        GetStringAndAssertIsNotNull(address);
+    }
 
-        public void GetStackExchangeRedisAsyncStrongName()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisAsyncStrongName";
+    public void GetStackExchangeRedisAsyncStrongName()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Redis/StackExchangeRedisAsyncStrongName";
 
-            GetStringAndAssertIsNotNull(address);
-        }
+        GetStringAndAssertIsNotNull(address);
     }
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MSMQBasicMVCApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/MSMQBasicMVCApplicationFixture.cs
@@ -2,51 +2,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-using System;
-using System.Net;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
+namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
+
+public class MSMQBasicMVCApplicationFixture : RemoteApplicationFixture
 {
-    public class MSMQBasicMVCApplicationFixture : RemoteApplicationFixture
+    public const string ExpectedTransactionName = @"WebTransaction/MVC/DefaultController/Index";
+
+    public MSMQBasicMVCApplicationFixture() : base(new RemoteWebApplication("MSMQBasicMvcApplication", ApplicationType.Unbounded))
     {
-        public const string ExpectedTransactionName = @"WebTransaction/MVC/DefaultController/Index";
-
-        public MSMQBasicMVCApplicationFixture() : base(new RemoteWebApplication("MSMQBasicMvcApplication", ApplicationType.Unbounded))
-        {
-        }
-
-        #region MSMQController Actions
-
-        public void GetMessageQueue_Msmq_Send(bool ignoreThisTransaction)
-        {
-            var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Send?ignoreThisTransaction={ignoreThisTransaction}";
-
-            GetStringAndAssertIsNotNull(address);
-        }
-
-        public void GetMessageQueue_Msmq_Receive()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Receive";
-
-            GetStringAndAssertIsNotNull(address);
-        }
-
-        public void GetMessageQueue_Msmq_Peek()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Peek";
-
-            GetStringAndAssertIsNotNull(address);
-        }
-
-        public void GetMessageQueue_Msmq_Purge()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Purge";
-
-            GetStringAndAssertIsNotNull(address);
-        }
-
-        #endregion
     }
+
+    #region MSMQController Actions
+
+    public void GetMessageQueue_Msmq_Send(bool ignoreThisTransaction)
+    {
+        var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Send?ignoreThisTransaction={ignoreThisTransaction}";
+
+        GetStringAndAssertIsNotNull(address);
+    }
+
+    public void GetMessageQueue_Msmq_Receive()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Receive";
+
+        GetStringAndAssertIsNotNull(address);
+    }
+
+    public void GetMessageQueue_Msmq_Peek()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Peek";
+
+        GetStringAndAssertIsNotNull(address);
+    }
+
+    public void GetMessageQueue_Msmq_Purge()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/MSMQ/Msmq_Purge";
+
+        GetStringAndAssertIsNotNull(address);
+    }
+
+    #endregion
 }

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/OracleBasicMvcFixture.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/RemoteServiceFixtures/OracleBasicMvcFixture.cs
@@ -5,45 +5,42 @@
 using System;
 using System.Net;
 using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
-using NewRelic.Agent.IntegrationTests.Shared;
-using Xunit;
 
-namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures
+namespace NewRelic.Agent.UnboundedIntegrationTests.RemoteServiceFixtures;
+
+public class OracleBasicMvcFixture : RemoteApplicationFixture
 {
-    public class OracleBasicMvcFixture : RemoteApplicationFixture
+    public string TableName { get; }
+
+    public OracleBasicMvcFixture() : base(new RemoteWebApplication("BasicMvcApplication", ApplicationType.Unbounded))
     {
-        public string TableName { get; }
+        TableName = GenerateTableName();
+    }
 
-        public OracleBasicMvcFixture() : base(new RemoteWebApplication("BasicMvcApplication", ApplicationType.Unbounded))
-        {
-            TableName = GenerateTableName();
-        }
+    public void CreateTable()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Oracle/CreateTable?tableName={TableName}";
 
-        public void CreateTable()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Oracle/CreateTable?tableName={TableName}";
+        GetAndAssertStatusCode(address, HttpStatusCode.OK);
+    }
 
-            GetAndAssertStatusCode(address, HttpStatusCode.OK);
-        }
+    public void DropTable()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Oracle/DropTable?tableName={TableName}";
 
-        public void DropTable()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Oracle/DropTable?tableName={TableName}";
+        GetAndAssertStatusCode(address, HttpStatusCode.OK);
+    }
+    public void GetEnterpriseLibraryOracle()
+    {
+        var address = $"http://{DestinationServerName}:{Port}/Oracle/EnterpriseLibraryOracle?tableName={TableName}";
 
-            GetAndAssertStatusCode(address, HttpStatusCode.OK);
-        }
-        public void GetEnterpriseLibraryOracle()
-        {
-            var address = $"http://{DestinationServerName}:{Port}/Oracle/EnterpriseLibraryOracle?tableName={TableName}";
+        GetStringAndAssertIsNotNull(address);
+    }
 
-            GetStringAndAssertIsNotNull(address);
-        }
-
-        private static string GenerateTableName()
-        {
-            //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
-            var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
-            return $"h{tableId}";
-        }
+    private static string GenerateTableName()
+    {
+        //Oracle tables must start w/ character and be <= 30 length. Table name = H{tableId}
+        var tableId = Guid.NewGuid().ToString("N").Substring(2, 29).ToLower();
+        return $"h{tableId}";
     }
 }


### PR DESCRIPTION
Applies the following refactoring to the remaining files in the `UnboundedIntegrationTests` solution:

* File-scoped namespace
* Sort usings
* Remove unused usings

There are no other changes in this PR so it shouldn't be too hard to review.

As previously mentioned, it will help if you set the "hide whitespace" setting when you first start reviewing the files in this PR. 

Try the new "experimental" view on the Files page of the PR and you can (very efficiently) see all files in the PR at once.