### PR TITLE
chore: replace darenm/Setup-VSTest with inline vswhere lookup

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -92,8 +92,25 @@ jobs:
         shell: powershell
         
       - name: Setup VSTest and add to PATH
-        uses: darenm/Setup-VSTest@3a16d909a1f3bbc65b52f8270d475d905e7d3e44 # 1.3
-        id: setup_vstest
+        shell: powershell
+        run: |
+          $vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            Write-Error "vswhere.exe not found at $vswhere"
+            exit 1
+          }
+          $vsInstallPath = & $vswhere -latest -property installationPath
+          if (-not $vsInstallPath) {
+            Write-Error "vswhere did not return a Visual Studio installation path"
+            exit 1
+          }
+          $vstestDir = Join-Path $vsInstallPath "Common7\IDE\CommonExtensions\Microsoft\TestWindow"
+          if (-not (Test-Path (Join-Path $vstestDir "vstest.console.exe"))) {
+            Write-Error "vstest.console.exe not found at $vstestDir"
+            exit 1
+          }
+          Write-Host "Adding $vstestDir to PATH"
+          Add-Content -Path $env:GITHUB_PATH -Value $vstestDir
 
       - name: Setup OpenCppCoverage and add to PATH
         id: setup_opencppcoverage


### PR DESCRIPTION
## Summary

Replaces the `darenm/Setup-VSTest` GitHub Action with an inline PowerShell step that locates `vstest.console.exe` via `vswhere` and adds it to PATH.

## Why

The `darenm/Setup-VSTest` action is pinned to a Node.js 20 runtime, and GitHub Actions is deprecating Node.js 20. The upstream action's latest release (v1.3) still declares `using: 'node20'` in its action.yml — there's no Node.js 24 version, no PR for one, and no announced timeline.

The action's only behavior is: find Visual Studio via `vswhere`, then add `<installPath>\Common7\IDE\CommonExtensions\Microsoft\TestWindow` to PATH so subsequent steps can call `vstest.console.exe` naked. We can do that inline.

## What changed

In `build_profiler.yml`, the `Setup VSTest and add to PATH` step:

- Was: `uses: darenm/Setup-VSTest@3a16d909a1f3bbc65b52f8270d475d905e7d3e44 # 1.3`
- Now: a PowerShell `run:` block that calls `vswhere.exe` from its canonical install path (`C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe` — present with every VS install on GitHub-hosted Windows runners), gets the latest VS install path, and appends the TestWindow directory to `$env:GITHUB_PATH`.

Each step is bounded by an explicit existence check with a clear error message — vswhere missing, vswhere returning empty, or `vstest.console.exe` not at the expected path all fail fast with a descriptive message.

## Test plan

- [x] CI green on this branch (run 25928575715) — the `Generate Report` step calls `vstest.console.exe` naked, and a successful run proves the inline replacement put it on PATH correctly.