### PR TITLE
ci: Switch profiler Windows build to windows-2025-vs2026 runner and v145 toolset

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-windows-profiler:
     name: Build Windows Profiler & Run Unit Tests / Code Coverage
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     needs: check-modified-files
     # only run this job if source files were modified, or if triggered by a manual execution
     if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}
@@ -82,13 +82,13 @@ jobs:
           Write-Host "List NuGet Sources"
           dotnet nuget list source # For unknown reasons, this step is necessary to avoid subsequent problems with NuGet package restore
           Write-Host "MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}"
-          MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release ${{ env.profiler_solution_path }}
+          MSBuild.exe -restore -m -p:Platform=x64 -p:Configuration=Release -p:NativeToolset=v145 ${{ env.profiler_solution_path }}
         shell: powershell
 
       - name: Build x86
         run: |
           Write-Host "MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}"
-          MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release ${{ env.profiler_solution_path }}
+          MSBuild.exe -restore -m -p:Platform=Win32 -p:Configuration=Release -p:NativeToolset=v145 ${{ env.profiler_solution_path }}
         shell: powershell
         
       - name: Setup VSTest and add to PATH
@@ -267,7 +267,7 @@ jobs:
       ]
     if: ${{ inputs.deploy }}
     name: Package and Deploy Profiler NuGet
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     permissions:
       id-token: write
 

--- a/src/Agent/NewRelic/Profiler/Directory.Build.props
+++ b/src/Agent/NewRelic/Profiler/Directory.Build.props
@@ -2,16 +2,13 @@
 <!--
   Shared MSBuild properties for the native profiler solution.
 
-  NativeToolset defaults to v143 (VS 2022 / windows-2022 CI runner).
+  NativeToolset defaults to v145 (VS 2025 / windows-2025-vs2026 CI runner).
   To build with a different toolset without editing project files, pass
-  /p:NativeToolset=v145 on the MSBuild command line or set the property
+  /p:NativeToolset=vNNN on the MSBuild command line or set the property
   in a CI workflow before invoking MSBuild.
-
-  The v143->v145 cutover is tracked separately; it requires verifying ATL
-  availability on the target runner image before scheduling.
 -->
 <Project>
   <PropertyGroup>
-    <NativeToolset Condition="'$(NativeToolset)'==''">v143</NativeToolset>
+    <NativeToolset Condition="'$(NativeToolset)'==''">v145</NativeToolset>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Migrates the profiler Windows CI jobs from the `windows-2022` runner (scheduled for retirement) to `windows-2025-vs2026`, and updates the default MSVC toolset from v143 to v145 in both the CI workflow and `Directory.Build.props`.

**Commits:**
1. Switch CI runner to `windows-2025-vs2026` (both Windows jobs)
2. Update `Directory.Build.props` default from v143 → v145

## Why v145 is required on the new runner

The `windows-2025-vs2026` runner ships v145 ATL as its primary toolset. The v143 compiler sidecar is present on that image but has **no paired ATL** — building with v143 fails at link time. This is the root cause of the abandoned `ci/fix-profiler-build` branch from 2026-05-05.

## What was verified before opening this PR

| Check | Result |
|---|---|
| Build (x64 + x86 Release, v145, local VS 2026) | ✅ 0 errors, 0 warnings |
| Native unit tests x64 (313 tests, local) | ✅ 313/313 |
| Export surface (11 named exports, ordinals) | ✅ Identical to v143 build |
| DLL dependencies | ✅ Identical: KERNEL32, USER32, ADVAPI32, SHELL32, VERSION, SHLWAPI |
| CI build + unit tests on `windows-2025-vs2026` | ✅ [Run 25882756163](https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/25882756163) — all jobs green |

Binary output intentionally differs from the v143 build (different compiler = different codegen). Byte-identical is not the right gate for a toolset version upgrade; functional equivalence is.

## Merge gate: integration tests required

Unit tests confirm internal profiler logic. The full integration suite is required before merge to verify correct behavior in the actual CLR profiling path (IL injection, JIT hooking, method rewriting against real .NET apps):

- [ ] IntegrationTests.sln — full pass, no new failures
- [ ] UnboundedIntegrationTests.sln — full pass, no new failures
- [ ] ContainerIntegrationTests.sln — full pass including **AlpineX64** fixture

## Other notes

`darenm/Setup-VSTest` is pinned to a Node.js 20 action (GitHub deprecated; forced cutover to Node.js 24 on 2026-06-02). Pre-existing and unrelated to this change, but will need a version bump before that date.