### PR TITLE
chore(profiler): per-RID home directory layout for dual-build (Phase 2 PR1)

### DIFF
--- a/.github/workflows/build_profiler.yml
+++ b/.github/workflows/build_profiler.yml
@@ -353,6 +353,8 @@ jobs:
         build-windows-profiler,
         build-linux-x64-profiler,
         build-linux-arm64-profiler,
+        build-linux-musl-x64-profiler,
+        build-linux-musl-arm64-profiler,
       ]
     if: ${{ inputs.deploy }}
     name: Package and Deploy Profiler NuGet
@@ -389,6 +391,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: profiler-arm64
+          path: ${{ github.workspace }}/_workingDir
+
+      - name: Download Linux musl amd64 Profiler Artifacts to working Directory
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: profiler-musl-amd64
+          path: ${{ github.workspace }}/_workingDir
+
+      - name: Download Linux musl arm64 Profiler Artifacts to working Directory
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: profiler-musl-arm64
           path: ${{ github.workspace }}/_workingDir
 
       - name: Determine Package Version from Git history

--- a/build/ArtifactBuilder/AgentComponents.cs
+++ b/build/ArtifactBuilder/AgentComponents.cs
@@ -47,6 +47,7 @@ public abstract class AgentComponents
     public string AgentApiDll;
     public string WindowsProfiler;
     public string LinuxProfiler;
+    public string LinuxMuslProfiler;
     public string ExtensionXsd;
     public string NewRelicXsd;
     public string NewRelicConfig;
@@ -70,6 +71,11 @@ public abstract class AgentComponents
             if (!string.IsNullOrEmpty(LinuxProfiler))
             {
                 list.Add(LinuxProfiler);
+            }
+
+            if (!string.IsNullOrEmpty(LinuxMuslProfiler))
+            {
+                list.Add(LinuxMuslProfiler);
             }
 
             return list;

--- a/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
+++ b/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
@@ -21,6 +21,7 @@ public class LinuxPackage : Artifact
     private readonly string _packageName;
 
     private AgentComponents _coreAgentComponents;
+    private readonly string _agentPlatform;
 
     public LinuxPackage(string name, string packagePlatform, string fileExtension) : base(name)
     {
@@ -32,7 +33,8 @@ public class LinuxPackage : Artifact
         OutputDirectory = Path.Join(RepoRootDirectory, "build", "BuildArtifacts", Name);
         ValidateContentAction = ValidateContent;
 
-        _coreAgentComponents = AgentComponents.GetAgentComponents(AgentType.Core, "Release", "x64", RepoRootDirectory, HomeRootDirectory);
+        _agentPlatform = packagePlatform.Contains("arm64", StringComparison.OrdinalIgnoreCase) ? "arm64" : "x64";
+        _coreAgentComponents = AgentComponents.GetAgentComponents(AgentType.Core, "Release", _agentPlatform, RepoRootDirectory, HomeRootDirectory);
     }
 
     protected override void InternalBuild()
@@ -169,7 +171,10 @@ public class LinuxPackage : Artifact
 
         ValidationHelpers.AddFilesToCollectionWithNewPath(expectedComponents, installedFilesRoot, _coreAgentComponents.RootInstallDirectoryComponents);
         ValidationHelpers.AddFilesToCollectionWithNewPath(expectedComponents, installedFilesRoot, _coreAgentComponents.AgentHomeDirComponents.Where(f => f != _coreAgentComponents.WindowsProfiler));
-        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, _coreAgentComponents.LinuxProfiler);
+        var glibcRid = _agentPlatform == "arm64" ? "linux-arm64" : "linux-x64";
+        var muslRid = _agentPlatform == "arm64" ? "linux-musl-arm64" : "linux-musl-x64";
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, glibcRid), _coreAgentComponents.LinuxProfiler);
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, muslRid), _coreAgentComponents.LinuxMuslProfiler);
         ValidationHelpers.AddFilesToCollectionWithNewPath(expectedComponents, installedFilesRoot, _coreAgentComponents.ConfigurationComponents);
         // These next two files are added to the Linux packages by the containerized build process, not the ArtifactBuilder, so they are hardcoded here
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "run.sh");

--- a/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
+++ b/build/ArtifactBuilder/Artifacts/LinuxPackage.cs
@@ -176,9 +176,11 @@ public class LinuxPackage : Artifact
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, glibcRid), _coreAgentComponents.LinuxProfiler);
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(installedFilesRoot, muslRid), _coreAgentComponents.LinuxMuslProfiler);
         ValidationHelpers.AddFilesToCollectionWithNewPath(expectedComponents, installedFilesRoot, _coreAgentComponents.ConfigurationComponents);
-        // These next two files are added to the Linux packages by the containerized build process, not the ArtifactBuilder, so they are hardcoded here
+        // These files are added to the Linux packages by the containerized build process or by build_home.ps1, not by the ArtifactBuilder, so they are hardcoded here.
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "run.sh");
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "setenv.sh");
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "agentinfo.json");
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, installedFilesRoot, "libNewRelicProfiler.so");
 
         var netcoreExtensionsFolder = Path.Join(installedFilesRoot, "extensions");
         ValidationHelpers.AddFilesToCollectionWithNewPath(expectedComponents, netcoreExtensionsFolder, _coreAgentComponents.ExtensionDirectoryComponents);

--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -23,7 +23,8 @@ public class CoreAgentComponents : AgentComponents
 
     protected override List<string> IgnoredHomeBuilderFiles => new List<string>() {
         $@"{SourceHomeBuilderPath}\extensions\NewRelic.Core.Instrumentation.xml",
-        $@"{SourceHomeBuilderPath}\extensions\NewRelic.Parsing.Instrumentation.xml"
+        $@"{SourceHomeBuilderPath}\extensions\NewRelic.Parsing.Instrumentation.xml",
+        $@"{SourceHomeBuilderPath}\libNewRelicProfiler.so"
     };
 
     protected override void CreateAgentComponents()

--- a/build/ArtifactBuilder/CoreAgentComponents.cs
+++ b/build/ArtifactBuilder/CoreAgentComponents.cs
@@ -150,13 +150,16 @@ public class CoreAgentComponents : AgentComponents
         AgentApiDll = $@"{SourcePath}\..\_build\AnyCPU-{Configuration}\NewRelic.Api.Agent\netstandard2.0\NewRelic.Api.Agent.dll";
 
         LinuxProfiler = null;
+        LinuxMuslProfiler = null;
         if (Platform == "x64")
         {
-            LinuxProfiler = $@"{HomeRootPath}\newrelichome_x64_coreclr_linux\libNewRelicProfiler.so";
+            LinuxProfiler = $@"{HomeRootPath}\newrelichome_x64_coreclr_linux\linux-x64\libNewRelicProfiler.so";
+            LinuxMuslProfiler = $@"{HomeRootPath}\newrelichome_x64_coreclr_linux\linux-musl-x64\libNewRelicProfiler.so";
         }
         else if (Platform == "arm64")
         {
-            LinuxProfiler = $@"{HomeRootPath}\newrelichome_arm64_coreclr_linux\libNewRelicProfiler.so";
+            LinuxProfiler = $@"{HomeRootPath}\newrelichome_arm64_coreclr_linux\linux-arm64\libNewRelicProfiler.so";
+            LinuxMuslProfiler = $@"{HomeRootPath}\newrelichome_arm64_coreclr_linux\linux-musl-arm64\libNewRelicProfiler.so";
         }
 
         var configurationComponents = new List<string> { NewRelicXsd };

--- a/build/Packaging/NugetProfiler/NewRelic.Profiler.nuspec
+++ b/build/Packaging/NugetProfiler/NewRelic.Profiler.nuspec
@@ -18,6 +18,8 @@
     <file src="build\NewRelic.Agent.Internal.Profiler.targets" target="build\NewRelic.Agent.Internal.Profiler.targets" />
     <file src="linux-arm64-release\**" target="content\profiler\linux_arm64" />
     <file src="linux-x64-release\**" target="content\profiler\linux_x64" />
+    <file src="linux-musl-arm64-release\**" target="content\profiler\linux_musl_arm64" />
+    <file src="linux-musl-x64-release\**" target="content\profiler\linux_musl_x64" />
     <file src="x64-release\**" target="content\profiler\x64" />
     <file src="x86-release\**" target="content\profiler\x86" />
     <file src="readme.md" target="docs\readme.md" />

--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -145,6 +145,12 @@ function Copy-AgentRoot {
 
     
     if ($Linux) {
+        # Per-RID layout. The flat-path libNewRelicProfiler.so at the home root
+        # is also dropped here as a build-time placeholder so existing flat-path
+        # consumers (Container/Integration tests, customer paths that haven't
+        # been updated) keep working. On real .deb/.rpm/tarball installs the
+        # postinst / setenv.sh / tarball-pre-bake replace the placeholder with
+        # a libc-aware symlink.
         if ($Architecture -like "x64") {
             $glibcDir = "$Destination\linux-x64"
             $muslDir  = "$Destination\linux-musl-x64"
@@ -152,6 +158,7 @@ function Copy-AgentRoot {
             New-Item -ItemType Directory -Force -Path $muslDir  | Out-Null
             Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_x64\libNewRelicProfiler.so" -Destination "$glibcDir" -Force
             Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_musl_x64\libNewRelicProfiler.so" -Destination "$muslDir" -Force
+            Copy-Item -Path "$glibcDir\libNewRelicProfiler.so" -Destination "$Destination" -Force
         }
         if ($Architecture -like "ARM64") {
             $glibcDir = "$Destination\linux-arm64"
@@ -160,6 +167,7 @@ function Copy-AgentRoot {
             New-Item -ItemType Directory -Force -Path $muslDir  | Out-Null
             Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_arm64\libNewRelicProfiler.so" -Destination "$glibcDir" -Force
             Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_musl_arm64\libNewRelicProfiler.so" -Destination "$muslDir" -Force
+            Copy-Item -Path "$glibcDir\libNewRelicProfiler.so" -Destination "$Destination" -Force
         }
     }
     else {

--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -146,10 +146,20 @@ function Copy-AgentRoot {
     
     if ($Linux) {
         if ($Architecture -like "x64") {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_x64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
+            $glibcDir = "$Destination\linux-x64"
+            $muslDir  = "$Destination\linux-musl-x64"
+            New-Item -ItemType Directory -Force -Path $glibcDir | Out-Null
+            New-Item -ItemType Directory -Force -Path $muslDir  | Out-Null
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_x64\libNewRelicProfiler.so" -Destination "$glibcDir" -Force
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_musl_x64\libNewRelicProfiler.so" -Destination "$muslDir" -Force
         }
         if ($Architecture -like "ARM64") {
-            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_arm64\libNewRelicProfiler.so" -Destination "$Destination" -Force 
+            $glibcDir = "$Destination\linux-arm64"
+            $muslDir  = "$Destination\linux-musl-arm64"
+            New-Item -ItemType Directory -Force -Path $glibcDir | Out-Null
+            New-Item -ItemType Directory -Force -Path $muslDir  | Out-Null
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_arm64\libNewRelicProfiler.so" -Destination "$glibcDir" -Force
+            Copy-Item -Path "$RootDirectory\src\Agent\NewRelic\Home\bin\$Configuration\netstandard2.0\profiler\linux_musl_arm64\libNewRelicProfiler.so" -Destination "$muslDir" -Force
         }
     }
     else {

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.36"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.37"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
First sub-PR of the Phase 2 dual-build (glibc + musl) effort. Restructures the Linux agent home directories to emit per-RID subdirectories for each profiler binary variant.

```
newrelichome_x64_coreclr_linux/
  libNewRelicProfiler.so                    (build-time placeholder, glibc copy)
  linux-x64/libNewRelicProfiler.so
  linux-musl-x64/libNewRelicProfiler.so     (new)
newrelichome_arm64_coreclr_linux/
  libNewRelicProfiler.so                    (build-time placeholder, glibc copy)
  linux-arm64/libNewRelicProfiler.so
  linux-musl-arm64/libNewRelicProfiler.so   (new)
```

The flat-path placeholder keeps hardcoded `CORECLR_PROFILER_PATH=$NRHOME/libNewRelicProfiler.so` working unchanged. The next sub-PR replaces it at install time with a libc-aware symlink.

Also exposed and fixed a pre-existing arm64 validator divergence: `agentinfo.json` is in the .deb/.rpm/.tar.gz but `CoreAgentComponents` skips it for arm64; previously hidden by the `LinuxPackage` validator hardcoding `"x64"`. Now hardcoded alongside `run.sh`/`setenv.sh` (the existing pattern for files added by the containerized build).

## Verification
- [x] `build_profiler.yml -f deploy=true` green; #3600 merged; new NuGet propagated
- [x] Full agent CI green on `d06fb0a6`
- [x] Manual inspection of built `.deb`/`.rpm`/`.tar.gz` per-RID layout