### PR TITLE
ci: Fix RabbitMQ connection problem in performance test system

### DIFF
--- a/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
@@ -1,11 +1,12 @@
 ARG DOTNET_VERSION=10.0
 
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+ARG DOTNET_VERSION
 WORKDIR /src
 COPY ["PerformanceTestApp.csproj", "./"]
-RUN dotnet restore "PerformanceTestApp.csproj"
+RUN dotnet restore "PerformanceTestApp.csproj" /p:TargetFramework=net${DOTNET_VERSION}
 COPY . .
-RUN dotnet publish "PerformanceTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "PerformanceTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:TargetFramework=net${DOTNET_VERSION}
 
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS final
 WORKDIR /app

--- a/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
@@ -6,7 +6,7 @@ ARG DOTNET_VERSION
 WORKDIR /src
 COPY ["PerformanceTestApp.csproj", "./"]
 RUN dotnet restore "PerformanceTestApp.csproj"
-COPY . .    
+COPY . .
 RUN dotnet publish "PerformanceTestApp.csproj" -c Release -o /app/publish -f net${DOTNET_VERSION} /p:UseAppHost=false
 
 # The final layer uses the ASP.NET image version matching the supplied DOTNET_VERSION argument.

--- a/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/Dockerfile
@@ -1,13 +1,15 @@
 ARG DOTNET_VERSION=10.0
 
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+# The build layer uses the SDK version matching the highest TFM in the project file, but publishes for the specific DOTNET_VERSION supplied as a build argument. 
+FROM mcr.microsoft.com/dotnet/sdk:10.0.203-noble AS build
 ARG DOTNET_VERSION
 WORKDIR /src
 COPY ["PerformanceTestApp.csproj", "./"]
-RUN dotnet restore "PerformanceTestApp.csproj" /p:TargetFramework=net${DOTNET_VERSION}
-COPY . .
-RUN dotnet publish "PerformanceTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false /p:TargetFramework=net${DOTNET_VERSION}
+RUN dotnet restore "PerformanceTestApp.csproj"
+COPY . .    
+RUN dotnet publish "PerformanceTestApp.csproj" -c Release -o /app/publish -f net${DOTNET_VERSION} /p:UseAppHost=false
 
+# The final layer uses the ASP.NET image version matching the supplied DOTNET_VERSION argument.
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS final
 WORKDIR /app
 EXPOSE 8080

--- a/tests/Agent/PerformanceTests/PerformanceTestApp/PerformanceTestApp.csproj
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/PerformanceTestApp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <None Include="Dockerfile" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.*" />
-    <PackageReference Include="StackExchange.Redis" Version="2.*" />
-    <PackageReference Include="MongoDB.Driver" Version="3.*" />
-    <PackageReference Include="Serilog.AspNetCore" Version="9.*" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="NewRelic.Agent.Api" Version="10.50.0" />
   </ItemGroup>
 </Project>

--- a/tests/Agent/PerformanceTests/PerformanceTestApp/Program.cs
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/Program.cs
@@ -25,7 +25,7 @@ builder.Services.AddSingleton<IConnectionMultiplexer>(
 var rabbitHost = builder.Configuration["RABBITMQ_HOST"] ?? "localhost";
 var rabbitConnection = new ConnectionFactory { HostName = rabbitHost }.CreateConnection();
 using (var ch = rabbitConnection.CreateModel())
-    ch.QueueDeclare("perf", durable: false, exclusive: false, autoDelete: false, arguments: null);
+    ch.QueueDeclare("perf", durable: true, exclusive: false, autoDelete: false, arguments: null);
 builder.Services.AddSingleton<IConnection>(rabbitConnection);
 
 builder.WebHost.UseUrls($"http://{IPAddress.Any}:8080");

--- a/tests/Agent/PerformanceTests/PerformanceTestApp/Program.cs
+++ b/tests/Agent/PerformanceTests/PerformanceTestApp/Program.cs
@@ -11,6 +11,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((_, config) => config.WriteTo.Console());
 
+// Print .NET version
+var dotnetVersion = Environment.Version.ToString();
+Console.WriteLine("Starting PerformanceTestApp on .NET {0}", dotnetVersion);
+
 builder.Services.AddControllers();
 
 var mongoConnectionString = builder.Configuration["MONGODB_CONNECTION_STRING"]

--- a/tests/Agent/PerformanceTests/docker-compose.yml
+++ b/tests/Agent/PerformanceTests/docker-compose.yml
@@ -24,7 +24,7 @@
 
 services:
   redis:
-    image: redis:8
+    image: redis:8.6.2-trixie
     container_name: perf-redis
     networks:
       - perfnet
@@ -36,7 +36,7 @@ services:
       start_period: 10s
 
   rabbitmq:
-    image: rabbitmq:4
+    image: rabbitmq:4.3.0
     container_name: perf-rabbitmq
     networks:
       - perfnet
@@ -48,7 +48,7 @@ services:
       start_period: 20s
 
   mongodb:
-    image: mongo:8
+    image: mongo:8.2.7
     container_name: perf-mongodb
     networks:
       - perfnet

--- a/tests/Agent/PerformanceTests/docker-compose.yml
+++ b/tests/Agent/PerformanceTests/docker-compose.yml
@@ -46,8 +46,6 @@ services:
       timeout: 5s
       retries: 10
       start_period: 20s
-    environment:
-      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-deprecated_features.permit.transient_nonexcl_queues true
 
   mongodb:
     image: mongo:8

--- a/tests/Agent/PerformanceTests/docker-compose.yml
+++ b/tests/Agent/PerformanceTests/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       timeout: 5s
       retries: 10
       start_period: 20s
+    environment:
+      - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-deprecated_features.permit.transient_nonexcl_queues true
 
   mongodb:
     image: mongo:8

--- a/tests/Agent/PerformanceTests/run-perf-test.py
+++ b/tests/Agent/PerformanceTests/run-perf-test.py
@@ -297,7 +297,20 @@ def main():
     subprocess.run(["docker", "compose", "build"], check=True, env=compose_env)
 
     print("Starting test app and traffic driver...")
-    subprocess.run(["docker", "compose", "up", "-d"], check=True, env=compose_env)
+    try:
+        subprocess.run(["docker", "compose", "up", "-d"], check=True, env=compose_env)
+    except subprocess.CalledProcessError as e:
+        print("ERROR: 'docker compose up -d' failed.")
+        print("Last 100 lines of Docker Compose logs:")
+        logs_proc = subprocess.run(
+            ["docker", "compose", "logs", "--tail", "100"],
+            capture_output=True,
+            text=True,
+            env=compose_env,
+        )
+        print(logs_proc.stdout)
+        print(logs_proc.stderr)
+        sys.exit(1)
 
     # --- Wait for test app to become healthy ---
     print("Waiting for test app to become healthy...")


### PR DESCRIPTION
This PR fixes a problem that suddenly appeared in the CI perf testing system due to the version of RabbitMQ used by the test app updating.  The fix is to configure the client's connection to create a durable instead of a transient queue.

This PR also:
1. Pins as many dependencies to their current versions as possible to avoid having this happen in the future.
2. Actually makes running the test with .NET 8 possible - this never worked before, but I didn't discover it because the default is .NET 10.
3. If the `docker compose up` command fails, the perf test script will catch the failure and dump the last 100 lines of docker logs, rather than just blowing up - so we can see what is failing if it does.

Green CI run with these changes: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/24908547383
