### PR TITLE
ci: Pin azure/aks-set-context to commit hash

### DIFF
--- a/.github/workflows/deploy-k8s-unboundedservices.yml
+++ b/.github/workflows/deploy-k8s-unboundedservices.yml
@@ -103,7 +103,7 @@ jobs:
           ./create_k8s_secrets.sh
       - name: Set AKS Context
         if: ${{ inputs.deploy_to_aks == true || inputs.restart_services == true }}
-        uses: azure/aks-set-context@v5
+        uses: azure/aks-set-context@60623acbdcbbdcf799ad50a1adf8703874339f8b # v5.0.0
         with:
           resource-group: ${{ env.RESOURCE_GROUP }}
           cluster-name: ${{ env.CLUSTER_NAME }}


### PR DESCRIPTION
## Summary
- Pin `azure/aks-set-context` to commit hash `60623ac...` (v5.0.0) in the unbounded services deploy workflow for supply chain security.