### PR TITLE
chore(profiler): per-RID layout in NewRelic.Agent NuGet (Phase 2 PR3)

### DIFF
--- a/build/ArtifactBuilder/Artifacts/NugetAgent.cs
+++ b/build/ArtifactBuilder/Artifacts/NugetAgent.cs
@@ -53,8 +53,12 @@ public class NugetAgent : Artifact
 
         _coreAgentComponents.CopyComponents($@"{package.GetContentFilesDirectory("any", "netstandard2.0")}\newrelic");
         FileHelpers.CopyFile(_coreAgentX86Components.WindowsProfiler, $@"{package.GetContentFilesDirectory("any", "netstandard2.0")}\newrelic\x86");
-        package.CopyToContentFiles(_coreAgentComponents.LinuxProfiler, @"any\netstandard2.0\newrelic");
+        package.CopyToContentFiles(_coreAgentComponents.LinuxProfiler, @"any\netstandard2.0\newrelic\linux-x64");
+        package.CopyToContentFiles(_coreAgentComponents.LinuxMuslProfiler, @"any\netstandard2.0\newrelic\linux-musl-x64");
         package.CopyToContentFiles(_coreAgentArm64Components.LinuxProfiler, @"any\netstandard2.0\newrelic\linux-arm64");
+        package.CopyToContentFiles(_coreAgentArm64Components.LinuxMuslProfiler, @"any\netstandard2.0\newrelic\linux-musl-arm64");
+        // Compat copy at flat path for hardcoded CORECLR_PROFILER_PATH consumers.
+        package.CopyToContentFiles(_coreAgentComponents.LinuxProfiler, @"any\netstandard2.0\newrelic");
         Directory.CreateDirectory($@"{StagingDirectory}\contentFiles\any\netstandard2.0\newrelic\logs");
         File.Create($@"{StagingDirectory}\contentFiles\any\netstandard2.0\newrelic\logs\placeholder").Dispose();
 
@@ -167,7 +171,10 @@ public class NugetAgent : Artifact
     {
         AddFullAgentComponents(expectedComponents, folder, _coreAgentComponents);
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(folder, "x86"), _coreAgentX86Components.WindowsProfiler);
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(folder, "linux-x64"), _coreAgentComponents.LinuxProfiler);
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(folder, "linux-musl-x64"), _coreAgentComponents.LinuxMuslProfiler);
         ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(folder, "linux-arm64"), _coreAgentArm64Components.LinuxProfiler);
+        ValidationHelpers.AddSingleFileToCollectionWithNewPath(expectedComponents, Path.Combine(folder, "linux-musl-arm64"), _coreAgentArm64Components.LinuxMuslProfiler);
     }
 
     private static void AddFullAgentComponents(SortedSet<string> expectedComponents, string rootFolder, AgentComponents agentComponents)

--- a/build/Packaging/AzureSiteExtension/Content/install.ps1
+++ b/build/Packaging/AzureSiteExtension/Content/install.ps1
@@ -166,12 +166,21 @@ function InstallNewAgent($newRelicNugetContentPath, $newRelicInstallPath, $newRe
 	###Restore saved newrelic.config and custom instrumemtation files###
 	RestoreCustomerRelatedFiles $newRelicInstallPath $newRelicLegacyInstallPath
 
-	###Remove Linux profiler since it won't be used.
-	$linuxProfiler = "$newRelicInstallPath\libNewRelicProfiler.so"
-	if(Test-Path $linuxProfiler)
+	###Remove Linux profiler files since they won't be used on Windows Azure App Service.
+	$linuxProfilerPaths = @(
+		"$newRelicInstallPath\libNewRelicProfiler.so",
+		"$newRelicInstallPath\linux-x64",
+		"$newRelicInstallPath\linux-musl-x64",
+		"$newRelicInstallPath\linux-arm64",
+		"$newRelicInstallPath\linux-musl-arm64"
+	)
+	foreach($linuxProfilerPath in $linuxProfilerPaths)
 	{
-		WriteToInstallLog "Remove Linux profiler since it won't be used"
-		Remove-Item $linuxProfiler
+		if(Test-Path $linuxProfilerPath)
+		{
+			WriteToInstallLog "Remove Linux profiler artifact $linuxProfilerPath"
+			Remove-Item -Recurse -Force $linuxProfilerPath
+		}
 	}
 }
 


### PR DESCRIPTION
Third sub-PR of the Phase 2 dual-build effort. Extends the consumer-facing `NewRelic.Agent` NuGet to ship per-RID Linux profiler binaries while keeping a flat-path compat copy for hardcoded `CORECLR_PROFILER_PATH` consumers.

`contentFiles/any/netstandard2.0/newrelic/` now contains:

```
libNewRelicProfiler.so                    (flat compat, = linux-x64 glibc)
linux-x64/libNewRelicProfiler.so
linux-musl-x64/libNewRelicProfiler.so     (new)
linux-arm64/libNewRelicProfiler.so
linux-musl-arm64/libNewRelicProfiler.so   (new)
```

Also extends the AzureSiteExtension `install.ps1` cleanup to remove all five Linux artifacts since Azure App Service is Windows-only. The existing cleanup only handled the flat path and was missing even today's `linux-arm64/` directory (~30 MB dead weight per install).

## Verification

- [x] Full agent CI green (run 26247622648, post-PR2 rebase on `dd069b2d9`)
- [x] Built `NewRelic.Agent.10.51.0.40.nupkg` shows all five Linux entries with correct sizes (flat=15.28 MB matching linux-x64; musl-x64=10.76 MB and musl-arm64=10.99 MB distinct)
- [x] AzureSiteExtension `install.ps1` (in the built `NewRelic.Azure.WebSites.Extension.nupkg`) iterates the five paths and `Remove-Item -Recurse -Force`s each
- [x] `dotnet publish -r linux-musl-x64` of an app referencing `NewRelic.Agent` yields a publish output containing `newrelic/linux-musl-x64/libNewRelicProfiler.so`

## Note on publish-output size (pre-existing behavior, unchanged by PR)

`contentFiles` always copy verbatim regardless of `-r` flag — there is no RID-aware filtering. Every consumer publish output (any RID, no RID, even `win-x64`) gets all five Linux `.so` files, ~67 MB total. This is the same mechanism that already shipped the glibc x64 + arm64 binaries in any publish output today; PR adds ~37 MB (musl-x64 + musl-arm64 + a duplicated linux-x64 copy). Lambda layer customers and other size-sensitive consumers should be aware. A follow-up could wire RID resolution via `runtimes/<RID>/native/` if size becomes a concern.