### PR TITLE
feat: Add alternative environment variables for expected and ignored error codes.

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2560,7 +2560,7 @@ public class DefaultConfiguration : IConfiguration
         var expectedStatusCodesArrayLocal = _localConfiguration.errorCollector.expectedStatusCodes?.Split(StringSeparators.Comma, StringSplitOptions.RemoveEmptyEntries);
         var expectedStatusCodesArrayServer = _serverConfiguration.RpmConfig.ErrorCollectorExpectedStatusCodes;
 
-        var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES");
+        var expectedStatusCodesArray = EnvironmentOverrides(ServerOverrides(expectedStatusCodesArrayServer, expectedStatusCodesArrayLocal), "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES", "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_STATUS_CODES");
 
         ExpectedStatusCodes = ParseExpectedStatusCodesArray(expectedStatusCodesArray);
         ExpectedErrorStatusCodesForAgentSettings = expectedStatusCodesArray ?? [];
@@ -2609,7 +2609,7 @@ public class DefaultConfiguration : IConfiguration
             }
         }
 
-        IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore, "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES");
+        IEnumerable<string> ignoreStatusCodes = EnvironmentOverrides(_serverConfiguration.RpmConfig.ErrorCollectorStatusCodesToIgnore, "NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES", "NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES");
         if (ignoreStatusCodes == null)
         {
             ignoreStatusCodes = _localConfiguration.errorCollector.ignoreStatusCodes.code

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -1003,7 +1003,7 @@ public class DefaultConfigurationTests
     {
         _serverConfig.RpmConfig.ErrorCollectorExpectedStatusCodes = server;
         _localConfig.errorCollector.expectedStatusCodes = (local);
-        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES")).Returns(env);
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES", "NEW_RELIC_ERROR_COLLECTOR_EXPECTED_STATUS_CODES")).Returns(env);
 
         CreateDefaultConfiguration();
 
@@ -1022,7 +1022,7 @@ public class DefaultConfigurationTests
     {
         _serverConfig.RpmConfig.ErrorCollectorStatusCodesToIgnore = server;
         _localConfig.errorCollector.ignoreStatusCodes.code = (local.ToList());
-        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES")).Returns(env);
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES", "NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES")).Returns(env);
 
         CreateDefaultConfiguration();
 


### PR DESCRIPTION
## Description

Adds a pair of alternative environment variables for the expected and ignored error codes:
- `NEW_RELIC_ERROR_COLLECTOR_EXPECTED_STATUS_CODES` added for `NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES` 
- `NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES` added for `NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES`

Includes updated unit tests.

Resolves #3588

# Author Checklist
- [ ] Unit tests, Integration tests, and Unbounded tests completed
- [ ] Performance testing completed with satisfactory results (if required)

# Reviewer Checklist
- [ ] Perform code review
- [ ] Pull request was adequately tested (new/existing tests, performance tests)
