### PR TITLE
chore: add musl-native profiler build target

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -256,6 +256,97 @@ jobs:
           path: ${{ github.workspace }}/src/Agent/_profilerBuild/
           if-no-files-found: error
 
+  build-linux-musl-x64-profiler:
+    name: Build Linux musl x64 Profiler
+    runs-on: ubuntu-22.04
+    needs: check-modified-files
+    # only run this job if source files were modified, or if triggered by a manual execution
+    if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+
+    env:
+      profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
+      CORECLR_NEW_RELIC_HOME: ${{ github.workspace }}/src/Agent/NewRelic/newrelichome_x64_coreclr_linux # not used but required by Profiler/docker-compose.yml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Clean out _profilerBuild directory
+        run: |
+          rm -f ${{ github.workspace }}/src/Agent/_profilerBuild/*.* || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-x64-release || true
+        shell: bash
+
+      - name: Build Linux musl x64 Profiler
+        run: |
+          cd ${{ env.profiler_path }}
+          docker compose build build_musl_x64
+          docker compose run build_musl_x64
+        shell: bash
+
+      - name: Move Profiler to staging folder
+        run: |
+          mkdir --parents ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-x64-release/
+          mv -f ${{ env.profiler_path }}/libNewRelicProfiler.so  ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-x64-release/libNewRelicProfiler.so
+        shell: bash
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: profiler-musl-amd64
+          path: ${{ github.workspace }}/src/Agent/_profilerBuild/
+          if-no-files-found: error
+
+  build-linux-musl-arm64-profiler:
+    name: Build Linux musl ARM64 Profiler
+    runs-on: ubuntu-24.04-arm
+    needs: check-modified-files
+    # only run this job if source files were modified, or if triggered by a manual execution
+    if: ${{ needs.check-modified-files.outputs.source-files-changed == 'true' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+
+    env:
+      profiler_path: ${{ github.workspace }}/src/Agent/NewRelic/Profiler
+      CORECLR_NEW_RELIC_HOME: ${{ github.workspace }}/src/Agent/NewRelic/newrelichome_arm64_coreclr_linux # not used but required by Profiler/docker-compose.yml
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Clean out _profilerBuild directory
+        run: |
+          rm -f ${{ github.workspace }}/src/Agent/_profilerBuild/*.* || true
+          rm -rf ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-arm64-release || true
+        shell: bash
+
+      - name: Build Linux musl ARM64 Profiler
+        run: |
+          cd ${{ env.profiler_path }}
+          docker compose build build_musl_arm64
+          docker compose run build_musl_arm64
+        shell: bash
+
+      - name: Move Profiler to staging folder
+        run: |
+          mkdir --parents ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-arm64-release/
+          mv -f ${{ env.profiler_path }}/libNewRelicProfiler.so  ${{ github.workspace }}/src/Agent/_profilerBuild/linux-musl-arm64-release/libNewRelicProfiler.so
+        shell: bash
+
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: profiler-musl-arm64
+          path: ${{ github.workspace }}/src/Agent/_profilerBuild/
+          if-no-files-found: error
+
   package-and-deploy:
     needs:
       [

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.35"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.36"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/CMakeLists.txt
+++ b/src/Agent/NewRelic/Profiler/CMakeLists.txt
@@ -36,8 +36,26 @@ if(${WIN32})
 else()
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing -stdlib=libc++ -Wno-invalid-noreturn -Wno-ignored-attributes -Wno-macro-redefined -fms-extensions -fdeclspec -fPIC")
-  set (CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++") 
+  if(DEFINED ENV{NR_MUSL_BUILD})
+    # musl path: clang + libstdc++ on Alpine.
+    # Alpine 3.23's libc++-static is not built with -fPIC and cannot be
+    # statically linked into a shared object, so we use libstdc++ instead —
+    # matching OTel's alpine.dockerfile approach.
+    # -fdelayed-template-parsing: clang 21 two-phase name lookup catches a real
+    # bug in vendored atl.h:367 (this->pElements in a never-called helper).
+    # This flag restores the old clang-3.9/MSVC behaviour of skipping unreached
+    # template bodies; no effect on emitted code.
+    # -Wl,-z,lazy: clang/lld on Alpine defaults to BIND_NOW; lazy binding is
+    # required so CLR-provided symbols (e.g. RaiseException) resolve after the
+    # CLR loads rather than at dlopen time.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fno-strict-aliasing -Wno-invalid-noreturn -Wno-ignored-attributes -Wno-macro-redefined -fms-extensions -fdeclspec -fPIC -fdelayed-template-parsing")
+    set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++ -static-libgcc -Wl,-z,lazy")
+  else()
+    # glibc path: unchanged from historical build to preserve byte-for-byte
+    # build behaviour.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing -stdlib=libc++ -Wno-invalid-noreturn -Wno-ignored-attributes -Wno-macro-redefined -fms-extensions -fdeclspec -fPIC")
+    set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+  endif()
 endif()
 
 file(GLOB SOURCES

--- a/src/Agent/NewRelic/Profiler/Common/xplat.h
+++ b/src/Agent/NewRelic/Profiler/Common/xplat.h
@@ -29,7 +29,14 @@
 #include <codecvt>
 #include <locale>
 
-#if defined(__llvm__)
+// libc++ in C++11 mode does not provide std::make_unique (it was added to
+// the standard in C++14). The glibc build path uses clang-3.9 + libc++ +
+// C++11 and so needs this shim. The musl build path uses clang + libstdc++
+// + C++14 (libstdc++ provides std::make_unique natively at C++14+), so
+// the shim must NOT activate there. Gate on _LIBCPP_VERSION (defined
+// only by libc++ headers, never by libstdc++) so the shim only ever fires
+// on the libc++ side.
+#if defined(_LIBCPP_VERSION)
 namespace std{
 template <class T, class... Args>
 typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
@@ -37,14 +44,14 @@ make_unique(Args &&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-/// \brief Constructs a `new T[n]` with the given args and returns a                           
-///        `unique_ptr<T[]>` which owns the object.                                            
-///                                                                                            
-/// \param n size of the new array.                                                            
-///                                                                                            
-/// Example:                                                                                   
-///                                                                                            
-///     auto p = make_unique<int[]>(2); // value-initializes the array with 0's.               
+/// \brief Constructs a `new T[n]` with the given args and returns a
+///        `unique_ptr<T[]>` which owns the object.
+///
+/// \param n size of the new array.
+///
+/// Example:
+///
+///     auto p = make_unique<int[]>(2); // value-initializes the array with 0's.
 template <class T>
 typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0,
     std::unique_ptr<T>>::type
@@ -52,7 +59,7 @@ typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0,
     return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
 }
 
-/// This function isn't used and is only here to provide better compile errors.                
+/// This function isn't used and is only here to provide better compile errors.
 template <class T, class... Args>
 typename std::enable_if<std::extent<T>::value != 0>::type
 make_unique(Args &&...) = delete;

--- a/src/Agent/NewRelic/Profiler/Logging/Logger.h
+++ b/src/Agent/NewRelic/Profiler/Logging/Logger.h
@@ -4,20 +4,29 @@
 */
 #pragma once
 #include <memory>
+// sal.h (vendored coreclr header) defines __valid as an empty macro for SAL
+// annotations. GCC 15's libstdc++ bits/parse_numbers.h uses __valid as an
+// internal template type alias. Push/undef/pop around the includes that
+// transitively pull in parse_numbers.h so the stdlib sees a clean identifier.
+#pragma push_macro("__valid")
+#undef __valid
 #include <mutex>
 #include <fstream> //wofstream
 #include <iostream>
 #include <ostream>
 #include <atomic>
 #include <cassert>
+#pragma pop_macro("__valid")
 #include "../Common/xplat.h"
 
 #ifdef PAL_STDCPP_COMPAT
-// This makes the logging calls work on unix systems by converting 2 byte wide strings into
-// 4 byte wide strings (convert char16_t chars to wchar_t.)
+// This makes the logging calls work on unix systems by converting 2 byte wide
+// strings (char16_t) into 4 byte wide strings (wchar_t).
 std::basic_ostream<wchar_t, std::char_traits<wchar_t>>& operator<<(std::basic_ostream<wchar_t, std::char_traits<wchar_t>>& _Ostr, const xstring_t& str)
 {
-    std::copy(str.cbegin(), str.cend(), std::ostream_iterator<wchar_t, wchar_t>(_Ostr));
+    for (auto c : str) {
+        _Ostr.put(static_cast<wchar_t>(c));
+    }
     return _Ostr;
 }
 #endif

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/GenericParamType.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/GenericParamType.h
@@ -3,6 +3,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 #pragma once
+#include <cstdint>
 #include <memory>
 #include "Type.h"
 

--- a/src/Agent/NewRelic/Profiler/Sicily/ast/TypeList.h
+++ b/src/Agent/NewRelic/Profiler/Sicily/ast/TypeList.h
@@ -5,6 +5,7 @@
 #ifndef _SIGPARSE_AST_TYPE_LIST_H_INCLUDED_
 #define _SIGPARSE_AST_TYPE_LIST_H_INCLUDED_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <string>

--- a/src/Agent/NewRelic/Profiler/ThreadProfiler/ThreadProfiler.h
+++ b/src/Agent/NewRelic/Profiler/ThreadProfiler/ThreadProfiler.h
@@ -3,6 +3,7 @@
 * SPDX-License-Identifier: Apache-2.0
 */
 #pragma once
+#include <condition_variable>
 #include <mutex>
 #include <atomic>
 #include <thread>

--- a/src/Agent/NewRelic/Profiler/docker-compose.yml
+++ b/src/Agent/NewRelic/Profiler/docker-compose.yml
@@ -26,3 +26,27 @@ services:
         volumes:
             - .:/profiler
         working_dir: /profiler/linux
+
+    build_musl_x64:
+        platform: linux/amd64
+        build:
+            context: linux/.
+            dockerfile: MuslDockerfile
+        command: bash -c "dos2unix ./build_profiler.sh && chmod 777 build_profiler.sh && ./build_profiler.sh"
+        environment:
+            NR_MUSL_BUILD: "1"
+        volumes:
+            - .:/profiler
+        working_dir: /profiler/linux
+
+    build_musl_arm64:
+        platform: linux/arm64/v8
+        build:
+            context: linux/.
+            dockerfile: MuslDockerfile
+        command: bash -c "dos2unix ./build_profiler.sh && chmod 777 build_profiler.sh && ./build_profiler.sh"
+        environment:
+            NR_MUSL_BUILD: "1"
+        volumes:
+            - .:/profiler
+        working_dir: /profiler/linux

--- a/src/Agent/NewRelic/Profiler/linux/MuslDockerfile
+++ b/src/Agent/NewRelic/Profiler/linux/MuslDockerfile
@@ -1,0 +1,31 @@
+# Builds an Alpine image and sets up the environment for compiling
+# the New Relic .NET profiler against musl libc. Used by the build_musl_x64
+# and build_musl_arm64 services in docker-compose.yml. The same Dockerfile
+# is used for both architectures; the platform is selected by the compose
+# service. CoreCLR profiling-API headers are vendored in the repo at
+# src/Agent/NewRelic/Profiler/externals/coreclr-headers/ and mounted in at
+# build time, so this image does not need to clone dotnet/coreclr.
+
+# alpine:3.23 - multi-platform image (linux/amd64 + linux/arm64/v8).
+# The musl-native profiler uses libstdc++ (matching OTel's alpine.dockerfile
+# choice) rather than libc++; Alpine's libc++-static package is not built
+# with -fPIC and cannot be statically linked into a shared object. See
+# PROFILER_DUAL_BUILD_DESIGN.md, Category A spike findings, for details.
+FROM alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+
+RUN apk add --no-cache \
+    clang \
+    cmake \
+    make \
+    musl-dev \
+    g++ \
+    linux-headers \
+    bash \
+    dos2unix
+
+# Use clang as the C/C++ compiler. The CMakeLists.txt musl branch
+# uses clang-specific flags (-fms-extensions, -fdeclspec,
+# -fdelayed-template-parsing). g++ is installed for libstdc++ headers
+# and the static libstdc++ library only.
+ENV CC=clang
+ENV CXX=clang++

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/LinuxUnicodeLogFileTestFixture.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/LinuxUnicodeLogFileTestFixture.cs
@@ -12,5 +12,8 @@ public class LinuxUnicodeLogFileTestFixture : ContainerTestFixtureBase
     private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.X64;
     private const string DistroTag = "noble";
 
-    public LinuxUnicodeLogFileTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
+    public LinuxUnicodeLogFileTestFixture() : base(DistroTag, Architecture, Dockerfile)
+    {
+        ProfilerLogExpected = true;
+    }
 }

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxUnicodeLogFileTest.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxUnicodeLogFileTest.cs
@@ -55,5 +55,16 @@ public class LinuxUnicodeLogFileTest : NewRelicIntegrationTest<LinuxUnicodeLogFi
         var actualMetrics = _fixture.AgentLog.GetMetrics();
 
         Assert.Contains(actualMetrics, m => m.MetricSpec.Name.Equals("WebTransaction/MVC/WeatherForecast/Get"));
+
+        // Smoke-check that the profiler's wide-string log path produced output: at finest
+        // level the profiler writes xstring_t values (assembly/type names) via the wostream
+        // operator<< in Logger.h. ASCII-only assertions cannot distinguish the put() vs
+        // formatted-insert implementations of that operator, but they will catch a path
+        // that is completely broken (chars dropped, log file never created).
+        Assert.True(_fixture.ProfilerLog.Found, "Profiler log file was not created.");
+
+        var profilerLog = _fixture.ProfilerLog.GetFullLogAsString();
+        Assert.Contains("SmokeTestApp", profilerLog);
+        Assert.Contains("WeatherForecastController", profilerLog);
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the [dual-build (glibc + musl) plan](https://github.com/newrelic/newrelic-dotnet-agent/blob/spike/profiler-musl-libstdcxx-migration/PROFILER_DUAL_BUILD_DESIGN.md). Adds a musl-native build target for `libNewRelicProfiler.so`. The musl artifacts upload to GitHub Actions for inspection only.

## ⚠️ Internal-only — no customer-facing impact

- `package-and-deploy` is unchanged — its `needs:` list does NOT include the new musl jobs.
- The `NewRelic.Agent.Internal.Profiler` NuGet package contains the **same set of files** as today (verified: file listing matches; no `linux_musl_*` directories added). Binaries are not byte-identical because the build embeds timestamps, but they are **functionally equivalent** to main:

| | v10.51.0.35 (last main) glibc x64 | v10.51.0.36 (this PR) glibc x64 | v10.51.0.35 glibc arm64 | v10.51.0.36 glibc arm64 |
|---|---|---|---|---|
| DT_NEEDED | libm, libgcc_s, libpthread, libc | (same) | + ld-linux-aarch64 | (same) |
| Max GLIBC_ ref | 2.14 | 2.14 | 2.17 | 2.17 |
| Exported symbols | 4551 | 4551 | 4183 | 4183 |

- Agent home directory layout, `setenv.sh`, customer install paths — all unchanged.

## What's in this PR

| Commit | What |
|---|---|
| `src:` | `NR_MUSL_BUILD`-gated branch in CMakeLists.txt + minor source changes for libstdc++ compat. Glibc path untouched. |
| `build:` | New `linux/MuslDockerfile` (Alpine 3.23, digest pinned) + `build_musl_x64` / `build_musl_arm64` compose services. |
| `ci:` | New `build-linux-musl-x64-profiler` / `build-linux-musl-arm64-profiler` jobs uploading `profiler-musl-{amd64,arm64}` artifacts. |

## Verification

- Local builds of both variants pass and produce binaries meeting the four design-doc properties (narrow DT_NEEDED, no GLIBC version refs on musl / max 2.14 on glibc, no `BIND_NOW`, no `libstdc++`/`libc++` in DT_NEEDED).
- Profiler workflow run with `deploy=true` succeeded; v10.51.0.36 published.
- v10.51.0.36 vs v10.51.0.35 NuGet package contents compared: same file set, glibc binaries functionally equivalent (table above).
- Auto-generated NuGet-update PR (#3598) merged into this branch; full agent CI is now running against v10.51.0.36.

Design doc + full spike report are on the [`spike/profiler-musl-libstdcxx-migration`](https://github.com/newrelic/newrelic-dotnet-agent/tree/spike/profiler-musl-libstdcxx-migration) branch.

## Test plan

- [ ] All Solutions Build green on the post-merge work branch
- [ ] Unit Tests and Code Coverage green on the post-merge work branch
- [ ] Profiler Build / Unit Test / Deploy green (pull_request trigger, no deploy)