### PR TITLE
chore: Ensure consistent DT header insertion/replacement logic across all wrappers

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/AwsSdk/SqsHelper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/AwsSdk/SqsHelper.cs
@@ -78,10 +78,6 @@ public static class SqsHelper
             var getMessageAttributes = _getMessageAttributes.GetOrAdd(smr.GetType(), t => VisibilityBypasser.Instance.GeneratePropertyAccessor<IDictionary>(t, "MessageAttributes"));
             var messageAttributes = getMessageAttributes(smr);
 
-            // if we can't add all DT headers, don't add any
-            if ((messageAttributes.Count + dtHeaderCount - headersInserted) > MaxSQSMessageAttributes)
-                return;
-
             // create a new MessageAttributeValue instance
             var messageAttributeValueTypeFactory = _messageAttributeValueTypeFactory ??= VisibilityBypasser.Instance.GenerateTypeFactory(smr.GetType().Assembly.FullName, "Amazon.SQS.Model.MessageAttributeValue");
             object newMessageAttributeValue = messageAttributeValueTypeFactory.Invoke();
@@ -92,7 +88,19 @@ public static class SqsHelper
             var stringValuePropertySetter = VisibilityBypasser.Instance.GeneratePropertySetter<string>(newMessageAttributeValue, "StringValue");
             stringValuePropertySetter(value);
 
-            messageAttributes.Add(key, newMessageAttributeValue);
+            if (messageAttributes.Contains(key))
+            {
+                // Replace existing header in place — no count change, no limit check needed
+                messageAttributes[key] = newMessageAttributeValue;
+            }
+            else
+            {
+                // New header — check that adding all remaining DT headers won't exceed the SQS limit
+                if ((messageAttributes.Count + dtHeaderCount - headersInserted) > MaxSQSMessageAttributes)
+                    return;
+
+                messageAttributes.Add(key, newMessageAttributeValue);
+            }
 
             ++headersInserted;
         });

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RestSharp/AppendHeaders.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/RestSharp/AppendHeaders.cs
@@ -26,14 +26,17 @@ public class AppendHeaders : IWrapper
     {
         var httpWebRequest = (HttpWebRequest)instrumentedMethodCall.MethodCall.MethodArguments[0];
 
-        var setHeaders = new Action<HttpWebRequest, string, string>((carrier, key, value) =>
+        // Insert DT headers after AppendHeaders completes, so they overwrite any
+        // pre-existing DT headers that RestSharp copied from the RestRequest.
+        return Delegates.GetDelegateFor(onComplete: () =>
         {
-            // 'Set' will replace an existing value
-            httpWebRequest.Headers?.Set(key, value);
+            var setHeaders = new Action<HttpWebRequest, string, string>((carrier, key, value) =>
+            {
+                // 'Set' will replace an existing value
+                carrier.Headers?.Set(key, value);
+            });
+
+            agent.CurrentTransaction.InsertDistributedTraceHeaders(httpWebRequest, setHeaders);
         });
-
-        agent.CurrentTransaction.InsertDistributedTraceHeaders(httpWebRequest, setHeaders);
-
-        return Delegates.NoOp;
     }
 }

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/ChannelFactoryWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Wcf3/ChannelFactoryWrapper.cs
@@ -119,7 +119,13 @@ public class NewRelicClientMessageInspector : IClientMessageInspector
 
     private void SetHeaders(Message carrier, string key, string value)
     {
-        // 'Set' will replace an existing value
+        // Remove existing header if present, then add the new one
+        var headerIndex = carrier.Headers.FindHeader(key, string.Empty);
+        if (headerIndex >= 0)
+        {
+            carrier.Headers.RemoveAt(headerIndex);
+        }
+
         carrier.Headers.Add(MessageHeader.CreateHeader(key, string.Empty, value));
     }
 

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DefaultController.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DefaultController.cs
@@ -160,6 +160,21 @@ public class DefaultController : Controller
         return "Worked";
     }
 
+    public string ChainedWebRequestWithExistingHeaders(string chainedServerName, string chainedPortNumber, string chainedAction)
+    {
+        var address = $"http://{chainedServerName}:{chainedPortNumber}/Default/{chainedAction}";
+#pragma warning disable SYSLIB0014 // obsolete usage is ok here
+        var httpWebRequest = (HttpWebRequest)WebRequest.Create(address);
+        // Pre-populate with stale DT headers — agent should replace them
+        httpWebRequest.Headers.Set("traceparent", "00-stale0000000000000000000000000-stale000000000-01");
+        httpWebRequest.Headers.Set("tracestate", "stale=value");
+        httpWebRequest.Headers.Set("newrelic", "stale-newrelic-payload");
+        httpWebRequest.GetResponse();
+#pragma warning restore SYSLIB0014
+
+        return "Worked";
+    }
+
     public async Task<string> ChainedHttpClient(string chainedServerName, string chainedPortNumber, string chainedAction)
     {
         var address = $"http://{chainedServerName}:{chainedPortNumber}/Default/{chainedAction}";

--- a/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DistributedTracingController.cs
+++ b/tests/Agent/IntegrationTests/Applications/BasicMvcApplication/Controllers/DistributedTracingController.cs
@@ -62,4 +62,23 @@ public class DistributedTracingController : Controller
         }
         return "Worked";
     }
+
+    [Route("DistributedTracing/MakeExternalCallUsingRestClientWithExistingHeaders")]
+    public async Task<string> MakeExternalCallUsingRestClientWithExistingHeaders(string externalCallUrl)
+    {
+        var uri = new Uri(externalCallUrl);
+        var client = new RestClient($"http://{uri.Host}:{uri.Port}");
+        var restRequest = new RestRequest(uri.PathAndQuery);
+        // Pre-populate with stale DT headers — agent should replace them
+        restRequest.AddHeader("traceparent", "00-stale0000000000000000000000000-stale000000000-01");
+        restRequest.AddHeader("tracestate", "stale=value");
+        restRequest.AddHeader("newrelic", "stale-newrelic-payload");
+        var response = await client.ExecuteTaskAsync<IEnumerable<Bird>>(restRequest);
+
+        if ((response.StatusCode != HttpStatusCode.OK) && (response.StatusCode != HttpStatusCode.NoContent))
+        {
+            return $"Unexpected HTTP status code {response.StatusCode}";
+        }
+        return "Worked";
+    }
 }

--- a/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Controllers/DistributedTracingSenderController.cs
+++ b/tests/Agent/IntegrationTests/Applications/Owin4WebApi/Controllers/DistributedTracingSenderController.cs
@@ -30,4 +30,29 @@ public class DistributedTracingSenderController : ApiController
             return result;
         }
     }
+
+    [HttpGet]
+    [Route("api/CallNextWithExistingHeaders")]
+    public async Task<string> CallNextWithExistingHeaders(string nextUrl)
+    {
+        try
+        {
+            using (var client = new HttpClient())
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, nextUrl);
+                // Pre-populate with stale DT headers — agent should replace them
+                request.Headers.Add("traceparent", "00-stale0000000000000000000000000-stale000000000-01");
+                request.Headers.Add("tracestate", "stale=value");
+                request.Headers.Add("newrelic", "stale-newrelic-payload");
+                var response = await client.SendAsync(request);
+                var result = await response.Content.ReadAsStringAsync();
+                return result;
+            }
+        }
+        catch (Exception ex)
+        {
+            var result = $"Exception occurred in {nameof(DistributedTracingSenderController)} calling [{nextUrl}]: {ex}";
+            return result;
+        }
+    }
 }

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExercisers/AwsSdkSQSExerciser.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/AwsSdkExercisers/AwsSdkSQSExerciser.cs
@@ -142,6 +142,29 @@ public class AwsSdkSQSExerciser : IDisposable
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    public async Task SQS_SendMessageWithExistingDTHeadersAsync(string message)
+    {
+        if (_sqsQueueUrl == null)
+        {
+            throw new InvalidOperationException("Queue URL is not set. Call SQS_Initialize or SQS_SetQueueUrl first.");
+        }
+
+        var request = new SendMessageRequest
+        {
+            QueueUrl = _sqsQueueUrl,
+            MessageBody = message,
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                { "traceparent", new MessageAttributeValue { DataType = "String", StringValue = "00-stale0000000000000000000000000-stale000000000-01" } },
+                { "tracestate", new MessageAttributeValue { DataType = "String", StringValue = "stale=value" } },
+                { "newrelic", new MessageAttributeValue { DataType = "String", StringValue = "stale-newrelic-payload" } },
+            }
+        };
+
+        await _amazonSqsClient.SendMessageAsync(request);
+    }
+
     // send message batch
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task SQS_SendMessageBatchAsync(string[] messages)

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkSQSController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Controllers/AwsSdkSQSController.cs
@@ -82,6 +82,18 @@ public class AwsSdkSQSController : ControllerBase
         _logger.LogInformation("Message {Message} sent to {Queue}", message, messageQueueUrl);
     }
 
+    // GET: /AwsSdk/SQS_SendMessageWithExistingDTHeadersToQueue?message=Hello&messageQueueUrl=MyQueue
+    [HttpGet("SQS_SendMessageWithExistingDTHeadersToQueue")]
+    public async Task SQS_SendMessageWithExistingDTHeadersToQueueAsync([Required]string message, [Required]string messageQueueUrl)
+    {
+        _logger.LogInformation("Sending message with existing DT headers {Message} to {Queue}", message, messageQueueUrl);
+        using var awsSdkSQSExerciser = new AwsSdkSQSExerciser();
+        awsSdkSQSExerciser.SQS_SetQueueUrl(messageQueueUrl);
+
+        await awsSdkSQSExerciser.SQS_SendMessageWithExistingDTHeadersAsync(message);
+        _logger.LogInformation("Message with existing DT headers {Message} sent to {Queue}", message, messageQueueUrl);
+    }
+
     // GET: /AwsSdk/SQS_SendMessageBatchToQueue?messageQueueUrl=MyQueue
     [HttpGet("SQS_ReceiveMessageFromQueue")]
     public async Task<IEnumerable<Message>> SQS_ReceiveMessageFromQueueAsync([Required]string messageQueueUrl)

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Controllers/KafkaController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Controllers/KafkaController.cs
@@ -38,6 +38,13 @@ public class KafkaController : ControllerBase
         return "Complete";
     }
 
+    [HttpGet("produceasyncwithexistingheaders")]
+    public async Task<string> ProduceAsyncWithExistingHeaders()
+    {
+        await _producer.ProduceAsyncWithExistingHeaders();
+        return "Complete";
+    }
+
     [HttpGet("bootstrap_server")]
     public string GetBootstrapServer() => Program.GetBootstrapServer();
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Producer.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Producer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
@@ -65,5 +66,26 @@ public class Producer
         var item = "asyncTestItem";
 
         await _producer.ProduceAsync(_topic, new Message<string, string> { Key = user, Value = item });
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task ProduceAsyncWithExistingHeaders()
+    {
+        var user = "asyncExistingHeadersUser";
+        var item = "asyncExistingHeadersItem";
+
+        var message = new Message<string, string>
+        {
+            Key = user,
+            Value = item,
+            Headers = new Headers
+            {
+                { "traceparent", Encoding.ASCII.GetBytes("00-stale0000000000000000000000000-stale000000000-01") },
+                { "tracestate", Encoding.ASCII.GetBytes("stale=value") },
+                { "newrelic", Encoding.ASCII.GetBytes("stale-newrelic-payload") }
+            }
+        };
+
+        await _producer.ProduceAsync(_topic, message);
     }
 }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerSQSTestFixture.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/AwsSdkContainerSQSTestFixture.cs
@@ -38,6 +38,19 @@ public class AwsSdkContainerSQSTestFixture : AwsSdkContainerTestFixtureBase
         return messagesJson;
     }
 
+    public string ExerciseSQS_SendAndReceiveWithExistingDTHeaders(string queueName)
+    {
+        var queueUrl = GetString($"{BaseUrl}/SQS_InitializeQueue?queueName={queueName}");
+
+        GetAndAssertStatusCode($"{BaseUrl}/SQS_SendMessageWithExistingDTHeadersToQueue?message=HelloDT&messageQueueUrl={queueUrl}", System.Net.HttpStatusCode.OK);
+
+        var messagesJson = GetString($"{BaseUrl}/SQS_ReceiveMessageFromQueue?messageQueueUrl={queueUrl}");
+
+        GetAndAssertStatusCode($"{BaseUrl}/SQS_DeleteQueue?messageQueueUrl={queueUrl}", System.Net.HttpStatusCode.OK);
+
+        return messagesJson;
+    }
+
     public string ExerciseSQS_ReceiveEmptyMessage(string queueName)
     {
         var queueUrl = GetString($"{BaseUrl}/SQS_InitializeQueue?queueName={queueName}");

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
@@ -31,12 +31,12 @@ public abstract class KafkaTestFixtureBase : RemoteApplicationFixture
         GetAndAssertStatusCode(address + "consumewithtimeout", System.Net.HttpStatusCode.OK);
         GetAndAssertStatusCode(address + "consumewithtimeout", System.Net.HttpStatusCode.OK);
 
-        GetAndAssertStatusCode(address + "produce", System.Net.HttpStatusCode.OK);
-        GetAndAssertStatusCode(address + "consumewithcancellationtoken", System.Net.HttpStatusCode.OK);
-
         // produce with pre-existing DT headers to verify agent replaces them
         GetAndAssertStatusCode(address + "produceasyncwithexistingheaders", System.Net.HttpStatusCode.OK);
         GetAndAssertStatusCode(address + "consumewithtimeout", System.Net.HttpStatusCode.OK);
+
+        GetAndAssertStatusCode(address + "produce", System.Net.HttpStatusCode.OK);
+        GetAndAssertStatusCode(address + "consumewithcancellationtoken", System.Net.HttpStatusCode.OK);
 
         // start a consume on an empty queue so we can verify that the Consume(CancellationToken) overload is correctly suppressing the Consume(int) overload calls
         GetAndAssertStatusCode(address + "consumewithcancellationtoken", System.Net.HttpStatusCode.OK);

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/KafkaTestFixtures.cs
@@ -34,6 +34,10 @@ public abstract class KafkaTestFixtureBase : RemoteApplicationFixture
         GetAndAssertStatusCode(address + "produce", System.Net.HttpStatusCode.OK);
         GetAndAssertStatusCode(address + "consumewithcancellationtoken", System.Net.HttpStatusCode.OK);
 
+        // produce with pre-existing DT headers to verify agent replaces them
+        GetAndAssertStatusCode(address + "produceasyncwithexistingheaders", System.Net.HttpStatusCode.OK);
+        GetAndAssertStatusCode(address + "consumewithtimeout", System.Net.HttpStatusCode.OK);
+
         // start a consume on an empty queue so we can verify that the Consume(CancellationToken) overload is correctly suppressing the Consume(int) overload calls
         GetAndAssertStatusCode(address + "consumewithcancellationtoken", System.Net.HttpStatusCode.OK);
         Delay(1); // wait a bit to ensure the consumer is started before we produce

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkSQSTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkSQSTest.cs
@@ -161,21 +161,24 @@ public abstract class AwsSdkSQSTestBase : NewRelicIntegrationTest<AwsSdkContaine
         }
 
         // Verify DT propagation works for queue 4 (pre-existing DT headers should have been replaced by agent)
+        // Uses transaction events instead of spans since adaptive sampling may not sample later transactions
         if (_initCollections)
         {
-            var queueProduceDT = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName4}";
-            var produceSpanDT = spans.LastOrDefault(s => s.IntrinsicAttributes["name"].Equals(queueProduceDT));
-            var processRequestSpanDT = spans.LastOrDefault(s =>
-                s.IntrinsicAttributes["name"].Equals("OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync")
-                && s.IntrinsicAttributes.ContainsKey("parentId")
-                && s.IntrinsicAttributes["parentId"].Equals(produceSpanDT?.IntrinsicAttributes["guid"]));
+            var sendDTTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope4);
+            var receiveDTTransactionEvents = _fixture.AgentLog.GetTransactionEvents()
+                .Where(e => e.IntrinsicAttributes["name"].Equals("OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync")
+                    && e.IntrinsicAttributes.ContainsKey("parentId")
+                    && e.IntrinsicAttributes.ContainsKey("traceId"));
+            // Find the receive event that shares the same traceId as the send event
+            var receiveDTTransactionEvent = sendDTTransactionEvent != null
+                ? receiveDTTransactionEvents.FirstOrDefault(e => e.IntrinsicAttributes["traceId"].Equals(sendDTTransactionEvent.IntrinsicAttributes["traceId"]))
+                : null;
 
             NrAssert.Multiple(
-                () => Assert.True(produceSpanDT != null, "produceSpanDT should not be null"),
-                () => Assert.True(processRequestSpanDT != null, "processRequestSpanDT (with existing DT headers) should not be null — agent should have replaced stale headers"),
-                () => Assert.Equal(produceSpanDT!.IntrinsicAttributes["traceId"], processRequestSpanDT!.IntrinsicAttributes["traceId"]),
+                () => Assert.True(sendDTTransactionEvent != null, "sendDTTransactionEvent should not be null"),
+                () => Assert.True(receiveDTTransactionEvent != null, "receiveDTTransactionEvent (with existing DT headers) should not be null — agent should have replaced stale headers"),
                 // Verify the stale traceId was NOT propagated
-                () => Assert.NotEqual("stale0000000000000000000000000", processRequestSpanDT!.IntrinsicAttributes["traceId"].ToString())
+                () => Assert.NotEqual("stale0000000000000000000000000", receiveDTTransactionEvent!.IntrinsicAttributes["traceId"].ToString())
             );
         }
 

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkSQSTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/AwsSdk/AwsSdkSQSTest.cs
@@ -21,8 +21,10 @@ public abstract class AwsSdkSQSTestBase : NewRelicIntegrationTest<AwsSdkContaine
     private readonly string _testQueueName1 = $"TestQueue1-{Guid.NewGuid()}";
     private readonly string _testQueueName2 = $"TestQueue2-{Guid.NewGuid()}";
     private readonly string _testQueueName3 = $"TestQueue3-{Guid.NewGuid()}";
+    private readonly string _testQueueName4 = $"TestQueue4-{Guid.NewGuid()}";
     private readonly string _metricScope1 = "WebTransaction/MVC/AwsSdkSQS/SQS_SendReceivePurge/{queueName}";
     private readonly string _metricScope2 = "WebTransaction/MVC/AwsSdkSQS/SQS_SendMessageToQueue/{message}/{messageQueueUrl}";
+    private readonly string _metricScope4 = "WebTransaction/MVC/AwsSdkSQS/SQS_SendMessageWithExistingDTHeadersToQueue/{message}/{messageQueueUrl}";
     private bool _initCollections;
 
     protected AwsSdkSQSTestBase(AwsSdkContainerSQSTestFixture fixture, ITestOutputHelper output, bool initCollections) : base(fixture)
@@ -51,6 +53,7 @@ public abstract class AwsSdkSQSTestBase : NewRelicIntegrationTest<AwsSdkContaine
                 _fixture.ExerciseSQS_SendReceivePurge(_testQueueName1);
                 _fixture.ExerciseSQS_SendAndReceiveInSeparateTransactions(_testQueueName2);
                 _fixture.ExerciseSQS_ReceiveEmptyMessage(_testQueueName3);
+                _fixture.ExerciseSQS_SendAndReceiveWithExistingDTHeaders(_testQueueName4);
 
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(2));
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(2));
@@ -93,12 +96,18 @@ public abstract class AwsSdkSQSTestBase : NewRelicIntegrationTest<AwsSdkContaine
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName3}", callCount = 1},
             new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName3}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
 
+            // Queue 4: send with pre-existing DT headers (verifies agent replaces them)
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName4}", callCount = 1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName4}", callCount = 1, metricScope = _metricScope4},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName4}", callCount = 1},
+            new() { metricName = $"MessageBroker/SQS/Queue/Consume/Named/{_testQueueName4}", callCount = 1, metricScope = "OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync"},
         };
 
         // If the AWS SDK is configured to NOT initialize empty collections, trace headers will not be accepted
         if (_initCollections)
         {
-            expectedMetrics.Add(new() { metricName = "Supportability/TraceContext/Accept/Success", callCount = 1 });
+            // 2 accept successes: one for queue 2 (normal) and one for queue 4 (with pre-existing DT headers replaced by agent)
+            expectedMetrics.Add(new() { metricName = "Supportability/TraceContext/Accept/Success", callCount = 2 });
         }
 
         var sendReceivePurgeTransactionEvent = _fixture.AgentLog.TryGetTransactionEvent(_metricScope1);
@@ -148,6 +157,25 @@ public abstract class AwsSdkSQSTestBase : NewRelicIntegrationTest<AwsSdkContaine
                 () => Assert.True(processRequestSpan != null, "processRequestSpan should not be null"),
                 () => Assert.Equal(produceSpan!.IntrinsicAttributes["traceId"], consumeSpan!.IntrinsicAttributes["traceId"]),
                 () => Assert.Equal(produceSpan!.IntrinsicAttributes["guid"], processRequestSpan!.IntrinsicAttributes["parentId"])
+            );
+        }
+
+        // Verify DT propagation works for queue 4 (pre-existing DT headers should have been replaced by agent)
+        if (_initCollections)
+        {
+            var queueProduceDT = $"MessageBroker/SQS/Queue/Produce/Named/{_testQueueName4}";
+            var produceSpanDT = spans.LastOrDefault(s => s.IntrinsicAttributes["name"].Equals(queueProduceDT));
+            var processRequestSpanDT = spans.LastOrDefault(s =>
+                s.IntrinsicAttributes["name"].Equals("OtherTransaction/Custom/AwsSdkTestApp.SQSBackgroundService.SQSReceiverService/ProcessRequestAsync")
+                && s.IntrinsicAttributes.ContainsKey("parentId")
+                && s.IntrinsicAttributes["parentId"].Equals(produceSpanDT?.IntrinsicAttributes["guid"]));
+
+            NrAssert.Multiple(
+                () => Assert.True(produceSpanDT != null, "produceSpanDT should not be null"),
+                () => Assert.True(processRequestSpanDT != null, "processRequestSpanDT (with existing DT headers) should not be null — agent should have replaced stale headers"),
+                () => Assert.Equal(produceSpanDT!.IntrinsicAttributes["traceId"], processRequestSpanDT!.IntrinsicAttributes["traceId"]),
+                // Verify the stale traceId was NOT propagated
+                () => Assert.NotEqual("stale0000000000000000000000000", processRequestSpanDT!.IntrinsicAttributes["traceId"].ToString())
             );
         }
 

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/InfiniteTracingContainerTests.cs
@@ -66,8 +66,8 @@ public abstract class InfiniteTracingContainerTest<T> : NewRelicIntegrationTest<
 
         var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
-            new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", callCount = expectedSeenCount },
-            new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", callCount = ExpectedSentCount },
+            new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Seen", CallCountAllHarvests = expectedSeenCount },
+            new Assertions.ExpectedMetric { metricName = @"Supportability/InfiniteTracing/Span/Sent", CallCountAllHarvests = ExpectedSentCount },
         };
 
         Assertions.MetricsExist(expectedMetrics, actualMetrics);

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -113,12 +113,12 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
             () => Assert.True(produceSpan.IntrinsicAttributes.ContainsKey("parentId")),
             () => Assert.NotNull(consumeWithTimeoutTxnSpan),
             () => Assert.True(consumeWithTimeoutTxnSpan.UserAttributes.ContainsKey("kafka.consume.byteCount")),
-            () => Assert.InRange((long)consumeWithTimeoutTxnSpan.UserAttributes["kafka.consume.byteCount"], 450, 470), // includes headers
+            () => Assert.InRange((long)consumeWithTimeoutTxnSpan.UserAttributes["kafka.consume.byteCount"], 450, 500), // includes headers; upper bound accommodates existing-headers message
             () => Assert.True(consumeWithTimeoutTxnSpan.IntrinsicAttributes.ContainsKey("traceId")),
             () => Assert.True(consumeWithTimeoutTxnSpan.IntrinsicAttributes.ContainsKey("parentId")),
             () => Assert.NotNull(consumeWithCancellationTxnSpan),
             () => Assert.True(consumeWithCancellationTxnSpan.UserAttributes.ContainsKey("kafka.consume.byteCount")),
-            () => Assert.InRange((long)consumeWithCancellationTxnSpan.UserAttributes["kafka.consume.byteCount"], 450, 470), // includes headers
+            () => Assert.InRange((long)consumeWithCancellationTxnSpan.UserAttributes["kafka.consume.byteCount"], 450, 500), // includes headers; upper bound accommodates potential race with existing-headers message
             () => Assert.True(consumeWithCancellationTxnSpan.IntrinsicAttributes.ContainsKey("traceId")),
             () => Assert.True(consumeWithCancellationTxnSpan.IntrinsicAttributes.ContainsKey("parentId"))
         );

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/KafkaTests.cs
@@ -68,6 +68,7 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
         var consumeWithTimeoutTransactionName = @"OtherTransaction/Custom/KafkaTestApp.Consumer/ConsumeOneWithTimeoutAsync";
         var consumeWithCancellationTransactionName = @"OtherTransaction/Custom/KafkaTestApp.Consumer/ConsumeOneWithCancellationTokenAsync";
         var produceWebTransactionName = @"WebTransaction/MVC/Kafka/Produce";
+        var produceWithExistingHeadersWebTransactionName = @"WebTransaction/MVC/Kafka/ProduceAsyncWithExistingHeaders";
 
         var messageBrokerNode = $"MessageBroker/Kafka/Nodes/{_bootstrapServer}";
         var messageBrokerNodeProduceTopic = $"MessageBroker/Kafka/Nodes/{_bootstrapServer}/Produce/{_topicName}";
@@ -84,24 +85,26 @@ public abstract class LinuxKafkaTest<T> : NewRelicIntegrationTest<T> where T : K
         var expectedMetrics = new List<Assertions.ExpectedMetric>
         {
             new() { metricName = produceWebTransactionName, CallCountAllHarvests = 4 }, // includes sync and async actions
-            new() { metricName = messageBrokerProduce, CallCountAllHarvests = 4 },
+            new() { metricName = produceWithExistingHeadersWebTransactionName, CallCountAllHarvests = 1 }, // produce with pre-existing DT headers
+            new() { metricName = messageBrokerProduce, CallCountAllHarvests = 5 }, // 4 normal + 1 with existing headers
             new() { metricName = messageBrokerProduce, metricScope = produceWebTransactionName, CallCountAllHarvests = 4 },
-            new() { metricName = messageBrokerProduceSerializationKey, CallCountAllHarvests = 4 },
+            new() { metricName = messageBrokerProduce, metricScope = produceWithExistingHeadersWebTransactionName, CallCountAllHarvests = 1 },
+            new() { metricName = messageBrokerProduceSerializationKey, CallCountAllHarvests = 5 },
             new() { metricName = messageBrokerProduceSerializationKey, metricScope = produceWebTransactionName, CallCountAllHarvests = 4 },
-            new() { metricName = messageBrokerProduceSerializationValue, CallCountAllHarvests = 4 },
+            new() { metricName = messageBrokerProduceSerializationValue, CallCountAllHarvests = 5 },
             new() { metricName = messageBrokerProduceSerializationValue, metricScope = produceWebTransactionName, CallCountAllHarvests = 4 },
 
-            new() { metricName = consumeWithTimeoutTransactionName, CallCountAllHarvests = 2 },
+            new() { metricName = consumeWithTimeoutTransactionName, CallCountAllHarvests = 3 }, // 2 normal + 1 for existing headers
             new() { metricName = consumeWithCancellationTransactionName, CallCountAllHarvests = 2 },
-            new() { metricName = messageBrokerConsume, CallCountAllHarvests = 4 },
-            new() { metricName = messageBrokerConsume, metricScope = consumeWithTimeoutTransactionName, CallCountAllHarvests = 2 },
+            new() { metricName = messageBrokerConsume, CallCountAllHarvests = 5 }, // 4 normal + 1 for existing headers
+            new() { metricName = messageBrokerConsume, metricScope = consumeWithTimeoutTransactionName, CallCountAllHarvests = 3 },
             new() { metricName = messageBrokerConsume, metricScope = consumeWithCancellationTransactionName, CallCountAllHarvests = 2 },
-            new() { metricName = "Supportability/TraceContext/Create/Success", CallCountAllHarvests = 4 },
-            new() { metricName = "Supportability/TraceContext/Accept/Success", CallCountAllHarvests = 4 },
+            new() { metricName = "Supportability/TraceContext/Create/Success", CallCountAllHarvests = 5 }, // 4 normal + 1 with existing headers replaced
+            new() { metricName = "Supportability/TraceContext/Accept/Success", CallCountAllHarvests = 5 }, // 4 normal + 1 with existing headers replaced
 
-            new() { metricName = messageBrokerNode, CallCountAllHarvests = 8 },
-            new() { metricName = messageBrokerNodeProduceTopic, CallCountAllHarvests = 4 },
-            new() { metricName = messageBrokerNodeConsumeTopic, CallCountAllHarvests = 4 }
+            new() { metricName = messageBrokerNode, CallCountAllHarvests = 10 }, // 8 normal + 2 for existing headers (produce+consume)
+            new() { metricName = messageBrokerNodeProduceTopic, CallCountAllHarvests = 5 },
+            new() { metricName = messageBrokerNodeConsumeTopic, CallCountAllHarvests = 5 }
         };
 
         NrAssert.Multiple(

--- a/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTHeaderReplacementTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/DistributedTracing/DTHeaderReplacementTests.cs
@@ -1,0 +1,130 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.DistributedTracing;
+
+/// <summary>
+/// Verifies that when outbound HTTP requests already have DT headers (traceparent, tracestate, newrelic),
+/// the agent replaces them rather than duplicating or erroring.
+/// Note: HttpClient header replacement is covered by unit tests (SendAsync uses Remove+Add which correctly replaces)
+/// and by the existing HttpClientW3CTests for regression. The Owin self-hosted fixture has infrastructure
+/// issues that prevent a standalone existing-headers test.
+/// </summary>
+public class HttpWebRequestDTHeaderReplacementTest : NewRelicIntegrationTest<FrameworkTracingChainFixture>
+{
+    private readonly FrameworkTracingChainFixture _fixture;
+
+    public HttpWebRequestDTHeaderReplacementTest(FrameworkTracingChainFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.SetOrDeleteSpanEventsEnabled(true);
+                configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                configModifier.SetLogLevel("debug");
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+
+                var environmentVariables = new Dictionary<string, string>();
+
+                _fixture.ReceiverApplication = _fixture.SetupReceiverApplication(isDistributedTracing: true, isWebApplication: true);
+                _fixture.ReceiverApplication.Start(string.Empty, environmentVariables, captureStandardOutput: true);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.ExecuteTraceRequestChainHttpWebRequestWithExistingHeaders();
+
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.AnalyticsEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void AgentReplacesExistingDTHeaders()
+    {
+        var receiverMetrics = _fixture.ReceiverAppAgentLog.GetMetrics().ToArray();
+
+        var receiverExpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = @"Supportability/TraceContext/Accept/Success", callCount = 1 },
+        };
+
+        Assertions.MetricsExist(receiverExpectedMetrics, receiverMetrics);
+
+        var receiverTxEvent = _fixture.ReceiverAppAgentLog.GetTransactionEvents().FirstOrDefault();
+        Assert.NotNull(receiverTxEvent);
+        Assert.True(receiverTxEvent.IntrinsicAttributes.ContainsKey("parentId"), "Receiver should have parentId from replaced DT headers");
+    }
+}
+
+public class RestSharpDTHeaderReplacementTest : NewRelicIntegrationTest<FrameworkTracingChainFixture>
+{
+    private readonly FrameworkTracingChainFixture _fixture;
+
+    public RestSharpDTHeaderReplacementTest(FrameworkTracingChainFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.Actions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                configModifier.SetOrDeleteSpanEventsEnabled(true);
+                configModifier.SetOrDeleteDistributedTraceEnabled(true);
+                configModifier.SetLogLevel("debug");
+                configModifier.ConfigureFasterMetricsHarvestCycle(10);
+                configModifier.ConfigureFasterSpanEventsHarvestCycle(10);
+
+                var environmentVariables = new Dictionary<string, string>();
+
+                _fixture.ReceiverApplication = _fixture.SetupReceiverApplication(isDistributedTracing: true, isWebApplication: true);
+                _fixture.ReceiverApplication.Start(string.Empty, environmentVariables, captureStandardOutput: true);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.ExecuteTraceRequestChainRestSharpWithExistingHeaders();
+
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.AnalyticsEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.SpanEventDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.ReceiverAppAgentLog.WaitForLogLine(AgentLogFile.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void AgentReplacesExistingDTHeaders()
+    {
+        var receiverMetrics = _fixture.ReceiverAppAgentLog.GetMetrics().ToArray();
+
+        var receiverExpectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = @"Supportability/TraceContext/Accept/Success", callCount = 1 },
+        };
+
+        Assertions.MetricsExist(receiverExpectedMetrics, receiverMetrics);
+
+        var receiverTxEvent = _fixture.ReceiverAppAgentLog.GetTransactionEvents().FirstOrDefault();
+        Assert.NotNull(receiverTxEvent);
+        Assert.True(receiverTxEvent.IntrinsicAttributes.ContainsKey("parentId"), "Receiver should have parentId from replaced DT headers");
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/TracingChainFixture.cs
@@ -142,6 +142,44 @@ public class TracingChainFixture : RemoteApplicationFixture
         GetStringAndAssertContains(senderUrl, "Worked", headers);
     }
 
+    public void ExecuteTraceRequestChainHttpClientWithExistingHeaders(IEnumerable<KeyValuePair<string, string>> headers = null)
+    {
+        // Same as ExecuteTraceRequestChainHttpClient but calls the endpoint that pre-populates stale DT headers
+        var senderBaseUrl = $"http://{DestinationServerName}:{RemoteApplication.Port}";
+        var receiverBaseUrl = $"http://{DestinationServerName}:{ReceiverApplication.Port}";
+
+        var receiverUrl = $"{receiverBaseUrl}/api/CallEnd";
+        var senderUrl = $"{senderBaseUrl}/api/CallNextWithExistingHeaders?nextUrl={receiverUrl}";
+
+        TestLogger?.WriteLine($"[{nameof(TracingChainFixture)}]: Starting A -> B request chain (with existing DT headers) with URL: {senderUrl}");
+
+        GetStringAndAssertContains(senderUrl, "Worked", headers);
+    }
+
+    public HttpResponseHeaders ExecuteTraceRequestChainHttpWebRequestWithExistingHeaders()
+    {
+        const string action = "Index";
+        var queryString = $"?chainedServerName={DestinationServerName}&chainedPortNumber={ReceiverApplication.Port}&chainedAction={action}";
+
+        var address = $"http://{DestinationServerName}:{Port}/Default/ChainedWebRequestWithExistingHeaders{queryString}";
+
+        using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, address))
+        {
+            using (var httpResponseMessage = _httpClient.SendAsync(httpRequestMessage).Result)
+            {
+                return httpResponseMessage.Headers;
+            }
+        }
+    }
+
+    public void ExecuteTraceRequestChainRestSharpWithExistingHeaders()
+    {
+        var secondCallUrl = $"http://{DestinationServerName}:{ReceiverApplication.Port}/api/RestAPI";
+        var firstCallUrl = $"http://{DestinationServerName}:{SenderApplication.Port}/DistributedTracing/MakeExternalCallUsingRestClientWithExistingHeaders?externalCallUrl={secondCallUrl}";
+
+        GetStringAndAssertEqual(firstCallUrl, "Worked");
+    }
+
     public void ExecuteTraceRequestChainRestSharp(IEnumerable<KeyValuePair<string, string>> headers)
     {
         var secondCallUrl = $"http://{DestinationServerName}:{ReceiverApplication.Port}/api/RestAPI";

--- a/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFDTHeaderReplacementTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/WCF/WCFDTHeaderReplacementTests.cs
@@ -1,0 +1,84 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.IntegrationTests.Shared.Wcf;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.WCF;
+
+/// <summary>
+/// Verifies that when outbound WCF HTTP requests already have DT headers
+/// (traceparent, tracestate, newrelic) in HttpRequestMessageProperty.Headers,
+/// the agent replaces them rather than duplicating or erroring.
+/// </summary>
+public class WCFClient_Self_BasicHTTP_DTHeaderReplacement : NewRelicIntegrationTest<ConsoleDynamicMethodFixtureFWLatest>
+{
+    private readonly ConsoleDynamicMethodFixtureFWLatest _fixture;
+
+    public WCFClient_Self_BasicHTTP_DTHeaderReplacement(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+
+        var relativePath = "WCFService";
+
+        // Start the self-hosted WCF service with BasicHttp binding
+        _fixture.AddCommand($"WCFServiceSelfHosted StartService {WCFBindingType.BasicHttp} {_fixture.RemoteApplication.Port} {relativePath}");
+
+        // Initialize client and call with existing DT headers
+        _fixture.AddCommand($"WCFClient InitializeClient_SelfHosted {WCFBindingType.BasicHttp} {_fixture.RemoteApplication.Port} {relativePath}");
+        _fixture.AddCommand("WCFClient GetDataWithExistingDTHeaders");
+
+        // Stop service
+        _fixture.AddCommand("WCFServiceSelfHosted StopService");
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                _fixture.RemoteApplication.NewRelicConfig.SetLogLevel("finest");
+                _fixture.RemoteApplication.NewRelicConfig.SetOrDeleteDistributedTraceEnabled(true);
+                _fixture.RemoteApplication.NewRelicConfig.EnableSpanEvents(true);
+                _fixture.RemoteApplication.NewRelicConfig.ForceTransactionTraces();
+                _fixture.RemoteApplication.NewRelicConfig.ConfigureFasterMetricsHarvestCycle(10);
+                _fixture.RemoteApplication.NewRelicConfig.ConfigureFasterSpanEventsHarvestCycle(10);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.MetricDataLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void AgentReplacesExistingDTHeaders()
+    {
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = "Supportability/TraceContext/Create/Success", CallCountAllHarvests = 1 },
+            new() { metricName = "Supportability/TraceContext/Accept/Success", CallCountAllHarvests = 1 },
+        };
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+
+        // Verify the service-side transaction has DT attributes, proving the stale headers were replaced
+        var serviceTxEvents = _fixture.AgentLog.GetTransactionEvents()
+            .Where(e => e.IntrinsicAttributes.TryGetValue("name", out var name) &&
+                        name.ToString().Contains("Wcf"))
+            .ToList();
+
+        // At least one service transaction should have parentId (from the replaced DT headers)
+        Assert.True(serviceTxEvents.Any(e => e.IntrinsicAttributes.ContainsKey("parentId")),
+            "At least one WCF service transaction should have parentId from replaced DT headers");
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/AzureServiceBus/AzureServiceBusExerciser.cs
@@ -69,6 +69,15 @@ internal class AzureServiceBusExerciser
     [LibraryMethod]
     [Transaction]
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    public static async Task SendAndReceiveWithExistingDTHeadersForQueue(string queueName)
+    {
+        await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
+        await SendAMessageWithExistingDTHeaders(client, queueName, "Hello with existing DT headers!");
+    }
+
+    [LibraryMethod]
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public static async Task ExerciseMultipleReceiveOperationsOnAMessageForQueue(string queueName)
     {
         await using var client = new ServiceBusClient(AzureServiceBusConfiguration.ConnectionString);
@@ -415,6 +424,17 @@ internal class AzureServiceBusExerciser
     {
         await using var sender = client.CreateSender(queueOrTopicName);
         var message = new ServiceBusMessage(messageBody);
+        await sender.SendMessageAsync(message);
+    }
+
+    private static async Task SendAMessageWithExistingDTHeaders(ServiceBusClient client, string queueOrTopicName, string messageBody)
+    {
+        await using var sender = client.CreateSender(queueOrTopicName);
+        var message = new ServiceBusMessage(messageBody);
+        // Pre-populate with stale DT headers — agent should replace them
+        message.ApplicationProperties["traceparent"] = "00-stale0000000000000000000000000-stale000000000-01";
+        message.ApplicationProperties["tracestate"] = "stale=value";
+        message.ApplicationProperties["newrelic"] = "stale-newrelic-payload";
         await sender.SendMessageAsync(message);
     }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ/RabbitMQModernExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/RabbitMQ/RabbitMQModernExerciser.cs
@@ -71,6 +71,24 @@ public class RabbitMQModernExerciser
     [LibraryMethod]
     [Transaction]
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    public async Task SendReceiveWithExistingDTHeadersAsync(string queueName, string message)
+    {
+        if (string.IsNullOrEmpty(message)) { message = "Caller provided no message."; }
+
+        await DeclareQueueAsync(queueName);
+
+        await BasicPublishMessageWithExistingDTHeadersAsync(queueName, message);
+
+        var receiveMessage = await BasicGetMessageAsync(queueName);
+
+        await DeleteQueueAsync(queueName);
+
+        Console.WriteLine($"method=SendReceiveWithExistingDTHeaders,sent message={message},received message={receiveMessage}, queueName={queueName}");
+    }
+
+    [LibraryMethod]
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
     public async Task SendReceiveWithEventingConsumerAsync(string queueName, string message)
     {
         if (string.IsNullOrEmpty(message)) { message = "Caller provided no message."; }
@@ -192,6 +210,23 @@ public class RabbitMQModernExerciser
         var props = new BasicProperties
         {
             Headers = userHeaders
+        };
+
+        await Channel.BasicPublishAsync("", queueName, false, props, body);
+    }
+
+    private async Task BasicPublishMessageWithExistingDTHeadersAsync(string queueName, string message)
+    {
+        var body = Encoding.UTF8.GetBytes(message);
+        var headers = new Dictionary<string, object>(userHeaders)
+        {
+            { "traceparent", "00-stale0000000000000000000000000-stale000000000-01" },
+            { "tracestate", "stale=value" },
+            { "newrelic", "stale-newrelic-payload" }
+        };
+        var props = new BasicProperties
+        {
+            Headers = headers
         };
 
         await Channel.BasicPublishAsync("", queueName, false, props, body);

--- a/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/ConsoleMultiFunctionApplicationFW/NetFrameworkLibraries/WCF/WCFClient.cs
@@ -237,6 +237,28 @@ public class WCFClient
         }
     }
 
+    [LibraryMethod]
+    public void GetDataWithExistingDTHeaders()
+    {
+        using (var scope = new OperationContextScope((_wcfClient as WcfClient).InnerChannel))
+        {
+            OperationContext.Current.OutgoingMessageProperties[HttpRequestMessageProperty.Name] = new HttpRequestMessageProperty()
+            {
+                Headers =
+                {
+                    // Pre-populate with stale DT headers — agent should replace them
+                    { "traceparent", "00-stale0000000000000000000000000-stale000000000-01" },
+                    { "tracestate", "stale=value" },
+                    { "newrelic", "stale-newrelic-payload" }
+                }
+            };
+
+            var result = _wcfClient.Sync_SyncGetData(2000);
+
+            ConsoleMFLogger.Info($"Result: {result ?? "<NULL>"}");
+        }
+    }
+
     /// <summary>
     /// Calls the WCF Service ThrowException function with both client and server invocation methods (sync,begin/end,tap async)
     /// </summary>

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
@@ -42,10 +42,9 @@ public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegratio
                 var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
 
                 configModifier
+                    .SetLogLevel("finest")
                     .EnableDistributedTrace()
                     .ForceTransactionTraces()
-                    .SetOrDeleteDistributedTraceEnabled(true)
-                    .SetOrDeleteSpanEventsEnabled(true)
                     .ConfigureFasterMetricsHarvestCycle(20)
                     .ConfigureFasterSpanEventsHarvestCycle(20)
                     .ConfigureFasterTransactionTracesHarvestCycle(25);
@@ -216,3 +215,87 @@ public class
 }
 
 #endregion Topic Tests
+
+#region DT Header Replacement Tests
+
+/// <summary>
+/// Verifies that when a ServiceBusMessage already has DT headers in ApplicationProperties,
+/// the agent replaces them rather than duplicating or erroring.
+/// </summary>
+public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
+{
+    private readonly TFixture _fixture;
+    private readonly string _queueName;
+
+    protected AzureServiceBusW3CDTHeaderReplacementTestsBase(TFixture fixture, ITestOutputHelper output) :
+        base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(1));
+        _fixture.TestLogger = output;
+
+        _queueName = $"test-dtheader-{Guid.NewGuid()}";
+
+        _fixture.AddCommand($"AzureServiceBusExerciser InitializeQueue {_queueName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser SendAndReceiveWithExistingDTHeadersForQueue {_queueName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser ReceiveAMessageForQueue {_queueName}");
+        _fixture.AddCommand($"AzureServiceBusExerciser DeleteQueue {_queueName}");
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                configModifier
+                    .SetLogLevel("finest")
+                    .EnableDistributedTrace()
+                    .ForceTransactionTraces()
+                    .ConfigureFasterMetricsHarvestCycle(20)
+                    .ConfigureFasterSpanEventsHarvestCycle(20)
+                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void AgentReplacesExistingDTHeaders()
+    {
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = "Supportability/TraceContext/Create/Success", callCount = 1 },
+            new() { metricName = "Supportability/TraceContext/Accept/Success", callCount = 1 },
+        };
+
+        Assertions.MetricsExist(expectedMetrics, metrics);
+
+        // Verify DT propagation — stale headers should have been replaced
+        var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
+        foreach (var span in spanEvents)
+        {
+            if (span.IntrinsicAttributes.TryGetValue("traceId", out var traceId))
+            {
+                Assert.NotEqual("stale0000000000000000000000000", traceId.ToString());
+            }
+        }
+    }
+}
+
+public class AzureServiceBusW3CDTHeaderReplacementTestsCoreLatest : AzureServiceBusW3CDTHeaderReplacementTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public AzureServiceBusW3CDTHeaderReplacementTestsCoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture,
+        ITestOutputHelper output) : base(fixture, output)
+    {
+    }
+}
+
+#endregion DT Header Replacement Tests

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/SqsHelperTests.cs
@@ -72,6 +72,56 @@ namespace Agent.Extensions.Tests.Helpers
             Assert.That(sendMessageRequest.MessageAttributes["tracestate"].StringValue, Is.EqualTo("tracestatevalue"));
         }
         [Test]
+        public void InsertDistributedTraceHeaders_ExistingHeaders_ReplacesHeaders()
+        {
+            // Arrange - pre-populate with DT headers that should be replaced
+            var sendMessageRequest = new MockMessageRequest
+            {
+                MessageAttributes = new Dictionary<string, MessageAttributeValue>
+                {
+                    { "traceparent", new MessageAttributeValue { DataType = "String", StringValue = "old-traceparent" } },
+                    { "tracestate", new MessageAttributeValue { DataType = "String", StringValue = "old-tracestate" } },
+                }
+            };
+
+            // Act
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, 2);
+
+            // Assert - headers should be replaced, not duplicated or errored
+            Assert.That(sendMessageRequest.MessageAttributes, Has.Count.EqualTo(2));
+            Assert.That(sendMessageRequest.MessageAttributes["traceparent"].StringValue, Is.EqualTo("traceparentvalue"));
+            Assert.That(sendMessageRequest.MessageAttributes["tracestate"].StringValue, Is.EqualTo("tracestatevalue"));
+        }
+
+        [Test]
+        public void InsertDistributedTraceHeaders_ExistingHeaders_AtAttributeLimit_StillReplacesHeaders()
+        {
+            // Arrange - pre-populate with DT headers + 8 others = 10 total (the SQS max)
+            var sendMessageRequest = new MockMessageRequest
+            {
+                MessageAttributes = new Dictionary<string, MessageAttributeValue>
+                {
+                    { "traceparent", new MessageAttributeValue { DataType = "String", StringValue = "old-traceparent" } },
+                    { "tracestate", new MessageAttributeValue { DataType = "String", StringValue = "old-tracestate" } },
+                }
+            };
+
+            for (int i = 0; i < 8; i++)
+            {
+                sendMessageRequest.MessageAttributes.Add($"key{i}",
+                    new MessageAttributeValue { DataType = "String", StringValue = $"value{i}" });
+            }
+
+            // Act
+            SqsHelper.InsertDistributedTraceHeaders(_mockTransaction, sendMessageRequest, 2);
+
+            // Assert - replacement should work even at the 10-attribute limit
+            Assert.That(sendMessageRequest.MessageAttributes, Has.Count.EqualTo(10));
+            Assert.That(sendMessageRequest.MessageAttributes["traceparent"].StringValue, Is.EqualTo("traceparentvalue"));
+            Assert.That(sendMessageRequest.MessageAttributes["tracestate"].StringValue, Is.EqualTo("tracestatevalue"));
+        }
+
+        [Test]
         [TestCase(7, true)]
         [TestCase(8, false)]
         public void InsertDistributedTraceHeaders_AttributeLimit_ExceedsLimitGracefully(int attributeCount, bool dtHeadersShouldBeAdded)


### PR DESCRIPTION
## Description
Validates and updates all distributed trace header insertion/replacement logic to ensure consistent behavior everywhere. Only SQS, RestSharp and the (very old) Wcf3 ChannelFactory wrapper were implemented inconsistently.

Adds unit and integration tests that ensure the replacement logic works correctly everywhere. 

See the [related Jira ticket](https://new-relic.atlassian.net/browse/NR-483373) and the Google doc referenced in it for a report on the entire inventory of DT header insertion across the .NET agent.

One change that's important to note is in the RestSharp `AppendHeaders` wrapper - header replacement was moved to the onComplete delegate to ensure anything added by the real `AppendHeaders` call would be correctly replaced if there was a collision. This was potentially a bug in the original implementation, but would have been very unlikely to occur.

Some wrapper implementations could not be tested easily or did not need a test because of the way the underlying library handles headers:
- NServiceBus — uses dictionary indexer headers[key] = value which inherently replaces. Headers are managed internally
   by the NServiceBus pipeline, so pre-populating DT headers before the agent's hook would require a custom pipeline
  behavior.
- MassTransit (current and legacy) — uses SendHeaders.Set(key, value) which is MassTransit's own API that replaces by
  design. Pre-populating would require a custom ISendObserver or IFilter.
- WCF NetTcp — the Message.Headers are not directly accessible before the agent's BeforeSendRequest inspector runs in
  the WCF client programming model, so there's no natural way for pre-existing DT headers to appear. The fix (FindHeader + RemoveAt + Add) was validated by code review.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
