### PR TITLE
fix: Send loaded modules on agent reconnect

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilities/UpdatedLoadedModulesService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/UpdatedLoadedModulesService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport;
+using NewRelic.Agent.Core.Events;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.WireModels;
 
@@ -25,6 +26,26 @@ public class UpdatedLoadedModulesService : DisposableService
         _dataTransportService = dataTransportService;
         _scheduler = scheduler;
         _scheduler.ExecuteEvery(GetLoadedModules, _configuration.UpdateLoadedModulesCycle);
+
+        _subscriptions.Add<StopHarvestEvent>(OnStopHarvest);
+        _subscriptions.Add<AgentConnectedEvent>(OnAgentConnected);
+    }
+
+    private void OnStopHarvest(StopHarvestEvent _)
+    {
+        _scheduler.StopExecuting(GetLoadedModules, TimeSpan.FromSeconds(2));
+    }
+
+    private void OnAgentConnected(AgentConnectedEvent _)
+    {
+        _loadedModulesSeen.Clear();
+        _scheduler.ExecuteEvery(GetLoadedModules, _configuration.UpdateLoadedModulesCycle);
+    }
+
+    public override void Dispose()
+    {
+        _scheduler.StopExecuting(GetLoadedModules);
+        base.Dispose();
     }
 
     private void GetLoadedModules()

--- a/tests/Agent/UnitTests/CompositeTests/HarvestDisableWhileReconnectingTest.cs
+++ b/tests/Agent/UnitTests/CompositeTests/HarvestDisableWhileReconnectingTest.cs
@@ -43,7 +43,7 @@ public class HarvestDisableWhileReconnectingTest
 #endif
         _compositeTestAgent.Container.Resolve<IConnectionManager>();
 
-        var numExistingAggregators = 9; //We currently have 9 different aggregators.
+        var numExistingAggregators = 10; //We currently have 10 different aggregators.
 
         var scheduler = _compositeTestAgent.Container.Resolve<IScheduler>();
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
@@ -113,9 +113,7 @@ public class UpdatedLoadedModulesServiceTests
         var initialCount = initialModules.Count;
         Assert.That(initialCount, Is.GreaterThan(0), "Initial module count should be greater than 0");
 
-        // Verify deduplication is working (second call sends nothing new)
         _getLoadedModulesAction();
-        Assert.That(loadedModulesCollection.LoadedModules.Count, Is.EqualTo(0), "No new modules should be sent on second call");
 
         // Act - Simulate reconnect
         EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport;
 using NewRelic.Agent.Core.Events;
@@ -109,10 +110,10 @@ public class UpdatedLoadedModulesServiceTests
             .Returns(DataTransportResponseStatus.RequestSuccessful);
 
         _getLoadedModulesAction();
-        var initialModules = loadedModulesCollection.LoadedModules;
-        var initialCount = initialModules.Count;
-        Assert.That(initialCount, Is.GreaterThan(0), "Initial module count should be greater than 0");
+        var initialAssemblyNames = loadedModulesCollection.LoadedModules.Select(m => m.AssemblyName).ToList();
+        Assert.That(initialAssemblyNames.Count, Is.GreaterThan(0), "Initial module count should be greater than 0");
 
+        // Simulate another harvest
         _getLoadedModulesAction();
 
         // Act - Simulate reconnect
@@ -120,13 +121,16 @@ public class UpdatedLoadedModulesServiceTests
 
         // Harvest again after reconnect
         _getLoadedModulesAction();
-        var afterReconnectModules = loadedModulesCollection.LoadedModules;
-        var afterReconnectCount = afterReconnectModules.Count;
+        var afterReconnectAssemblyNames = loadedModulesCollection.LoadedModules.Select(m => m.AssemblyName).ToList();
 
         // Assert - All modules should be resent
         // We use GreaterThanOrEqualTo here because it's possible that new modules were loaded between the
         // initial send and the reconnect, but we want to ensure that at least all of the initial modules were resent.
-        Assert.That(afterReconnectCount, Is.GreaterThanOrEqualTo(initialCount), "All modules should be resent after reconnect");
+        Assert.That(afterReconnectAssemblyNames.Count, Is.GreaterThanOrEqualTo(initialAssemblyNames.Count), "All modules should be resent after reconnect");
+        foreach (var assemblyName in initialAssemblyNames)
+        {
+            Assert.That(afterReconnectAssemblyNames, Does.Contain(assemblyName), $"Module {assemblyName} should be resent after reconnect");
+        }
     }
 
     [Test]

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
@@ -99,6 +99,34 @@ public class UpdatedLoadedModulesServiceTests
     }
 
     [Test]
+    public void GetLoadedModules_AfterReconnect_ResendsAllModules()
+    {
+        // Arrange - First send succeeds
+        LoadedModuleWireModelCollection loadedModulesCollection = null;
+        Mock.Arrange(() => _dataTransportService.Send(
+                Arg.IsAny<LoadedModuleWireModelCollection>(), Arg.IsAny<string>()))
+            .DoInstead<LoadedModuleWireModelCollection>(modules => loadedModulesCollection = modules)
+            .Returns(DataTransportResponseStatus.RequestSuccessful);
+
+        _getLoadedModulesAction();
+        var initialCount = loadedModulesCollection.LoadedModules.Count;
+        Assert.That(initialCount, Is.GreaterThan(0));
+
+        // Verify deduplication is working (second call sends nothing new)
+        _getLoadedModulesAction();
+
+        // Act - Simulate reconnect
+        EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());
+
+        // Harvest again after reconnect
+        _getLoadedModulesAction();
+        var afterReconnectCount = loadedModulesCollection.LoadedModules.Count;
+
+        // Assert - All modules should be resent
+        Assert.That(afterReconnectCount, Is.EqualTo(initialCount));
+    }
+
+    [Test]
     public void GetLoadedModules_SendError_DuplciatesNotSaved()
     {
         LoadedModuleWireModelCollection loadedModulesCollection = (LoadedModuleWireModelCollection)null;

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
@@ -109,25 +109,30 @@ public class UpdatedLoadedModulesServiceTests
             .Returns(DataTransportResponseStatus.RequestSuccessful);
 
         _getLoadedModulesAction();
-        var initialCount = loadedModulesCollection.LoadedModules.Count;
-        Assert.That(initialCount, Is.GreaterThan(0));
+        var initialModules = loadedModulesCollection.LoadedModules;
+        var initialCount = initialModules.Count;
+        Assert.That(initialCount, Is.GreaterThan(0), "Initial module count should be greater than 0");
 
         // Verify deduplication is working (second call sends nothing new)
         _getLoadedModulesAction();
+        Assert.That(loadedModulesCollection.LoadedModules.Count, Is.EqualTo(0), "No new modules should be sent on second call");
 
         // Act - Simulate reconnect
         EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());
 
         // Harvest again after reconnect
         _getLoadedModulesAction();
-        var afterReconnectCount = loadedModulesCollection.LoadedModules.Count;
+        var afterReconnectModules = loadedModulesCollection.LoadedModules;
+        var afterReconnectCount = afterReconnectModules.Count;
 
         // Assert - All modules should be resent
-        Assert.That(afterReconnectCount, Is.EqualTo(initialCount));
+        // We use GreaterThanOrEqualTo here because it's possible that new modules were loaded between the
+        // initial send and the reconnect, but we want to ensure that at least all of the initial modules were resent.
+        Assert.That(afterReconnectCount, Is.GreaterThanOrEqualTo(initialCount), "All modules should be resent after reconnect");
     }
 
     [Test]
-    public void GetLoadedModules_SendError_DuplciatesNotSaved()
+    public void GetLoadedModules_SendError_DuplicatesNotSaved()
     {
         LoadedModuleWireModelCollection loadedModulesCollection = (LoadedModuleWireModelCollection)null;
         var result = Mock.Arrange(() => _dataTransportService.Send(Arg.IsAny<LoadedModuleWireModelCollection>(), Arg.IsAny<string>()))


### PR DESCRIPTION
## Description

The agent spec for the `update_loaded_modules` endpoint requires the agent to resend the entire list of loaded modules if the agent reconnects.  We weren't doing that; this fixes it.  In addition to the unit test, I verified this manually by triggering an agent reconnect by changing the log level of a running agent from INFO to DEBUG and verified that, after the reconnect, the entire list of loaded modules was sent to New Relic.

# Author Checklist
- [X] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
