### PR TITLE
ci: Temporarily pin Windows profiler build to windows-2022

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-windows-profiler:
     name: Build Windows Profiler & Run Unit Tests / Code Coverage
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: check-modified-files
     # only run this job if source files were modified, or if triggered by a manual execution
     if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
This is to fix current Windows profiler build issues caused by the `windows-latest` runner being updated to use newer Visual Studio tooling that does not include the necessary ATL workload components by default.

Note that we only have until October 2026 to come up with a more permanent fix.

Successful Windows profiler build from this branch: https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/25398414398/job/74491362791