### PR TITLE
fix: Ensure all StackExchange.Redis segments are created and added to transaction before it is harvested

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
+++ b/src/Agent/NewRelic/Agent/Core/Segments/Segment.cs
@@ -113,17 +113,17 @@ public class Segment : IInternalSpan, ISegmentDataState, IHybridAgentSegment
 
     public Segment(ITransactionSegmentState transactionSegmentState, MethodCallData methodCallData)
     {
+        Combinable = false;
+        IsLeaf = false;
+        IsAsync = methodCallData.IsAsync;
         ThreadId = transactionSegmentState.CurrentManagedThreadId;
         RelativeStartTime = transactionSegmentState.GetRelativeTime();
         _transactionSegmentState = transactionSegmentState;
         ParentUniqueId = transactionSegmentState.ParentSegmentId();
-        UniqueId = transactionSegmentState.CallStackPush(this);
         MethodCallData = methodCallData;
         Data = new MethodSegmentData(methodCallData.TypeName, methodCallData.MethodName);
+        UniqueId = transactionSegmentState.CallStackPush(this);
         Data.AttachSegmentDataState(this);
-        Combinable = false;
-        IsLeaf = false;
-        IsAsync = methodCallData.IsAsync;
     }
 
     /// <summary>
@@ -135,18 +135,18 @@ public class Segment : IInternalSpan, ISegmentDataState, IHybridAgentSegment
     /// <param name="relativeEndTime"></param>
     public Segment(ITransactionSegmentState transactionSegmentState, MethodCallData methodCallData, TimeSpan relativeStartTime, TimeSpan relativeEndTime)
     {
+        Combinable = false;
+        IsLeaf = true;
+        IsAsync = methodCallData.IsAsync;
         ThreadId = transactionSegmentState.CurrentManagedThreadId;
         RelativeStartTime = relativeStartTime;
         RelativeEndTime = relativeEndTime;
         _transactionSegmentState = transactionSegmentState;
         ParentUniqueId = transactionSegmentState.ParentSegmentId();
-        UniqueId = transactionSegmentState.CallStackPush(this);
         MethodCallData = methodCallData;
         Data = new MethodSegmentData(methodCallData.TypeName, methodCallData.MethodName);
+        UniqueId = transactionSegmentState.CallStackPush(this);
         Data.AttachSegmentDataState(this);
-        Combinable = false;
-        IsLeaf = true;
-        IsAsync = methodCallData.IsAsync;
     }
 
     /// <summary>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/StackExchangeRedis2Plus/SessionCache.cs
@@ -62,21 +62,32 @@ public class SessionCache : IStackExchangeRedisCache
 
         var xTransaction = (ITransactionExperimental)transaction;
         var commands = sessionData.session.FinishProfiling();
-        foreach (var command in commands)
+
+        // Hold the transaction open while we create and finish segments for each command.  This allows us to get the timing information into the transaction
+        // and ensures the segments are created before the transaction is potentially finished from another thread
+        transaction.Hold();
+        try
         {
-            // We need to build the relative start and stop time based on the transaction start time.
-            var relativeStartTime = command.CommandCreated - xTransaction.StartTime;
-            var relativeEndTime = relativeStartTime + command.ElapsedTime;
+            foreach (var command in commands)
+            {
+                // We need to build the relative start and stop time based on the transaction start time.
+                var relativeStartTime = command.CommandCreated - xTransaction.StartTime;
+                var relativeEndTime = relativeStartTime + command.ElapsedTime;
 
-            // This new segment maker accepts relative start and stop times since we will be starting and ending(RemoveSegmentFromCallStack) the segment immediately.
-            // This also sets the segment as a Leaf.
-            var segment = xTransaction.StartStackExchangeRedisSegment(_invocationTargetHashCode,
-                ParsedSqlStatement.FromOperation(DatastoreVendor.Redis, command.Command),
-                GetConnectionInfo(command.EndPoint), relativeStartTime, relativeEndTime);
+                // This new segment maker accepts relative start and stop times since we will be starting and ending(RemoveSegmentFromCallStack) the segment immediately.
+                // This also sets the segment as a Leaf.
+                var segment = xTransaction.StartStackExchangeRedisSegment(_invocationTargetHashCode,
+                    ParsedSqlStatement.FromOperation(DatastoreVendor.Redis, command.Command),
+                    GetConnectionInfo(command.EndPoint), relativeStartTime, relativeEndTime);
 
-            // This version of End does not set the end time or check for redis Harvests
-            // This calls Finish and removes the segment from the callstack.
-            segment.EndStackExchangeRedis();
+                // This version of End does not set the end time or check for redis Harvests
+                // This calls Finish and removes the segment from the callstack.
+                segment.EndStackExchangeRedis();
+            }
+        }
+        finally
+        {
+            transaction.Release();
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes a problem with our StackExchange.Redis instrumentation, where a transaction with Redis activity could be harvested and transformed while Redis segments were still being added to the transaction.  This could lead to a null reference exception (caused by an uninitialized `Data` property) being logged as an error in the agent logs and telemetry data being lost.

The fix is twofold:
1. During StackExchangeRedis segment harvest, hold the parent transaction open until harvest is completed.
2. Reorder `Segment` constructor methods to make sure that the `Data` property is initialized before making the segment available to other objects.

Note that the second change is not strictly necessary to prevent the issue, but "leaking this from a constructor" is an antipattern and I want to make our use of it as safe as possible by making sure that the statements that do it happen at the very end of the constructor methods.

No additional unit or integration tests are necessary; this issue was only observed in the context of the performance test application which is a very high-throughput synthetic benchmarking scenario.  In my development testing, before applying the transaction hold/release pattern, the null reference exception would happen every time I ran the performance test locally, for five minutes, with the endpoint mix set to only exercise Redis.  After applying the fix, the same exact test process ran 40 times without seeing the problem, making me confident that the issue is really fixed.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
