### PR TITLE
fix: write serverless NR_LAMBDA_MONITORING payload to fd 1 directly to bypass Lambda runtime log prefix

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/ServerlessModePayloadManager.cs
@@ -72,10 +72,28 @@ public class ServerlessModePayloadManager : IServerlessModePayloadManager
 
         if (!success)
         {
-            // fall back to writing to stdout
+            // Fall back to writing to stdout.
+            // Write directly to file descriptor 1 (stdout) to bypass the .NET Lambda runtime's
+            // structured logging wrapper (WrapperTextWriter / LogLevelLoggerWriter), which intercepts
+            // Console.SetOut and prepends a timestamp\trequestId\tinfo\t prefix to every Console.WriteLine
+            // call. That prefix prevents aws-log-ingestion from parsing the NR_LAMBDA_MONITORING payload.
+            // Other agents (Python, Node.js, Ruby, Go, Java) write to fd 1 directly and produce clean
+            // output that aws-log-ingestion can parse without additional configuration.
             Log.Debug("Writing serverless payload to stdout");
-
-            Console.WriteLine(payloadJson);
+            try
+            {
+                using var fd1 = new System.IO.FileStream(
+                    new Microsoft.Win32.SafeHandles.SafeFileHandle(new System.IntPtr(1), ownsHandle: false),
+                    System.IO.FileAccess.Write, bufferSize: 4096, isAsync: false);
+                var bytes = System.Text.Encoding.UTF8.GetBytes(payloadJson + System.Environment.NewLine);
+                fd1.Write(bytes, 0, bytes.Length);
+                fd1.Flush();
+            }
+            catch
+            {
+                // Fallback to Console.WriteLine if direct fd write is unavailable
+                Console.WriteLine(payloadJson);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- The `.NET` Lambda runtime (`Amazon.Lambda.RuntimeSupport` `ConsoleLoggerWriter`) intercepts `Console.SetOut` and `Console.SetError`, wrapping both streams with `WrapperTextWriter` that prepends `timestamp\trequestId\tinfo\t` to every `Console.WriteLine` call.
- The `ServerlessModePayloadManager.WritePayload` stdout fallback uses `Console.WriteLine`, so every `NR_LAMBDA_MONITORING` payload in CloudWatch gets this prefix.
- `aws-log-ingestion` cannot parse the prefixed format by default, requiring customers to set `NEW_RELIC_FORMAT_LOGS=true`. Other agents (Python, Node.js, Ruby, Go, Java) write to fd 1 directly and produce clean, parseable output.

## Fix

Write the payload directly to file descriptor 1 via `SafeFileHandle(new IntPtr(1), ownsHandle: false)`, bypassing `WrapperTextWriter`. The fd 1 pipe to CloudWatch remains active regardless of `Console.SetOut` replacement (confirmed by other language runtimes). A `Console.WriteLine` fallback is retained for safety.

## Validation

Live test in Lambda sandbox (`repro-00327799-kmullaney`, dotnet8, `NewRelicDotnet:53`):

```
Console.WriteLine("FD1_TEST_CONSOLE")  →  CW: 2026-06-03T23:27:31Z\t7a732b6c...\tinfo\tFD1_TEST_CONSOLE
WriteFd1Direct("FD1_TEST_DIRECT")      →  CW: FD1_TEST_DIRECT
```

fd 1 direct write produces clean output identical to Python/Node/Ruby/Go/Java agents.

## Impact

After this PR:
- `.NET` Lambda users on the CloudWatch delivery path no longer need `NEW_RELIC_FORMAT_LOGS=true` on `aws-log-ingestion` for Logs-in-Context trace correlation.
- Output format matches all other NR Lambda agents.

## Related

- Companion fix in `newrelic/aws-log-ingestion` for customers using existing agent versions: https://github.com/newrelic/aws-log-ingestion/pull/160

## Test plan

- [x] fd 1 direct write validated in live Lambda environment (see above)
- [x] Console.WriteLine fallback retained for non-Lambda or restricted environments
- [x] `ownsHandle: false` prevents fd 1 from being closed on FileStream dispose
- [ ] Unit tests for `ServerlessModePayloadManager.WritePayload` stdout fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)