### PR TITLE
ci: Switch build_profiler workflow to NuGet trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 # only allow one instance of this workflow to be running per PR or branch, cancels any that are already running
 concurrency:
@@ -270,6 +271,8 @@ jobs:
     if: ${{ inputs.deploy }}
     name: Package and Deploy Profiler NuGet
     runs-on: windows-2022
+    permissions:
+      id-token: write
 
     env:
       nuget_source: https://www.nuget.org
@@ -331,17 +334,19 @@ jobs:
           nuget pack ${{ github.workspace }}/build/Packaging/NugetProfiler/NewRelic.Profiler.nuspec -BasePath ${{ github.workspace }}/_workingDir -OutputDirectory ${{ github.workspace }}/_workingDir/NugetProfiler -Version ${{ steps.agentVersion.outputs.version }} -Verbosity detailed
         shell: powershell
 
-      - name: Setup NuGet API Key
-        run: |
-          nuget.exe setApiKey ${{ secrets.NUGET_APIKEY }} -Source ${{ env.nuget_source }}
-        shell: pwsh
+      # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_TRUSTED_PUBLISH_POLICY_USER }}
 
       - name: Deploy Profiler Package to Nuget
         run: |
           $packageName = Get-ChildItem ${{ github.workspace }}/_workingDir/NugetProfiler/NewRelic.Agent.Internal.Profiler.*.nupkg -Name
           $packagePath = Convert-Path ${{ github.workspace }}//_workingDir/NugetProfiler/$packageName
           $version = $packageName.TrimStart('NewRelic.Agent.Internal.Profiler').TrimStart('.').TrimEnd('.nupkg')
-          nuget.exe push $packagePath -Source ${{ env.nuget_source }}
+          dotnet nuget push $packagePath --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source ${{ env.nuget_source }}
         shell: powershell
 
   update-nuget-reference:


### PR DESCRIPTION
## Summary

- Replaces the `NUGET_APIKEY` secret with the `NuGet/login` OIDC action to obtain a short-lived API key in the `package-and-deploy` job
- Adds `id-token: write` to both the top-level permissions and the job-level permissions (required for OIDC token issuance)
- Switches `nuget.exe push` to `dotnet nuget push --api-key` to match the pattern used elsewhere

This brings `build_profiler.yml` in line with `deploy_agent.yml` and `deploy_siteextension.yml`, which were already updated to use trusted publishing. Scanning all other workflows confirmed no further changes are needed.

## Test plan

- [ ] Verify the workflow runs successfully on next manual `workflow_dispatch` with `deploy: true`
- [x] Confirm the `NUGET_APIKEY` secret is no longer needed by this workflow (only `NUGET_TRUSTED_PUBLISH_POLICY_USER` is required)