### PR TITLE
test: Update MySql startup command in docker-compose

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
+++ b/tests/Agent/IntegrationTests/UnboundedServices/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
     mysql:
         build: ./mysql
-        command: mysqld --default-authentication-plugin=mysql_native_password
+        command: mysqld --mysql_native_password=FORCE
         ports:
             - "3306:3306"
         environment:


### PR DESCRIPTION
A recent update to the `lts` image for MySql has changed an old startup commandline parameter; this PR sets the correct parameter for the current image. Recall that `docker-compose.yml` is only used for local testing; there is no change required for the unbounded services k8s cluster, as it uses a slightly different configuration.