### PR TITLE
test: Handle new collector entity-redirect URL format in integration test helpers

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -105,22 +105,41 @@ public abstract class AgentLogBase
 
     public string GetAccountId()
     {
-        var reportingAppLink = GetReportingAppLink();
-        var reportingAppUri = new Uri(reportingAppLink);
-        var accountId = reportingAppUri.Segments[2];
-        if (accountId == null)
-            throw new Exception("Could not find account ID in second segment of reporting app link: " + reportingAppLink);
-        return accountId.TrimEnd('/');
+        var (accountId, _) = ParseReportingAppLink();
+        return accountId;
     }
 
     public string GetApplicationId()
     {
+        var (_, applicationId) = ParseReportingAppLink();
+        return applicationId;
+    }
+
+    // Handles both URL formats the collector has used:
+    //   Old: https://rpm.newrelic.com/accounts/{accountId}/applications/{appId}
+    //   New: https://.../redirect/entity/{base64({accountId}|APM|APPLICATION|{appId})}
+    private (string accountId, string applicationId) ParseReportingAppLink()
+    {
         var reportingAppLink = GetReportingAppLink();
-        var reportingAppUri = new Uri(reportingAppLink);
-        var applicationId = reportingAppUri.Segments[4];
-        if (applicationId == null)
-            throw new Exception("Could not find application ID in second segment of reporting app link: " + reportingAppLink);
-        return applicationId.TrimEnd('/');
+        var uri = new Uri(reportingAppLink);
+
+        // New entity-redirect format: /redirect/entity/{base64EncodedEntityGuid}
+        if (uri.Segments.Length >= 4 && uri.Segments[1].TrimEnd('/') == "redirect" && uri.Segments[2].TrimEnd('/') == "entity")
+        {
+            var encoded = uri.Segments[3].TrimEnd('/');
+            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            // decoded format: "{accountId}|APM|APPLICATION|{appId}"
+            var parts = decoded.Split('|');
+            if (parts.Length >= 4)
+                return (parts[0], parts[3]);
+            throw new Exception($"Unexpected entity GUID format in reporting app link: {decoded}");
+        }
+
+        // Legacy format: /accounts/{accountId}/applications/{appId}
+        if (uri.Segments.Length >= 5)
+            return (uri.Segments[2].TrimEnd('/'), uri.Segments[4].TrimEnd('/'));
+
+        throw new Exception($"Could not parse account/application IDs from reporting app link: {reportingAppLink}");
     }
 
     public string GetCrossProcessId()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -126,8 +126,7 @@ public abstract class AgentLogBase
         // New entity-redirect format: /redirect/entity/{base64EncodedEntityGuid}
         if (uri.Segments.Length >= 4 && uri.Segments[1].TrimEnd('/') == "redirect" && uri.Segments[2].TrimEnd('/') == "entity")
         {
-            var encoded = uri.Segments[3].TrimEnd('/');
-            var decoded = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            var decoded = System.Text.Encoding.UTF8.GetString(System.Buffers.Text.Base64Url.DecodeFromChars(uri.Segments[3].TrimEnd('/')));
             // decoded format: "{accountId}|APM|APPLICATION|{appId}"
             var parts = decoded.Split('|');
             if (parts.Length >= 4)


### PR DESCRIPTION
## Summary

- The NR collector changed the "Reporting to:" URL in its connect response from `/accounts/{id}/applications/{id}` to `/redirect/entity/{base64urlEntityGuid}`, where the base64url value decodes to `{accountId}|APM|APPLICATION|{appId}`
- `GetApplicationId()` in `AgentLogBase.cs` was accessing `Segments[4]` on the new 4-segment URL, throwing `IndexOutOfRangeException` and causing ~10 test suites to fail consistently on `main`
- `GetAccountId()` was silently returning `"entity"` instead of the actual account ID on the new URL format

The new private `ParseReportingAppLink()` method detects both URL formats. For the new format it uses `System.Buffers.Text.Base64Url.DecodeFromChars` (available since .NET 8) to correctly decode the entity GUID and extract both IDs.

## Test plan

- [x] `OwinDTChainTests` — passes locally
- [x] `HttpClientW3CTestsNetCore` — passes locally
- [x] `HttpWebRequestW3CTestsNetCore` — passes locally
- [x] `HttpClientW3CTests` — passes locally
- [x] `CatInbound` — passes locally
- [ ] `WCF DT` — requires IIS hosting, covered by CI
- [ ] `RabbitMq legacy W3C` — covered by CI