### PR TITLE
ci: Fix Windows profiler build error caused by missing ATL components

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -87,8 +87,6 @@ jobs:
             'modify',
             '--installPath', "`"$installPath`"",
             '--add', 'Microsoft.VisualStudio.Component.VC.ATL',
-            '--add', 'Microsoft.VisualStudio.Component.VC.ATL.ARM64',
-            '--add', 'Microsoft.VisualStudio.Component.VC.v142.ATL',
             '--quiet', '--norestart', '--nocache'
           )
           Write-Host "Running: $installer $args"

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -76,6 +76,29 @@ jobs:
           Remove-Item -Path "${{ github.workspace }}\src\Agent\_profilerBuild\*.*" -Force -Recurse -ErrorAction SilentlyContinue
         shell: powershell
 
+      - name: Install Visual Studio ATL components
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -latest -products * -property installationPath
+          Write-Host "Visual Studio install path: $installPath"
+          $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          $args = @(
+            'modify',
+            '--installPath', $installPath,
+            '--add', 'Microsoft.VisualStudio.Component.VC.ATL',
+            '--add', 'Microsoft.VisualStudio.Component.VC.ATL.ARM64',
+            '--add', 'Microsoft.VisualStudio.Component.VC.v142.ATL',
+            '--quiet', '--norestart', '--nocache'
+          )
+          Write-Host "Running: $installer $args"
+          $process = Start-Process -FilePath $installer -ArgumentList $args -Wait -PassThru -NoNewWindow
+          Write-Host "VS Installer exit code: $($process.ExitCode)"
+          # Exit codes 0 and 3010 (reboot required, but not needed here) are success
+          if ($process.ExitCode -ne 0 -and $process.ExitCode -ne 3010) {
+            throw "VS Installer failed with exit code $($process.ExitCode)"
+          }
+        shell: powershell
+
       - name: Build x64
         run: |
           Write-Host "List NuGet Sources"

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -82,9 +82,10 @@ jobs:
           $installPath = & $vswhere -latest -products * -property installationPath
           Write-Host "Visual Studio install path: $installPath"
           $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          # Quote installPath because it contains spaces; Start-Process -ArgumentList does not quote individual array elements.
           $args = @(
             'modify',
-            '--installPath', $installPath,
+            '--installPath', "`"$installPath`"",
             '--add', 'Microsoft.VisualStudio.Component.VC.ATL',
             '--add', 'Microsoft.VisualStudio.Component.VC.ATL.ARM64',
             '--add', 'Microsoft.VisualStudio.Component.VC.v142.ATL',


### PR DESCRIPTION
The `windows-latest` GHA runner image recently switched to new Visual Studio tooling and no longer includes the ATL components needed by the profiler by default.  This PR adds a step to the Windows profiler build job to explicitly install the ATL components needed.

Note: the initial list of ATL components being installed is probably overkill; I'll try to get them down to the minimum required set before marking this ready for review.
