### PR TITLE
ci: Enable testing specific perf test workloads

### DIFF
--- a/.github/actions/run-perf-test/action.yml
+++ b/.github/actions/run-perf-test/action.yml
@@ -31,6 +31,9 @@ inputs:
   dotnet-version:
     description: '.NET version for the test app container (e.g. "10.0", "8.0")'
     default: '10.0'
+  enabled-tasks:
+    description: 'Comma-separated Locust task names to exercise (empty = all). Valid: simple, nested_async, rabbitmq_publish, rabbitmq_consume, redis_crud, mongo_crud, health.'
+    default: ''
   license-key:
     description: 'New Relic license key (only used when attach-agent is true)'
     default: ''
@@ -166,6 +169,7 @@ runs:
           --dotnet-version  "${{ inputs.dotnet-version }}" \
           --license-key     "${{ inputs.license-key }}" \
           --collector-host  "${{ inputs.collector-host }}" \
+          --enabled-tasks   "${{ inputs.enabled-tasks }}" \
           "${EXTRA_ENV_ARGS[@]}"
 
     # -------------------------------------------------------------------------

--- a/.github/actions/run-perf-test/action.yml
+++ b/.github/actions/run-perf-test/action.yml
@@ -183,6 +183,13 @@ runs:
         path: ${{ env.PERF_TEST_DIR }}/results/
         if-no-files-found: warn
 
+    - name: Fix log file permissions
+      if: always()
+      shell: bash
+      run: |
+        sudo chown -R "$(id -u):$(id -g)" "${{ env.PERF_TEST_DIR }}/logs" || true
+        sudo chmod -R a+rX "${{ env.PERF_TEST_DIR }}/logs" || true
+
     - name: Upload perf logs
       if: always()
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/compare_performance.yml
+++ b/.github/workflows/compare_performance.yml
@@ -135,6 +135,11 @@ on:
         type: string
         default: '10.0'
         required: false
+      enabled_tasks:
+        description: 'Comma-separated Locust task names to exercise (empty = all). Valid: simple, nested_async, rabbitmq_publish, rabbitmq_consume, redis_crud, mongo_crud, health.'
+        type: string
+        default: ''
+        required: false
 
   schedule:
     # Run nightly on weekdays: latest published release vs. latest scheduled nightly build
@@ -197,6 +202,7 @@ jobs:
       locust_users:        ${{ steps.inputs.outputs.locust_users }}
       locust_spawn_rate:   ${{ steps.inputs.outputs.locust_spawn_rate }}
       dotnet_version:      ${{ steps.inputs.outputs.dotnet_version }}
+      enabled_tasks:       ${{ steps.inputs.outputs.enabled_tasks }}
       license_key:         ${{ steps.inputs.outputs.license_key }}
       collector_host:      ${{ steps.inputs.outputs.collector_host }}
     steps:
@@ -265,6 +271,7 @@ jobs:
             echo "locust_users=10"                 >> "$GITHUB_OUTPUT"
             echo "locust_spawn_rate=2"             >> "$GITHUB_OUTPUT"
             echo "dotnet_version=10.0"             >> "$GITHUB_OUTPUT"
+            echo "enabled_tasks="                  >> "$GITHUB_OUTPUT"
           else
             echo "include_no_agent=${{ inputs.include_no_agent }}" >> "$GITHUB_OUTPUT"
             echo "run1_label=${{ inputs.run1_label }}"             >> "$GITHUB_OUTPUT"
@@ -287,6 +294,7 @@ jobs:
             echo "locust_users=${{ inputs.locust_users }}"         >> "$GITHUB_OUTPUT"
             echo "locust_spawn_rate=${{ inputs.locust_spawn_rate }}" >> "$GITHUB_OUTPUT"
             echo "dotnet_version=${{ inputs.dotnet_version }}"     >> "$GITHUB_OUTPUT"
+            echo "enabled_tasks=${{ inputs.enabled_tasks }}"       >> "$GITHUB_OUTPUT"
           fi
           echo "license_key=${PERF_TEST_ACCOUNT%%,*}"   >> "$GITHUB_OUTPUT"
           echo "collector_host=${PERF_TEST_ACCOUNT##*,}" >> "$GITHUB_OUTPUT"
@@ -318,6 +326,7 @@ jobs:
           locust-users:      ${{ needs.resolve-inputs.outputs.locust_users }}
           locust-spawn-rate: ${{ needs.resolve-inputs.outputs.locust_spawn_rate }}
           dotnet-version:    ${{ needs.resolve-inputs.outputs.dotnet_version }}
+          enabled-tasks:     ${{ needs.resolve-inputs.outputs.enabled_tasks }}
           github-token:      ${{ secrets.GITHUB_TOKEN }}
 
   run-1:
@@ -348,6 +357,7 @@ jobs:
           locust-users:      ${{ needs.resolve-inputs.outputs.locust_users }}
           locust-spawn-rate: ${{ needs.resolve-inputs.outputs.locust_spawn_rate }}
           dotnet-version:    ${{ needs.resolve-inputs.outputs.dotnet_version }}
+          enabled-tasks:     ${{ needs.resolve-inputs.outputs.enabled_tasks }}
           license-key:       ${{ needs.resolve-inputs.outputs.license_key }}
           collector-host:    ${{ needs.resolve-inputs.outputs.collector_host }}
           github-token:      ${{ secrets.GITHUB_TOKEN }}
@@ -381,6 +391,7 @@ jobs:
           locust-users:      ${{ needs.resolve-inputs.outputs.locust_users }}
           locust-spawn-rate: ${{ needs.resolve-inputs.outputs.locust_spawn_rate }}
           dotnet-version:    ${{ needs.resolve-inputs.outputs.dotnet_version }}
+          enabled-tasks:     ${{ needs.resolve-inputs.outputs.enabled_tasks }}
           license-key:       ${{ needs.resolve-inputs.outputs.license_key }}
           collector-host:    ${{ needs.resolve-inputs.outputs.collector_host }}
           github-token:      ${{ secrets.GITHUB_TOKEN }}
@@ -414,6 +425,7 @@ jobs:
           locust-users:      ${{ needs.resolve-inputs.outputs.locust_users }}
           locust-spawn-rate: ${{ needs.resolve-inputs.outputs.locust_spawn_rate }}
           dotnet-version:    ${{ needs.resolve-inputs.outputs.dotnet_version }}
+          enabled-tasks:     ${{ needs.resolve-inputs.outputs.enabled_tasks }}
           license-key:       ${{ needs.resolve-inputs.outputs.license_key }}
           collector-host:    ${{ needs.resolve-inputs.outputs.collector_host }}
           github-token:      ${{ secrets.GITHUB_TOKEN }}
@@ -447,6 +459,7 @@ jobs:
           locust-users:      ${{ needs.resolve-inputs.outputs.locust_users }}
           locust-spawn-rate: ${{ needs.resolve-inputs.outputs.locust_spawn_rate }}
           dotnet-version:    ${{ needs.resolve-inputs.outputs.dotnet_version }}
+          enabled-tasks:     ${{ needs.resolve-inputs.outputs.enabled_tasks }}
           license-key:       ${{ needs.resolve-inputs.outputs.license_key }}
           collector-host:    ${{ needs.resolve-inputs.outputs.collector_host }}
           github-token:      ${{ secrets.GITHUB_TOKEN }}

--- a/tests/Agent/PerformanceTests/TrafficDriver/locustfile.py
+++ b/tests/Agent/PerformanceTests/TrafficDriver/locustfile.py
@@ -5,13 +5,17 @@
 # Drives traffic to all endpoints with a realistic mix of request types.
 #
 # Environment variables:
-#   TARGET_HOST  - base URL of the test app (default: http://testapp:8080)
+#   TARGET_HOST          - base URL of the test app (default: http://testapp:8080)
+#   LOCUST_ENABLED_TASKS - optional comma-separated list of task names to
+#                          exercise (e.g. "simple,redis_crud"). Unset or empty
+#                          runs every task. Unknown names abort the run.
 #
 # Run headless (non-interactive) with:
 #   locust --headless -u <users> -r <spawn_rate> --run-time <duration>
 #          --host http://testapp:8080 --csv results --exit-code-on-error 0
 
 import os
+import sys
 from locust import HttpUser, TaskSet, task, between, events
 import logging
 
@@ -69,6 +73,37 @@ class PerformanceTasks(TaskSet):
         with self.client.get("/health", catch_response=True) as response:
             if response.status_code != 200:
                 response.failure(f"Health check failed: {response.status_code}")
+
+
+def _apply_task_filter():
+    """Filter PerformanceTasks.tasks based on LOCUST_ENABLED_TASKS."""
+    raw = os.environ.get("LOCUST_ENABLED_TASKS", "").strip()
+    if not raw:
+        return
+
+    requested = {name.strip() for name in raw.split(",") if name.strip()}
+    if not requested:
+        return
+
+    known = {t.__name__ for t in PerformanceTasks.tasks}
+    unknown = requested - known
+    if unknown:
+        logger.error(
+            "LOCUST_ENABLED_TASKS contains unknown task name(s): %s. Valid: %s",
+            ", ".join(sorted(unknown)),
+            ", ".join(sorted(known)),
+        )
+        sys.exit(2)
+
+    PerformanceTasks.tasks = [t for t in PerformanceTasks.tasks if t.__name__ in requested]
+    if not PerformanceTasks.tasks:
+        logger.error("LOCUST_ENABLED_TASKS filtered out every task; aborting.")
+        sys.exit(2)
+
+    logger.info("Locust task filter active: %s", ", ".join(sorted(requested)))
+
+
+_apply_task_filter()
 
 
 class PerformanceTestUser(HttpUser):

--- a/tests/Agent/PerformanceTests/compare.example.yml
+++ b/tests/Agent/PerformanceTests/compare.example.yml
@@ -13,6 +13,14 @@ test:
   locust_users: 10      # Concurrent Locust users
   locust_spawn_rate: 2  # Users to spawn per second
   dotnet_version: "10.0"
+  # Optional: restrict traffic to a subset of Locust tasks. Accepts a
+  # comma-separated string or a YAML list. Omit or leave empty to run all.
+  # Valid: simple, nested_async, rabbitmq_publish, rabbitmq_consume,
+  #        redis_crud, mongo_crud, health.
+  # enabled_tasks: "simple,redis_crud"
+  # enabled_tasks:
+  #   - simple
+  #   - redis_crud
 
 runs:
   # --- Baseline: no agent ---

--- a/tests/Agent/PerformanceTests/docker-compose.yml
+++ b/tests/Agent/PerformanceTests/docker-compose.yml
@@ -21,6 +21,11 @@
 #   extra.env               Written by run-perf-test.sh from --env NAME=VALUE args.
 #                           Keys in this file are overridden by the explicit
 #                           'environment' block below if the same name appears there.
+#
+# Optional traffic-driver environment variables:
+#
+#   LOCUST_ENABLED_TASKS    Comma-separated Locust task names to exercise
+#                           (e.g. "simple,redis_crud"). Empty/unset = all tasks.
 
 services:
   redis:
@@ -123,6 +128,8 @@ services:
       --csv /results/locust
       --logfile /logs/locust.log
       --exit-code-on-error 0
+    environment:
+      LOCUST_ENABLED_TASKS: ${LOCUST_ENABLED_TASKS:-}
     volumes:
       - ./results:/results
       - ./logs:/logs

--- a/tests/Agent/PerformanceTests/run-perf-comparison.py
+++ b/tests/Agent/PerformanceTests/run-perf-comparison.py
@@ -224,6 +224,12 @@ def run_perf_test(run_cfg, test_cfg, label, agent_app_name, add_label_to_app_nam
         "--dotnet-version", str(test_cfg.get("dotnet_version", "10.0")),
     ]
 
+    enabled_tasks = test_cfg.get("enabled_tasks", "")
+    if enabled_tasks:
+        if isinstance(enabled_tasks, list):
+            enabled_tasks = ",".join(str(t) for t in enabled_tasks)
+        cmd += ["--enabled-tasks", str(enabled_tasks)]
+
     license_key = os.environ.get("NEW_RELIC_LICENSE_KEY", "")
     collector_host = os.environ.get("NEW_RELIC_HOST", "")
     if license_key:

--- a/tests/Agent/PerformanceTests/run-perf-test.py
+++ b/tests/Agent/PerformanceTests/run-perf-test.py
@@ -57,6 +57,8 @@ def parse_args():
     parser.add_argument("--license-key",        default=os.environ.get("NEW_RELIC_LICENSE_KEY", ""))
     parser.add_argument("--collector-host",     default=os.environ.get("NEW_RELIC_HOST", ""))
     parser.add_argument("--env",                action="append", default=[], dest="extra_envs", metavar="NAME=VALUE")
+    parser.add_argument("--enabled-tasks",      default="",
+                        help="Comma-separated Locust task names to exercise (e.g. 'simple,redis_crud'). Empty = all tasks.")
     parser.add_argument("--verbose",            default="false")
     return parser.parse_args()
 
@@ -263,6 +265,7 @@ def main():
         "NEW_RELIC_LICENSE_KEY": args.license_key,
         "NEW_RELIC_HOST":        args.collector_host,
         "NEW_RELIC_APP_NAME":    args.app_name,
+        "LOCUST_ENABLED_TASKS":  args.enabled_tasks,
     })
     if attach_agent:
         compose_env["AGENT_PATH"] = agent_home


### PR DESCRIPTION
This adds the ability to only exercise specific endpoints of the performance test app to the perf test system.

It also fixes an permissions issue where any crash dumps created during the test could not be added to the logs artifact.