### PR TITLE
ci: Clean up perf test merge conflicts and add timeouts to run commands

### DIFF
--- a/tests/Agent/PerformanceTests/docker-compose.yml
+++ b/tests/Agent/PerformanceTests/docker-compose.yml
@@ -122,11 +122,9 @@ services:
       --run-time ${TEST_DURATION:-2m}
       --csv /results/locust
       --logfile /logs/locust.log
-      --logfile /logs/locust.log
       --exit-code-on-error 0
     volumes:
       - ./results:/results
-      - ./logs:/logs
       - ./logs:/logs
     networks:
       - perfnet

--- a/tests/Agent/PerformanceTests/run-perf-test.py
+++ b/tests/Agent/PerformanceTests/run-perf-test.py
@@ -287,6 +287,7 @@ def main():
             capture_output=True,
             check=False,
             env=compose_env,
+            timeout=30
         )
 
     atexit.register(cleanup)
@@ -360,6 +361,7 @@ def main():
         ["docker", "compose", "down", "--volumes", "--remove-orphans"],
         check=False,
         env=compose_env,
+        timeout=30,
     )
     print("Containers stopped.")
 


### PR DESCRIPTION
Cleaning up a few issues I noticed when running performance tests locally.
