### PR TITLE
ci: add empty performance tests workflow

### DIFF
--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -3,6 +3,8 @@ name: Performance Tests
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   performance-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will allow testing of the real workflow staged in PR #3460 