### PR TITLE
chore: Add appSettings switch / env var to enable instrumentation of websockets in ASP.NET Core 6+

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2132,6 +2132,11 @@ public class DefaultConfiguration : IConfiguration
     public bool EnableAspNetCore6PlusBrowserInjection =>
         _enableAspNetCore6PlusBrowserInjection ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("EnableAspNetCore6PlusBrowserInjection", true), "NEW_RELIC_ENABLE_ASPNETCORE6PLUS_BROWSER_INJECTION");
 
+    private bool? _instrumentAspNetCore6PlusWebsockets;
+    public bool InstrumentAspNetCore6PlusWebsockets =>
+        _instrumentAspNetCore6PlusWebsockets ??= EnvironmentOverrides(TryGetAppSettingAsBoolWithDefault("InstrumentAspNetCore6PlusWebsockets", false), "NEW_RELIC_INSTRUMENT_ASPNETCORE6PLUS_WEBSOCKETS");
+
+
     private TimeSpan? _metricsHarvestCycleOverride = null;
     public TimeSpan MetricsHarvestCycle
     {

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ReportedConfiguration.cs
@@ -620,6 +620,9 @@ public class ReportedConfiguration : IConfiguration
     [JsonProperty("agent.enable_asp_net_core_6plus_browser_injection")]
     public bool EnableAspNetCore6PlusBrowserInjection => _configuration.EnableAspNetCore6PlusBrowserInjection;
 
+    [JsonProperty("agent.instrument_asp_net_core_6plus_websockets")]
+    public bool InstrumentAspNetCore6PlusWebsockets => _configuration.InstrumentAspNetCore6PlusWebsockets;
+
     [JsonProperty("agent.exclude_new_relic_header")]
     public bool ExcludeNewrelicHeader => _configuration.ExcludeNewrelicHeader;
 

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Configuration/IConfiguration.cs
@@ -191,6 +191,8 @@ public interface IConfiguration
     int DatabaseStatementCacheCapacity { get; }
     bool ForceSynchronousTimingCalculationHttpClient { get; }
     bool EnableAspNetCore6PlusBrowserInjection { get; }
+
+    bool InstrumentAspNetCore6PlusWebsockets { get; }
     bool ExcludeNewrelicHeader { get; }
 
     SamplerType RootSamplerType { get; }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AspNetCore6Plus/WrapPipelineMiddleware.cs
@@ -45,14 +45,19 @@ internal class WrapPipelineMiddleware
             return;
         }
 
-        // if there's a "Sec-WebSocket-Key" header, this is a websocket handshake request and we should not create a transaction for it
-        // as it is a long-running connection that would skew transaction timings.
-        // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Key for more information on this header.
-        if (context.Request.Headers.ContainsKey("Sec-WebSocket-Key"))
+        // undocumented switch to restore previous behavior of instrumenting websocket handshake requests.
+        if (!_agent.Configuration.InstrumentAspNetCore6PlusWebsockets)
         {
-            _agent.Logger.Debug("WebSocket handshake request detected; not instrumenting this long-running request.");
-            await _next(context);
-            return;
+            // if there's a "Sec-WebSocket-Key" header, this is a websocket handshake request and we should not create a transaction for it
+            // as it is a long-running connection that would skew transaction timings.
+            // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Key for more information on this header.
+            if (context.Request.Headers.ContainsKey("Sec-WebSocket-Key"))
+            {
+                _agent.Logger.Debug(
+                    "WebSocket handshake request detected; not instrumenting this long-running request.");
+                await _next(context);
+                return;
+            }
         }
 
         ITransaction transaction = null;

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/AgentSettingsTests.cs
@@ -308,6 +308,7 @@ public class AgentSettingsTests
                                         "transaction_tracer.database_statement_cache_capacity": 1234,
                                         "agent.force_synchronous_timing_calculation_for_http_client": true,
                                         "agent.enable_asp_net_core_6plus_browser_injection": true,
+                                        "agent.instrument_asp_net_core_6plus_websockets": false,
                                         "agent.exclude_new_relic_header": true,
                                         "application_logging.enabled": true,
                                         "application_logging.metrics.enabled": true,

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ConnectModelTests.cs
@@ -380,6 +380,7 @@ public class ConnectModelTests
                                                     "transaction_tracer.database_statement_cache_capacity": 1234,
                                                     "agent.force_synchronous_timing_calculation_for_http_client": true,
                                                     "agent.enable_asp_net_core_6plus_browser_injection": true,
+                                                    "agent.instrument_asp_net_core_6plus_websockets": false,
                                                     "agent.exclude_new_relic_header": true,
                                                     "application_logging.enabled": true,
                                                     "application_logging.metrics.enabled": true,

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/ExhaustiveTestConfiguration.cs
@@ -427,6 +427,8 @@ public class ExhaustiveTestConfiguration : IConfiguration
 
     public bool EnableAspNetCore6PlusBrowserInjection => true;
 
+    public bool InstrumentAspNetCore6PlusWebsockets => false;
+
     public bool ExcludeNewrelicHeader => true;
 
     public bool ApplicationLoggingEnabled => true;


### PR DESCRIPTION
Adds an (undocumented) switch that can be used to enable instrumentation of websockets connections in ASP.NET Core 6+ to match behavior in .NET agent v10.49.0 and earlier. 

In `newrelic.config`, add an `<appSettings>` section:
```
  <appSettings>
    <add key="InstrumentAspNetCore6PlusWebsockets" value="true" />
  </appSettings>
```

or set an environment variable: 
```
NEW_RELIC_INSTRUMENT_ASPNETCORE6PLUS_WEBSOCKETS=true
```