### PR TITLE
chore: Tighten update-dotty-docs skill

### DIFF
--- a/.claude/skills/update-dotty-docs/SKILL.md
+++ b/.claude/skills/update-dotty-docs/SKILL.md
@@ -4,225 +4,89 @@ description: Update .NET agent compatibility docs based on a Dotty PR. Use when 
 disable-model-invocation: true
 ---
 
-# Update .NET Agent Compatibility Docs from Dotty PR
+## Step 0: Prerequisites
 
-Update the "compatibility and requirements" documentation in the docs-website repo based on package updates from the current open Dotty PR.
-
-## Step 0: Check prerequisites
-
-Verify that all required tools are available before proceeding. Run each check and **stop with a clear error message** if any are missing:
-
-1. **GitHub CLI (`gh`)**: Run `gh --version`. If not found, stop with: "GitHub CLI (`gh`) is required but not installed. Install it from https://cli.github.com/"
-2. **GitHub CLI auth**: Run `gh auth status`. If not authenticated, stop with: "GitHub CLI is not authenticated. Run `gh auth login` first."
-3. **Git**: Run `git --version`. If not found, stop with: "Git is required but not installed."
-
-If all checks pass, continue silently — do not list the results.
+Run `gh auth status`. If it fails, stop and report the error to the user. (This also covers "gh not installed" and "not authenticated." Git is assumed.)
 
 ## Step 1: Find the open Dotty PR
 
-Search for the open Dotty PR:
 ```
 gh pr list --repo newrelic/newrelic-dotnet-agent --search "dotty" --state open --limit 1 --json number,title,body,url
 ```
 
-If no open Dotty PR is found, inform the user and stop.
+If none found, stop.
 
-## Step 2: Parse the package updates
+## Step 2 & 3: Fetch diff and CI status (run in parallel)
 
-Fetch the PR diff:
 ```
 gh pr diff <number> --repo newrelic/newrelic-dotnet-agent
-```
-
-From each `<PackageReference>` change, extract:
-- **Package name** (`Include` attribute)
-- **Old version** and **new version**
-- **Target framework** from `Condition` attribute:
-  - `net4xx` (e.g., `net481`) = .NET Framework section
-  - `net8.0`, `net10.0`, etc. = .NET Core section
-  - No condition = both sections
-
-## Step 3: Check CI status
-
-Check the all_solutions workflow status for the Dotty PR:
-```
 gh pr checks <number> --repo newrelic/newrelic-dotnet-agent
 ```
 
-Look for any failing jobs, especially in:
-- **Integration test** jobs (`Run IntegrationTests (*)`)
-- **Unbounded integration test** jobs (`Run UnboundedIntegrationTests (*)`)
-- **Container test** jobs (`Run Linux Container Tests (*)`)
+**Parse the diff.** For each `<PackageReference>` change, extract: package name (`Include`), old/new versions, and section from `Condition`:
+- `net4xx` → .NET Framework
+- `net8.0`/`net10.0`/etc. → .NET Core
+- No condition → both
 
-If there are **any failing CI jobs**, report them prominently:
+**Check CI.** Focus on `Run IntegrationTests (*)`, `Run UnboundedIntegrationTests (*)`, `Run Linux Container Tests (*)`.
 
-> **CI FAILURES:** The following jobs are failing on the Dotty PR:
-> - {job name} — [link]
->
-> An all-passing CI run is required to confirm the updated libraries don't break tests.
+If any fail, report them with links, then for each failing job use `AskUserQuestion` with three options:
+- **Analyze** — fetch logs (`gh api repos/newrelic/newrelic-dotnet-agent/actions/jobs/<job_id>/logs`), correlate errors with updated packages, check for transitive dependency conflicts (e.g., `OpenAI` 2.9.0 removed a type `Azure.AI.OpenAI` depends on — compare dependency chains in `MFALatestPackages.csproj`). Report which packages are implicated.
+- **Skip** — exclude potentially-related packages from the docs update; continue.
+- **Stop** — end the skill.
 
-Then loop through **each failing job individually**, asking the user how to proceed using `AskUserQuestion` with three options:
-
-> **Failing job: {job name}** — [link]
-
-1. **Analyze** — Diagnose whether this failure is caused by the Dotty package updates
-2. **Skip** — Skip this failure and move on to the next one
-3. **Stop** — Stop the skill and wait for a green build before retrying
-
-**If the user chooses "Stop":** End the skill run immediately.
-
-**If the user chooses "Skip":** Record this job as unanalyzed, exclude any packages that could be related to it from docs updates, and move to the next failing job.
-
-**If the user chooses "Analyze":** Perform a detailed diagnosis of that job:
-
-1. Fetch the failing job's logs:
-   ```
-   gh api repos/newrelic/newrelic-dotnet-agent/actions/jobs/<job_id>/logs
-   ```
-2. Search the logs for error messages, exceptions, and stack traces.
-3. Correlate failures with specific package updates from Step 2 — check whether the error references types, assemblies, or versions from updated packages.
-4. Check for **transitive dependency conflicts** — a common pattern is Package A being updated to a version that's incompatible with Package B (e.g., `OpenAI` 2.9.0 removing a type that `Azure.AI.OpenAI` depends on). Compare the dependency chains of updated packages against their co-dependencies in `MFALatestPackages.csproj`.
-5. Present findings:
-   - Which test(s) failed and the specific error
-   - Whether the failure is caused by a Dotty package update (and which one)
-   - Recommended remediation (e.g., revert the specific package, pin a version, or wait for an upstream fix)
-   - Which docs updates are safe to proceed with and which should be held
-
-Then move to the next failing job.
-
-After processing all failing jobs, summarize which packages are safe to update in docs and which should be excluded, then continue to Step 4.
+After the loop, summarize which packages are safe to update.
 
 ## Step 4: Flag major version bumps
 
-If any package has a **major version change** (e.g., 3.x to 4.x), report it prominently BEFORE proceeding:
-
-> **MAJOR VERSION BUMP:** {Package} {old} -> {new}
-> Major version updates require deeper compatibility evaluation and may block merging the Dotty PR.
+For any major version change (e.g., 3.x → 4.x), report prominently — may block merging the Dotty PR.
 
 ## Step 5: Prepare the docs repo
 
-Clone the user's fork of `newrelic/docs-website` to a temporary directory and set up remotes.
-
-1. **Find the user's fork** by querying the GitHub API:
+1. Capture the user's GitHub login: `gh api user --jq '.login'` → `$GH_USER`. Verify fork exists: `gh api repos/$GH_USER/docs-website --jq '.full_name'`. If no fork, stop (do not create one).
+2. Clone to a known path (not a bash tempdir — the path must survive across tool calls). Use `~/tmp/docs-website-dotty-<date>` or similar; **record the absolute path** for later steps.
    ```
-   gh api user
-   gh api repos/<github-username>/docs-website --jq '.full_name'
-   ```
-   If the user does not have a fork of `newrelic/docs-website`, inform them and stop. Do not attempt to create one.
-
-2. **Clone to a temp directory:**
-   ```
-   DOCS_REPO=$(mktemp -d)/docs-website
-   git clone --depth 1 --branch develop https://github.com/<github-username>/docs-website.git "$DOCS_REPO"
-   cd "$DOCS_REPO"
-   ```
-
-3. **Add upstream remote and sync:**
-   ```
+   git clone --branch develop https://github.com/$GH_USER/docs-website.git <path>
+   cd <path>
    git remote add upstream https://github.com/newrelic/docs-website.git
    git fetch upstream develop
-   git merge upstream/develop
+   git reset --hard upstream/develop
    git push origin develop
+   git checkout -b dotnet/dotty-updates-YYYY-MM-DD
    ```
+   (`reset --hard` is safe — the fork's `develop` has no local commits to preserve.)
 
-4. **Create a feature branch** from `develop` (e.g., `dotnet/dotty-updates-YYYY-MM-DD`).
-
-All subsequent steps operate inside `$DOCS_REPO`.
+All subsequent steps run inside the clone path.
 
 ## Step 6: Update the docs file
 
-The file to edit is:
-```
-src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
-```
+File: `src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx`
 
-This MDX file has two tabbed sections: `.NET Core` (`id="core"`) and `.NET Framework` (`id="framework"`). Update the correct section based on the target framework from Step 2. Only update entries for packages where CI tests are passing.
+Two tabbed sections: `.NET Core` (`id="core"`) and `.NET Framework` (`id="framework"`). Update the section(s) matching each package's target framework from Step 2. Only update packages whose CI is passing.
 
-### Package-to-docs mapping
+**Package-to-docs mapping.** Not every Dotty package has a docs entry — skip silently if no match. Always search the docs file for the package name. Non-obvious mappings: `Microsoft.Azure.Cosmos` → Cosmos DB, `CouchbaseNetClient` → Couchbase, `EnyimMemcachedCore` → Memcached, `AWSSDK.BedrockRuntime` → AWS Bedrock, `Elastic.Clients.Elasticsearch` → Elasticsearch, `MySql.Data` → MySQL, `Npgsql` → PostgreSQL, `AWSSDK.DynamoDBv2` → DynamoDB. Logging/LLM/AWS-SDK packages typically map by exact name.
 
-Not every Dotty package has a docs entry. Some are supporting dependencies (e.g., `AWSSDK.SecurityToken`) that aren't directly instrumented. Skip packages that don't have a matching entry — do not mention skipped packages in the output.
+**Version formats.** Update only the version number, nothing else.
+- Bullet (Datastores, Messaging): `* Latest verified compatible version: 3.57.0`
+- Table column (LLM, Logging — last `<td>` in row): `<td>\n    2.8.0\n</td>`
 
-Search the docs file to find matching entries. Common mappings include:
+## Step 7: Present for review
 
-| NuGet Package | Docs Entry |
-|---|---|
-| `Microsoft.Azure.Cosmos` | Cosmos DB |
-| `CouchbaseNetClient` | Couchbase |
-| `StackExchange.Redis` | StackExchange.Redis |
-| `EnyimMemcachedCore` | Memcached |
-| `AWSSDK.DynamoDBv2` | DynamoDB |
-| `Confluent.Kafka` | Confluent.Kafka |
-| `AWSSDK.SQS` | AWSSDK.SQS |
-| `AWSSDK.Kinesis` | AWSSDK.Kinesis |
-| `AWSSDK.KinesisFirehose` | AWSSDK.KinesisFirehose |
-| `AWSSDK.BedrockRuntime` | AWS Bedrock |
-| `OpenAI` | OpenAI |
-| `Azure.AI.OpenAI` | Azure.AI.OpenAI |
-| `log4net` | Log4Net |
-| `NLog` | NLog |
-| `Serilog` | Serilog |
-| `Microsoft.Extensions.Logging` | Microsoft.Extensions.Logging |
-| `NServiceBus` | NServiceBus |
-| `RabbitMQ.Client` | RabbitMQ.Client |
-| `MassTransit` | MassTransit |
-| `Elastic.Clients.Elasticsearch` | Elasticsearch |
-| `MySql.Data` | MySQL |
-| `Npgsql` | PostgreSQL |
-| `MongoDB.Driver` | MongoDB |
+Show: (1) summary table of updates (package, old, new, section), (2) major version bumps from Step 4, (3) the full diff. **Do not commit or push without explicit approval.**
 
-This table is not exhaustive. Always search the docs file for the package name to find the correct entry.
+## Step 8: After approval — commit, push, PR, comment
 
-### Version formats in the docs
-
-The "latest verified compatible version" appears in two formats:
-
-**Bullet list** (Datastores, Messaging sections):
-```
-* Latest verified compatible version: 3.57.0
-```
-
-**Table column** (LLM, Logging sections — last `<td>` in the row):
-```html
-<td>
-    2.8.0
-</td>
-```
-
-Update only the version number. Do not change any surrounding text or structure.
-
-## Step 7: Present changes for review
-
-Show the user:
-1. A summary table of docs updates (package, old version, new version, section)
-2. Any major version bumps flagged in Step 3
-3. The full diff of the docs file
-
-**Do NOT commit or push until the user explicitly approves.**
-
-## Step 8: Commit, push, and create PR
-
-After user approval:
-
-1. Commit with message: `chore(.net agent): Update compatibility docs for latest Dotty package versions`
-2. Push the branch to origin (the fork).
-3. Create a PR against **upstream** `newrelic/docs-website` on the `develop` branch, using the GitHub username discovered in Step 5:
+1. Commit: `chore(.net agent): Update compatibility docs for latest Dotty package versions`
+2. Push the branch to origin.
+3. Create PR against upstream:
    ```
-   gh pr create --repo newrelic/docs-website --base develop --head <github-username>:<branch-name> --title "<title>" --body "<body>"
+   gh pr create --repo newrelic/docs-website --base develop --head $GH_USER:<branch> \
+     --title "chore(.net agent): Updating latest supported framework versions" \
+     --body "<brief list of packages updated>"
    ```
-   Keep the title and body concise, e.g.:
-   - Title: `chore(.net agent): Updating latest supported framework versions`
-   - Body: Brief list of packages updated with new versions.
-
-## Step 9: Comment on the Dotty PR
-
-Add a comment on the original Dotty PR in the .NET agent repo linking to the newly created docs PR:
-```
-gh pr comment <dotty-pr-number> --repo newrelic/newrelic-dotnet-agent --body "Compatibility docs update PR created: <docs-pr-url>"
-```
-
-## Step 10: Clean up
-
-Remove the temporary docs repo clone:
-```
-rm -rf "$DOCS_REPO"
-```
+4. Comment on the Dotty PR:
+   ```
+   gh pr comment <dotty-pr-number> --repo newrelic/newrelic-dotnet-agent \
+     --body "Compatibility docs update PR created: <docs-pr-url>"
+   ```
+5. Remove the clone directory (use the absolute path recorded in Step 5).


### PR DESCRIPTION
## Summary

Improvements to `.claude/skills/update-dotty-docs/SKILL.md` after running it end-to-end against Dotty PR #3556 and finding a few rough edges.

### Bug fixes
- **Stale cross-reference.** Step 7 said "any major version bumps flagged in Step 3" — those are flagged in Step 4; Step 3 is CI status. Fixed.
- **Shallow clone + merge is fragile.** `git clone --depth 1` followed by `git merge upstream/develop` frequently fails or pulls a huge history on demand. Replaced with a full clone + `git fetch upstream develop && git reset --hard upstream/develop` — the fork's `develop` has no local commits to preserve.
- **`$DOCS_REPO` doesn't survive across tool calls.** Each Bash invocation is a fresh shell, so the Step 10 `rm -rf "$DOCS_REPO"` would expand to `rm -rf /docs-website` (empty var → dangerous). Replaced with an instruction to record an absolute path and reuse it. Also made `$GH_USER` capture explicit.

### Token / prose reduction (~60% smaller)
- Collapsed the prerequisite block from 8 lines to 1 (`gh auth status` covers all the cases).
- Reduced the 22-row package-to-docs mapping table to a short list of non-obvious mappings — the skill already says "search the docs file for the package name."
- Compressed the Step 3 failing-job analyze/skip/stop loop from ~30 lines to a few bullets.
- Merged Steps 8 (commit), 9 (PR), 10 (comment + cleanup) into a single post-approval section.
- Marked Steps 2 and 3 as parallelizable.

File is now 92 lines / 4.8 KB, down from 229 lines / 9.2 KB.

## Test plan
- [ ] Next Dotty PR: run the skill end-to-end and confirm each step still reads clearly
- [ ] Verify the clone/sync sequence works when the fork's `develop` has drifted from upstream
- [ ] Verify cleanup step removes the clone directory