### PR TITLE
chore: Add debug logging for MassTransit URI parsing exceptions

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Helpers/MassTransit.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/Helpers/MassTransit.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using NewRelic.Agent.Extensions.Logging;
 using NewRelic.Agent.Extensions.Providers.Wrapper;
 
 
@@ -107,8 +108,10 @@ public static class MassTransitHelpers
 
             return data;
         }
-        catch
+        catch (Exception ex)
         {
+            Log.Debug(ex, "Unexpected error parsing MassTransit URI. Falling back to default values.");
+
             return data;
         }
     }

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/MassTransitHelperTests.cs
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/Helpers/MassTransitHelperTests.cs
@@ -125,4 +125,20 @@ public class MassTransitHelperTests
             Assert.That(data.DestinationType, Is.EqualTo(expectedDestType));
         });
     }
+
+    [Test]
+    public void GetQueueData_ReturnsDefaults_WhenParsingThrows()
+    {
+        // A relative Uri passes the null check but throws InvalidOperationException
+        // when .Scheme is accessed, exercising the catch block.
+        var relativeUri = new Uri("relative-path", UriKind.Relative);
+
+        var data = MassTransitHelpers.GetQueueData(relativeUri);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(data.QueueName, Is.EqualTo("Unknown"));
+            Assert.That(data.DestinationType, Is.EqualTo(MessageBrokerDestinationType.Queue));
+        });
+    }
 }


### PR DESCRIPTION
## Summary
Add Log.Debug call in the MassTransitHelpers.GetQueueDataFromUri catch block to log exceptions that occur during URI parsing, following the same pattern used by other connection string parsers in the Extensions library (e.g., MsSqlConnectionStringParser, MySqlConnectionStringParser).

## Changes
- **MassTransit.cs**: Log the caught exception via Log.Debug(ex, ...) instead of silently swallowing it.
- **MassTransitHelperTests.cs**: Add GetQueueData_ReturnsDefaults_WhenParsingThrows test that passes a relative URI to exercise the catch block and verify default values are returned.