### PR TITLE
chore: Add agent metadata action to release

### DIFF
--- a/.github/workflows/deploy_agent.yml
+++ b/.github/workflows/deploy_agent.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
   packages: read
   id-token: write
-  
+
 env:
   DOTNET_NOLOGO: true
 
@@ -72,16 +72,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      
+
       - name: Get Release Version and Run ID
         if: ${{ inputs.get-version-automatically }}
         id: step1
         run: |
           # Get the commit sha for the most recent release
           COMMIT_SHA=$(git rev-list -n 1 "$(gh release list --limit 1 | awk '{ print $1 }')")
-          if [[ -z "$COMMIT_SHA" ]]; then 
+          if [[ -z "$COMMIT_SHA" ]]; then
             echo "::error::Unable to find SHA of most recent release"
-            exit 1 
+            exit 1
           fi
           echo "Found commit sha: $COMMIT_SHA"
 
@@ -149,7 +149,7 @@ jobs:
           fi
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   get-external-artifacts:
     name: Get and Publish Deploy Artifacts Locally
     needs: get-release-info
@@ -169,7 +169,7 @@ jobs:
           name: deploy-artifacts
           path: ${{ github.workspace }}
           repository: ${{ github.repository }}
-      
+
       - name: Upload Deploy Artifacts Locally
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -270,14 +270,14 @@ jobs:
         with:
           name: deploy-artifacts
           path: ${{ github.workspace }}\working_dir
-          
+
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
         uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
         id: login
         with:
           user: ${{ secrets.NUGET_TRUSTED_PUBLISH_POLICY_USER }}
-        
+
       - name: Deploy Agent to Nuget
         run: |
           $packageName = Get-ChildItem ${{ github.workspace }}\working_dir\NugetAgent\NewRelic.Agent.*.nupkg -Name
@@ -415,7 +415,7 @@ jobs:
           echo "AGENT_VERSION=$AGENT_VERSION" >> docker.env
           echo "ACTION=release" >> docker.env
           if [ "${{ inputs.linux-deploy-to-production }}" == "true" ] ; then
-            # We're actually deploying to production (apt.newrelic.com and yum.newrelic.com)           
+            # We're actually deploying to production (apt.newrelic.com and yum.newrelic.com)
             echo "S3_BUCKET=${{ secrets.PROD_MAIN_S3 }}" >> docker.env
             echo "AWS_ACCESS_KEY_ID=${{ secrets.LINUX_AWS_ACCESS_KEY_ID }}" >> docker.env
             echo "AWS_SECRET_ACCESS_KEY=${{ secrets.LINUX_AWS_SECRET_ACCESS_KEY }}" >> docker.env
@@ -484,3 +484,13 @@ jobs:
       wait_for_apt_and_yum: true
     secrets: inherit
 
+  agent-metadata:
+      permissions:
+          contents: read
+      needs: [post-deploy]
+      if: ${{ inputs.post-deploy }}
+      name: Run Agent Metadata Workflow
+      uses: newrelic/newrelic-dotnet-agent/.github/workflows/agent_metadata.yml@main
+      with:
+          version: ${{ needs.get-release-info.outputs.release_version }}
+      secrets: inherit


### PR DESCRIPTION
## Description

This PR completes the ability for the NR agent team to send agent metadata to New Relic for use in fleets and other features. This will be triggered normally during a release, but if it fails, it will not fail the release. It can also be run on-demand for backfilling older agent versions, to make corrections, or to re-run the job after a failure.

GH action info: https://github.com/newrelic/agent-metadata-action/blob/main/README.md

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
