### PR TITLE
test: add AlpineArm64 container test fixture (Phase 2 PR4)

### DIFF
--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -79,6 +79,9 @@ jobs:
           - arch: arm64
             distro: Fedora
             runner: ubuntu-24.04-arm
+          - arch: arm64
+            distro: Alpine
+            runner: ubuntu-24.04-arm
 
     env:
       test_results_path: tests/TestResults

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Applications/ContainerApplication.cs
@@ -80,6 +80,18 @@ public class ContainerApplication : RemoteApplication
     {
         CopyNewRelicHomeCoreClrLinuxDirectoryToRemote(_agentArch);
 
+        // Alpine is musl-based. The build-output default symlink points to the glibc variant
+        // (linux-{arch}/libNewRelicProfiler.so), which Alpine arm64 cannot load (no glibc compat).
+        // Redirect to the musl-native binary so the profiler attaches correctly.
+        if (_distroTag.Contains("alpine", StringComparison.OrdinalIgnoreCase))
+        {
+            var symlinkPath = Path.Combine(DestinationNewRelicHomeDirectoryPath, "libNewRelicProfiler.so");
+            var muslTarget = Path.Combine($"linux-musl-{_agentArch}", "libNewRelicProfiler.so");
+            if (Path.Exists(symlinkPath))
+                File.Delete(symlinkPath);
+            File.CreateSymbolicLink(symlinkPath, muslTarget);
+        }
+
         ModifyNewRelicConfig();
     }
 

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Fixtures/ContainerTestFixtures.cs
@@ -48,6 +48,15 @@ public class AlpineX64ContainerTestFixture : ContainerTestFixtureBase
     public AlpineX64ContainerTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
 }
 
+public class AlpineArm64ContainerTestFixture : ContainerTestFixtureBase
+{
+    private const string Dockerfile = "SmokeTestApp/Dockerfile";
+    private const ContainerApplication.Architecture Architecture = ContainerApplication.Architecture.Arm64;
+    private const string DistroTag = "alpine";
+
+    public AlpineArm64ContainerTestFixture() : base(DistroTag, Architecture, Dockerfile) { }
+}
+
 public class UbuntuArm64ContainerTestFixture : ContainerTestFixtureBase
 {
     private const string Dockerfile = "SmokeTestApp/Dockerfile";

--- a/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
+++ b/tests/Agent/IntegrationTests/ContainerIntegrationTests/Tests/LinuxContainerTests.cs
@@ -65,6 +65,15 @@ public class AlpineX64ContainerTest : LinuxContainerTest<AlpineX64ContainerTestF
 }
 
 [Trait("Architecture", "arm64")]
+[Trait("Distro", "Alpine")]
+public class AlpineArm64ContainerTest : LinuxContainerTest<AlpineArm64ContainerTestFixture>
+{
+    public AlpineArm64ContainerTest(AlpineArm64ContainerTestFixture fixture, ITestOutputHelper output) : base(fixture, output)
+    {
+    }
+}
+
+[Trait("Architecture", "arm64")]
 [Trait("Distro", "Ubuntu")]
 public class UbuntuArm64ContainerTest : LinuxContainerTest<UbuntuArm64ContainerTestFixture>
 {


### PR DESCRIPTION
Adds AlpineArm64ContainerTestFixture / AlpineArm64ContainerTest mirroring the existing X64 variant, plus the corresponding arm64/Alpine matrix entry in `linux_container_tests.yml`. Exercises the arm64 musl profiler binary the dual-build adds.

## Verification
- [ ] Full agent CI green
- [ ] New `Container Test (Alpine/arm64)` job runs and passes