### PR TITLE
chore: Add FileVersionInfo.FileVersion to update_loaded_modules payload and remove copyright attribute.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/FileWrapper.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace NewRelic.Agent.Core.Utilities;
@@ -18,6 +19,7 @@ public interface IFileWrapper
     string[] ReadAllLines(string path);
     DateTime GetLastWriteTimeUtc(string path);
     FileStream Open(string path, FileMode mode, FileAccess access, FileShare share);
+    string GetFileVersion(string path);
 }
 
 [NrExcludeFromCodeCoverage]
@@ -70,5 +72,11 @@ public class FileWrapper : IFileWrapper
     public FileStream Open(string path, FileMode mode, FileAccess access, FileShare share)
     {
         return File.Open(path, mode, access, share);
+    }
+
+    public string GetFileVersion(string path)
+    {
+        var fvi = FileVersionInfo.GetVersionInfo(path);
+        return fvi.FileVersion;
     }
 }

--- a/src/Agent/NewRelic/Agent/Core/Utilities/UpdatedLoadedModulesService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Utilities/UpdatedLoadedModulesService.cs
@@ -18,14 +18,16 @@ public class UpdatedLoadedModulesService : DisposableService
     private readonly IScheduler _scheduler;
     private readonly IDataTransportService _dataTransportService;
     private readonly IConfigurationService _configurationService;
+    private readonly IFileWrapper _fileWrapper;
     private IConfiguration _configuration => _configurationService?.Configuration;
 
-    public UpdatedLoadedModulesService(IScheduler scheduler, IDataTransportService dataTransportService, IConfigurationService configurationService)
+    public UpdatedLoadedModulesService(IScheduler scheduler, IDataTransportService dataTransportService, IConfigurationService configurationService, IFileWrapper fileWrapper)
     {
         _configurationService = configurationService;
         _dataTransportService = dataTransportService;
         _scheduler = scheduler;
         _scheduler.ExecuteEvery(GetLoadedModules, _configuration.UpdateLoadedModulesCycle);
+        _fileWrapper = fileWrapper;
 
         _subscriptions.Add<StopHarvestEvent>(OnStopHarvest);
         _subscriptions.Add<AgentConnectedEvent>(OnAgentConnected);
@@ -63,7 +65,7 @@ public class UpdatedLoadedModulesService : DisposableService
             return;
         }
 
-        var loadedModulesCollection = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModulesCollection = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         SendUpdatedLoadedModules(loadedModulesCollection);
     }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
 using NewRelic.Agent.Core.JsonConverters;
+using NewRelic.Agent.Core.Utilities;
 using Newtonsoft.Json;
 
 namespace NewRelic.Agent.Core.WireModels;
@@ -23,7 +24,7 @@ public class LoadedModuleWireModelCollection
         LoadedModules = new List<LoadedModuleWireModel>();
     }
 
-    public static LoadedModuleWireModelCollection Build(IList<Assembly> assemblies)
+    public static LoadedModuleWireModelCollection Build(IList<Assembly> assemblies, IFileWrapper fileWrapper)
     {
         var loadedModulesCollection = new LoadedModuleWireModelCollection();
         foreach (var assembly in assemblies)
@@ -44,7 +45,7 @@ public class LoadedModuleWireModelCollection
                 loadedModule.Data.Add("publicKeyToken", publicKey);
             }
 
-            if (TryGetShaFileHashes(assembly, out var sha1FileHash, out var sha512FileHash))
+            if (TryGetShaFileHashes(assembly, fileWrapper, out var sha1FileHash, out var sha512FileHash))
             {
                 loadedModule.Data.Add("sha1Checksum", sha1FileHash);
                 loadedModule.Data.Add("sha512Checksum", sha512FileHash);
@@ -58,9 +59,11 @@ public class LoadedModuleWireModelCollection
             {
                 loadedModule.Data.Add("Implementation-Vendor", companyName);
             }
-            if (TryGetCopyright(assembly, out var copyright))
+
+            // Added to provide an alternative way to identify assemblies that only provide major version in the assembly version.
+            if (TryGetAssemblyFileVersion(assembly, fileWrapper, out var fileVersion))
             {
-                loadedModule.Data.Add("copyright", copyright);
+                loadedModule.Data.Add("fileVersion", fileVersion);
             }
 
             // Use the .Name here and in GetLoadedModules
@@ -112,26 +115,19 @@ public class LoadedModuleWireModelCollection
         }
     }
 
-    private static bool TryGetShaFileHashes(Assembly assembly, out string sha1FileHash, out string sha512FileHash)
+    private static bool TryGetShaFileHashes(Assembly assembly, IFileWrapper fileWrapper, out string sha1FileHash, out string sha512FileHash)
     {
         try
         {
             var location = assembly.Location;
-            if (string.IsNullOrEmpty(location))
+            if (string.IsNullOrEmpty(location) || !fileWrapper.Exists(location))
             {
                 sha1FileHash = null;
                 sha512FileHash = null;
                 return false;
             }
 
-            if (!File.Exists(location))
-            {
-                sha1FileHash = null;
-                sha512FileHash = null;
-                return false;
-            }
-
-            using (var fs = new FileStream(location, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var fs = fileWrapper.Open(location, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 var sha1 = SHA1.Create();
                 var sha512 = SHA512.Create();
@@ -213,6 +209,27 @@ public class LoadedModuleWireModelCollection
         catch
         {
             copyright = null;
+            return false;
+        }
+    }
+
+    private static bool TryGetAssemblyFileVersion(Assembly assembly, IFileWrapper fileWrapper, out string version)
+    {
+        try
+        {
+            var location = assembly.Location;
+            if (string.IsNullOrEmpty(location) || !fileWrapper.Exists(location))
+            {
+                version = null;
+                return false;
+            }
+
+            version = fileWrapper.GetFileVersion(location);
+            return !string.IsNullOrWhiteSpace(version);
+        }
+        catch
+        {
+            version = null;
             return false;
         }
     }

--- a/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
+++ b/src/Agent/NewRelic/Agent/Core/WireModels/LoadedModuleWireModelCollection.cs
@@ -120,7 +120,7 @@ public class LoadedModuleWireModelCollection
         try
         {
             var location = assembly.Location;
-            if (string.IsNullOrEmpty(location) || !fileWrapper.Exists(location))
+            if (!fileWrapper.Exists(location))
             {
                 sha1FileHash = null;
                 sha512FileHash = null;
@@ -192,33 +192,12 @@ public class LoadedModuleWireModelCollection
         }
     }
 
-    private static bool TryGetCopyright(Assembly assembly, out string copyright)
-    {
-        try
-        {
-            var attributes = assembly.GetCustomAttributes(typeof(AssemblyCopyrightAttribute), true);
-            if (attributes.Length < 1)
-            {
-                copyright = null;
-                return false;
-            }
-
-            copyright = ((AssemblyCopyrightAttribute)attributes[0]).Copyright;
-            return !string.IsNullOrWhiteSpace(copyright);
-        }
-        catch
-        {
-            copyright = null;
-            return false;
-        }
-    }
-
     private static bool TryGetAssemblyFileVersion(Assembly assembly, IFileWrapper fileWrapper, out string version)
     {
         try
         {
             var location = assembly.Location;
-            if (string.IsNullOrEmpty(location) || !fileWrapper.Exists(location))
+            if (!fileWrapper.Exists(location))
             {
                 version = null;
                 return false;

--- a/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/VulnerabilityManagementTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/AgentFeatures/VulnerabilityManagementTests.cs
@@ -21,8 +21,8 @@ public abstract class VulnerabilityManagementTestsBase<TFixture> : NewRelicInteg
     private const string Sha512Checksum = "sha512Checksum";
     private const string AssemblyHashCode = "assemblyHashCode";
     private const string ImplementationVendor = "Implementation-Vendor";
-    private const string Copyright = "copyright";
     private const string MicrosoftName = "Microsoft";
+    private const string FileVersion = "fileVersion";
 
     protected readonly TFixture _fixture;
 
@@ -89,9 +89,8 @@ public abstract class VulnerabilityManagementTestsBase<TFixture> : NewRelicInteg
             () => Assert.False(string.IsNullOrWhiteSpace(mscorlib.Data[ImplementationVendor])),
             () => Assert.Contains(MicrosoftName, mscorlib.Data[ImplementationVendor]),
 
-            () => Assert.True(mscorlib.Data.ContainsKey(Copyright)),
-            () => Assert.False(string.IsNullOrWhiteSpace(mscorlib.Data[Copyright])),
-            () => Assert.Contains(MicrosoftName, mscorlib.Data[Copyright])
+            () => Assert.True(mscorlib.Data.ContainsKey(FileVersion)),
+            () => Assert.False(string.IsNullOrWhiteSpace(mscorlib.Data[FileVersion]))
         );
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LoadedModuleWireModelCollectionJsonConverterTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using NewRelic.Agent.Core.WireModels;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Telerik.JustMock;
 
 namespace NewRelic.Agent.Core.Utilities;
 
@@ -22,11 +24,28 @@ public class LoadedModuleWireModelCollectionJsonConverterTests
     private const int BaseHashCode = 42;
     private const string BasePublicKeyToken = "publickeytoken";
     private const string BasePublicKey = "7075626C69636B6579746F6B656E";
+    private const string BaseFileVersion = "1.0.0.0";
+
+    private IFileWrapper _fileWrapper;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var fileStream = Mock.Create<FileStream>();
+        Mock.Arrange(() => fileStream.Length).Returns(1024);
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(1024).InSequence(); // send some bytes
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(0).InSequence(); // FileStream.Read returns 0 when the end of the stream is reached.
+        _fileWrapper = Mock.Create<IFileWrapper>();
+        Mock.Arrange(() => _fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
+        Mock.Arrange(() => _fileWrapper.Open(Arg.IsAny<string>(), Arg.IsAny<FileMode>(), Arg.IsAny<FileAccess>(), Arg.IsAny<FileShare>()))
+            .Returns(fileStream);
+        Mock.Arrange(() => _fileWrapper.GetFileVersion(Arg.IsAny<string>())).Returns(BaseFileVersion);
+    }
 
     [Test]
     public void LoadedModuleWireModelCollectionIsJsonSerializable()
     {
-        var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42"",""Implementation-Vendor"":""MyCompany"",""copyright"":""Copyright 2008""}]]]";
+        var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""sha1Checksum"":""60cacbf3d72e1e7834203da608037b1bf83b40e8"",""sha512Checksum"":""8efb4f73c5655351c444eb109230c556d39e2c7624e9c11abc9e3fb4b9b9254218cc5085b454a9698d085cfa92198491f07a723be4574adc70617b73eb0b6461"",""assemblyHashCode"":""42"",""Implementation-Vendor"":""MyCompany"",""fileVersion"":""1.0.0.0""}]]]";
 
         var baseAssemblyName = new AssemblyName();
         baseAssemblyName.Name = BaseAssemblyName;
@@ -38,11 +57,10 @@ public class LoadedModuleWireModelCollectionJsonConverterTests
         baseTestAssembly.SetHashCode = BaseHashCode;
         baseTestAssembly.SetLocation = BaseAssemblyPath;
         baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
-        baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
 
         var assemblies = new List<Assembly>();
         assemblies.Add(baseTestAssembly);
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         var serialized = JsonConvert.SerializeObject(new[] { loadedModules }, Formatting.None);
         Assert.That(serialized, Is.EqualTo(expected));
@@ -51,7 +69,7 @@ public class LoadedModuleWireModelCollectionJsonConverterTests
     [Test]
     public void LoadedModuleWireModelCollectionHandlesNulls()
     {
-        var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""assemblyHashCode"":""42""}]]]";
+        var expected = @"[""Jars"",[[""MyTestAssembly.dll"",""1.0.0"",{""namespace"":""MyTestAssembly"",""publicKeyToken"":""7075626C69636B6579746F6B656E"",""sha1Checksum"":""60cacbf3d72e1e7834203da608037b1bf83b40e8"",""sha512Checksum"":""8efb4f73c5655351c444eb109230c556d39e2c7624e9c11abc9e3fb4b9b9254218cc5085b454a9698d085cfa92198491f07a723be4574adc70617b73eb0b6461"",""assemblyHashCode"":""42"",""fileVersion"":""1.0.0.0""}]]]";
 
         var baseAssemblyName = new AssemblyName();
         baseAssemblyName.Name = BaseAssemblyName;
@@ -63,11 +81,10 @@ public class LoadedModuleWireModelCollectionJsonConverterTests
         baseTestAssembly.SetHashCode = BaseHashCode;
         baseTestAssembly.SetLocation = BaseAssemblyPath;
         baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(null));
-        baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(null));
 
         var assemblies = new List<Assembly> { baseTestAssembly };
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         var serialized = JsonConvert.SerializeObject(new[] { loadedModules }, Formatting.None);
         Assert.That(serialized, Is.EqualTo(expected));

--- a/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Utilities/UpdatedLoadedModulesServiceTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.IO;
 using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.DataTransport;
@@ -44,7 +45,17 @@ public class UpdatedLoadedModulesServiceTests
         Mock.Arrange(() => scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()))
             .DoInstead<Action, TimeSpan, TimeSpan?>((action, harvestCycle, __) => { _getLoadedModulesAction = action; _harvestCycle = harvestCycle; });
 
-        _updatedLoadedModulesService = new UpdatedLoadedModulesService(scheduler, _dataTransportService, configurationService);
+        var fileStream = Mock.Create<FileStream>();
+        Mock.Arrange(() => fileStream.Length).Returns(1024);
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(1024).InSequence(); // send some bytes
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(0).InSequence(); // FileStream.Read returns 0 when the end of the stream is reached.
+        var fileWrapper = Mock.Create<IFileWrapper>();
+        Mock.Arrange(() => fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
+        Mock.Arrange(() => fileWrapper.Open(Arg.IsAny<string>(), Arg.IsAny<FileMode>(), Arg.IsAny<FileAccess>(), Arg.IsAny<FileShare>()))
+            .Returns(fileStream);
+        Mock.Arrange(() => fileWrapper.GetFileVersion(Arg.IsAny<string>())).Returns("1.0.0.0");
+
+        _updatedLoadedModulesService = new UpdatedLoadedModulesService(scheduler, _dataTransportService, configurationService, fileWrapper);
 
         EventBus<AgentConnectedEvent>.Publish(new AgentConnectedEvent());
     }

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Text;
+using NewRelic.Agent.Core.Utilities;
 using NUnit.Framework;
+using Telerik.JustMock;
 
 namespace NewRelic.Agent.Core.WireModels;
 
@@ -18,13 +21,17 @@ public class LoadedModuleWireModelCollectionTests
     private string BaseAssemblyVersion;
     private string BaseAssemblyPath;
     private string BaseCompanyName;
-    private string BaseCopyrightValue;
     private int    BaseHashCode;
     private string BasePublicKeyToken;
     private string BasePublicKey;
+    private string Sha1Checksum;
+    private string Sha512Checksum;
+    private string BaseFileVersion;
 
     private AssemblyName _baseAssemblyName;
     private TestAssembly _baseTestAssembly;
+
+    private IFileWrapper _fileWrapper;
 
     [SetUp]
     public void SetUp()
@@ -33,10 +40,12 @@ public class LoadedModuleWireModelCollectionTests
         BaseAssemblyVersion = "1.0.0";
         BaseAssemblyPath = @"C:\path\to\assembly\MyTestAssembly.dll";
         BaseCompanyName = "MyCompany";
-        BaseCopyrightValue = "Copyright 2008";
         BaseHashCode = 42;
         BasePublicKeyToken = "publickeytoken";
         BasePublicKey = "7075626C69636B6579746F6B656E";
+        Sha1Checksum = "60cacbf3d72e1e7834203da608037b1bf83b40e8";
+        Sha512Checksum = "8efb4f73c5655351c444eb109230c556d39e2c7624e9c11abc9e3fb4b9b9254218cc5085b454a9698d085cfa92198491f07a723be4574adc70617b73eb0b6461";
+        BaseFileVersion = "1.0.0.0";
 
         _baseAssemblyName = new AssemblyName();
         _baseAssemblyName.Name = BaseAssemblyNamespace;
@@ -49,7 +58,16 @@ public class LoadedModuleWireModelCollectionTests
         _baseTestAssembly.SetHashCode = BaseHashCode;
         _baseTestAssembly.SetLocation = BaseAssemblyPath;
         _baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
-        _baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
+
+        var fileStream = Mock.Create<FileStream>();
+        Mock.Arrange(() => fileStream.Length).Returns(1024);
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(1024).InSequence(); // send some bytes
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(0).InSequence(); // FileStream.Read returns 0 when the end of the stream is reached.
+        _fileWrapper = Mock.Create<IFileWrapper>();
+        Mock.Arrange(() => _fileWrapper.Exists(Arg.IsAny<string>())).Returns(true);
+        Mock.Arrange(() => _fileWrapper.Open(Arg.IsAny<string>(), Arg.IsAny<FileMode>(), Arg.IsAny<FileAccess>(), Arg.IsAny<FileShare>()))
+            .Returns(fileStream);
+        Mock.Arrange(() => _fileWrapper.GetFileVersion(Arg.IsAny<string>())).Returns(BaseFileVersion);
     }
 
     [TearDown] public void TearDown()
@@ -75,7 +93,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(_baseTestAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         return loadedModules.LoadedModules.Count;
     }
@@ -88,12 +106,11 @@ public class LoadedModuleWireModelCollectionTests
         zeroVersioned.SetHashCode = BaseHashCode;
         zeroVersioned.SetLocation = BaseAssemblyPath;
         zeroVersioned.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(BaseCompanyName));
-        zeroVersioned.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(BaseCopyrightValue));
 
         var assemblies = new List<Assembly>();
         assemblies.Add(zeroVersioned);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(0));
     }
@@ -105,7 +122,7 @@ public class LoadedModuleWireModelCollectionTests
         _baseTestAssembly.SetDynamic = true;
         assemblies.Add(_baseTestAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(0));
     }
@@ -116,7 +133,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(_baseTestAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
 
@@ -130,12 +147,9 @@ public class LoadedModuleWireModelCollectionTests
             Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
             Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
             Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
-            Assert.That(loadedModule.Data["copyright"], Is.EqualTo(BaseCopyrightValue));
-        });
-        Assert.Multiple(() =>
-        {
-            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data["sha1Checksum"], Is.EqualTo(Sha1Checksum));
+            Assert.That(loadedModule.Data["sha512Checksum"], Is.EqualTo(Sha512Checksum));
+            Assert.That(loadedModule.Data["fileVersion"], Is.EqualTo(BaseFileVersion));
         });
     }
 
@@ -148,7 +162,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Is.Empty);
     }
@@ -162,7 +176,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Is.Empty);
     }
@@ -176,7 +190,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
 
@@ -187,18 +201,12 @@ public class LoadedModuleWireModelCollectionTests
             Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
             Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
             Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
-        });
-        Assert.That(loadedModule.Data.ContainsKey("assemblyHashCode"), Is.False);
-        Assert.Multiple(() =>
-        {
             Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
             Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
-            Assert.That(loadedModule.Data["copyright"], Is.EqualTo(BaseCopyrightValue));
-        });
-        Assert.Multiple(() =>
-        {
-            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data["sha1Checksum"], Is.EqualTo(Sha1Checksum));
+            Assert.That(loadedModule.Data["sha512Checksum"], Is.EqualTo(Sha512Checksum));
+            Assert.That(loadedModule.Data["fileVersion"], Is.EqualTo(BaseFileVersion));
+            Assert.That(loadedModule.Data.ContainsKey("assemblyHashCode"), Is.False);
         });
     }
 
@@ -211,7 +219,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Is.Empty);
     }
@@ -225,7 +233,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
 
@@ -238,13 +246,10 @@ public class LoadedModuleWireModelCollectionTests
             Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
             Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
             Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
-        });
-        Assert.Multiple(() =>
-        {
+            Assert.That(loadedModule.Data["sha1Checksum"], Is.EqualTo(Sha1Checksum));
+            Assert.That(loadedModule.Data["sha512Checksum"], Is.EqualTo(Sha512Checksum));
             Assert.That(loadedModule.Data.ContainsKey("Implementation-Vendor"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("copyright"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data["fileVersion"], Is.EqualTo(BaseFileVersion));
         });
     }
 
@@ -252,7 +257,6 @@ public class LoadedModuleWireModelCollectionTests
     public void ErrorsHandled_GetCustomAttributes_HandlesNulls()
     {
         _baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCompanyAttribute(null));
-        _baseTestAssembly.AddOrReplaceCustomAttribute(new AssemblyCopyrightAttribute(null));
 
         var evilAssembly = new EvilTestAssembly(_baseTestAssembly);
         evilAssembly.ItemToTest = "";
@@ -260,17 +264,13 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
 
         var loadedModule = loadedModules.LoadedModules[0];
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(loadedModule.Data.ContainsKey("Implementation-Vendor"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("copyright"), Is.False);
-        });
+        Assert.That(loadedModule.Data.ContainsKey("Implementation-Vendor"), Is.False);
     }
 
     [Test]
@@ -282,7 +282,7 @@ public class LoadedModuleWireModelCollectionTests
         var assemblies = new List<Assembly>();
         assemblies.Add(evilAssembly);
 
-        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies);
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, _fileWrapper);
 
         Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
 
@@ -294,17 +294,11 @@ public class LoadedModuleWireModelCollectionTests
             Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
             Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
             Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
-        });
-        Assert.That(loadedModule.Data.ContainsKey("publicKeyToken"), Is.False);
-        Assert.Multiple(() =>
-        {
             Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
-            Assert.That(loadedModule.Data["copyright"], Is.EqualTo(BaseCopyrightValue));
-        });
-        Assert.Multiple(() =>
-        {
-            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
-            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data["sha1Checksum"], Is.EqualTo(Sha1Checksum));
+            Assert.That(loadedModule.Data["sha512Checksum"], Is.EqualTo(Sha512Checksum));
+            Assert.That(loadedModule.Data["fileVersion"], Is.EqualTo(BaseFileVersion));
+            Assert.That(loadedModule.Data.ContainsKey("publicKeyToken"), Is.False);
         });
     }
 }

--- a/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/WireModels/LoadedModuleWireModelCollectionTests.cs
@@ -301,6 +301,71 @@ public class LoadedModuleWireModelCollectionTests
             Assert.That(loadedModule.Data.ContainsKey("publicKeyToken"), Is.False);
         });
     }
+
+    [Test]
+    public void FileDoesNotExist_Sha1_Sha512_FileVersion()
+    {
+        var fileWrapper = Mock.Create<IFileWrapper>();
+        Mock.Arrange(() => fileWrapper.Exists(Arg.IsAny<string>())).Returns(false);
+
+        var assemblies = new List<Assembly>();
+        assemblies.Add(_baseTestAssembly);
+
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, fileWrapper);
+
+        Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
+
+        var loadedModule = loadedModules.LoadedModules[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
+            Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
+            Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
+            Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
+            Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
+            Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
+            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
+            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data.ContainsKey("fileVersion"), Is.False);
+        });
+    }
+
+    [Test]
+    public void ErrorsHandled_Sha1_Sha512_FileVersion()
+    {
+        var fileStream = Mock.Create<FileStream>();
+        Mock.Arrange(() => fileStream.Length).Returns(1024);
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(1024).InSequence(); // send some bytes
+        Mock.Arrange(() => fileStream.Read(Arg.IsAny<byte[]>(), Arg.IsAny<int>(), Arg.IsAny<int>())).Returns(0).InSequence(); // FileStream.Read returns 0 when the end of the stream is reached.
+        var fileWrapper = Mock.Create<IFileWrapper>();
+        Mock.Arrange(() => fileWrapper.Exists(Arg.IsAny<string>())).Returns(false);
+        Mock.Arrange(() => fileWrapper.Open(Arg.IsAny<string>(), Arg.IsAny<FileMode>(), Arg.IsAny<FileAccess>(), Arg.IsAny<FileShare>()))
+            .Throws(new Exception());
+        Mock.Arrange(() => fileWrapper.GetFileVersion(Arg.IsAny<string>())).Throws(new Exception());
+
+        var assemblies = new List<Assembly>();
+        assemblies.Add(_baseTestAssembly);
+
+        var loadedModules = LoadedModuleWireModelCollection.Build(assemblies, fileWrapper);
+
+        Assert.That(loadedModules.LoadedModules, Has.Count.EqualTo(1));
+
+        var loadedModule = loadedModules.LoadedModules[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(loadedModule.AssemblyName, Is.EqualTo(BaseAssemblyName));
+            Assert.That(loadedModule.Version, Is.EqualTo(BaseAssemblyVersion));
+            Assert.That(loadedModule.Data["namespace"], Is.EqualTo(BaseAssemblyNamespace));
+            Assert.That(loadedModule.Data["assemblyHashCode"], Is.EqualTo(BaseHashCode.ToString()));
+            Assert.That(loadedModule.Data["publicKeyToken"], Is.EqualTo(BasePublicKey));
+            Assert.That(loadedModule.Data["Implementation-Vendor"], Is.EqualTo(BaseCompanyName));
+            Assert.That(loadedModule.Data.ContainsKey("sha1Checksum"), Is.False);
+            Assert.That(loadedModule.Data.ContainsKey("sha512Checksum"), Is.False);
+            Assert.That(loadedModule.Data.ContainsKey("fileVersion"), Is.False);
+        });
+    }
 }
 
 public class TestAssembly : Assembly


### PR DESCRIPTION
## Description

Add FileVersionInfo.FileVersion to update_loaded_modules payload and remove copyright attribute. 

Basically, Assembly.Version is not specific enough for many assemblies due to only having major version or a different unrelated version.  FileVersionInfo.GetVersionInfo.FileVersion has a potentially more useful version.

In order to keep the payload around the same size, we are removing the copyright attribute. Overall, this should result in a small decrease in payload size.  Note, this payload is sent exactly once per connect so the difference will be minor at best.

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
