### PR TITLE
chore: Tighten and restructure CLAUDE.md documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,8 @@
       "Bash(tail *)",
       "Bash(find *)",
       "Bash(echo *)",
-      "Bash(pwd)"
+      "Bash(pwd)",
+      "Bash(xsd2code *)"
     ],
     "deny": [
       "Bash(rm -rf *)",

--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -41,8 +41,16 @@ jobs:
               filters: |
                 source-files-changed:
                   - '**'
+                  - '!**/*.md'
                   - '!.github/**'
                   - '!.claude/**'
+                  - '!.vscode/**'
+                  - '!.idea/**'
+                  - '!.editorconfig'
+                  - '!.gitignore'
+                  - '!.gitattributes'
+                  - '!LICENSE'
+                  - '!CODEOWNERS'
                   - '!docs/**'
                   - '!tests/Agent/IntegrationTests/UnboundedServices/**'
               list-files: 'csv'

--- a/build/claude-build.md
+++ b/build/claude-build.md
@@ -1,523 +1,133 @@
-# New Relic .NET Agent - Build System
+# Build System
 
-This document describes the build tools, packaging, and release process for the New Relic .NET Agent.
+Tools that turn the solutions into shippable artifacts (NuGet, MSI, Linux
+packages, Azure Site Extension, download-site bundle). See the
+[root claude.md](../claude.md) for local-development build basics.
 
-## Overview
-
-The build system is responsible for:
-- Building and packaging agent artifacts
-- Creating installation packages (MSI, NuGet, etc.)
-- Validating releases
-- Linux package creation
-- Azure Site Extensions
-- Release automation
-
-## Directory Structure
+## Layout
 
 ```
 build/
-├── ArtifactBuilder/          # Main build orchestration tool
-├── Packaging/                # Package creation scripts
-├── Linux/                    # Linux package building
-├── Scripts/                  # Build and test scripts
+├── ArtifactBuilder/          # Orchestrates full-release builds
+├── Packaging/                # Per-artifact packaging (NuGet, MSI, DownloadSite, AzureSiteExtension, ...)
+├── Linux/                    # Linux .deb / .rpm build (Docker-driven)
+├── Scripts/                  # PowerShell helpers (see below)
 ├── NewRelic.NuGetHelper/     # NuGet package utilities
-├── NugetValidator/           # Validates NuGet packages
-├── NugetVersionDeprecator/   # Deprecates old NuGet versions
-├── S3Validator/              # Validates S3 uploads
-├── ReleaseNotesBuilder/      # Generates release notes
-├── Dotty/                    # .NET SDK management tool
-├── keys/                     # Signing keys
-└── Tools/                    # Build tools (NUnit, xUnit, etc.)
+├── NugetValidator/           # Validates built NuGet packages
+├── NugetVersionDeprecator/   # Marks old NuGet versions deprecated
+├── S3Validator/              # Validates uploaded artifacts on the download site
+├── ReleaseNotesBuilder/      # Generates release notes from CHANGELOG + commits
+├── Dotty/                    # .NET SDK version management helper
+└── Tools/                    # Bundled toolchain (xsd2code, NuGet, NUnit-Console, XUnit-Console)
 ```
 
-## Build Tools
-
-### 1. ArtifactBuilder (`ArtifactBuilder/`)
-
-The primary build orchestration tool that creates all distributable artifacts.
-
-**Purpose:**
-- Coordinates multi-step build process
-- Creates platform-specific agent packages
-- Builds NuGet packages
-- Creates MSI installer
-- Generates Azure Site Extensions
-- Organizes output artifacts
-
-**Key Responsibilities:**
-- Build FullAgent.sln for all configurations
-- Copy profiler binaries to agent home directories
-- Create NuGet packages for agent, API, and profiler
-- Build MSI installer (if HeatWave installed)
-- Create download site structure
-- Generate Azure Site Extension packages
-- Create Linux packages
-
-**Output:**
-All artifacts are organized in a structured output directory ready for release.
-
-**Usage:**
-Typically invoked by CI/CD pipelines or manually for local testing.
-
-### 2. Dotty (`Dotty/`)
-
-.NET SDK version management tool.
-
-**Purpose:**
-Helps manage multiple .NET SDK versions for testing across different frameworks.
-
-**Features:**
-- Download specific .NET SDK versions
-- Manage multiple SDK installations
-- Switch between SDK versions for testing
-
-### 3. NuGet Helper (`NewRelic.NuGetHelper/`)
-
-Utilities for working with NuGet packages.
-
-**Features:**
-- Package creation helpers
-- Version management
-- Dependency resolution
-- Package manipulation
-
-### 4. NuGet Validator (`NugetValidator/`)
-
-Validates NuGet packages before release.
-
-**Validation Checks:**
-- Package metadata correctness
-- File contents verification
-- Dependency version validation
-- Breaking change detection
-- License information
-- Documentation presence
-
-### 5. NuGet Version Deprecator (`NugetVersionDeprecator/`)
-
-Manages deprecation of old NuGet package versions.
-
-**Purpose:**
-- Mark old versions as deprecated on NuGet.org
-- Provide migration guidance
-- Automate deprecation process
-
-### 6. S3 Validator (`S3Validator/`)
-
-Validates uploaded artifacts on S3/CDN.
-
-**Validation:**
-- Verifies all expected files present
-- Checks file integrity
-- Validates download URLs
-- Ensures proper permissions
-
-### 7. Release Notes Builder (`ReleaseNotesBuilder/`)
-
-Generates release notes from changelog and git history.
-
-**Features:**
-- Parses CHANGELOG.md
-- Formats for different audiences
-- Generates HTML/Markdown output
-- Integration with release process
-
-## Packaging
-
-### Package Types
-
-The build system creates multiple package formats:
-
-#### 1. NuGet Packages (`Packaging/NugetAgent/`, etc.)
-
-**Agent Package:**
-- Package: `NewRelic.Agent`
-- Contains: Full agent for all platforms
-- Usage: Install agent via NuGet
-
-**API Package:**
-- Package: `NewRelic.Agent.Api`
-- Contains: Public API only
-- Usage: Compile-time reference for custom instrumentation
-
-**Profiler Package:**
-- Package: `NewRelic.Agent.Internal.Profiler`
-- Contains: Native profiler binaries
-- Usage: Internal dependency of agent package
-
-**Azure Packages:**
-- `NewRelic.Azure.WebSites.x64`
-- `NewRelic.Azure.WebSites.x86`
-- `NewRelic.Azure.WebSites.Extension`
-- Platform-specific packages for Azure App Service
-
-**Cloud Services:**
-- `NewRelic.Azure.CloudServices`
-- Package for Azure Cloud Services (classic)
-
-#### 2. MSI Installer (`../src/Agent/MsiInstaller/`)
-
-**Package:** `NewRelicAgent_x64.msi` / `NewRelicAgent_x86.msi`
-**Usage:** Windows installer for IIS and .NET Framework applications
-
-**Features:**
-- GUI installation wizard
-- IIS integration
-- Registry configuration
-- Environment variable setup
-- Uninstall support
-
-**Building:**
-Requires HeatWave extension in Visual Studio. See [../src/Agent/MsiInstaller/](../src/Agent/MsiInstaller/).
-
-#### 3. Download Site (`Packaging/DownloadSite/`)
-
-**Package:** Structured directory for download.newrelic.com
-**Contents:**
-- Agent home directories (zipped)
-- MSI installers
-- NuGet packages
-- Linux packages
-- SHA256 checksums
-- README files
-
-**Structure:**
-```
-newrelic-dotnet-agent_VERSION/
-├── newrelic-dotnet-agent_VERSION_amd64.deb
-├── newrelic-dotnet-agent-VERSION-1.x86_64.rpm
-├── newrelic-dotnet-agent_VERSION_arm64.deb
-├── newrelic-dotnet-agent-VERSION-1.aarch64.rpm
-├── NewRelicAgent_x64_VERSION.msi
-├── NewRelicAgent_x86_VERSION.msi
-├── newrelichome_x64_coreclr_VERSION.zip
-├── newrelichome_x86_coreclr_VERSION.zip
-├── newrelichome_x64_VERSION.zip
-├── newrelichome_x86_VERSION.zip
-└── SHA256/checksums
-```
-
-#### 4. Linux Packages (`Linux/`)
-
-**Packages:**
-- `.deb` for Debian/Ubuntu (x64, arm64)
-- `.rpm` for RHEL/CentOS (x64, arm64)
-
-**Installation Locations:**
-- Agent: `/usr/local/newrelic-dotnet-agent/`
-- Configuration: `/usr/local/newrelic-dotnet-agent/newrelic.config`
-
-**Building:**
-- Uses Docker containers for clean builds
-- Creates packages for multiple architectures
-- Signs packages with GPG
-
-**Build Scripts:**
-- [Linux/build/docker-compose.yml](Linux/docker-compose.yml) - Docker compose file for building and testing the .deb and .rpm packages
-- [Linux/build/linux_packaging.md](Linux/linux_packaging.md) - Documents how to use the Docker compose file
-- [Linux/build/rpm/newrelic-dotnet-agent.spec](Linux/build/rpm/newrelic-dotnet-agent.spec) - RPM spec
-- [Linux/build/deb/](Linux/build/deb/) - Debian package scripts
-
-#### 5. Azure Site Extension (`Packaging/AzureSiteExtension/`)
-
-**Package:** Azure Site Extension for App Service
-**Installation:** Via Azure Portal Extensions tab
-
-**Features:**
-- One-click installation in Azure
-- Automatic configuration
-- Per-app or per-site installation
-
-## Build Workflows
-
-### Local Development Build
-
-1. Open `FullAgent.sln` in Visual Studio
-2. Select configuration (Debug/Release)
-3. Build solution (Ctrl+Shift+B)
-4. Agent home directories created in `src/Agent/newrelichome_*/`
-5. Ready for local testing
-
-### Full Release Build
-
-1. **Version Update**
-   - Update version in source files
-   - Update CHANGELOG.md
-   - Commit changes
-
-2. **Build All Configurations**
-   - Build FullAgent.sln (Release)
-   - Build Profiler.sln (all platforms)
-   - Build MsiInstaller.sln
-
-3. **Run ArtifactBuilder**
-   - Packages all artifacts
-   - Creates NuGet packages
-   - Builds Linux packages
-   - Creates download site structure
-
-4. **Validation**
-   - Run NugetValidator
-   - Run S3Validator (after upload)
-   - Manual smoke testing
-
-5. **Release**
-   - Upload to S3/download site
-   - Push to NuGet.org
-   - Create GitHub release
-   - Update documentation
-
-### CI/CD Pipeline
-
-The project uses GitHub Actions for CI/CD. See [../.github/workflows/](../.github/workflows/).
-
-**Key Workflows:**
-- `all_solutions.yml` - Builds and tests all solutions
-- Build validation on all PRs
-- Automated testing
-- Code coverage reporting
-- Nightly builds
-
-## Build Scripts
-
-### PowerShell Scripts (`Scripts/`)
-
-**Integration Test Scripts:**
-- [run-integration-tests.ps1](Scripts/run-integration-tests.ps1) - Run integration tests
-- [run-platform-tests.ps1](Scripts/run-platform-tests.ps1) - Run platform-specific tests
-
-**Usage:**
+## ArtifactBuilder
+
+The entry point for release builds. It drives `FullAgent.sln` + `Profiler.sln`,
+copies profiler binaries into the agent home directories, assembles NuGet
+packages, builds the MSI (when HeatWave is installed), and produces the
+download-site bundle. Usually invoked by CI — rarely needed locally.
+
+## Artifacts produced
+
+**NuGet** (IDs verified against nuspecs under `build/Packaging/*`):
+- `NewRelic.Agent` — full agent, all platforms
+- `NewRelic.Agent.Api` — public API only (compile-time reference)
+- `NewRelic.Agent.Internal.Profiler` — native profiler binaries
+- `NewRelic.Azure.WebSites.x64` — Azure App Service, 64-bit
+- `NewRelic.Azure.WebSites` — Azure App Service, 32-bit (no `.x86` suffix)
+- `NewRelic.Azure.WebSites.Extension` — Azure Site Extension entry point
+- `NewRelicWindowsAzure` — classic Azure Cloud Services
+
+**MSI (`src/Agent/MsiInstaller/`):** `NewRelicAgent_x64.msi`,
+`NewRelicAgent_x86.msi`. Build requires the HeatWave VS extension.
+
+**Linux (`build/Linux/`):** `.deb` and `.rpm` for x64 and arm64. Installs
+land at `/usr/local/newrelic-dotnet-agent/` with `newrelic.config` alongside.
+Docker-driven via [Linux/docker-compose.yml](Linux/docker-compose.yml); see
+[Linux/linux_packaging.md](Linux/linux_packaging.md) for the workflow.
+Packaging sources live under `Linux/build/deb/`, `Linux/build/rpm/`, and
+`Linux/build/common/`.
+
+**Azure Site Extension (`Packaging/AzureSiteExtension/`):** installed via
+the Azure Portal Extensions tab.
+
+**Download site (`Packaging/DownloadSite/`):** structured directory of
+zipped home directories, MSIs, Linux packages, and SHA-256 checksums,
+ready to publish to `download.newrelic.com`.
+
+## Scripts
+
+PowerShell test-run helpers in [Scripts/](Scripts/):
+- [Scripts/run-integration-tests.ps1](Scripts/run-integration-tests.ps1)
+- [Scripts/run-platform-tests.ps1](Scripts/run-platform-tests.ps1)
+
+Invoke from repo root, e.g.:
 ```powershell
-# Run integration tests
 .\build\Scripts\run-integration-tests.ps1
-
-# Run platform tests
-.\build\Scripts\run-platform-tests.ps1
 ```
 
-## Build Configuration Files
+## Bundled tools (`Tools/`)
 
-### Directory.Build.props
+- `xsd2code/` — regenerates `Configuration.cs` from `Configuration.xsd`
+  (command + license-header restore in
+  [src/claude-source.md](../src/claude-source.md))
+- `NUnit-Console/`, `XUnit-Console/` — CLI test runners
+- `NuGet/`, `nuget.exe` — NuGet CLI
+- `vswhere.exe` — Visual Studio discovery
+- `sqlncli.msi` — SQL Server Native Client (MSI build dependency)
 
-Global MSBuild properties at repository root and various subdirectories.
+## MSBuild configuration
 
-**Common Settings:**
-- Version numbers
-- Compiler flags
-- Warning levels
-- Code analysis rules
-- Output paths
+- **`Directory.Build.props`** at repo root and in subdirectories defines the
+  agent version, `TreatWarningsAsErrors`, `LangVersion`, output paths, and
+  analyzer rules. The agent version defined here propagates to NuGet
+  package versions, the MSI product version, and Linux package versions.
+- **`.editorconfig`** enforces indentation, line endings, naming
+  conventions, and file-scoped namespaces.
 
-**Key Properties:**
-```xml
-<PropertyGroup>
-  <AgentVersion>10.48.1</AgentVersion>
-  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  <LangVersion>latest</LangVersion>
-</PropertyGroup>
-```
+## Linux build specifics
 
-### .editorconfig
+Build host: Docker Desktop (on Windows) or a Linux host with clang/gcc,
+cmake, and `dpkg-dev` / `rpm-build`. Supported targets: Ubuntu 16.04+,
+Debian 9+, RHEL/CentOS 7+, Amazon Linux 2, any systemd-based distro;
+architectures x64 and arm64. RPMs are GPG-signed; the public key ships
+with the repo config.
 
-Code style and formatting rules.
+## CI / release
 
-**Enforces:**
-- Indentation style
-- Line endings
-- Naming conventions
-- Code analysis rules
-- File-scoped namespaces
+CI runs in GitHub Actions — see [../.github/workflows/](../.github/workflows/),
+primarily `all_solutions.yml` for build + unit/integration tests on every
+PR. Releases are driven by **release-please**: conventional commits bump
+the version, regenerate `CHANGELOG.md`, open a release PR; merging tags
+and publishes artifacts.
 
-## Signing and Security
+## Troubleshooting
 
-### Code Signing
+**Profiler build fails:**
+- C++ ATL for the current VS build tools installed (x86 *and* x64)?
+- Docker Desktop running (required for the Linux profiler build)?
+- Did you open `Profiler.sln` with the latest Visual Studio?
 
-**Windows:**
-- Profiler DLL signed with Authenticode
-- MSI installer signed
-- Certificate stored securely
+**MSI build fails:**
+- HeatWave (WiX) VS extension installed?
+- WiX toolset version matches what `MsiInstaller.sln` expects?
+- All upstream agent-home outputs exist (build `FullAgent.sln` first)?
 
-**Linux:**
-- RPM packages signed with GPG
-- Public key distributed via repo config
+**NuGet pack errors:**
+- Clear the NuGet cache: `dotnet nuget locals all --clear`.
+- Verify package references resolved in `FullAgent.sln`.
+- Connectivity to nuget.org / internal feeds.
 
-### Keys Directory (`keys/`)
+**Linux package build fails:**
+- Docker Desktop running with enough disk and memory?
+- Scripts under `build/Linux/build/` have execute permissions
+  (`chmod +x` if cloned on Windows and mounted into Linux containers)?
+- Conflicting prior container state — `docker compose down -v` to reset.
 
-Contains signing keys and certificates (not committed to repo).
+## Code signing
 
-**Key Management:**
-- Production keys stored in secure vault
-- CI/CD accesses keys via secrets
-- Local development uses test keys
-
-## Platform-Specific Builds
-
-### Windows
-
-**Architectures:**
-- x86 (32-bit)
-- x64 (64-bit)
-
-**Frameworks:**
-- .NET Framework 4.6.2+
-- .NET Core 3.1+
-- .NET 6+
-
-**Build Requirements:**
-- Visual Studio 2022
-- Windows SDK
-- C++ ATL libraries
-
-### Linux
-
-**Architectures:**
-- x64 (amd64)
-- arm64 (aarch64)
-
-**Supported Distributions:**
-- Ubuntu 16.04+ (.deb)
-- Debian 9+ (.deb)
-- RHEL/CentOS 7+ (.rpm)
-- Amazon Linux 2 (.rpm)
-- Any systemd-based distribution
-
-**Build Requirements:**
-- Docker Desktop (for building on Windows)
-- Linux build environment with:
-  - clang/gcc
-  - cmake
-  - dpkg-dev / rpm-build
-
-## Build Tools Directory (`Tools/`)
-
-Third-party tools used during build:
-
-- `NuGet/` - NuGet command-line tool
-- `NUnit-Console/` - NUnit test runner
-- `XUnit-Console/` - xUnit test runner
-- `xsd2code/` - XML schema code generation
-
-## Versioning
-
-### Version Numbers
-
-Format: `MAJOR.MINOR.PATCH` (Semantic Versioning)
-
-**Example:** `10.48.1`
-- Major: Breaking changes
-- Minor: New features
-- Patch: Bug fixes
-
-### Version Sources
-
-1. **Source of Truth:** Agent assembly version
-2. **Propagated To:**
-   - NuGet package versions
-   - MSI product version
-   - Linux package versions
-   - File names
-
-### Version Management
-
-- Versions updated via release-please automation
-- Based on conventional commits
-- CHANGELOG.md auto-generated
-
-## Release Process
-
-### Automated Release (via release-please)
-
-1. **Development:**
-   - Developers commit with conventional commit messages
-   - Example: `feat: add OpenAI instrumentation`
-   - Example: `fix: handle disposed streams`
-
-2. **Release PR Created:**
-   - release-please bot creates PR
-   - Bumps version based on commits
-   - Updates CHANGELOG.md
-   - Updates version in source files
-
-3. **Release PR Merged:**
-   - Tag created automatically
-   - GitHub release created
-   - Artifacts built by CI
-   - Artifacts uploaded to release
-
-4. **Post-Release:**
-   - Packages pushed to NuGet
-   - Artifacts uploaded to download site
-   - Announcements made
-
-### Manual Release Steps
-
-If manual intervention needed:
-
-1. Update version in code
-2. Update CHANGELOG.md
-3. Build all artifacts via ArtifactBuilder
-4. Validate packages
-5. Create Git tag
-6. Push to NuGet.org
-7. Upload to download.newrelic.com
-8. Create GitHub release
-9. Announce release
-
-## Troubleshooting Builds
-
-### Common Issues
-
-**Profiler Build Fails:**
-- Ensure C++ ATL installed
-- Check Visual Studio version
-- Docker running for Linux builds
-
-**MSI Build Fails:**
-- Install HeatWave extension
-- Check WiX toolset version
-- Verify all dependencies present
-
-**NuGet Package Errors:**
-- Clear NuGet cache: `dotnet nuget locals all --clear`
-- Verify package references
-- Check NuGet.org connectivity
-
-**Linux Package Build Fails:**
-- Docker Desktop running
-- Sufficient disk space
-- Build scripts have execute permissions
-
-### Build Logs
-
-**Local Builds:**
-- Visual Studio Output window
-- MSBuild logs in `src/_build/`
-
-**CI Builds:**
-- GitHub Actions workflow logs
-- Artifact download for failed builds
-
-## Performance Considerations
-
-**Parallel Builds:**
-- Use `/m` flag with MSBuild for parallel compilation
-- Visual Studio automatically parallelizes
-
-**Incremental Builds:**
-- Don't clean unless necessary
-- Use Debug configuration for fast iteration
-- Release builds slower due to optimizations
-
-**Build Times:**
-- Full agent build: ~5-10 minutes
-- Profiler build: ~2-5 minutes
-- Integration tests: ~30-60 minutes
-
-## Related Documentation
-
-- @../claude.md - Main repository guide
-- @../src/claude-source.md - Source code architecture
-- @../tests/claude-tests.md - Testing guide
-- [Development guide](../docs/development.md)
-- [MSI Installer](../src/Agent/MsiInstaller/)
-- [Profiler build guide](../src/Agent/NewRelic/Profiler/README.md)
+Windows profiler DLL and MSI are Authenticode-signed; Linux RPMs are
+GPG-signed. Production keys live in the secret vault and are only
+available to CI. `build/keys/` is present for local work but its contents
+are gitignored.

--- a/claude.md
+++ b/claude.md
@@ -1,328 +1,208 @@
-# New Relic .NET Agent Repository Guide
+# New Relic .NET Agent
 
-This repository contains the New Relic .NET Agent, an Application Performance Monitoring (APM) solution for .NET applications.
+Profiler-based APM agent for .NET Framework and .NET Core on Windows and Linux.
+A native C++ profiler injects IL into JIT-compiled methods; the managed agent
+core collects telemetry and ships it to the collector.
 
-## Repository Overview
+Sub-docs (read when working in that area):
+- [src/claude-source.md](src/claude-source.md) — agent/profiler/extensions internals
+- [build/claude-build.md](build/claude-build.md) — build, packaging, release
+- [tests/claude-tests.md](tests/claude-tests.md) — unit + integration test layout
 
-The New Relic .NET Agent is a profiler-based instrumentation agent that monitors .NET applications and reports performance data to New Relic. It supports both .NET Framework and .NET Core/.NET applications on Windows and Linux.
+## Solutions
 
-### Key Components
+- **FullAgent.sln** (repo root) — primary. Builds managed code; emits
+  platform-specific `src/Agent/newrelichome_*` directories. Use for almost
+  all work.
+- **Profiler.sln** (`src/Agent/NewRelic/Profiler/`) — native C++ profiler.
+  Only needed when changing the profiler itself; otherwise consumed via NuGet.
+- **IntegrationTests.sln** (`tests/Agent/IntegrationTests/`) — host-run
+  end-to-end tests against real test applications. Requires a built
+  FullAgent.sln (agent home directories must exist).
+- **UnboundedIntegrationTests.sln** (`tests/Agent/IntegrationTests/`) —
+  integration tests that require external infrastructure (databases,
+  brokers, etc.). Start services first via
+  `tests/Agent/IntegrationTests/UnboundedServices` docker compose.
+- **ContainerIntegrationTests.sln** (`tests/Agent/IntegrationTests/`) —
+  tests that run instrumented apps inside Docker containers; primary
+  coverage for the Linux agent and container-specific scenarios. Needs
+  Docker Desktop.
 
-1. **Profiler**: Native C++ component that uses the .NET Profiling API to inject instrumentation bytecode
-2. **Agent Core**: Managed C# code that collects telemetry, manages configuration, and communicates with New Relic
-3. **Extensions**: Framework-specific wrappers that instrument popular libraries and frameworks
-4. **Public API**: User-facing API for custom instrumentation
+## Agent home directories
 
-## Repository Structure
+Building `FullAgent.sln` creates/updates these directories under `src/Agent/`.
+Integration, unbounded, and container tests all read from them — so before
+running any of those test solutions, (re)build `FullAgent.sln` first so the
+test runs pick up your latest changes.
 
+| Framework | OS    | Arch  | Directory                         |
+|-----------|-------|-------|-----------------------------------|
+| .NET FW   | Win   | x64   | `newrelichome_x64`                |
+| .NET FW   | Win   | x86   | `newrelichome_x86`                |
+| .NET Core | Win   | x64   | `newrelichome_x64_coreclr`        |
+| .NET Core | Win   | x86   | `newrelichome_x86_coreclr`        |
+| .NET Core | Linux | x64   | `newrelichome_x64_coreclr_linux`  |
+| .NET Core | Linux | arm64 | `newrelichome_arm64_coreclr_linux`|
+
+## Attaching the agent locally
+
+.NET Framework:
 ```
-newrelic-dotnet-agent/
-├── src/               # Source code (@src/claude-source.md)
-├── build/             # Build tools and packaging (@build/claude-build.md)
-├── tests/             # Tests and test infrastructure (@tests/claude-tests.md)
-├── docs/              # Documentation
-├── deploy/            # Deployment configurations
-└── .github/           # GitHub workflows and CI/CD
-```
-
-### Detailed Documentation
-
-For comprehensive information about each area, see:
-- [Agent implementation details](src/claude-source.md)
-- [Build tools, packaging, and release process](build/claude-build.md)
-- [Unit and integration test structure](tests/claude-tests.md)
-
-## Quick Start for Development
-
-### Requirements
-
-- Visual Studio 2022 with:
-  - .NET desktop development workload
-  - Desktop development with C++ workload
-  - C++ ATL for v142 build tools (x86 & x64)
-- Optional: Docker Desktop for Linux builds and containerized tests
-
-### Building
-
-The agent consists of two main solutions:
-
-1. **FullAgent.sln** (Primary): Builds all managed code and creates platform-specific agent home directories
-   - Located at repository root
-   - Outputs to `src/Agent/newrelichome_*` directories
-   - Build this solution for most development work
-
-2. **Profiler.sln** (Advanced): Builds the native profiler component
-   - Located at `src/Agent/NewRelic/Profiler/`
-   - Only needed when modifying profiler code
-   - Available as NuGet package for normal development
-
-### Agent Home Directories
-
-Building FullAgent.sln creates these deployment directories:
-
-| Framework      | OS      | Arch  | Output Directory                           |
-|----------------|---------|-------|--------------------------------------------|
-| .NET Framework | Windows | x64   | src/Agent/newrelichome_x64                 |
-| .NET Framework | Windows | x86   | src/Agent/newrelichome_x86                 |
-| .NET Core      | Windows | x64   | src/Agent/newrelichome_x64_coreclr         |
-| .NET Core      | Windows | x86   | src/Agent/newrelichome_x86_coreclr         |
-| .NET Core      | Linux   | x64   | src/Agent/newrelichome_x64_coreclr_linux   |
-| .NET Core      | Linux   | arm64 | src/Agent/newrelichome_arm64_coreclr_linux |
-
-### Testing Locally
-
-Configure these environment variables to attach the agent to a process:
-
-**For .NET Framework:**
-```bash
-NEWRELIC_LICENSE_KEY=<your license key>
-NEWRELIC_HOME=path\to\home\directory
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-COR_PROFILER_PATH=path\to\home\directory\NewRelic.Profiler.dll
+COR_PROFILER_PATH=<home>\NewRelic.Profiler.dll
+NEWRELIC_HOME=<home>
+NEWRELIC_LICENSE_KEY=...
 ```
 
-**For .NET Core/.NET:**
-```bash
-NEWRELIC_LICENSE_KEY=<your license key>
-CORECLR_NEWRELIC_HOME=path\to\home\directory
+.NET Core/.NET:
+```
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-CORECLR_PROFILER_PATH=path\to\home\directory\NewRelic.Profiler.dll
+CORECLR_PROFILER_PATH=<home>\NewRelic.Profiler.dll
+CORECLR_NEWRELIC_HOME=<home>
+NEWRELIC_LICENSE_KEY=...
 ```
 
-## How the Agent Works
+Debug logs: `NEWRELIC_LOG_LEVEL=debug` → `<home>/logs/`. Profiler load
+failures surface in the Windows Event Viewer.
 
-### Profiler Attachment Process
+## How instrumentation works (short version)
 
-1. CLR checks `COR_ENABLE_PROFILING` / `CORECLR_ENABLE_PROFILING` environment variable
-2. Loads profiler DLL from `COR_PROFILER_PATH` / `CORECLR_PROFILER_PATH`
-3. Profiler subscribes to JIT compilation events
-4. When methods are JIT compiled, profiler modifies bytecode to inject instrumentation
-5. Injected bytecode calls into agent core to create tracers and record telemetry
+1. CLR loads the profiler via `*_PROFILER_PATH`.
+2. Profiler subscribes to JIT events and consults XML extension files under
+   `src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/*` to decide which
+   methods to rewrite.
+3. Target methods get wrapped in try/catch/finally IL that calls
+   `AgentShim.GetFinishTracerDelegate()` to start/finish a tracer.
+4. Tracers record timing, errors, and segment data into the current
+   transaction.
 
-### Instrumentation Model
+**Runtime extension layout:** at runtime, instrumentation XML and wrapper
+DLLs live in `<agent-home>/extensions/` (and `extensions/netcore/` for
+the .NET Core wrappers). The agent watches this directory and picks up
+new or modified XML without a process restart — if new instrumentation
+isn't taking effect, verify the files are actually present there.
 
-The profiler wraps instrumented methods with try-catch-finally blocks that:
-1. Call `AgentShim.GetFinishTracerDelegate()` to start timing
-2. Execute the original method body
-3. Handle exceptions and record errors
-4. Finish the tracer with result/exception information
+### instrumentation.xml version ranges
 
-### Extension System
-
-The agent uses an XML-based extension system to define instrumentation points:
-- Extension files in `extensions/` directory define which methods to instrument
-- Profiler reads extensions and identifies target methods during JIT compilation
-- Agent can refresh instrumentation at runtime when extensions change
-
-## Key Architecture Concepts
-
-### Transactions
-A transaction represents a single unit of work (e.g., web request, background job). Transactions:
-- Track timing and performance metrics
-- Contain segments representing nested operations
-- Generate transaction traces when slow
-- Create transaction events for analytics
-
-### Segments
-Segments represent individual operations within a transaction:
-- External HTTP calls
-- Database queries
-- Custom instrumentation
-- Framework operations
-
-### Spans
-Distributed tracing spans provide detailed timing information:
-- Created for transactions and segments
-- Linked across services via trace context
-- Sent to New Relic for distributed tracing visualization
-
-### Metrics
-Aggregated performance measurements collected over time:
-- Transaction metrics (throughput, response time, error rate)
-- External call metrics
-- Database metrics
-- Custom metrics
+`maxVersion` is **exclusive** (strictly less than). To cover all versions up
+to but not including 9.7.0, write `maxVersion="9.7.0"` — not `"9.6.9999"`.
 
 ## Configuration
 
-Agent configuration sources (in priority order):
-1. Environment variables (highest priority)
-2. `newrelic.config` XML file
-3. Server-side configuration from New Relic
-4. Default values
+Precedence: env vars > `newrelic.config` > server-side config > defaults.
 
-Key configuration locations:
-- [src/Agent/NewRelic/Agent/Core/Configuration](src/Agent/NewRelic/Agent/Core/Configuration) - Configuration models
-- [src/Agent/NewRelic/Agent/Core/Config](src/Agent/NewRelic/Agent/Core/Config) - Configuration loading
+- Models: `src/Agent/NewRelic/Agent/Core/Configuration/`
+- Loader: `src/Agent/NewRelic/Agent/Core/Config/`
 
-## Important Files and Locations
+**Editing `Configuration.xsd`** requires regenerating `Configuration.cs`
+via `xsd2code` and restoring the license header — never hand-edit the
+generated file. Exact command and caveats in
+[src/claude-source.md](src/claude-source.md) under Configuration.
 
-- [FullAgent.sln](FullAgent.sln) - Main solution file
-- [src/Agent/CHANGELOG.md](src/Agent/CHANGELOG.md) - Release notes
-- [docs/development.md](docs/development.md) - Development guide
-- [docs/integration-tests.md](docs/integration-tests.md) - Integration test documentation
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
+## Building and testing from the CLI
 
-## Common Development Tasks
+Full build: open `FullAgent.sln` in the latest Visual Studio or run its
+MSBuild equivalent.
 
-### Adding New Instrumentation
+**Core.UnitTest** (and any project depending on `Core.csproj`) fails from
+the CLI with `AssemblyModifier.exe` / `*Undefined*` errors unless
+`SolutionDir` is passed explicitly — VS sets it, plain `dotnet` does not:
 
-1. Create or modify extension XML in `src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/<Framework>/`
-2. Implement wrapper classes that create tracers
-3. Add integration tests in `tests/Agent/IntegrationTests/`
-4. Update documentation
+Run from the repo root so `$PWD` resolves correctly; the trailing backslash
+on `SolutionDir` is required by MSBuild:
 
-### Debugging the Agent
-
-1. Set `NEWRELIC_LOG_LEVEL=debug` environment variable
-2. Check logs in agent home directory's `logs/` folder
-3. Use Visual Studio debugger attached to instrumented process
-4. For profiler issues, check Windows Event Viewer
-
-### Running Tests
-
-- **Unit Tests**: Use Visual Studio Test Explorer
-- **Integration Tests**: See @tests/claude-tests.md
-- Some integration tests require infrastructure (databases, message queues)
-
-## Common Code Patterns
-
-### Creating Transactions
-
-Transactions are typically created by framework instrumentation:
-- ASP.NET/ASP.NET Core wrappers create web transactions
-- Background frameworks create non-web transactions
-- Custom transactions via public API
-
-### Creating Segments
-
-Segments are created within transactions:
-1. Wrapper creates a tracer via the instrumentation wrapper interface
-2. Tracer records timing and metadata
-3. Tracer is finished when operation completes
-
-### Recording Custom Data
-
-Use the public API in `src/Agent/NewRelic.Api.Agent/`:
-- `IAgent.CurrentTransaction` - Access current transaction
-- `ITransaction.AddCustomAttribute()` - Add custom attributes
-- `NewRelic.Api.Agent.NewRelic.*` - Static helper methods
-
-## Coding Standards
-
-The .NET agent team follows coding standards that should be adhered to when generating or modifying code. These are best practices and encouraged guidelines rather than absolute requirements.
-
-### C# / Managed Agent
-
-**Indentation:**
-- Use spaces for indentation (Visual Studio default)
-- Follow Visual Studio default settings for number of spaces per indentation level
-
-**Naming Conventions:**
-- **Types**: Use type aliases (`int`, `string`) over BCL types (`Int32`, `String`)
-- **Private fields**: `_camelCase` with underscore prefix
-- **Public fields**: `PascalCase`
-- **Local variables**: `camelCase`, use `var` when possible
-- **Classes**: `PascalCase`, singular (plural for collections)
-- **Interfaces**: `PascalCase` with `I` prefix (e.g., `IAttributeFilter`)
-- **Methods**: `PascalCase`, descriptive action names
-- **Method parameters**: `camelCase`, named after their type
-
-**Class Structure (in order):**
-1. Fields (const, static readonly, readonly, static, private, public)
-2. Properties
-3. Constructors
-4. Methods
-5. Events
-
-**Code Organization:**
-- Fields declared and initialized at top of class
-- All declarations must have explicit access modifiers
-- Avoid multiple optional boolean parameters (use named parameters or overloads)
-- Line breaks between all code blocks
-
-**Example:**
-```csharp
-public class TransactionProcessor
-{
-	// Fields first
-	private const int MaxRetries = 3;
-	private readonly ILogger _logger;
-	private static int _instanceCount = 0;
-
-	// Properties second
-	public int TransactionCount { get; private set; }
-
-	// Constructor third
-	public TransactionProcessor(ILogger logger)
-	{
-		_logger = logger;
-		_instanceCount++;
-	}
-
-	// Methods fourth
-	public void ProcessTransaction(string transactionName)
-	{
-		var transaction = CreateTransaction(transactionName);
-		// ...
-	}
-}
+```powershell
+$sln = "$((Resolve-Path .).Path)\"
+dotnet build tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj `
+  -f net10.0 -p:SolutionDir="$sln"
+dotnet test  tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj `
+  -f net10.0 -p:SolutionDir="$sln" `
+  --filter "FullyQualifiedName~SomeTest"
 ```
 
-### C++ / Profiler
+Root cause: `Core.csproj` has a post-build ILRepack + AssemblyModifier step
+that references `$(SolutionDir)`.
 
-- Follow [WebKit C++ style guide](https://webkit.org/code-style-guidelines/)
-- Use compact namespaces: `namespace NewRelic::Profiler::Logger { ... }`
-- Formatting defined in `.clang-format` at solution root
-- ReSharper settings in `NewRelic.Profiler.sln.DotSettings`
+**Extensions tests** (`NewRelic.Agent.Extensions.Tests`) build fine with
+plain `dotnet build`, but `dotnet test` against the `.csproj` silently fails
+via VSTestTask. Run against the built DLL instead:
 
-### General Practices
+```
+dotnet test tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/bin/Debug/net10.0/NewRelic.Agent.Extensions.Tests.dll `
+  --filter "FullyQualifiedName~SomeTest"
+```
 
-**Testing:**
-- Unit tests required for all new code
-- Near 100% code coverage for shared libraries
-- Test all behavior including exceptions
+**Unbounded integration tests** need infrastructure containers first:
 
-**Documentation:**
-- XML documentation on public APIs
-- Clear, descriptive naming to reduce need for comments
-- Comment only when logic isn't self-evident
+```
+cd tests/Agent/IntegrationTests/UnboundedServices
+docker compose up -d
+```
 
-**Code Quality:**
-- Minimal public surface area
-- Prefer dependency injection for services
-- Prefer records for immutable data
-- Use file-scoped namespaces (recent standard)
+## Testing conventions
 
-**Important:** When Claude generates or modifies code, these standards should be followed to maintain consistency with the existing codebase.
+- Unit tests: `tests/Agent/UnitTests/` (NUnit primary, xUnit used in some
+  places). Mocking is **JustMock Lite** (free tier) — interfaces and virtual
+  members only. No sealed / static / non-virtual mocking. Design new code
+  with interfaces and virtual methods so it can be mocked.
+- **Wrapper projects** under `src/.../Extensions/Providers/Wrapper/*` have
+  **no unit tests and should not** — they are covered by the Integration
+  and Unbounded test solutions only. The `NewRelic.Agent.Extensions` project
+  (shared helpers like `SqsHelper`) is the only Extensions-side code that
+  is unit tested. When adding non-trivial logic to a wrapper — parsing,
+  URI/version handling, header manipulation, data-shape transforms — lift
+  it into a helper in `NewRelic.Agent.Extensions` and call it from the
+  wrapper. That keeps the interesting logic unit-testable while the
+  wrapper itself stays thin (match, create segment, delegate, finish).
+- Integration tests: `tests/Agent/IntegrationTests/` — see
+  [tests/claude-tests.md](tests/claude-tests.md).
+- **Never use `InternalsVisibleTo`** in any production or test assembly.
+  If a test needs to reach non-public code, refactor the production type to
+  expose what's needed through a proper surface (interface, public helper,
+  or a dedicated testable seam) rather than piercing encapsulation.
 
-## Development Workflow
+## Coding standards (repo-specific bits)
 
-1. Create feature branch from `main`
-2. Make changes and add tests
-3. Run unit tests locally
-4. Build FullAgent.sln successfully
-5. Test locally with sample application
-6. Submit pull request
-7. CI runs all tests and checks
-8. Review and merge
+### C#
 
-## Release Process
+- Type aliases (`int`, `string`) — not `Int32` / `String`.
+- Private fields `_camelCase`; public fields / properties / methods
+  `PascalCase`; interfaces `I`-prefixed; locals `camelCase` with `var`.
+- Class member order: fields → properties → ctors → methods → events.
+  Fields grouped: const, static readonly, readonly, static, private, public.
+- Explicit access modifiers on every declaration.
+- Avoid multiple optional `bool` parameters — use overloads or named args.
+- **File-scoped namespaces are required.** Block-scoped namespaces are
+  configured as a **build error** — new and modified files must use
+  `namespace Foo.Bar;` form.
+- **Unused `using` directives fail the build.** Remove them before
+  compiling; don't leave speculative imports in place.
 
-Releases are managed via release-please:
-- Conventional commits drive version bumping
-- Release notes auto-generated from commits
-- See [release-please](release-please/) directory
+### Wrapper projects: prefer `VisibilityBypasser`
 
-## Getting Help
+In `src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/*`, reach for
+`VisibilityBypasser` before `MethodInfo.Invoke`, `GetMethods`, or the
+`dynamic` keyword. It generates IL-compiled delegates via `DynamicMethod`,
+avoiding boxing / `object[]` allocation / DLR overhead on hot paths.
 
-- **Documentation**: [docs.newrelic.com](https://docs.newrelic.com/docs/agents/net-agent/)
-- **Community**: [New Relic Community Forum](https://forum.newrelic.com/)
-- **Issues**: GitHub Issues in this repository
-- **Development Questions**: Check existing documentation in `docs/`
+Cache generated delegates per instrumented type (e.g., a
+`ConcurrentDictionary<Type, Func<...>>`) so IL generation happens once per
+type. Useful overloads:
 
-## License
+- `GeneratePropertyAccessor<TResult>(ownerType, propertyName)`
+- `GenerateParameterlessMethodCaller<TResult>(...)`
+- `GenerateOneParameterMethodCaller<TParam, TResult>(assemblyName, typeName, methodName)`
 
-Apache 2.0 - See [LICENSE](LICENSE)
+When the owner type is only known at runtime, use
+`t.Assembly.GetName().Name` and `t.FullName`; wrap the cache factory in
+`try/catch` for missing members. `dynamic` / `MethodInfo.Invoke` are fine
+only when no suitable overload exists *and* the call is not on a hot path.
+
+### C++ (profiler)
+
+- WebKit C++ style guide.
+- Compact namespaces: `namespace NewRelic::Profiler::Logger { ... }`.
+- `.clang-format` at the profiler solution root is authoritative.
+

--- a/src/claude-source.md
+++ b/src/claude-source.md
@@ -1,313 +1,109 @@
-# New Relic .NET Agent - Source Code Architecture
+# Source Code Architecture
 
-This document describes the source code organization and architecture of the New Relic .NET Agent.
+Orientation map for `src/`. See the [root claude.md](../claude.md) for how
+instrumentation works end-to-end and for coding standards.
 
-## Overview
-
-The agent consists of two main components:
-1. **Native Profiler** - C++ code that hooks into the CLR profiling API
-2. **Managed Agent** - C# code that collects telemetry and communicates with New Relic
-
-## Directory Structure
+## Layout
 
 ```
-src/
-├── Agent/
-│   ├── NewRelic/
-│   │   ├── Agent/
-│   │   │   ├── Core/             # Main agent implementation
-│   │   │   └── Extensions/       # Framework instrumentation
-│   │   ├── Profiler/             # Native profiler (C++)
-│   │   └── Home/                 # Home directory project
-│   ├── NewRelic.Api.Agent/       # Public API
-│   ├── Configuration/            # Configuration schemas
-│   ├── MsiInstaller/             # Windows installer
-│   ├── newrelichome_*/           # Built agent home directories
-│   └── Scripts/                  # Build scripts
-└── _build/                       # Build output
+src/Agent/
+├── NewRelic/
+│   ├── Agent/
+│   │   ├── Core/        # Managed agent core (C#)
+│   │   └── Extensions/  # Instrumentation framework + per-framework wrappers
+│   ├── Profiler/        # Native profiler (C++)
+│   └── Home/            # Home-directory layout project (assembles newrelichome_*)
+├── NewRelic.Api.Agent/  # Public API consumed by customer code
+├── Configuration/       # XSD / config surface (see note below)
+├── MsiInstaller/        # Windows MSI
+├── newrelichome_*/      # Built agent homes (FullAgent.sln output)
+└── Scripts/             # Misc maintenance scripts (e.g. flush_dotnet_temp.cmd)
 ```
 
-## Core Components
+## Profiler (`Agent/NewRelic/Profiler/`)
 
-### 1. Native Profiler (`Agent/NewRelic/Profiler/`)
+Native C++ implementing the CLR Profiling API. On JIT, matches methods
+against instrumentation XML, requests ReJIT, and wraps the bytecode with
+`try/catch/finally` IL that calls into `AgentShim`.
 
-The profiler is written in C++ and implements the .NET Profiling API to inject instrumentation bytecode.
+**Entry points worth knowing:**
+- `Profiler/CorProfilerCallbackImpl.h` — main profiler callbacks
+- `MethodRewriter/InstrumentFunctionManipulator.h` — bytecode injection
+- `MethodRewriter/FunctionManipulator.h` — low-level IL manipulation
 
-**Key Files:**
-- [Profiler/CorProfilerCallbackImpl.h](Agent/NewRelic/Profiler/Profiler/CorProfilerCallbackImpl.h) - Main profiler callback implementation
-- [MethodRewriter/InstrumentFunctionManipulator.h](Agent/NewRelic/Profiler/MethodRewriter/InstrumentFunctionManipulator.h) - Bytecode injection logic
-- [MethodRewriter/FunctionManipulator.h](Agent/NewRelic/Profiler/MethodRewriter/FunctionManipulator.h) - Low-level bytecode manipulation
-
-**How It Works:**
-1. Profiler attaches to CLR via `COR_ENABLE_PROFILING` environment variable
-2. Sets flags to monitor JIT compilation events
-3. On `JITCompilationStarted`, checks if method should be instrumented
-4. Requests ReJIT for instrumented methods
-5. On `ReJITCompilationStarted`, modifies bytecode to wrap method with try-catch-finally
-6. Injected code calls into agent core via `AgentShim.GetFinishTracerDelegate()`
-
-**Profiler GUIDs:**
-- .NET Framework: `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`
-- .NET Core/.NET: `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`
-
-**Building:**
-Use PowerShell script at [Profiler/build/build.ps1](Agent/NewRelic/Profiler/build/build.ps1):
+**Build:** `src/Agent/NewRelic/Profiler/build/build.ps1`
 ```powershell
-# Windows x64
-build.ps1 -Platform x64 -Configuration Debug
-
-# Linux (requires Docker)
-build.ps1 -Platform linux
+build.ps1 -Platform x64 -Configuration Debug    # Windows x64
+build.ps1 -Platform linux                       # Linux (requires Docker)
 ```
 
-### 2. Agent Core (`Agent/NewRelic/Agent/Core/`)
+Profiler GUIDs are documented in the [root claude.md](../claude.md).
 
-The core agent is the heart of the monitoring solution, written in C#.
-
-#### Core Structure
+## Agent Core (`Agent/NewRelic/Agent/Core/`)
 
 ```
 Core/
-├── AgentHealth/              # Agent health monitoring
-├── Aggregators/              # Metric and event aggregation
-├── Api/                      # Internal API implementations
-├── Attributes/               # Attribute collection and filtering
-├── BrowserMonitoring/        # Real User Monitoring (RUM)
-├── CallStack/                # Call stack tracking
-├── Commands/                 # Server commands from New Relic
-├── Configuration/            # Configuration management
-├── DataTransport/            # Communication with New Relic
-├── DistributedTracing/       # Distributed tracing implementation
-├── Errors/                   # Error tracking
-├── Events/                   # Event models
-├── Instrumentation/          # Instrumentation coordination
-├── Metrics/                  # Metric collection and aggregation
-├── Samplers/                 # Periodic sampling (CPU, memory, etc.)
-├── Segments/                 # Segment creation and tracking
-├── Spans/                    # Span creation for distributed tracing
-├── ThreadProfiling/          # Thread profiler
-├── Transactions/             # Transaction management
-├── TransactionTraces/        # Transaction trace generation
-├── Transformers/             # Data transformation pipeline
-├── Utilities/                # Helper utilities
-├── Utilization/              # Host utilization detection
-├── WireModels/               # Data models for New Relic protocol
-└── Wrapper/                  # Wrapper base classes
+├── AgentHealth/          Aggregators/         Api/
+├── Attributes/           BrowserMonitoring/   CallStack/
+├── Commands/             Configuration/       DataTransport/
+├── DependencyInjection/  DistributedTracing/  Errors/
+├── Events/               Instrumentation/     Metrics/
+├── Samplers/             Segments/            Spans/
+├── ThreadProfiling/      Transactions/        TransactionTraces/
+├── Transformers/         Utilities/           Utilization/
+├── WireModels/           Wrapper/
 ```
 
-#### Key Subsystems
+**Notable classes / entry points:**
+- **Transactions:** `Transaction`, `ImmutableTransaction` (snapshot handed
+  to the pipeline when the transaction ends), `TransactionName`,
+  `TransactionMetricNameMaker`. Lifecycle: created by framework
+  instrumentation → segments added as operations run → custom attributes
+  collected → finished → transformed → aggregated into metrics, traces,
+  events, and spans.
+- **Segments:** `Segment` plus `*SegmentData` variants that carry the
+  per-category metadata. Segment categories: **external** (HTTP client
+  calls), **datastore** (SQL, NoSQL, caches), **message broker**
+  (queue/topic produce & consume), and **custom** (public-API or
+  wrapper-defined). Wrappers pick the category by which `*SegmentData`
+  they attach.
+- **Distributed tracing:** `DistributedTracePayload`,
+  `DistributedTracingApiModel`, `TracePriorityManager`. Inbound wrappers
+  accept trace context from headers and link the current transaction to
+  its parent span; outbound wrappers inject trace context into outgoing
+  calls. Implements W3C Trace Context plus the New Relic payload.
+- **Data transport:** `ConnectionManager`, `DataTransportService`,
+  `HttpCollectorWire`, `AgentCommands` (processes server-side config
+  returned by the collector).
+- **Aggregators:** one per data type (metrics, transaction events, error
+  events, span events, custom events, SQL traces, transaction traces).
+  Harvest cycle is ~60s by default: aggregators sample/combine, serialize,
+  and ship, then reset.
+- **DI:** `Core/DependencyInjection/AgentContainer`.
 
-##### Transaction Management (`Transactions/`)
-
-Transactions represent units of work being monitored.
-
-**Key Classes:**
-- `Transaction` - Main transaction implementation
-- `TransactionName` - Transaction naming logic
-- `TransactionMetricNameMaker` - Metric name generation
-- `ImmutableTransaction` - Immutable snapshot for data pipeline
-
-**Transaction Lifecycle:**
-1. Created by framework instrumentation (e.g., ASP.NET request handler)
-2. Segments added as operations execute
-3. Custom attributes and metadata collected
-4. Transaction finished when work completes
-5. Sent through data transformation pipeline
-6. Aggregated into metrics, traces, events, and spans
-
-##### Segments (`Segments/`)
-
-Segments track individual operations within transactions.
-
-**Segment Types:**
-- External segments (HTTP calls)
-- Database segments (SQL queries)
-- Datastore segments (NoSQL operations)
-- Message broker segments
-- Custom segments
-
-**Key Classes:**
-- `Segment` - Base segment implementation
-- `ExternalSegmentData` - HTTP call metadata
-- `DatastoreSegmentData` - Database operation metadata
-- `MessageBrokerSegmentData` - Message queue metadata
-
-##### Distributed Tracing (`DistributedTracing/`)
-
-Implements W3C Trace Context and New Relic distributed tracing.
-
-**Key Classes:**
-- `DistributedTracePayload` - Trace context payload
-- `DistributedTracingApiModel` - API for accepting trace context
-- `TracePriorityManager` - Sampling priority calculation
-
-**Flow:**
-1. Inbound: Accept trace context from headers
-2. Link current transaction to parent span
-3. Outbound: Inject trace context into outgoing calls
-4. Generate spans for distributed tracing visualization
-
-##### Data Transport (`DataTransport/`)
-
-Manages communication with New Relic's data ingest services.
-
-**Key Classes:**
-- `ConnectionManager` - Manages connections to New Relic
-- `DataTransportService` - Sends data to New Relic
-- `AgentCommands` - Processes server-side configuration
-- `HttpCollectorWire` - HTTP protocol implementation
-
-**Data Flow:**
-1. Agent collects metrics, events, traces, spans
-2. Data aggregated in harvest cycle (typically 60 seconds)
-3. Serialized to JSON
-4. Compressed with gzip
-5. Sent via HTTPS to New Relic collectors
-6. Response processed for server-side configuration
-
-##### Aggregators (`Aggregators/`)
-
-Aggregate telemetry data before sending to New Relic.
-
-**Key Aggregators:**
-- `MetricAggregator` - Aggregates metrics
-- `TransactionEventAggregator` - Transaction events
-- `ErrorEventAggregator` - Error events
-- `SpanEventAggregator` - Distributed tracing spans
-- `CustomEventAggregator` - Custom events
-- `SqlTraceAggregator` - SQL traces
-- `TransactionTraceAggregator` - Transaction traces
-
-**Harvest Cycle:**
-1. Data collected during 60-second window
-2. Aggregators combine and sample data
-3. Data serialized and sent to New Relic
-4. Aggregators reset for next cycle
-
-##### Configuration (`Configuration/`)
-
-Hierarchical configuration system with multiple sources.
-
-**Configuration Sources (Priority Order):**
-1. Environment variables (highest)
-2. Local `newrelic.config` file
-3. Server-side configuration
-4. Default values (lowest)
-
-**Key Classes:**
-- `Configuration` - Main configuration model
-- `ConfigurationService` - Configuration loading and updates
-- `EnvironmentVariables` - Environment variable access
-- `ServerConfiguration` - Server-side config from New Relic
-
-**Important Configuration:**
-- License key
-- Application name
-- Transaction tracer settings
-- Distributed tracing settings
-- Error collection settings
-- Instrumentation settings
-
-### 3. Extensions System (`Agent/NewRelic/Agent/Extensions/`)
-
-The extensions system provides framework-specific instrumentation.
-
-#### Extension Architecture
-
+**Data pipeline:**
 ```
-Extensions/
-├── NewRelic.Agent.Extensions/    # Base extension framework
-│   ├── Providers/
-│   │   ├── Storage/              # Async context storage
-│   │   └── Wrapper/              # Framework wrappers
+method → tracer/wrapper → segment/transaction → ImmutableTransaction
+      → transformers → aggregators → DataTransport → collector
 ```
 
-#### Storage Providers (`Providers/Storage/`)
+## Extensions (`Agent/NewRelic/Agent/Extensions/`)
 
-Manage async context across async/await boundaries.
-
-**Implementations:**
-- `AsyncLocal/` - Uses AsyncLocal<T> (.NET Core/.NET)
-- `CallContext/` - Uses CallContext (.NET Framework)
-- `HttpContext/` - Uses HttpContext for ASP.NET
-- `OperationContext/` - Uses OperationContext for WCF
-- `HybridHttpContext/` - Hybrid approach
-
-#### Wrapper Providers (`Providers/Wrapper/`)
-
-Instrument specific frameworks and libraries. Over 40 instrumentation providers:
-
-**Web Frameworks:**
-- `AspNet/` - ASP.NET Framework (MVC, Web Forms, etc.)
-- `AspNetCore/` - ASP.NET Core 1.0-5.0
-- `AspNetCore6Plus/` - ASP.NET Core 6.0+
-- `Mvc3/` - ASP.NET MVC 3+
-- `WebApi1/`, `WebApi2/` - ASP.NET Web API
-- `Owin/` - OWIN middleware
-- `OpenRasta/` - OpenRasta framework
-
-**Databases:**
-- `Sql/` - ADO.NET (SqlClient, etc.)
-- `MongoDb/`, `MongoDb26/` - MongoDB drivers
-- `Couchbase/`, `Couchbase3/` - Couchbase
-- `CosmosDb/` - Azure Cosmos DB
-- `Elasticsearch/` - Elasticsearch
-- `OpenSearch/` - OpenSearch
-- `ServiceStackRedis/` - ServiceStack.Redis
-- `StackExchangeRedis/`, `StackExchangeRedis2Plus/` - StackExchange.Redis
-- `Memcached/` - Memcached
-
-**HTTP Clients:**
-- `HttpClient/` - HttpClient
-- `HttpWebRequest/` - HttpWebRequest
-- `RestSharp/` - RestSharp
-
-**Messaging:**
-- `RabbitMq/` - RabbitMQ
-- `Kafka/` - Kafka
-- `Msmq/` - MSMQ
-- `NServiceBus/` - NServiceBus
-- `MassTransit/`, `MassTransitLegacy/` - MassTransit
-- `AzureServiceBus/` - Azure Service Bus
-
-**Cloud Services:**
-- `AwsSdk/` - AWS SDK
-- `AwsLambda/` - AWS Lambda
-- `AzureFunction/` - Azure Functions
-- `Bedrock/` - AWS Bedrock (AI)
-
-**AI/ML:**
-- `OpenAI/` - OpenAI SDK (GPT, etc.)
-- `Bedrock/` - AWS Bedrock
-
-**Logging:**
-- `Log4NetLogging/` - log4net
-- `NLogLogging/` - NLog
-- `SerilogLogging/` - Serilog
-- `MicrosoftExtensionsLogging/` - Microsoft.Extensions.Logging
-
-**Other:**
-- `Wcf3/` - WCF
-- `WebServices/` - ASMX web services
-- `ScriptHandlerFactory/` - ASP.NET AJAX
-- `WebOptimization/` - ASP.NET bundling and minification
-
-#### Creating a Wrapper
-
-Each wrapper typically contains:
-1. **Extension XML** - Defines instrumentation points
-2. **Wrapper classes** - Implement instrumentation logic
-3. **Tracer factories** - Create tracers for instrumented methods
-
-**Example Structure:**
 ```
-MyFramework/
-├── MyFramework.csproj
-├── MyFrameworkInstrumentation.xml
-└── MyFrameworkWrapper.cs
+Extensions/NewRelic.Agent.Extensions/
+└── Providers/
+    ├── Storage/   Async-context storage (AsyncLocal, CallContext, HttpContext,
+    │             OperationContext, HybridHttpContext)
+    └── Wrapper/   Per-framework instrumentation wrappers (40+ projects —
+                   one subfolder per instrumented library; ls to enumerate)
 ```
 
-**Extension XML Format:**
+### Creating a wrapper
+
+Each wrapper project contains the csproj, an `*Instrumentation.xml` that
+tells the profiler what to hook, and the `IWrapper` implementation(s).
+
+Minimal instrumentation XML:
 ```xml
 <extension>
   <instrumentation>
@@ -320,215 +116,147 @@ MyFramework/
 </extension>
 ```
 
-**Wrapper Implementation:**
+Minimal wrapper:
 ```csharp
 public class MyFrameworkWrapper : IWrapper
 {
+    // true  = wrapper is skipped if no transaction is in progress
+    //         (use when the wrapper only adds a segment to an existing tx)
+    // false = wrapper runs regardless; typically it creates a transaction
+    //         itself (entry points: request handlers, message consumers,
+    //         lambda handlers, background job starts)
+    public bool IsTransactionRequired => true;
+
+    public CanWrapResponse CanWrap(InstrumentedMethodInfo methodInfo) =>
+        new CanWrapResponse(methodInfo.RequestedWrapperName == nameof(MyFrameworkWrapper));
+
     public AfterWrappedMethodDelegate BeforeWrappedMethod(
         InstrumentedMethodCall instrumentedMethodCall,
         IAgent agent,
         ITransaction transaction)
     {
         var segment = transaction.StartTransactionSegment(
-            instrumentedMethodCall.MethodCall,
-            "MyFramework");
-
+            instrumentedMethodCall.MethodCall, "MyFramework");
         return Delegates.GetDelegateFor(segment);
     }
 }
 ```
 
-### 4. Public API (`NewRelic.Api.Agent/`)
+**Debugging tip:** if a wrapper seems not to fire, check
+`IsTransactionRequired`. A `true` wrapper on a method that runs outside
+any transaction (e.g. a background poller, a message consumer invoked by
+an SDK thread before a transaction exists) will be silently skipped —
+`transaction` would be null, so the agent bypasses the wrapper entirely.
+Wrappers that *start* transactions must return `false`.
 
-The public API allows developers to add custom instrumentation.
+`maxVersion` in instrumentation XML is **exclusive**. Prefer
+`VisibilityBypasser` over reflection / `dynamic` when reaching into
+instrumented types; cache generated delegates per type. Both conventions
+are detailed in the [root claude.md](../claude.md).
 
-**Key Interfaces:**
-- `IAgent` - Access to agent functionality
-- `ITransaction` - Current transaction operations
-- `ISegment` - Custom segment creation
-- `ISpan` - Current span access
+Wrapper projects have **no unit tests** — they're covered by integration
+and unbounded test solutions. Only `NewRelic.Agent.Extensions` (shared
+helpers like `SqsHelper`) is unit tested. When adding non-trivial logic
+to a wrapper, lift it into a helper in `NewRelic.Agent.Extensions` so it
+can be unit tested — keep the wrapper itself thin. The same rule is
+covered in the [root claude.md](../claude.md) testing conventions.
 
-**Static API:**
-```csharp
-// Located in NewRelic.Api.Agent.NewRelic class
-AddCustomAttribute(string key, object value)
-NoticeError(Exception exception)
-SetTransactionName(string category, string name)
-GetAgent()
-StartAgent()
+## Public API (`NewRelic.Api.Agent/`)
+
+Customer-facing surface:
+- Interfaces: `IAgent`, `ITransaction`, `ISegment`, `ISpan`
+- Static helpers on `NewRelic.Api.Agent.NewRelic` (`AddCustomAttribute`,
+  `NoticeError`, `SetTransactionName`, `GetAgent`, `StartAgent`)
+- Attributes: `[Transaction]`, `[Trace]` for custom instrumentation
+
+Changes here are gated by `PublicApiChangeTests` — intentional breaks need
+an explicit baseline update.
+
+## Configuration
+
+Runtime config precedence is in the [root claude.md](../claude.md).
+
+The canonical schema is `src/Agent/NewRelic/Agent/Core/Config/Configuration.xsd`
+and it generates `Configuration.cs` in the same directory.
+`src/Agent/Configuration/` holds additional config surface / validation
+artifacts.
+
+### Regenerating `Configuration.cs` after editing the XSD
+
+`Configuration.cs` is **auto-generated — never hand-edit it.** After
+changing `Configuration.xsd`, regenerate by running the following from
+the repo root:
+
+```powershell
+$root = (Resolve-Path .).Path
+& "$root\build\Tools\xsd2code\xsd2code.exe" `
+  "$root\src\Agent\NewRelic\Agent\Core\Config\Configuration.xsd" `
+  NewRelic.Agent.Core.Config `
+  "$root\src\Agent\NewRelic\Agent\Core\Config\Configuration.cs" `
+  /cl /ap /sc /xa
 ```
 
-**Custom Instrumentation:**
-```csharp
-[Transaction]
-public void MyBusinessMethod()
-{
-    // Creates a transaction if none exists
-}
-
-[Trace]
-public void MyTracedMethod()
-{
-    // Creates a segment within transaction
-}
+`xsd2code` strips file headers, so re-prepend the two-line license header
+to the regenerated file:
+```
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 ```
 
-### 5. Configuration Schemas (`Agent/Configuration/`)
+See [docs/config-development.md](../docs/config-development.md) for the
+full reference on config development.
 
-XML schemas and related files for agent configuration.
+## Performance principles
 
-**Key Files:**
-- `newrelic.xsd` - Schema for newrelic.config
-- Configuration validation and documentation
+The agent runs inside every instrumented process, so overhead directly
+taxes customer apps. When writing or modifying agent code, honor these:
 
-## Agent Initialization Flow
+- **Minimize allocations on hot paths.** Tracer start/finish, segment
+  creation, and per-call wrapper code run on every instrumented method
+  call. Avoid LINQ, closures, string concatenation, `params` arrays, and
+  boxing in these paths.
+- **Cache reflection.** Any `Type.GetMethod` / `PropertyInfo` / generated
+  delegate must be cached per type (typically in a
+  `ConcurrentDictionary<Type, …>`). In wrapper projects, use
+  `VisibilityBypasser` — it both caches and compiles to IL (see root
+  claude.md).
+- **Keep the non-instrumented fast path cheap.** When a method isn't
+  matched by any wrapper, the agent code in its path should do as little
+  as possible — ideally a single guard check.
+- **Lazy initialization** for anything not needed at agent startup.
+- **Favor immutable + snapshot handoffs** (see `ImmutableTransaction`)
+  over locking shared mutable state; use lock-free structures where
+  practical and `ReaderWriterLockSlim` when you must share.
+- **Prefer pooling / reuse** (`StringBuilder`, buffers, event reservoirs)
+  on repeated per-transaction work.
 
-1. **Profiler Attachment**
-   - CLR loads profiler DLL
-   - Profiler initializes and sets event masks
-   - Profiler reads instrumentation XML from extensions
+**Sampling keeps volume bounded:**
+- Transaction traces: 1/min by default.
+- Span events: sampled by priority.
+- Custom events: reservoir sampling.
 
-2. **Agent Core Initialization**
-   - AgentInitializer.Initialize() called
-   - Configuration loaded from all sources
-   - Services registered in dependency injection container
-   - Connection to New Relic established
-   - Background services started (samplers, aggregators)
+Respect these when adding new telemetry — unsampled firehoses are not an
+option.
 
-3. **Instrumentation Active**
-   - Methods JIT compiled with instrumentation
-   - Transactions and segments created
-   - Data collected and aggregated
-   - Periodic harvest sends data to New Relic
+## Agent initialization order
 
-## Instrumentation Workflow
+1. CLR loads profiler via `*_PROFILER_PATH`.
+2. Profiler reads instrumentation XML from the agent home + extensions
+   directory and sets event masks.
+3. Agent core `AgentInitializer.Initialize()` runs: loads config from all
+   sources, registers services in `AgentContainer`, opens connection to
+   New Relic, starts samplers and aggregators.
+4. JIT compiles application methods; matched methods get ReJIT'd with
+   instrumented bytecode.
+5. Harvest cycle (~60s) aggregates and ships data.
 
-1. **Method JIT Compilation**
-   - Profiler intercepts JIT event
-   - Checks if method matches instrumentation XML
-   - Requests ReJIT if match found
+## Debugging signals
 
-2. **ReJIT Event**
-   - Profiler gets original method bytecode
-   - Wraps bytecode with try-catch-finally blocks
-   - Injects calls to AgentShim
-   - Returns modified bytecode to CLR
-
-3. **Method Execution**
-   - Try: Call GetFinishTracerDelegate (starts tracer)
-   - Original method body executes
-   - Catch: Report exception to tracer
-   - Finally: Finish tracer with result
-
-4. **Tracer Lifecycle**
-   - Tracer created by wrapper
-   - Segment/transaction started
-   - Timing begins
-   - Custom data collected
-   - Segment/transaction finished
-   - Data sent to aggregators
-
-## Data Pipeline
-
-```
-Method Execution
-    ↓
-Tracer/Wrapper
-    ↓
-Segment/Transaction
-    ↓
-ImmutableTransaction
-    ↓
-Transformers
-    ↓
-Aggregators
-    ↓
-DataTransport
-    ↓
-New Relic Platform
-```
-
-## Dependency Injection
-
-The agent uses a custom DI container for service management.
-
-**Container:** `Core/DependencyInjection/AgentContainer`
-
-**Key Services:**
-- Configuration services
-- Aggregators
-- Data transport
-- Samplers
-- API implementations
-- Metric builders
-
-## Threading Model
-
-- **Agent thread** - Background thread for harvesting and sampling
-- **Instrumented threads** - Application threads being monitored
-- **Async context** - Maintains transaction context across async boundaries
-
-**Synchronization:**
-- Lock-free data structures where possible
-- ReaderWriterLockSlim for shared state
-- Immutable objects for thread safety
-
-## Performance Considerations
-
-**Low Overhead Design:**
-- Minimize allocations in hot paths
-- Cache reflection results
-- Fast path for non-instrumented methods
-- Lazy initialization where possible
-- Aggressive inlining of small methods
-
-**Sampling:**
-- Transaction traces sampled (1 per minute by default)
-- Span events sampled based on priority
-- Custom events reservoir sampling
-
-## Debugging Tips
-
-**Enable Debug Logging:**
-```xml
-<configuration>
-  <log level="debug" />
-</configuration>
-```
-
-Or environment variable:
-```
-NEWRELIC_LOG_LEVEL=debug
-```
-
-**Common Log Locations:**
-- `{NEWRELIC_HOME}/logs/` - Agent logs
-- Windows Event Viewer - Profiler errors
-
-**Attach Debugger:**
-1. Set environment variables for target app
-2. Start target app
-3. Attach Visual Studio debugger to process
-4. Set breakpoints in agent code
-
-**Profiler Debugging:**
-- Check profiler loads: Look for "Profiler attached" in logs
-- Enable profiler debug logging: See profiler documentation
-- Windows Event Viewer for profiler failures
-
-## Code Conventions
-
-- File-scoped namespaces (recent refactoring)
-- Prefer records for immutable data
-- Use dependency injection for services
-- Minimal public surface area
-- XML documentation on public APIs
-- Unit tests for all new code
-
-## Related Documentation
-
-- [Main repository guide](../claude.md)
-- [Build system](../build/claude-build.md)
-- [Testing guide](../tests/claude-tests.md)
-- [Profiler README](Agent/NewRelic/Profiler/README.md)
-- [Development guide](../docs/development.md)
+When an agent appears attached but does nothing:
+- Check the agent log (`<home>/logs/`) for a **"Profiler attached"** line —
+  absence means the profiler never loaded.
+- If the log itself is missing, the profiler failed to load. Check the
+  Windows **Event Viewer** (Applications and Services Logs → Application)
+  for profiler DLL load errors — GUID mismatch, bitness mismatch, or
+  missing dependencies all surface here.
+- Turn up verbosity with `NEWRELIC_LOG_LEVEL=debug` for the managed side.

--- a/tests/claude-tests.md
+++ b/tests/claude-tests.md
@@ -1,293 +1,84 @@
-# New Relic .NET Agent - Testing Guide
+# Testing Guide
 
-This document describes the testing infrastructure and strategies for the New Relic .NET Agent.
+Four test layers. See the [root claude.md](../claude.md) for CLI build /
+test commands and for the no-unit-tests-for-wrappers rule.
 
-## Overview
+- **Unit tests** — `tests/Agent/UnitTests/` (NUnit-primary, some xUnit)
+- **Integration tests** — `IntegrationTests.sln`, host-run
+- **Unbounded integration tests** — `UnboundedIntegrationTests.sln`, need
+  external infra (databases, brokers)
+- **Container integration tests** — `ContainerIntegrationTests.sln`, run
+  instrumented apps inside Docker
 
-The test suite consists of:
-- **Unit Tests** - Fast, isolated tests of individual components
-- **Integration Tests** - End-to-end tests with real applications
-- **Container Tests** - Tests running in Docker containers
-- **Unbounded Tests** - Tests requiring external infrastructure
+All three integration solutions read from the built agent home
+directories, so **build `FullAgent.sln` first** before running them.
 
-## Directory Structure
+## Layout
 
 ```
 tests/
 ├── Agent/
-│   ├── UnitTests/                    # Unit tests
-│   │   ├── Core.UnitTest/            # Core agent tests
-│   │   ├── NewRelic.Agent.Extensions.Tests/  # Extension tests
-│   │   ├── CompositeTests/           # Cross-component tests
-│   │   ├── NewRelic.Agent.TestUtilities/     # Test helpers
-│   │   ├── AsyncLocalTests/          # Async context tests
-│   │   ├── ParsingTests/             # Parser tests
-│   │   └── PublicApiChangeTests/     # API compatibility tests
-│   ├── IntegrationTests/             # Integration tests
-│   │   ├── IntegrationTests/         # Main integration tests
-│   │   ├── ContainerIntegrationTests/        # Docker-based tests
-│   │   ├── UnboundedIntegrationTests/        # Infrastructure tests
-│   │   ├── Applications/             # Test applications
-│   │   ├── SharedApplications/       # Shared test apps
-│   │   ├── UnboundedApplications/    # Apps for unbounded tests
-│   │   ├── ContainerApplications/    # Apps for container tests
-│   │   ├── IntegrationTestHelpers/   # Test utilities
-│   │   ├── ApplicationHelperLibraries/       # Helper libraries
-│   │   └── Models/                   # Test data models
-│   ├── Shared/                       # Shared test code
-│   │   ├── TestSerializationHelpers/ # Serialization test utils
-│   │   └── TestSerializationHelpers.Test/    # Tests for test utils
-│   └── NewRelic.Testing.Assertions/  # Custom assertions
-└── NewRelic.Core.Tests/              # Core library tests
+│   ├── UnitTests/
+│   │   ├── Core.UnitTest/                       # Agent core
+│   │   ├── NewRelic.Agent.Extensions.Tests/     # Extensions shared code (not wrappers)
+│   │   ├── CompositeTests/                      # Cross-component flows
+│   │   ├── NewRelic.Agent.TestUtilities/        # Shared test helpers
+│   │   ├── AsyncLocalTests/                     # Async-context behavior
+│   │   ├── ParsingTests/                        # SQL / config / JSON parsers
+│   │   └── PublicApiChangeTests/                # Public-API stability gate
+│   ├── IntegrationTests/
+│   │   ├── IntegrationTests/                    # Host-run tests
+│   │   ├── ContainerIntegrationTests/           # Docker-based tests
+│   │   ├── UnboundedIntegrationTests/           # Infra-backed tests
+│   │   ├── UnboundedServices/                   # docker-compose for unbounded infra
+│   │   ├── Applications/                        # Windows / .NET FW + .NET Core test apps
+│   │   ├── ContainerApplications/               # Linux / container test apps
+│   │   ├── UnboundedApplications/               # Apps exercising external infra
+│   │   ├── SharedApplications/                  # Shared app code
+│   │   ├── ApplicationHelperLibraries/          # Helper libs consumed by test apps
+│   │   ├── IntegrationTestHelpers/              # Fixtures, log parsers, wire models
+│   │   └── Models/                              # Telemetry wire-model types
+│   ├── Shared/
+│   │   ├── TestSerializationHelpers/
+│   │   └── TestSerializationHelpers.Test/
+│   └── NewRelic.Testing.Assertions/             # Custom asserts (metrics, traces, spans, events)
+└── NewRelic.Core.Tests/
 ```
 
-## Unit Tests
+## Unit tests
 
-Unit tests focus on testing individual classes and methods in isolation.
+- Primary framework: **NUnit**. A few projects use xUnit.
+- Mocking: **Telerik JustMock Lite** (free tier) — interfaces and virtual
+  members only. No sealed / static / non-virtual mocking. Design new code
+  with interfaces + virtual methods so it stays mockable.
+- Helpers: `NewRelic.Agent.TestUtilities` (mock builders, config builders,
+  data generators) and `NewRelic.Testing.Assertions` (metric / trace /
+  span / event asserts).
+- **`PublicApiChangeTests`** compares the current public API surface to a
+  baseline; breaking changes intentional? Update the baseline explicitly.
+- **Never use `InternalsVisibleTo`** to reach non-public code — refactor
+  the production type instead (see root claude.md).
 
-### Location
+CLI build/test commands — including the `-p:SolutionDir=…` workaround for
+`Core.UnitTest` and the DLL-direct workaround for
+`NewRelic.Agent.Extensions.Tests` — are in the [root claude.md](../claude.md).
 
-All unit tests are in [Agent/UnitTests/](Agent/UnitTests/)
+## Integration tests
 
-### Key Test Projects
+**Pattern:** start a test application with the agent attached, exercise
+its endpoints, wait for a harvest, then assert on the parsed agent log.
 
-#### Core.UnitTest
-
-Tests for the main agent core functionality.
-
-**Test Coverage:**
-- Transaction management
-- Segment creation
-- Metric aggregation
-- Configuration loading
-- Data serialization
-- Distributed tracing
-- Error handling
-- API implementations
-
-**Example Test Structure:**
 ```csharp
-[TestFixture]
-public class TransactionTests
-{
-    [Test]
-    public void Transaction_HasCorrectName()
-    {
-        // Arrange
-        var transaction = CreateTransaction();
-
-        // Act
-        transaction.SetWebTransactionName("Category", "Name");
-
-        // Assert
-        Assert.That(transaction.TransactionName.Name, Is.EqualTo("Name"));
-    }
-}
-```
-
-#### NewRelic.Agent.Extensions.Tests
-
-Tests for extension providers and wrappers.
-
-**Test Coverage:**
-- Wrapper implementations
-- Storage providers
-- Instrumentation logic
-- Framework-specific behavior
-
-#### CompositeTests
-
-Tests that span multiple components or test complex interactions.
-
-**Test Coverage:**
-- Agent initialization
-- End-to-end workflows
-- Configuration scenarios
-- Cross-cutting concerns
-
-#### AsyncLocalTests
-
-Specialized tests for async context management.
-
-**Test Coverage:**
-- AsyncLocal behavior
-- CallContext behavior
-- Context flow across async/await
-- Thread local storage
-
-#### ParsingTests
-
-Tests for parsing and serialization logic.
-
-**Test Coverage:**
-- SQL parsing
-- Configuration parsing
-- JSON serialization
-- Protocol parsing
-
-#### PublicApiChangeTests
-
-Tests that detect breaking changes to public API.
-
-**Purpose:**
-- Prevent accidental API changes
-- Enforce semantic versioning
-- Document API surface
-
-**Approach:**
-- Compares current API to baseline
-- Fails if breaking changes detected
-- Must be explicitly updated for intentional changes
-
-### Running Unit Tests
-
-**Visual Studio:**
-1. Open Test Explorer (Test > Test Explorer)
-2. Click "Run All Tests"
-3. Or right-click project/test and "Run Tests"
-
-**Command Line:**
-```bash
-dotnet test tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
-```
-
-**Run All Unit Tests:**
-```bash
-dotnet test --filter "FullyQualifiedName~UnitTest"
-```
-
-### Test Frameworks
-
-The agent test suite uses multiple testing frameworks:
-
-- **NUnit** - Primary test framework for unit tests
-- **XUnit** - Used for integration tests and some unit tests
-- Custom assertions in `NewRelic.Testing.Assertions`
-
-**When to use each:**
-- **NUnit**: Default choice for unit tests, provides rich assertion library
-- **XUnit**: Preferred for integration tests, better isolation between tests (creates new instance per test)
-
-### Mocking Framework
-
-- **Telerik JustMock Lite** - Free version of JustMock used for mocking
-- **Important limitation**: Tests can only use features available in the free JustMock Lite version
-- **What's available**: Mock interfaces, virtual methods, properties
-- **Not available**: Mock sealed classes, non-virtual methods, static methods (these require paid version)
-
-**Example:**
-```csharp
-// JustMock Lite - creating mocks
-var mockAgent = Mock.Create<IAgent>();
-var mockTransaction = Mock.Create<ITransaction>();
-
-// Arranging behavior
-Mock.Arrange(() => mockAgent.CurrentTransaction).Returns(mockTransaction);
-
-// Asserting
-Mock.Assert(() => mockTransaction.AddCustomAttribute("key", "value"), Occurs.Once());
-```
-
-**Design consideration**: When writing testable code, prefer interfaces and virtual methods to ensure they can be mocked with JustMock Lite.
-
-### Testing Utilities
-
-#### NewRelic.Agent.TestUtilities
-
-Common utilities for unit tests:
-- Mock builders
-- Test data generators
-- Helper methods
-- Configuration builders
-
-**Example:**
-```csharp
-var mockAgent = Mock.Create<IAgent>();
-var transaction = new TransactionBuilder()
-    .WithName("MyTransaction")
-    .WithSegments(3)
-    .Build();
-```
-
-#### NewRelic.Testing.Assertions
-
-Custom assertions for agent-specific validation:
-- Metric assertions
-- Transaction trace assertions
-- Event assertions
-- Span assertions
-
-**Example:**
-```csharp
-MetricAssertions.ExpectMetric(metrics, "WebTransaction/MVC/Home/Index");
-```
-
-## Integration Tests
-
-Integration tests run the agent against real applications and verify end-to-end behavior.
-
-### Test Types
-
-1. **Regular Integration Tests** - Tests that run on host machine
-2. **Container Integration Tests** - Tests that run in Docker
-3. **Unbounded Integration Tests** - Tests requiring external infrastructure
-
-### Integration Test Structure
-
-#### Test Applications ([IntegrationTests/Applications/](Agent/IntegrationTests/Applications/))
-
-Real applications instrumented by the agent:
-- ASP.NET Framework applications
-- ASP.NET Core applications
-- Console applications
-- Windows Services
-- Azure Functions
-- AWS Lambda functions
-
-**Example Applications:**
-- `BasicMvcApplication` - Simple ASP.NET MVC app
-- `AspNetCoreBasicWebApiApplication` - ASP.NET Core API
-- `ConsoleMultiFunctionApplicationFW` - Multi-framework console app
-- `Owin2WebApi` - OWIN-based application
-- Many framework-specific test apps
-
-**Application Structure:**
-Each test application:
-- Is a real, runnable application
-- Includes instrumented code paths
-- Has endpoints/methods that trigger specific behavior
-- Can be started programmatically by tests
-
-#### Integration Tests ([IntegrationTests/IntegrationTests/](Agent/IntegrationTests/IntegrationTests/))
-
-Test classes that exercise the applications.
-
-**Test Pattern:**
-1. Start test application with agent attached
-2. Exercise application (HTTP requests, method calls, etc.)
-3. Wait for agent to harvest data
-4. Retrieve agent data from application
-5. Assert on metrics, traces, events, spans
-
-**Example Test:**
-```csharp
-[TestFixture]
 public class BasicMvcTests : NewRelicIntegrationTest<AspNetFrameworkBasicMvcApplication>
 {
     private readonly AspNetFrameworkBasicMvcApplication _fixture;
 
-    public BasicMvcTests()
-    {
-        _fixture = new AspNetFrameworkBasicMvcApplication();
-    }
+    public BasicMvcTests() => _fixture = new AspNetFrameworkBasicMvcApplication();
 
     [Test]
-    public void HomeIndexCreatesTransaction()
+    public void HomeIndexCreatesWebTransaction()
     {
-        // Act
         var result = _fixture.Get("Home/Index");
-
-        // Assert
         var metrics = _fixture.AgentLog.GetMetrics();
 
         Assert.Multiple(() =>
@@ -299,434 +90,160 @@ public class BasicMvcTests : NewRelicIntegrationTest<AspNetFrameworkBasicMvcAppl
 }
 ```
 
-### Integration Test Helpers
+**Where new test apps go** — three parallel directories under
+`tests/Agent/IntegrationTests/`:
+- `Applications/` — host-run .NET Framework / .NET apps for standard
+  integration tests.
+- `ContainerApplications/` — apps that run inside Docker for container
+  integration tests (Linux agent coverage, container-specific scenarios).
+- `UnboundedApplications/` — apps that exercise external infrastructure
+  (DBs, brokers) and are paired with `UnboundedServices/` docker compose.
 
-#### IntegrationTestHelpers
+**Prefer the MFA (Console MultiFunction App) pattern over writing a new
+test app.** Only create a new `*Applications/` project when the scenario
+requires a specific hosting model (IIS/OWIN, ASP.NET Core startup, WCF,
+Azure Functions, Lambda, etc.).
 
-Utilities for integration tests:
-- Application fixture base classes
-- HTTP client helpers
-- Agent log parsing
-- Metric/event/trace extractors
-- Timing utilities
+### Console MultiFunction App (MFA) pattern
 
-**Key Classes:**
-- `RemoteApplication` - Base class for test applications
-- `AgentLogFile` - Parses agent logs
-- `MetricWireModel` - Metric data model
-- `TransactionTraceWireModel` - Transaction trace model
-- `SpanEventWireModel` - Span event model
+Two shared console hosts dispatch string commands to **exerciser**
+classes; tests drive them via a `ConsoleDynamicMethodFixture*` fixture.
 
-#### Application Helpers ([ApplicationHelperLibraries/](Agent/IntegrationTests/ApplicationHelperLibraries/))
+**Projects** under `tests/Agent/IntegrationTests/SharedApplications/`:
+- `ConsoleMultiFunctionApplicationFW/` — .NET Framework host.
+- `ConsoleMultiFunctionApplicationCore/` — .NET (Core) host.
+- `Common/MultiFunctionApplicationHelpers/` — all exercisers live here,
+  grouped by instrumented library. Its csproj pins **oldest / minimum
+  supported** package versions per TFM (net462/471/48/481/8.0/10.0).
+- `Common/MFALatestPackages/` — parallel csproj pinning **latest**
+  versions (net481, net10.0). **When bumping a library to test a newer
+  version, edit this file, not the helpers csproj.**
 
-Libraries included in test applications:
-- `ConsoleDynamicMethodFixtureFWLatest` - Dynamic method testing
-- `LoggingHelpers` - Logging instrumentation testing
-- Test data generators
+**Exerciser shape:** `[Library]` on the class, `[LibraryMethod]` on each
+command entry point. Include at least one `[Transaction]`-marked method
+so the agent initializes. Example: `NetStandardLibraries/StackExchangeRedisExerciser.cs`.
 
-### Running Integration Tests
+Drive from a test: `_fixture.AddCommand("ExerciserClassName MethodName arg1 arg2")`
+then `_fixture.Initialize()`.
 
-**Prerequisites:**
-- Agent built (FullAgent.sln)
-- Agent home directories present in `src/Agent/newrelichome_*`
-- Docker Desktop (for container tests)
-- External services (for unbounded tests)
+**Fixture variants** (in `IntegrationTestHelpers/RemoteServiceFixtures/ConsoleDynamicMethodFixture.cs`):
+- FW: `FW462`, `FW471`, `FW48`, `FW481`, `FWLatest`
+- Core: `Core80`, `Core100`, `CoreOldest`, `CoreLatest`
+- Security-mode suffixes on `Latest` fixtures: `AIM` / `HSM` / `CSP`.
 
-**Visual Studio:**
-1. Set integration test project as startup project
-2. Run specific tests from Test Explorer
+To exercise the same scenario across runtimes, make the test class
+generic on the fixture type and derive concrete classes bound to
+`ConsoleDynamicMethodFixtureCoreLatest`, `…CoreOldest`, `…FWLatest`, etc.
 
-**Command Line:**
-```bash
-# Run all integration tests
-dotnet test tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+**Gotchas:**
+- Dispatcher matches commands to methods by parameter **count**, not
+  type — do not overload `[LibraryMethod]` methods, they fail silently.
+- Non-static exerciser classes need a parameterless constructor
+  (instantiated by reflection).
+- Exercisers must be in the helpers project; external assemblies aren't
+  resolved by the reflection-based loader unless directly referenced.
+- Use `Log.Info` / `Log.Error` inside exercisers — output is timestamped
+  and captured in test logs.
 
-# Run specific test
-dotnet test --filter "FullyQualifiedName~BasicMvcTests"
+**Key fixture types** (in `IntegrationTestHelpers/`):
+- `RemoteApplication` — base for test-app fixtures; owns app lifecycle,
+  env-var config, and log collection.
+- `AgentLogFile` — parses the agent log produced by the test run.
+- Wire models (`MetricWireModel`, `TransactionTraceWireModel`,
+  `SpanEventWireModel`, etc.) for strongly-typed assertions.
 
-# Run category
-dotnet test --filter "Category=AspNetCore"
-```
+**Configuring the agent in a test:** per-app `newrelic.config`, plus env
+vars via `fixture.SetEnvironmentVariable(...)`.
 
-**PowerShell Script:**
+**Collectors:** integration tests connect to **real New Relic staging
+collectors** using a shared test license key. The agent actually harvests
+and emits data; assertions then read telemetry back from the agent log
+(harvested payloads are captured there as well as sent). A small number
+of tests that need deterministic collector behavior — response-handling
+and connect-flow tests — use the `MockNewRelic` fixture
+(`tests/Agent/IntegrationTests/Applications/MockNewRelic/`) which stands
+in for the collector locally. If you're writing a new test, default to
+the staging collector unless you specifically need to simulate
+collector-side behavior.
+
+**Always use `NewRelicConfigModifier`** (in `IntegrationTestHelpers/`) to
+tweak `newrelic.config` for a test. **Never manipulate the XML directly**
+from a test class. If the setting you need doesn't already have a method
+on `NewRelicConfigModifier`, **add one** — don't work around it with
+ad-hoc XML edits. There is a parallel `WebConfigModifier` for
+`web.config` changes in ASP.NET Framework test apps; same rule applies.
+Keeping all config mutation routed through these helpers makes test
+setup readable and the supported config surface visible in one place.
+
+**Running from the CLI:**
 ```powershell
+dotnet test tests/Agent/IntegrationTests/IntegrationTests/IntegrationTests.csproj
+dotnet test --filter "FullyQualifiedName~BasicMvcTests"
+dotnet test --filter "Category=AspNetCore"
+
+# or via the bundled PowerShell helper
 .\build\Scripts\run-integration-tests.ps1
 ```
 
-### Container Integration Tests
-
-Tests that run applications in Docker containers.
-
-**Location:** [IntegrationTests/ContainerIntegrationTests/](Agent/IntegrationTests/ContainerIntegrationTests/)
-
-**Purpose:**
-- Test Linux agent
-- Test in isolated environment
-- Test container-specific scenarios
-- Test with different base images
-
-**Container Applications:** [IntegrationTests/ContainerApplications/](Agent/IntegrationTests/ContainerApplications/)
-
-**Example:**
-```csharp
-[TestFixture]
-public class AspNetCoreDistTracingTests : NewRelicIntegrationTest<AspNetCoreDistTracingApplication>
-{
-    private readonly AspNetCoreDistTracingApplication _fixture;
-
-    public AspNetCoreDistTracingTests()
-    {
-        _fixture = new AspNetCoreDistTracingApplication();
-    }
-
-    [Test]
-    public void DistributedTracingWorksInContainer()
-    {
-        // Test distributed tracing in containerized app
-    }
-}
-```
-
-**Running:**
-```bash
-dotnet test tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
-```
-
-### Unbounded Integration Tests
-
-Tests requiring external infrastructure (databases, message queues, etc.).
-
-**Location:** [IntegrationTests/UnboundedIntegrationTests/](Agent/IntegrationTests/UnboundedIntegrationTests/)
-
-**Infrastructure:**
-- MySQL
-- PostgreSQL
-- Microsoft SQL Server
-- MongoDB
-- Redis
-- RabbitMQ
-- Kafka
-- Elasticsearch
-- Couchbase
-- And more...
-
-**Setup:**
-Some tests use docker-compose to start infrastructure:
-```yaml
-# Example docker-compose.yml
-services:
-  mysql:
-    image: mysql:8.0
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-  redis:
-    image: redis:6
-  rabbitmq:
-    image: rabbitmq:3-management
-```
-
-**Running:**
-```bash
-# Start infrastructure
-docker-compose up -d
-
-# Run unbounded tests
-dotnet test tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
-```
-
-### Integration Test Configuration
-
-Tests use configuration files to control agent behavior:
-
-**newrelic.config:**
-Each test application can have custom configuration:
-```xml
-<configuration>
-  <service licenseKey="INTEGRATION_TEST_KEY"/>
-  <application>
-    <name>IntegrationTestApp</name>
-  </application>
-  <transactionTracer enabled="true"/>
-  <distributedTracing enabled="true"/>
-</configuration>
-```
-
-**Environment Variables:**
-Tests set environment variables to configure agent:
-```csharp
-fixture.SetEnvironmentVariable("NEW_RELIC_LICENSE_KEY", "test_key");
-fixture.SetEnvironmentVariable("NEW_RELIC_HOST", "fake_collector");
-```
-
-## Test Data Models
-
-### Models Project ([IntegrationTests/Models/](Agent/IntegrationTests/Models/))
-
-Data models for agent telemetry:
-- `MetricWireModel` - Metrics sent to New Relic
-- `TransactionTraceWireModel` - Transaction traces
-- `TransactionEventWireModel` - Transaction events
-- `ErrorEventWireModel` - Error events
-- `SpanEventWireModel` - Span events
-- `CustomEventWireModel` - Custom events
-- `LogEventWireModel` - Log events
-
-**Purpose:**
-- Deserialize agent output
-- Strongly-typed assertions
-- Schema validation
-
-## Testing Best Practices
-
-### Unit Tests
-
-**Do:**
-- Test one thing per test
-- Use descriptive test names
-- Arrange-Act-Assert pattern
-- Mock external dependencies using JustMock Lite
-- Test edge cases and error conditions
-- Keep tests fast
-- Design code with interfaces and virtual methods for mockability
-
-**Don't:**
-- Access file system or network
-- Depend on test execution order
-- Use Thread.Sleep (use synchronization)
-- Test framework code (trust the framework)
-- Create code that requires paid mocking features (sealed classes, static methods, non-virtual methods)
-
-### Integration Tests
-
-**Do:**
-- Test realistic scenarios
-- Verify end-to-end behavior
-- Test agent with real frameworks
-- Assert on actual telemetry
-- Clean up resources
-- Use appropriate timeouts
-
-**Don't:**
-- Make tests flaky
-- Depend on external services (use unbounded tests)
-- Skip error handling
-- Hard-code timing assumptions
-
-### Test Naming
-
-**Convention:**
-```
-MethodName_Scenario_ExpectedBehavior
-```
-
-**Examples:**
-- `CreateTransaction_WithWebRequest_SetsWebTransactionName`
-- `GetMetrics_WhenNoData_ReturnsEmptyCollection`
-- `DistributedTracing_AcrossTwoServices_CreatesConnectedSpans`
-
-## Debugging Tests
-
-### Unit Tests
-
-1. Set breakpoint in test
-2. Right-click test in Test Explorer
-3. Select "Debug Test"
-4. Step through code
-
-### Integration Tests
-
-1. Set breakpoint in test or agent code
-2. Debug integration test
-3. Agent runs in-process, so breakpoints work
-4. Check agent logs in test output
-
-**Agent Logs:**
-Tests typically capture agent logs:
-```csharp
-var logs = _fixture.AgentLog.GetFileLines();
-foreach (var log in logs)
-{
-    Console.WriteLine(log);
-}
-```
-
-### Container Tests
-
-1. Debug flag can make container wait for attach
-2. Remote debugging into container
-3. View container logs: `docker logs <container-id>`
-
-## Test Infrastructure
-
-### Fake Collector
-
-Integration tests use a fake New Relic collector:
-- Receives agent data
-- Returns configuration
-- Allows data retrieval for assertions
-- No actual data sent to New Relic
-
-### Test Fixtures
-
-**Application Fixtures:**
-- Manage application lifecycle
-- Start/stop applications
-- Configure agent
-- Collect telemetry
-- Provide helper methods
-
-**Example Lifecycle:**
-1. Constructor: Configure application
-2. Test Setup: Start application and agent
-3. Test: Exercise application
-4. Test Teardown: Stop application
-5. Dispose: Clean up resources
-
-## Code Coverage
-
-Code coverage tracked via Codecov.
-
-**Running with Coverage:**
-```bash
-dotnet test --collect:"XPlat Code Coverage"
-```
-
-**Coverage Report:**
-- Uploaded to Codecov automatically by CI
-- Badge in README shows coverage percentage
-- PRs show coverage changes
-
-## Continuous Integration
-
-### GitHub Actions
-
-Tests run automatically on:
-- Every push
-- Every pull request
-- Scheduled (nightly)
-
-**Workflows:**
-- [../.github/workflows/all_solutions.yml](../.github/workflows/all_solutions.yml) - Main build and test workflow
-
-**Test Matrix:**
-- Multiple .NET versions
-- Multiple operating systems
-- Multiple configurations
-
-**Test Results:**
-- Published as workflow artifacts
-- Visible in PR checks
-- Failed tests block merge
-
-## Performance Tests
-
-While not a dedicated performance test suite, integration tests measure:
-- Agent overhead
-- Memory usage
-- Instrumentation impact
-
-**Monitoring:**
-- Watch for degradation in test execution time
-- Profile slow tests
-- Optimize hot paths
-
-## Testing New Instrumentation
-
-When adding new instrumentation:
-
-1. **Add Unit Tests**
-   - Test wrapper logic in isolation
-   - Test error handling
-   - Test configuration options
-
-2. **Create Test Application**
-   - New application or modify existing
-   - Exercise instrumented code path
-   - Include edge cases
-
-3. **Add Integration Test**
-   - Start application with agent
-   - Trigger instrumented behavior
-   - Assert on telemetry:
-     - Correct metrics created
-     - Spans have right attributes
-     - Transaction names correct
-     - No agent errors
-
-4. **Test Across Versions**
-   - Test with multiple framework versions
-   - Test backward compatibility
-   - Test forward compatibility
-
-## Troubleshooting Tests
-
-### Flaky Tests
-
-**Common Causes:**
-- Timing assumptions
-- Shared state between tests
-- External dependencies
-- Port conflicts
-
-**Solutions:**
-- Use proper synchronization
-- Isolate test state
-- Mock external dependencies
-- Use random/available ports
-
-### Integration Test Failures
-
-**Check:**
-1. Agent built successfully?
-2. Agent home directories present?
-3. Environment variables set correctly?
-4. Ports available?
-5. Agent logs for errors
-6. Test application logs
-
-**Agent Logs Location:**
-Tests typically put logs in temp directory. Check test output for path.
-
-### Container Test Failures
-
-**Check:**
-1. Docker Desktop running?
-2. Sufficient Docker resources?
-3. Image built successfully?
-4. Container started?
-5. Network connectivity?
-
-**Debug:**
-```bash
-# List containers
-docker ps -a
-
-# View container logs
-docker logs <container-id>
-
-# Exec into container
-docker exec -it <container-id> /bin/bash
-```
-
-## Test Configuration
-
-### test.runsettings
-
-Repository root contains [../test.runsettings](../test.runsettings) for test configuration:
-- Test timeout
-- Parallelization
-- Data collectors
-- Environment variables
-
-**Usage:**
-```bash
+**`test.runsettings`** at the repo root sets timeout, parallelization, and
+data collectors:
+```powershell
 dotnet test --settings test.runsettings
 ```
 
-## Related Documentation
+## Container integration tests
 
-- [Main repository guide](../claude.md) 
-- [Source code architecture](../src/claude-source.md)
-- [Build system]()../build/claude-build.md)
-- [Integration tests documentation](../docs/integration-tests.md)
+Under `tests/Agent/IntegrationTests/ContainerIntegrationTests/` with apps
+in `ContainerApplications/`. This is the primary coverage for the Linux
+agent and container-specific scenarios. Requires Docker Desktop.
+
+```powershell
+dotnet test tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
+```
+
+## Unbounded integration tests
+
+Tests that exercise real infrastructure — MySQL, PostgreSQL, SQL Server,
+MongoDB, Redis, RabbitMQ, Kafka, Elasticsearch, Couchbase, and more.
+
+Start the services first:
+```powershell
+cd tests/Agent/IntegrationTests/UnboundedServices
+docker compose up -d
+```
+
+Then:
+```powershell
+dotnet test tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
+```
+
+## Troubleshooting
+
+**Integration test failures — check in this order:**
+1. Did `FullAgent.sln` build successfully?
+2. Are the `src/Agent/newrelichome_*` directories present and up to date?
+3. Are the expected env vars set on the fixture?
+4. Ports free (test apps bind to localhost)?
+5. Agent log — each test writes one under a temp path that appears in the
+   test output; grep for `NR-ERROR` / `NR-FATAL` first.
+6. Test-application stdout/stderr captured by the fixture.
+
+**Container test failures — check:**
+1. Docker Desktop running with enough CPU / memory / disk?
+2. Did the container image build?
+3. Did the container actually start, and is it still running?
+4. Network reachable between the test host and the container?
+
+## CI
+
+GitHub Actions runs unit + integration tests on every PR via
+[`.github/workflows/all_solutions.yml`](../.github/workflows/all_solutions.yml).
+Code coverage goes to Codecov (badge in the repo README).
+
+## Related docs
+
+- [Main repository guide](../claude.md)
+- [Source architecture](../src/claude-source.md)
+- [Build system](../build/claude-build.md)
+- [Integration test details](../docs/integration-tests.md)
 - [Development guide](../docs/development.md)

--- a/tests/claude-tests.md
+++ b/tests/claude-tests.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-Four test layers. See the [root claude.md](../claude.md) for CLI build /
+Five test layers. See the [root claude.md](../claude.md) for CLI build /
 test commands and for the no-unit-tests-for-wrappers rule.
 
 - **Unit tests** — `tests/Agent/UnitTests/` (NUnit-primary, some xUnit)
@@ -9,6 +9,10 @@ test commands and for the no-unit-tests-for-wrappers rule.
   external infra (databases, brokers)
 - **Container integration tests** — `ContainerIntegrationTests.sln`, run
   instrumented apps inside Docker
+- **Performance tests** — `PerformanceTests.sln` in
+  `tests/Agent/PerformanceTests/`, measures agent overhead against a
+  containerized workload app; orchestrated via Python scripts, not
+  `dotnet test`
 
 All three integration solutions read from the built agent home
 directories, so **build `FullAgent.sln` first** before running them.
@@ -216,6 +220,56 @@ Then:
 ```powershell
 dotnet test tests/Agent/IntegrationTests/UnboundedIntegrationTests/UnboundedIntegrationTests.csproj
 ```
+
+## Performance tests
+
+Agent-overhead harness under `tests/Agent/PerformanceTests/`
+(`PerformanceTests.sln`). Not run via `dotnet test` — driven by Python
+orchestration scripts that spin up a Docker Compose stack, run a load
+test, and post-process the results.
+
+**Components:**
+- `PerformanceTestApp/` — ASP.NET Core workload app (.NET 10) with
+  endpoints exercising simple JSON, nested async, MongoDB CRUD, Redis
+  CRUD, RabbitMQ publish/consume, and a health probe.
+- `TrafficDriver/` — Python / Locust container that drives a weighted
+  mix of requests and enforces a <1% error-rate threshold.
+- `ReportGenerator/` — .NET console app that reads Locust and Docker
+  stats CSVs and emits ScottPlot PNG charts plus a `summary.md`.
+- `run-perf-test.py` — orchestrates a single run (writes `extra.env`,
+  starts Compose, polls health, collects Docker stats, validates
+  results). Results → `results/`, logs → `logs/`.
+- `run-perf-comparison.py` — runs multiple sequential configurations
+  (e.g. no-agent baseline, local build, release, CI artifact) defined in
+  `compare.yml`, then invokes `ReportGenerator` across the collected
+  result sets.
+
+**How the agent is attached:** `run-perf-test.py` bind-mounts the
+supplied agent-home directory into the container at
+`/usr/local/newrelic-dotnet-agent` and sets `CORECLR_ENABLE_PROFILING=1`
+(or `0` for the no-agent baseline). The `agent-home/` directory is
+repopulated before each run — from a local path, a downloaded archive,
+or a GitHub Actions artifact — and cleared between runs so no files
+from a previous run linger.
+
+**Typical local use:**
+```powershell
+cd tests/Agent/PerformanceTests
+
+# No-agent baseline
+python run-perf-test.py
+
+# With agent attached
+python run-perf-test.py `
+  --attach-agent true `
+  --agent-home <path>/newrelichome_x64_coreclr_linux `
+  --license-key $env:NEW_RELIC_LICENSE_KEY
+```
+
+Prerequisites: Docker Desktop in Linux-containers mode, Python 3, and
+`pip install pyyaml` for the comparison runner. Full option reference
+and CI wiring are in
+[PerformanceTests/README.md](Agent/PerformanceTests/README.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
Consolidate and trim the `claude.md` / `claude-*.md` family of docs so each file is high-signal context for AI retrieval. Net **-1264 lines** across four doc files. No code changes.

## What changed
- **`claude.md`** — cut generic APM/boilerplate content; kept and added repo-specific, non-obvious facts: `maxVersion` exclusive semantics, CLI build workarounds (`SolutionDir`, Extensions-DLL-direct), `InternalsVisibleTo` prohibition, file-scoped-namespaces-are-a-build-error, unused-usings-fail-the-build, `VisibilityBypasser` preference, runtime extensions folder layout.
- **`src/claude-source.md`** — orientation map for `src/`; added performance principles for hot-path code, `IWrapper` minimal example with `IsTransactionRequired` + `CanWrap`, profiler-attach debugging signals, and relocated the `Configuration.xsd` / `xsd2code` regeneration command here from the root.
- **`build/claude-build.md`** — verified NuGet package IDs against the actual nuspecs and corrected two fabricated names (`NewRelic.Azure.WebSites.x86` → `NewRelic.Azure.WebSites`; `NewRelic.Azure.CloudServices` → `NewRelicWindowsAzure`); added troubleshooting checklists.
- **`tests/claude-tests.md`** — documented the MFA (Console MultiFunction App) pattern as the preferred integration/unbounded test approach, including the `MFALatestPackages` vs `MultiFunctionApplicationHelpers` version-pinning split, fixture variant catalog (`FW462`…`Core100`, `CoreOldest`/`CoreLatest`, `AIM`/`HSM`/`CSP`), exerciser gotchas. Corrected the prior "fake collector" claim — tests actually connect to real New Relic staging collectors (`MockNewRelic` is only used for a small set of connect-flow/response-handling tests). Documented the `NewRelicConfigModifier` requirement (no direct XML edits from tests). Added placement rules for new test apps across `Applications/` / `ContainerApplications/` / `UnboundedApplications/`.
- **`.claude/settings.json`** — add `Bash(xsd2code *)` to the team-wide allow list so the documented `Configuration.xsd` regeneration command runs without per-user prompting.
- Update `check_modified_files.yml` to exclude `*.md` and other common, non-code files.
## Cross-cutting fixes
- References to "Visual Studio 2022" replaced with "latest Visual Studio".
- Removed hard-coded developer paths (`C:\Source\repos\newrelic-dotnet-agent\...`) in favor of `Resolve-Path`-based / relative commands.
- Corrected broken / stale cross-doc pointers.

## Test plan
- [x] No code or test changes; CI expected green.
- [x] Review each file for accuracy against current repo state.