### PR TITLE
chore: source aarch64 cmake from Kitware GitHub releases

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -231,9 +231,13 @@ jobs:
             apt-get install -q -y wget curl git dos2unix software-properties-common make binutils libc++-dev clang-3.9 lldb-3.9 build-essential
             echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
             wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-            curl -sSL https://virtuoso-testing.s3.us-west-2.amazonaws.com/cmake-3.9.0-rc3-aarch64.tar.gz | tar -xzC ~
-            chmod 777 ~/cmake-3.9.0-rc3-aarch64/bin/cmake
-            ln -s ~/cmake-3.9.0-rc3-aarch64/bin/cmake /usr/bin/cmake || true
+            CMAKE_VERSION=4.3.2
+            CMAKE_SHA256=377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481
+            curl -fsSL -o /tmp/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
+            echo "${CMAKE_SHA256}  /tmp/cmake.tar.gz" | sha256sum -c -
+            tar -xzC ~ -f /tmp/cmake.tar.gz
+            rm /tmp/cmake.tar.gz
+            ln -s ~/cmake-${CMAKE_VERSION}-linux-aarch64/bin/cmake /usr/bin/cmake || true
             rm /usr/bin/cc || true
             ln -s /usr/bin/clang-3.9 /usr/bin/cc
             rm /usr/bin/c++ || true

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -231,8 +231,13 @@ jobs:
             apt-get install -q -y wget curl git dos2unix software-properties-common make binutils libc++-dev clang-3.9 lldb-3.9 build-essential
             echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
             wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-            CMAKE_VERSION=4.3.2
-            CMAKE_SHA256=377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481
+            # Pinned to cmake 3.20.5: Kitware's post-3.20 Linux binaries are built against
+            # glibc 2.28+ and won't run on this Ubuntu 18.04 environment (glibc 2.27).
+            # Validated by the OTel .NET instrumentation project, which uses the same
+            # release on Ubuntu 16.04 (glibc 2.23) in production CI. See
+            # https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/ubuntu1604.dockerfile
+            CMAKE_VERSION=3.20.5
+            CMAKE_SHA256=d2fa6678e5f716de349be23f7096a935f35ed69caebea982f6d16368489c45a0
             curl -fsSL -o /tmp/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
             echo "${CMAKE_SHA256}  /tmp/cmake.tar.gz" | sha256sum -c -
             tar -xzC ~ -f /tmp/cmake.tar.gz

--- a/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
@@ -24,10 +24,13 @@ RUN apt-get install -q -y \
 RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
 RUN wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-RUN curl -sSL https://virtuoso-testing.s3.us-west-2.amazonaws.com/cmake-3.9.0-rc3-aarch64.tar.gz | tar -xzC ~
-RUN chmod 777 ~/cmake-3.9.0-rc3-aarch64/bin/cmake
-
-RUN ln -s ~/cmake-3.9.0-rc3-aarch64/bin/cmake /usr/bin/cmake || true
+ARG CMAKE_VERSION=4.3.2
+ARG CMAKE_SHA256=377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481
+RUN curl -fsSL -o /tmp/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" \
+ && echo "${CMAKE_SHA256}  /tmp/cmake.tar.gz" | sha256sum -c - \
+ && tar -xzC ~ -f /tmp/cmake.tar.gz \
+ && rm /tmp/cmake.tar.gz
+RUN ln -s ~/cmake-${CMAKE_VERSION}-linux-aarch64/bin/cmake /usr/bin/cmake || true
 RUN rm /usr/bin/cc || true
 RUN ln -s /usr/bin/clang-3.9 /usr/bin/cc
 RUN rm /usr/bin/c++ || true

--- a/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile
@@ -24,8 +24,14 @@ RUN apt-get install -q -y \
 RUN echo "deb https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
 RUN wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-ARG CMAKE_VERSION=4.3.2
-ARG CMAKE_SHA256=377079ab739f5765176f427609d9a2015b756ea20d5cba908d279c3731a2f481
+# Pinned to cmake 3.20.5 because Kitware's post-3.20 Linux binaries are built
+# against glibc 2.28+ and won't run on Ubuntu 18.04 (glibc 2.27). 3.20.5 was
+# the last release built on the old glibc baseline. Validated by the OTel
+# .NET instrumentation project, which uses the same release on Ubuntu 16.04
+# (glibc 2.23) in production CI:
+# https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/ubuntu1604.dockerfile
+ARG CMAKE_VERSION=3.20.5
+ARG CMAKE_SHA256=d2fa6678e5f716de349be23f7096a935f35ed69caebea982f6d16368489c45a0
 RUN curl -fsSL -o /tmp/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz" \
  && echo "${CMAKE_SHA256}  /tmp/cmake.tar.gz" | sha256sum -c - \
  && tar -xzC ~ -f /tmp/cmake.tar.gz \


### PR DESCRIPTION
## Summary

Replaces the NR-owned virtuoso-testing S3 dependency for aarch64 cmake with Kitware's official GitHub release artifact, pinned to v3.20.5 with SHA-256 verification before extraction.

## Why

The arm64 build container previously pulled cmake from `https://virtuoso-testing.s3.us-west-2.amazonaws.com/cmake-3.9.0-rc3-aarch64.tar.gz` — an NR-owned S3 bucket with no preservation guarantee. Kitware never published an official aarch64 binary for cmake 3.9, so somebody hand-built that tarball and put it on the bucket. If the bucket disappears, the arm64 build breaks with no notice.

This PR moves to Kitware's official GitHub releases for the aarch64 binary, with a pinned version + SHA-256 enforced before extraction.

## Why cmake 3.20.5 specifically

Kitware's post-3.20 Linux binaries are built against glibc 2.28+ and won't run on Ubuntu 18.04 (glibc 2.27) — the build container we use here. cmake 3.20.5 is the last release built on the older glibc baseline.

This is empirically validated by the OpenTelemetry .NET instrumentation project, which uses the same 3.20.5 release on Ubuntu 16.04 (glibc 2.23) in production CI. See [their ubuntu1604.dockerfile](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/ubuntu1604.dockerfile) — the comment there ("Kitware Xenial apt repo no longer serves cmake") was the smoking gun.

A comment explaining the version pin lives in both files so the next person doesn't try to bump it casually.

## What changed

- `linux/Arm64Dockerfile`: replaced the S3 cmake download with a SHA-pinned Kitware download. `Arm64Dockerfile` is currently orphaned (CI uses an inline install block in the workflow YAML), but it's kept aligned for the eventual consolidation.
- `.github/workflows/build_profiler.yml` arm64 inline install block: same change as above. This is the active code path today.

## Test plan

- [x] CI fully green on this branch (run 25926533239): Windows, Linux x64, Linux ARM64 all pass.
- [ ] Reviewer to confirm comment placement and pin justification.