### PR TITLE
chore: Update license key configuration handling and logging

### DIFF
--- a/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
+++ b/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
@@ -388,12 +388,13 @@ public class CustomActions
             return licenseKey;
         }
 
-        if (licenseKey.Length == 40)
+        const int PlaintextPrefixLength = 10;
+        if (licenseKey.Length <= PlaintextPrefixLength)
         {
-            return licenseKey.Substring(0, 10) + new string('*', 30);
+            return new string('*', licenseKey.Length);
         }
 
-        return new string('*', licenseKey.Length);
+        return licenseKey.Substring(0, PlaintextPrefixLength) + new string('*', licenseKey.Length - PlaintextPrefixLength);
     }
 }
 

--- a/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
+++ b/src/Agent/MsiInstaller/InstallerActions/CustomActions.cs
@@ -101,7 +101,7 @@ public class CustomActions
             session.Log("licenseKey attribute found in /configuration/service node.");
 
             licenseKeyAttribute.Value = licenseKey;
-            session.Log("License key set to " + licenseKey);
+            session.Log("License key set to " + ObfuscateLicenseKey(licenseKey));
 
             document.Save(session.CustomActionData["NETAGENTCOMMONFOLDER"] + @"\newrelic.config");
             session.Log("newrelic.config saved with updated license key.");
@@ -380,6 +380,21 @@ public class CustomActions
     {
         session["LogHack"] = String.Format(message, arguments);
     }
+
+    internal static string ObfuscateLicenseKey(string licenseKey)
+    {
+        if (string.IsNullOrEmpty(licenseKey))
+        {
+            return licenseKey;
+        }
+
+        if (licenseKey.Length == 40)
+        {
+            return licenseKey.Substring(0, 10) + new string('*', 30);
+        }
+
+        return new string('*', licenseKey.Length);
+    }
 }
 
 internal abstract class MySession
@@ -524,7 +539,7 @@ internal class LicenseKeyFinder : MySession
             String licenseKey = GetKeyFromFolder(folderPath);
             if (licenseKey == null) continue;
 
-            Log("Setting NR_LICENSE_KEY to {0} found in {1}", licenseKey, folderPath);
+            Log("Setting NR_LICENSE_KEY to {0} found in {1}", CustomActions.ObfuscateLicenseKey(licenseKey), folderPath);
             session["NR_LICENSE_KEY"] = licenseKey;
             session["PREVLICENSEKEYFOUND"] = "1";
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -223,43 +223,27 @@ public class DefaultConfiguration : IConfiguration
 
         foreach (var candidateKey in candidateKeys)
         {
-            // Did we find a key?
             if (string.IsNullOrWhiteSpace(candidateKey.Value))
             {
                 continue;
             }
 
-            // We found something, but is it a valid key?
-
-            // If the key is the default value from newrelic.config, we return the default value
+            // If the key is the default value from newrelic.config, return it untrimmed.
             // AgentManager.AssertAgentEnabled() relies on this behavior and will throw an exception if the key is the default value
             if (candidateKey.Value.ToLower().Contains("license"))
             {
-                // newrelic.config is the last place to look
                 return candidateKey.Value;
             }
 
-            // Keys are only 40 characters long, but we trim to be safe
+            // Per the Preconnect spec, the agent must not validate license keys by length or character content.
+            // Trim surrounding whitespace for safety, then return whatever the user configured.
             var trimmedCandidateKey = candidateKey.Value.Trim();
-            if (trimmedCandidateKey.Length != 40)
-            {
-                Log.Warn($"License key from {candidateKey.Key} is not 40 characters long. Checking for other license keys.");
-                continue;
-            }
-
-            // Keys can only contain printable ASCII characters from 0x21 to 0x7E
-            if (!trimmedCandidateKey.All(c => c >= 0x21 && c <= 0x7E))
-            {
-                Log.Warn($"License key from {candidateKey.Key} contains invalid characters. Checking for other license keys.");
-                continue;
-            }
-
-            Log.Info($"License key from {candidateKey.Key} appears to be in the correct format.");
+            Log.Info($"Using license key from {candidateKey.Key}.");
             return trimmedCandidateKey;
         }
 
         // return string.Empty instead of null to allow caching and prevent checking repeatedly
-        Log.Warn("No valid license key found.");
+        Log.Warn("No license key configured.");
         return string.Empty;
     }
 

--- a/src/Agent/NewRelic/Agent/Core/Utilities/Strings.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/Strings.cs
@@ -194,16 +194,19 @@ public static class Strings
 
     public static string ObfuscateLicenseKey(string licenseKey)
     {
-        // We can log up to 10 characters of a 40-character license key, the rest must be obfuscated
-        // For our agent, the license key should always be 40 characters. For safety, if it isn't, just obfuscate the whole thing
-        if (licenseKey.Length == 40)
+        if (string.IsNullOrEmpty(licenseKey))
         {
-            return licenseKey.Substring(0, 10) + new string('*', 30);
+            return licenseKey;
         }
-        else
+
+        // Show up to the first 10 characters; if the key is 10 or fewer characters, obfuscate the whole thing.
+        const int PlaintextPrefixLength = 10;
+        if (licenseKey.Length <= PlaintextPrefixLength)
         {
             return new string('*', licenseKey.Length);
         }
+
+        return licenseKey.Substring(0, PlaintextPrefixLength) + new string('*', licenseKey.Length - PlaintextPrefixLength);
     }
 
 

--- a/src/Agent/NewRelic/Agent/Core/Utilities/Strings.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/Strings.cs
@@ -194,11 +194,11 @@ public static class Strings
 
     public static string ObfuscateLicenseKey(string licenseKey)
     {
-        // We can log up to 8 characters of a 40-character license key, the rest must be obfuscated
+        // We can log up to 10 characters of a 40-character license key, the rest must be obfuscated
         // For our agent, the license key should always be 40 characters. For safety, if it isn't, just obfuscate the whole thing
         if (licenseKey.Length == 40)
         {
-            return licenseKey.Substring(0, 8) + new string('*', 32);
+            return licenseKey.Substring(0, 10) + new string('*', 30);
         }
         else
         {

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1452,19 +1452,20 @@ public class DefaultConfigurationTests
     // local on its own
     [TestCase(null, null, "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
     [TestCase(null, null, "REPLACE_WITH_LICENSE_KEY", ExpectedResult = "REPLACE_WITH_LICENSE_KEY")]
-    // Length must be 40
+    // Surrounding whitespace is trimmed
     [TestCase("       foo1234567890abcdefghijklmnopqrstuvwxyz0         ", null, null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase("foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", null, null, ExpectedResult = "")]
-    [TestCase("foo", null, null, ExpectedResult = "")]
-    // Allowed characters
-    [TestCase("foo1234567890abcdefghijklmnopqrstuvyz\tzz", null, null, ExpectedResult = "")]
-    // Bad keys skipped for lower priority keys
-    [TestCase("foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase(null, "foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase("foo", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase(null, "foo", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase("foo1234567890abcdefghijklmnopqrstuvyz\tzz", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
-    [TestCase(null, "foo1234567890abcdefghijklmnopqrstuvyz\tzz", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0")]
+    // Per Preconnect spec, license keys are not validated by length or character content.
+    // Keys of any length or containing any characters must be accepted as-is (aside from surrounding-whitespace trim).
+    [TestCase("foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", null, null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0123456789")]
+    [TestCase("foo", null, null, ExpectedResult = "foo")]
+    [TestCase("foo1234567890abcdefghijklmnopqrstuvyz\tzz", null, null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvyz\tzz")]
+    // Higher-priority sources always win, even when they carry unusual values
+    [TestCase("foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0123456789")]
+    [TestCase(null, "foo1234567890abcdefghijklmnopqrstuvwxyz0123456789", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvwxyz0123456789")]
+    [TestCase("foo", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo")]
+    [TestCase(null, "foo", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo")]
+    [TestCase("foo1234567890abcdefghijklmnopqrstuvyz\tzz", "foo1234567890abcdefghijklmnopqrstuvwxyz0", null, ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvyz\tzz")]
+    [TestCase(null, "foo1234567890abcdefghijklmnopqrstuvyz\tzz", "foo1234567890abcdefghijklmnopqrstuvwxyz0", ExpectedResult = "foo1234567890abcdefghijklmnopqrstuvyz\tzz")]
     public string LicenseKeyEnvironmentOverridesLocal(string appSettingEnvironmentName, string newEnvironmentName, string local)
     {
         _localConfig.service.licenseKey = local;

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
@@ -102,10 +102,24 @@ public class StringsTest
     [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde&marshal_format=json&protocol_version=17",
         ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabcde******************************&marshal_format=json&protocol_version=17")]
     [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=shortLicenseKey&marshal_format=json&protocol_version=17",
-        ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=***************&marshal_format=json&protocol_version=17")]
+        ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=shortLicen*****&marshal_format=json&protocol_version=17")]
+    [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=tinykey&marshal_format=json&protocol_version=17",
+        ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=*******&marshal_format=json&protocol_version=17")]
     public string ObfuscateLicenseKeyForAuditLog(string inputText)
     {
         return Strings.ObfuscateLicenseKeyInAuditLog(inputText, "license_key");
+    }
+
+    [TestCase(null, ExpectedResult = null)]
+    [TestCase("", ExpectedResult = "")]
+    [TestCase("tinykey", ExpectedResult = "*******")]
+    [TestCase("exactlyten", ExpectedResult = "**********")]
+    [TestCase("elevenchars", ExpectedResult = "elevenchar*")]
+    [TestCase("abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde", ExpectedResult = "abcdeabcde******************************")]
+    [TestCase("abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeEXTRA", ExpectedResult = "abcdeabcde***********************************")]
+    public string ObfuscateLicenseKey_Tests(string licenseKey)
+    {
+        return Strings.ObfuscateLicenseKey(licenseKey);
     }
 
     private static IEnumerable<object[]> ConvertBytesToStringTestData()

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/StringsTest.cs
@@ -100,7 +100,7 @@ public class StringsTest
 
     [TestCase("[{\"high_security\":false}]", ExpectedResult = "[{\"high_security\":false}]")]
     [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde&marshal_format=json&protocol_version=17",
-        ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabc********************************&marshal_format=json&protocol_version=17")]
+        ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=abcdeabcde******************************&marshal_format=json&protocol_version=17")]
     [TestCase("https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=shortLicenseKey&marshal_format=json&protocol_version=17",
         ExpectedResult = "https://collector.newrelic.com/agent_listener/invoke_raw_method?method=preconnect&license_key=***************&marshal_format=json&protocol_version=17")]
     public string ObfuscateLicenseKeyForAuditLog(string inputText)


### PR DESCRIPTION
This PR brings the agent into compliance with a couple of agent specs, one new and one previously existing:

The new spec: Update ObfuscateLicenseKey (used whenever a license key is logged) to show the first ten characters in plaintext, as long as the key is more than ten characters long (currently agent license keys are 40 chars long).  

The old spec: while agent license keys are currently 40 (printable, ASCII) chars long, the agent should not assume or constrain this to be the case.

Additionally, redact the license key in the MSI installer's log, which was not previously happening.

