### PR TITLE
chore: consolidate arm64 profiler build onto docker compose + Arm64Dockerfile

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -213,10 +213,10 @@ jobs:
     if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}
     permissions:
       contents: read # for actions/checkout to fetch code
-      packages: write # for uraimo/run-on-arch-action to cache docker images
 
     env:
       profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
+      CORECLR_NEW_RELIC_HOME: ${{ github.workspace }}/src/Agent/NewRelic/newrelichome_arm64_coreclr_linux # not used but required by Profiler/docker-compose.yml
 
     steps:
       - name: Harden Runner
@@ -236,41 +236,17 @@ jobs:
           rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
         shell: bash
 
-      - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
-        name: Run commands
-        id: runcmd
+      - name: Set up QEMU for arm64 emulation
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
-          arch: aarch64
-          distro: ubuntu18.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update -q -y
-            apt-get install -q -y wget curl git dos2unix software-properties-common make binutils libc++-dev clang-3.9 lldb-3.9 build-essential
-            install -d -m 0755 /etc/apt/keyrings
-            wget --no-cache --no-cookies -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] https://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
-            # Pinned to cmake 3.20.5: Kitware's post-3.20 Linux binaries are built against
-            # glibc 2.28+ and won't run on this Ubuntu 18.04 environment (glibc 2.27).
-            # Validated by the OTel .NET instrumentation project, which uses the same
-            # release on Ubuntu 16.04 (glibc 2.23) in production CI. See
-            # https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/docker/ubuntu1604.dockerfile
-            CMAKE_VERSION=3.20.5
-            CMAKE_SHA256=d2fa6678e5f716de349be23f7096a935f35ed69caebea982f6d16368489c45a0
-            curl -fsSL -o /tmp/cmake.tar.gz "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
-            echo "${CMAKE_SHA256}  /tmp/cmake.tar.gz" | sha256sum -c -
-            tar -xzC ~ -f /tmp/cmake.tar.gz
-            rm /tmp/cmake.tar.gz
-            ln -s ~/cmake-${CMAKE_VERSION}-linux-aarch64/bin/cmake /usr/bin/cmake || true
-            rm /usr/bin/cc || true
-            ln -s /usr/bin/clang-3.9 /usr/bin/cc
-            rm /usr/bin/c++ || true
-            ln -s /usr/bin/clang++-3.9 /usr/bin/c++
-          dockerRunArgs: |
-            --volume "${{ env.profiler_path }}:/profiler"
-          run: |
-            cd /profiler
-            chmod 777 ./linux/build_profiler.sh
-            ./linux/build_profiler.sh
+          platforms: arm64
+
+      - name: Build Linux ARM64 Profiler
+        run: |
+          cd ${{ env.profiler_path }}
+          docker compose build build_arm64
+          docker compose run build_arm64
+        shell: bash
 
       - name: Move Profiler to staging folder
         run: |

--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -207,7 +207,7 @@ jobs:
 
   build-linux-arm64-profiler:
     name: Build Linux ARM64 Profiler
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     needs: check-modified-files
     # only run this job if source files were modified, or if triggered by a manual execution
     if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}
@@ -235,11 +235,6 @@ jobs:
           rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x64-Release || true
           rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/x86-Release || true
         shell: bash
-
-      - name: Set up QEMU for arm64 emulation
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          platforms: arm64
 
       - name: Build Linux ARM64 Profiler
         run: |

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.33"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.35"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.26"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.33"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Replaces the `uraimo/run-on-arch-action` step in the arm64 profiler build job with a native arm64 GitHub-hosted runner (`ubuntu-24.04-arm`) running `docker compose run build_arm64`. The `Arm64Dockerfile` becomes the single source of truth for the arm64 build environment, matching the pattern already used by the x64 build.

## Why

Two configurations described the arm64 build environment:

1. `src/Agent/NewRelic/Profiler/linux/Arm64Dockerfile` — referenced by `docker-compose.yml`'s `build_arm64` service, but **not used by CI**.
2. `.github/workflows/build_profiler.yml`'s arm64 inline `install:` block under `uraimo/run-on-arch-action` — the actual code path CI ran.

The two were kept in sync only by manual diligence — touching one and not the other meant silent drift between the orphaned Dockerfile and the live config. Recent PRs (#3590 cmake, #3591 apt-key) had to make matching edits in both places to keep them aligned.

This PR collapses the two onto `Arm64Dockerfile` and runs the build on a native arm64 runner, the same overall pattern that the OpenTelemetry .NET instrumentation project uses for its multi-architecture native builds.

## What changed

In `.github/workflows/build_profiler.yml`'s `build-linux-arm64-profiler` job:

- Removed the `uraimo/run-on-arch-action` step and its 18-line inline `install:` block (the duplicate of `Arm64Dockerfile`).
- Switched the runner from `ubuntu-22.04` to `ubuntu-24.04-arm` (native arm64 runner).
- Added a `docker compose build build_arm64 && docker compose run build_arm64` step. This matches exactly the pattern used by the existing x64 job two jobs above.
- Set `CORECLR_NEW_RELIC_HOME` env (mirror of x64 pattern; defensive against `docker-compose.yml`'s `build_debug` service `:-` reference).
- Removed `permissions: packages: write` (was needed for `run-on-arch-action`'s ghcr image cache; not needed here).

The `build_arm64` service in `docker-compose.yml` already existed (`platform: linux/arm64/v8`, `dockerfile: Arm64Dockerfile`) — this PR just wires the CI job to use it.

The first iteration of this PR used `docker/setup-qemu-action` to register binfmt for aarch64 emulation on an x64 runner, then proved binary-shape parity. After that landed, review feedback from @nrcventura suggested using a native arm runner instead. That switch dropped CI time from 9m18s to 1m39s (5.6× speedup) while remaining byte-identical to the QEMU output (see test plan).

## Why this matters for future dual-build (glibc + musl)

Today, adding a new arm64 build variant means writing another inline-install block in the workflow YAML. After this PR, adding a variant means: write a new Dockerfile, add a service to `docker-compose.yml`, add a CI job that calls `docker compose run <service>`. That mirrors how OTel's `docker/` directory organizes their per-target builds (alpine, debian, debian-arm64, centos-stream9, ubuntu1604).

## Test plan

- [x] CI green on this branch — Windows, Linux x64, Linux ARM64 all pass.
- [x] **Binary-shape parity check (the actual gate for this PR).** Downloaded `libNewRelicProfiler.so` from this run and from the most recent post-#3590 main run and compared:

  | Property | Baseline (run-on-arch-action / QEMU on ubuntu-22.04) | New (docker compose on ubuntu-24.04-arm native) |
  |---|---|---|
  | SHA-256 | `7fa2827fbfd6316530c47871ccda8db48d32ef38d252783d2ccb357954eff4a4` | identical |
  | DT_NEEDED set | `libm.so.6, libgcc_s.so.1, libpthread.so.0, libc.so.6, ld-linux-aarch64.so.1` | identical |
  | Max GLIBC referenced | 2.17 | identical |
  | libc++/libstdc++ runtime dep | none | none |
  | Exported symbol count | 4183 | identical |

  The arm64 binary is **bit-for-bit identical** between the old run-on-arch-action build and the new native-arm-runner build. The plan's gate was parity on the four binary properties; the actual result is byte-identity, which is the strongest possible parity outcome.

- [x] **CI duration: 9m18s (QEMU baseline) → 1m39s (native arm runner), a 5.6× speedup on the arm64 job.**