### PR TITLE
chore(profiler): libc-aware compat symlinks for dual-build (Phase 2 PR2)

### DIFF
--- a/build/Linux/build/common/run.sh
+++ b/build/Linux/build/common/run.sh
@@ -2,4 +2,34 @@
 
 # This script can be used to run a dotnet application with New Relic monitoring.
 
-CORECLR_NEWRELIC_HOME="${CORECLR_NEWRELIC_HOME:-${CORECLR_NEW_RELIC_HOME:-/usr/local/newrelic-dotnet-agent}}" CORECLR_ENABLE_PROFILING=1 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} CORECLR_PROFILER_PATH="$CORECLR_NEWRELIC_HOME/libNewRelicProfiler.so" "$@"
+CORECLR_NEWRELIC_HOME="${CORECLR_NEWRELIC_HOME:-${CORECLR_NEW_RELIC_HOME:-/usr/local/newrelic-dotnet-agent}}"
+
+case "$(uname -m)" in
+    x86_64)  __nr_arch=x64 ;;
+    aarch64) __nr_arch=arm64 ;;
+    *)       __nr_arch="" ;;
+esac
+if ldd /bin/ls 2>/dev/null | grep -q musl; then
+    __nr_libc=musl-
+else
+    __nr_libc=
+fi
+__nr_rid="linux-${__nr_libc}${__nr_arch}"
+
+if [ -n "$__nr_arch" ] && [ -d "$CORECLR_NEWRELIC_HOME/$__nr_rid" ]; then
+    __nr_target="$__nr_rid/libNewRelicProfiler.so"
+    __nr_link="$CORECLR_NEWRELIC_HOME/libNewRelicProfiler.so"
+    if [ -L "$__nr_link" ]; then
+        if [ "$(readlink "$__nr_link")" != "$__nr_target" ]; then
+            ln -sf "$__nr_target" "$__nr_link" 2>/dev/null || true
+        fi
+    elif [ ! -e "$__nr_link" ]; then
+        ln -sf "$__nr_target" "$__nr_link" 2>/dev/null || true
+    fi
+fi
+
+CORECLR_NEWRELIC_HOME="$CORECLR_NEWRELIC_HOME" \
+CORECLR_ENABLE_PROFILING=1 \
+CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
+CORECLR_PROFILER_PATH="$CORECLR_NEWRELIC_HOME/libNewRelicProfiler.so" \
+    "$@"

--- a/build/Linux/build/common/setenv.sh
+++ b/build/Linux/build/common/setenv.sh
@@ -4,7 +4,36 @@ if [ -z "$CORECLR_NEWRELIC_HOME" ] && [ -z "$CORECLR_NEW_RELIC_HOME" ]; then
     echo "CORECLR_NEWRELIC_HOME is undefined"
 else
     NRHOME=${CORECLR_NEWRELIC_HOME:-${CORECLR_NEW_RELIC_HOME}}
-    
+
+    case "$(uname -m)" in
+        x86_64)  __nr_arch=x64 ;;
+        aarch64) __nr_arch=arm64 ;;
+        *)       __nr_arch="" ;;
+    esac
+    if ldd /bin/ls 2>/dev/null | grep -q musl; then
+        __nr_libc=musl-
+    else
+        __nr_libc=
+    fi
+    __nr_rid="linux-${__nr_libc}${__nr_arch}"
+
+    # Refresh the libc-aware compat symlink at the home root. If a customer
+    # carried a tarball-pre-baked symlink into a runtime container with a
+    # different libc, this re-points it.
+    if [ -n "$__nr_arch" ] && [ -d "$NRHOME/$__nr_rid" ]; then
+        __nr_target="$__nr_rid/libNewRelicProfiler.so"
+        __nr_link="$NRHOME/libNewRelicProfiler.so"
+        if [ -L "$__nr_link" ]; then
+            if [ "$(readlink "$__nr_link")" != "$__nr_target" ]; then
+                ln -sf "$__nr_target" "$__nr_link" 2>/dev/null || true
+            fi
+        elif [ ! -e "$__nr_link" ]; then
+            ln -sf "$__nr_target" "$__nr_link" 2>/dev/null || true
+        fi
+        unset __nr_target __nr_link
+    fi
+    unset __nr_arch __nr_libc __nr_rid
+
     export CORECLR_ENABLE_PROFILING=1
     export CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
     export CORECLR_PROFILER_PATH=$NRHOME/libNewRelicProfiler.so

--- a/build/Linux/build/deb/build.sh
+++ b/build/Linux/build/deb/build.sh
@@ -66,6 +66,20 @@ cp /tmp/${ARCH}/${PACKAGE_NAME}.deb /release/${PACKAGE_NAME}_${ARCH}.deb
 # agentinfo.json for tar.gz
 cp /common/agentinfo.json .
 
+# Pre-bake a default libc-aware compat symlink so that customers who extract
+# the tarball and hardcode CORECLR_PROFILER_PATH=$NRHOME/libNewRelicProfiler.so
+# get a working binary on a glibc host without sourcing setenv.sh. The build
+# host is always glibc, so the default points at the matching glibc binary;
+# setenv.sh refreshes the symlink to the musl variant on Alpine hosts.
+case "$ARCH" in
+    amd64) RID_ARCH=x64 ;;
+    arm64) RID_ARCH=arm64 ;;
+    *)     RID_ARCH="" ;;
+esac
+if [ -n "$RID_ARCH" ] && [ -f "linux-${RID_ARCH}/libNewRelicProfiler.so" ]; then
+    ln -sf "linux-${RID_ARCH}/libNewRelicProfiler.so" libNewRelicProfiler.so
+fi
+
 # create tar.gz archive
 cd ..
 

--- a/build/Linux/build/deb/postinst
+++ b/build/Linux/build/deb/postinst
@@ -45,6 +45,29 @@ fi
 rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.Instrumentation.xml 2> /dev/null
 rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.dll 2> /dev/null
 
+# Create the libc-aware compat symlink at the home root so customers who
+# hardcode CORECLR_PROFILER_PATH=$NEWRELIC_HOME/libNewRelicProfiler.so keep
+# working after the per-RID layout move. Detect the host's libc and arch and
+# point the link at the matching variant.
+case "$(uname -m)" in
+    x86_64)  __nr_arch=x64 ;;
+    aarch64) __nr_arch=arm64 ;;
+    *)       __nr_arch="" ;;
+esac
+if ldd /bin/ls 2>/dev/null | grep -q musl; then
+    __nr_libc=musl-
+else
+    __nr_libc=
+fi
+if [ -n "$__nr_arch" ]; then
+    __nr_target="linux-${__nr_libc}${__nr_arch}/libNewRelicProfiler.so"
+    if [ -f "$NEWRELIC_HOME/$__nr_target" ]; then
+        ln -sf "$__nr_target" "$NEWRELIC_HOME/libNewRelicProfiler.so"
+    fi
+    unset __nr_target
+fi
+unset __nr_arch __nr_libc
+
 echo "export CORECLR_NEWRELIC_HOME=${NEWRELIC_HOME}" > /etc/profile.d/${PACKAGE_NAME}-path.sh
 source /etc/profile.d/${PACKAGE_NAME}-path.sh
 

--- a/build/Linux/build/rpm/newrelic-dotnet-agent.spec
+++ b/build/Linux/build/rpm/newrelic-dotnet-agent.spec
@@ -88,6 +88,26 @@ fi
 rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.Instrumentation.xml 2> /dev/null
 rm -f $NEWRELIC_HOME/extensions/NewRelic.Providers.Wrapper.Logging.dll 2> /dev/null
 
+# libc-aware compat symlink at the home root for hardcoded CORECLR_PROFILER_PATH
+case "$(uname -m)" in
+    x86_64)  __nr_arch=x64 ;;
+    aarch64) __nr_arch=arm64 ;;
+    *)       __nr_arch="" ;;
+esac
+if ldd /bin/ls 2>/dev/null | grep -q musl; then
+    __nr_libc=musl-
+else
+    __nr_libc=
+fi
+if [ -n "$__nr_arch" ]; then
+    __nr_target="linux-${__nr_libc}${__nr_arch}/libNewRelicProfiler.so"
+    if [ -f "$NEWRELIC_HOME/$__nr_target" ]; then
+        ln -sf "$__nr_target" "$NEWRELIC_HOME/libNewRelicProfiler.so"
+    fi
+    unset __nr_target
+fi
+unset __nr_arch __nr_libc
+
 echo "export CORECLR_NEWRELIC_HOME=${NEWRELIC_HOME}" > /etc/profile.d/%{name}-path.sh
 source /etc/profile.d/%{name}-path.sh
 

--- a/src/Agent/NewRelic/Profiler/linux/README.md
+++ b/src/Agent/NewRelic/Profiler/linux/README.md
@@ -2,23 +2,33 @@
 
 ### Active build images (used by CI)
 
-**`Dockerfile`** — x64 Linux build container. Ubuntu 14.04, clang-3.9, cmake-3.9.
+**`Dockerfile`** — x64 glibc Linux build container. Ubuntu 14.04, clang-3.9, cmake-3.9.
 Used by the `build_profiler.yml` `build-linux-profiler-x64` job via `docker compose`.
 
-**`Arm64Dockerfile`** — arm64 Linux build container. Ubuntu 18.04, clang-3.9,
+**`Arm64Dockerfile`** — arm64 glibc Linux build container. Ubuntu 18.04, clang-3.9,
 cmake 3.9 pulled from an NR-owned S3 bucket.
 Used by the `build_profiler.yml` `build-linux-profiler-arm64` job.
 
-Both images compile with `-stdlib=libc++ -static-libstdc++`, which together with the
-profiler's narrow set of external dependencies produces binaries that work on glibc-based
-distros **and** musl-based distros (Alpine) — see below.
+**`MuslDockerfile`** — x64 + arm64 musl Linux build container. Alpine-based,
+clang + libstdc++ toolchain. Used by the `build_profiler.yml`
+`build-linux-musl-x64-profiler` and `build-linux-musl-arm64-profiler` jobs.
+
+The agent ships **four** Linux profiler binaries — one per (libc, arch) combination —
+into per-RID subdirectories of the agent home: `linux-x64/`, `linux-arm64/`,
+`linux-musl-x64/`, `linux-musl-arm64/`. A libc-aware compat symlink at the home root
+keeps the legacy flat path (`$NRHOME/libNewRelicProfiler.so`) working for customers
+who hardcode `CORECLR_PROFILER_PATH`. The symlink is created by the `.deb`/`.rpm`
+postinst, by `setenv.sh` on first source, and pre-baked at tarball build time.
 
 ### Alpine compatibility
 
-The shipped `libNewRelicProfiler.so` loads successfully on Alpine Linux (including the
-`mcr.microsoft.com/dotnet/aspnet:*-alpine` images) **without `gcompat`**. This is not
-accidental — it is a direct consequence of four binary properties that the current build
-images preserve:
+Alpine support comes from the dedicated **`linux-musl-{x64,arm64}/libNewRelicProfiler.so`**
+binary — a true musl-native build linked against musl libc and libstdc++. On an Alpine
+host, the postinst (or `setenv.sh`) detects musl via `ldd /bin/ls 2>&1 | grep musl` and
+points the home-root compat symlink at the musl variant.
+
+**Historical context (legacy compat path).** Before the dual-build, the single shipped
+glibc binary loaded on Alpine via four properties of its build:
 
 | Property | x64 | arm64 |
 |---|---|---|
@@ -27,15 +37,19 @@ images preserve:
 | libc++/libstdc++ runtime dep | None (static-linked) | None |
 | Lazy binding (RTLD_LAZY) | Yes | Yes |
 
-Alpine's musl libc exposes the `libc.so.6` / `libm.so.6` / `libpthread.so.0` sonames,
-satisfying the ELF loader, and provides native equivalents of all referenced glibc symbols
-at those ancient version levels. `RaiseException` is a CoreCLR PAL export resolved from
-the already-loaded `libcoreclr.so`. The three `ldd`-reported misses (`strtoll_l`,
-`strtoull_l`) are lazy-binding holes that the profiler's normal code paths never reach.
+Alpine's musl exposes the `libc.so.6` / `libm.so.6` / `libpthread.so.0` sonames,
+satisfying the ELF loader, and provides native equivalents of those ancient glibc
+symbols. `RaiseException` is a CoreCLR PAL export resolved from `libcoreclr.so`. The
+`ldd`-reported lazy-binding holes (`strtoll_l`, `strtoull_l`) were not hit by the
+profiler's normal code paths. This was a fragile arrangement that survived through
+luck, not design — any build-image change that raised the max GLIBC_ version, added a
+libc++/libstdc++ `DT_NEEDED`, or changed the `DT_NEEDED` soname set would have broken it.
 
-**Do not break these properties.** Any build-image change that raises the max GLIBC_
-version above 2.17, adds a libc++/libstdc++ `DT_NEEDED`, or changes the `DT_NEEDED`
-soname set will break Alpine. Verify with `readelf -d` and `readelf -V` before merging.
+**The dedicated musl binary supersedes that mechanism.** The four-property invariant
+above no longer governs Alpine compatibility — it governs only the glibc binary's
+floor for old glibc distros. Alpine customers transparently move onto the musl-native
+binary via the compat symlink; no `gcompat` workaround, no lazy-binding luck, no
+`strtoll_l` fragility.
 
 ### Other files
 
@@ -43,9 +57,12 @@ soname set will break Alpine. Verify with `readelf -d` and `readelf -V` before m
 dotnet-sos, lldb). Not used by CI. Still references the old `dotnet/coreclr` clone
 that was removed from the main build in PR #3576; this file has not been updated.
 
-### Planned modernization
+### Planned modernization (Phase 3)
 
-The `Dockerfile` and `Arm64Dockerfile` images are based on old Ubuntu / clang versions
-and have known reliability risks (Ubuntu 14.04 EOL, apt-key deprecation, S3-hosted cmake
-for arm64). The hard constraint on any modernization effort is preserving the four binary
-properties listed above.
+With Alpine compatibility now provided by the dedicated musl binary, the glibc build
+base no longer has to preserve the four-property invariant — it is free to track .NET's
+own portable-build glibc baseline (Ubuntu 18.04 / glibc 2.27 if .NET 10 is the agent's
+minimum supported runtime). Phase 3 of the dual-build effort moves the glibc base
+forward, drops the libc++ static-link, and addresses the Ubuntu 14.04 EOL / apt-key /
+S3-cmake reliability risks. Phase 3 is gated on the agent moving its minimum supported
+runtime past .NET 8.


### PR DESCRIPTION
Second sub-PR of the Phase 2 dual-build effort. Adds the load-bearing customer-facing piece: libc-aware compat symlinks at the home root so customers who hardcode `CORECLR_PROFILER_PATH=$NRHOME/libNewRelicProfiler.so` (the dominant Linux install pattern) keep working unchanged after #3599's per-RID layout.

The four mitigation surfaces from the Phase 2 design:

| | Action |
|---|---|
| `setenv.sh` | libc/arch probe → create or refresh symlink to matching per-RID variant |
| `run.sh` | same probe, then existing one-shot exec |
| `.deb` postinst + `.rpm` `%post` | `ln -sf` libc-aware symlink at install time (clobbers #3599's placeholder) |
| Tarball pre-bake (`deb/build.sh`) | `ln -sf` default symlink → `linux-x64/` (or `linux-arm64/`) before `tar.gz` |

Also rewrites `src/Agent/NewRelic/Profiler/linux/README.md` — the old four-property invariant for Alpine compat is now historical context; Alpine compat comes from the dedicated `linux-musl-{x64,arm64}/libNewRelicProfiler.so`.

## Verification
- [x] `bash -n` clean on all four shell files
- [x] Rebase onto post-#3599 feature branch + full CI green
- [x] Manual smoke: glibc Ubuntu, Alpine, tarball-on-glibc, tarball-on-Alpine refresh