### PR TITLE
ci: Fix markdown check failure

### DIFF
--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Note that the specified exact version of Chrome is required by the version of linkspector being used, and may need to be updated if the linkspector version is updated.
       - name: Install Chrome for linkspector
         run: |
           npx puppeteer browsers install chrome@148.0.7778.97

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -27,6 +27,12 @@ jobs:
           egress-policy: audit # Leave it audit mode
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Chrome for linkspector
+        run: |
+          npx puppeteer browsers install chrome@148.0.7778.215
+        shell: bash
+        
       
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@963b6264d7de32c904942a70b488d3407453049e # v1.5.1

--- a/.github/workflows/markdowncheck.yml
+++ b/.github/workflows/markdowncheck.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Chrome for linkspector
         run: |
-          npx puppeteer browsers install chrome@148.0.7778.215
+          npx puppeteer browsers install chrome@148.0.7778.97
         shell: bash
         
       


### PR DESCRIPTION
Dependabot updated the version of Linkspector to a newer version that doesn't include its own Chrome dependency, and so we need to add a step to install Chrome for node with `npx puppeteer`.  Note that the specific version of Chrome being installed is the one that the pinned version of Linkspector requires, so if the Linkspector version gets bumped again, I suspect that the Chrome version will need to be updated as well.
