### PR TITLE
chore(otel-bridge): Enforce NR OTLP data collection limits (NR-574462)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/DataTransport/OtlpAuditHandler.cs
+++ b/src/Agent/NewRelic/Agent/Core/DataTransport/OtlpAuditHandler.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,10 @@ namespace NewRelic.Agent.Core.DataTransport;
 /// </summary>
 public class OtlpAuditHandler : DelegatingHandler
 {
+    // NR OTLP ingest hard limit (REQ-015). After GzipCompressionHandler runs,
+    // bytesSent reflects the compressed wire payload - which is what NR enforces.
+    private const long MaxPayloadSizeBytes = 1_000_000;
+
     private readonly IAgentHealthReporter _agentHealthReporter;
 
     public OtlpAuditHandler(IAgentHealthReporter agentHealthReporter = null)
@@ -36,6 +41,13 @@ public class OtlpAuditHandler : DelegatingHandler
             
         // Audit log the outgoing request and capture size - single read for both audit log and metrics
         var bytesSent = await LogOtlpRequest(request).ConfigureAwait(false);
+
+        if (bytesSent > MaxPayloadSizeBytes)
+        {
+            Log.Warn("OTLP metrics payload ({BytesSent} bytes) exceeds 1MB; dropping this export cycle.", bytesSent);
+            _agentHealthReporter?.ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(request.RequestUri?.ToString() ?? "unknown");
+            return new HttpResponseMessage(HttpStatusCode.RequestEntityTooLarge);
+        }
 
         HttpResponseMessage response = null;
         try

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/MeterBridgingService.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/MeterBridgingService.cs
@@ -283,7 +283,7 @@ public class MeterBridgingService : DisposableService, IMeterBridgingService
         var type = originalMeter.GetType();
         var name = type.GetProperty("Name")?.GetValue(originalMeter) as string ?? "Unknown";
         var version = type.GetProperty("Version")?.GetValue(originalMeter) as string;
-        var tags = GetInstrumentTags(originalMeter);
+        var tags = ApplyScopeTagLimits(GetInstrumentTags(originalMeter));
         var scope = GetMeterScope(originalMeter);
 
         Meter bridgedMeter;
@@ -521,10 +521,7 @@ public class MeterBridgingService : DisposableService, IMeterBridgingService
                     
                 var val = accessors.ValueAccessor != null ? (T)accessors.ValueAccessor(m) : default(T);
                 var tags = accessors.TagsAccessor?.Invoke(m);
-                    
-                // Filter out tags with null keys
-                var validTags = tags?.Where(tag => tag.Key != null);
-                    
+                var validTags = ApplyTagLimits(tags);
                 list.Add(new Measurement<T>(val, validTags));
             }
         }
@@ -631,32 +628,95 @@ public class MeterBridgingService : DisposableService, IMeterBridgingService
 
     #region Helper Methods
 
+    // NR OTLP ingest limits (REQ-015 / REQ-016)
+    private const int AttributeCountLimit = 64;
+    private const int AttributeKeyLengthLimit = 255;
+    private const int AttributeValueLengthLimit = 4095;
+    private const int ArrayLengthLimit = 64;
+    private const int ByteArrayLengthLimit = 128_000;
+    private const int ScopeAttributeCountLimit = 8;
+
     /// <summary>
-    /// Filters tags to remove entries with null keys, preventing NullReferenceExceptions.
-    /// Optimized to avoid double array allocation.
+    /// Filters tags to remove entries with null keys, enforces NR OTLP attribute count (64)
+    /// and string value length (4095) limits per data point.
     /// </summary>
     private static KeyValuePair<string, object>[] FilterValidTags(ReadOnlySpan<KeyValuePair<string, object>> tags)
     {
-        // Single-pass: count valid tags, allocate once, populate
+        // First pass: count valid tags up to the attribute count limit
         var count = 0;
-        for (var i = 0; i < tags.Length; i++)
-        {
-            if (tags[i].Key != null) count++;
-        }
-            
-        if (count == 0) return Array.Empty<KeyValuePair<string, object>>();
-        if (count == tags.Length) return tags.ToArray(); // All valid, direct copy
-            
-        var result = new KeyValuePair<string, object>[count];
-        var index = 0;
         for (var i = 0; i < tags.Length; i++)
         {
             if (tags[i].Key != null)
             {
-                result[index++] = tags[i];
+                count++;
+                if (count == AttributeCountLimit) break;
             }
         }
+
+        if (count == 0) return Array.Empty<KeyValuePair<string, object>>();
+
+        var result = new KeyValuePair<string, object>[count];
+        var index = 0;
+        for (var i = 0; i < tags.Length && index < count; i++)
+        {
+            if (tags[i].Key != null)
+                result[index++] = TruncateTagValue(tags[i]);
+        }
         return result;
+    }
+
+    private static KeyValuePair<string, object> TruncateTagValue(KeyValuePair<string, object> tag)
+    {
+        var key = tag.Key.Length > AttributeKeyLengthLimit
+            ? tag.Key.Substring(0, AttributeKeyLengthLimit)
+            : tag.Key;
+        var value = tag.Value;
+        if (value is string s && s.Length > AttributeValueLengthLimit)
+            value = s.Substring(0, AttributeValueLengthLimit);
+        else if (value is byte[] bytes && bytes.Length > ByteArrayLengthLimit)
+        {
+            var truncated = new byte[ByteArrayLengthLimit];
+            Array.Copy(bytes, truncated, ByteArrayLengthLimit);
+            value = truncated;
+        }
+        else if (value is Array arr && arr.Length > ArrayLengthLimit)
+            value = TruncateArray(arr);
+        return ReferenceEquals(key, tag.Key) && ReferenceEquals(value, tag.Value)
+            ? tag
+            : new KeyValuePair<string, object>(key, value);
+    }
+
+    private static object TruncateArray(Array arr)
+    {
+        var truncated = Array.CreateInstance(arr.GetType().GetElementType(), ArrayLengthLimit);
+        Array.Copy(arr, truncated, ArrayLengthLimit);
+        return truncated;
+    }
+
+    private static IEnumerable<KeyValuePair<string, object>> ApplyScopeTagLimits(IEnumerable<KeyValuePair<string, object>> tags)
+    {
+        if (tags == null) return null;
+        var result = new List<KeyValuePair<string, object>>();
+        foreach (var tag in tags)
+        {
+            if (tag.Key == null) continue;
+            if (result.Count >= ScopeAttributeCountLimit) break;
+            result.Add(TruncateTagValue(tag));
+        }
+        return result.Count > 0 ? result : null;
+    }
+
+    private static IEnumerable<KeyValuePair<string, object>> ApplyTagLimits(IEnumerable<KeyValuePair<string, object>> tags)
+    {
+        if (tags == null) return null;
+        var result = new List<KeyValuePair<string, object>>();
+        foreach (var tag in tags)
+        {
+            if (tag.Key == null) continue;
+            if (result.Count >= AttributeCountLimit) break;
+            result.Add(TruncateTagValue(tag));
+        }
+        return result.Count > 0 ? result : null;
     }
 
     /// <summary>

--- a/tests/Agent/UnitTests/Core.UnitTest/DataTransport/OtlpAuditHandlerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/DataTransport/OtlpAuditHandlerTests.cs
@@ -378,6 +378,69 @@ public class OtlpAuditHandlerAdditionalTests
     }
 
     [Test]
+    public async Task SendAsync_WithPayloadExceeding1MB_DropsRequestAndReportsSupportability()
+    {
+        // Arrange
+        var mockAgentHealthReporter = Mock.Create<IAgentHealthReporter>();
+        string reportedEndpoint = null;
+        Mock.Arrange(() => mockAgentHealthReporter.ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit(Arg.IsAny<string>()))
+            .DoInstead((string endpoint) => reportedEndpoint = endpoint);
+
+        using var auditHandler = new OtlpAuditHandler(mockAgentHealthReporter);
+        var mockInnerHandler = new TestHttpMessageHandler();
+        auditHandler.InnerHandler = mockInnerHandler;
+
+        var httpClient = new HttpClient(auditHandler);
+        var oversizedContent = new ByteArrayContent(new byte[1_000_001]);
+        oversizedContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-protobuf");
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://otlp.newrelic.com/v1/metrics")
+        {
+            Content = oversizedContent
+        };
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert - inner handler never called, 413 returned, supportability metric recorded
+        Assert.That(response.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.RequestEntityTooLarge));
+        Assert.That(mockInnerHandler.RequestSent, Is.Null);
+        Assert.That(reportedEndpoint, Is.Not.Null);
+
+        httpClient.Dispose();
+        mockInnerHandler.Dispose();
+    }
+
+    [Test]
+    public async Task SendAsync_WithPayloadAt1MB_SendsNormally()
+    {
+        // Arrange - exactly 1_000_000 bytes should pass through
+        using var auditHandler = new OtlpAuditHandler(null);
+        var mockInnerHandler = new TestHttpMessageHandler
+        {
+            Response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        };
+        auditHandler.InnerHandler = mockInnerHandler;
+
+        var httpClient = new HttpClient(auditHandler);
+        var content = new ByteArrayContent(new byte[1_000_000]);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-protobuf");
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://otlp.newrelic.com/v1/metrics")
+        {
+            Content = content
+        };
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert - exactly at the limit passes through
+        Assert.That(response.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.OK));
+        Assert.That(mockInnerHandler.RequestSent, Is.Not.Null);
+
+        httpClient.Dispose();
+        mockInnerHandler.Dispose();
+    }
+
+    [Test]
     public async Task SendAsync_WithNullAgentHealthReporter_DoesNotThrow()
     {
         // Arrange - No agent health reporter

--- a/tests/Agent/UnitTests/Core.UnitTest/OpenTelemetryBridge/MeterBridgingServiceTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/OpenTelemetryBridge/MeterBridgingServiceTests.cs
@@ -3,10 +3,13 @@
 
 // Private callback methods (OnMeasurementRecorded, FilterValidTags, BridgeMeasurements)
 // are tested indirectly through integration tests rather than unit tests.
+// Tag-limit enforcement (AttributeCountLimit / AttributeValueLengthLimit) is tested
+// directly in MeterBridgingServiceTagLimitTests below using TestMeterListenerWrapper.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using System.Linq;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.Metrics;
 using NewRelic.Agent.Core.OpenTelemetryBridge.Metrics;
@@ -680,4 +683,408 @@ public class MeterBridgingServiceTests
         // Assert
         Mock.Assert(() => _mockListener.EnableMeasurementEvents(Arg.IsAny<object>(), Arg.IsAny<object>()), Occurs.Once());
     }
+}
+
+/// <summary>
+/// Tests that verify the NR OTLP attribute count (64) and string value length (4095) limits
+/// are enforced by MeterBridgingService for both regular and observable instruments.
+///
+/// Strategy: TestMeterListenerWrapper captures the MeasurementCallbackDelegate registered
+/// by MeterBridgingService.RegisterMeasurementCallbacks so tests can invoke OnMeasurementRecorded
+/// directly with a ReadOnlySpan of test tags. A real MeterListener (captureListener) then
+/// observes the bridged instrument to see what tags actually reached it after filtering.
+/// Source vs bridged instruments are distinguished by meter instance identity.
+/// </summary>
+[TestFixture]
+public class MeterBridgingServiceTagLimitTests
+{
+    private IConfigurationService _mockConfigService;
+    private IConfiguration _mockConfig;
+    private IOtelBridgeSupportabilityMetricCounters _mockMetrics;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockConfigService = Mock.Create<IConfigurationService>();
+        _mockConfig = Mock.Create<IConfiguration>();
+        _mockMetrics = Mock.Create<IOtelBridgeSupportabilityMetricCounters>();
+        Mock.Arrange(() => _mockConfigService.Configuration).Returns(_mockConfig);
+        Mock.Arrange(() => _mockConfig.OpenTelemetryMetricsIncludeFilters).Returns((IEnumerable<string>)null);
+        Mock.Arrange(() => _mockConfig.OpenTelemetryMetricsExcludeFilters).Returns((IEnumerable<string>)null);
+    }
+
+    [Test]
+    public void FilterValidTags_With100Tags_LimitsTo64()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_Count");
+        var counter = appMeter.CreateCounter<int>("count-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+
+        var bridgedState = wrapper.GetState(counter);
+        Assert.That(bridgedState, Is.Not.Null);
+
+        var capturedTagCount = -1;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "count-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+            capturedTagCount = tags.Length);
+        captureListener.Start();
+
+        var manyTags = Enumerable.Range(0, 100)
+            .Select(i => new KeyValuePair<string, object>($"k{i}", $"v{i}"))
+            .ToArray();
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(manyTags), bridgedState);
+
+        Assert.That(capturedTagCount, Is.EqualTo(64));
+    }
+
+    [Test]
+    public void FilterValidTags_With64Tags_PassesAllThrough()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_Boundary");
+        var counter = appMeter.CreateCounter<int>("boundary-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        var capturedTagCount = -1;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "boundary-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+            capturedTagCount = tags.Length);
+        captureListener.Start();
+
+        var exactTags = Enumerable.Range(0, 64)
+            .Select(i => new KeyValuePair<string, object>($"k{i}", $"v{i}"))
+            .ToArray();
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(exactTags), bridgedState);
+
+        Assert.That(capturedTagCount, Is.EqualTo(64));
+    }
+
+    [Test]
+    public void FilterValidTags_WithLongStringValue_TruncatesTo4095()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_Length");
+        var counter = appMeter.CreateCounter<int>("length-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        string capturedValue = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "length-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedValue = tags[0].Value as string;
+        });
+        captureListener.Start();
+
+        var tags = new[] { new KeyValuePair<string, object>("key", new string('x', 5000)) };
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(tags), bridgedState);
+
+        Assert.That(capturedValue, Has.Length.EqualTo(4095));
+    }
+
+    [Test]
+    public void FilterValidTags_WithStringValueAt4095Chars_PassesThrough()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_LengthBoundary");
+        var counter = appMeter.CreateCounter<int>("length-boundary");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        string capturedValue = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "length-boundary" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedValue = tags[0].Value as string;
+        });
+        captureListener.Start();
+
+        var tags = new[] { new KeyValuePair<string, object>("key", new string('x', 4095)) };
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(tags), bridgedState);
+
+        Assert.That(capturedValue, Has.Length.EqualTo(4095));
+    }
+
+    [Test]
+    public void FilterValidTags_WithNullKeys_DoNotCountTowardLimit()
+    {
+        // 70 null-key tags + 10 valid: all 10 valid should be kept (null keys excluded before count cap)
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_NullKey");
+        var counter = appMeter.CreateCounter<int>("null-key-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        var capturedTagCount = -1;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "null-key-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+            capturedTagCount = tags.Length);
+        captureListener.Start();
+
+        var mixedTags = Enumerable.Range(0, 70)
+            .Select(_ => new KeyValuePair<string, object>(null, "ignored"))
+            .Concat(Enumerable.Range(0, 10).Select(i => new KeyValuePair<string, object>($"k{i}", $"v{i}")))
+            .ToArray();
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(mixedTags), bridgedState);
+
+        Assert.That(capturedTagCount, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void ApplyTagLimits_ObservableInstrument_With100Tags_LimitsTo64()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        var manyTags = Enumerable.Range(0, 100)
+            .Select(i => new KeyValuePair<string, object>($"k{i}", $"v{i}"))
+            .ToArray();
+
+        using var appMeter = new Meter("TagLimit_ObsCount");
+        var sourceInstrument = appMeter.CreateObservableCounter<int>("obs-count-limit",
+            () => new[] { new Measurement<int>(42, manyTags) });
+        service.OnInstrumentPublished(sourceInstrument, wrapper);
+
+        var capturedTagCount = -1;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "obs-count-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+            capturedTagCount = tags.Length);
+        captureListener.Start();
+        captureListener.RecordObservableInstruments();
+
+        Assert.That(capturedTagCount, Is.EqualTo(64));
+    }
+
+    [Test]
+    public void ApplyTagLimits_ObservableInstrument_WithLongStringValue_TruncatesTo4095()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        var tags = new[] { new KeyValuePair<string, object>("key", new string('y', 5000)) };
+
+        using var appMeter = new Meter("TagLimit_ObsLen");
+        var sourceInstrument = appMeter.CreateObservableCounter<int>("obs-len-limit",
+            () => new[] { new Measurement<int>(42, tags) });
+        service.OnInstrumentPublished(sourceInstrument, wrapper);
+
+        string capturedValue = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "obs-len-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedValue = tags[0].Value as string;
+        });
+        captureListener.Start();
+        captureListener.RecordObservableInstruments();
+
+        Assert.That(capturedValue, Has.Length.EqualTo(4095));
+    }
+
+    [Test]
+    public void FilterValidTags_WithKeyExceeding255Chars_TruncatesKey()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_KeyLen");
+        var counter = appMeter.CreateCounter<int>("key-len-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        string capturedKey = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "key-len-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedKey = tags[0].Key;
+        });
+        captureListener.Start();
+
+        var longKey = new string('k', 300);
+        var tags = new[] { new KeyValuePair<string, object>(longKey, "value") };
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(tags), bridgedState);
+
+        Assert.That(capturedKey, Has.Length.EqualTo(255));
+    }
+
+    [Test]
+    public void FilterValidTags_WithStringArrayExceeding64Entries_PrunesTo64()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_ArrayLen");
+        var counter = appMeter.CreateCounter<int>("array-len-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        Array capturedArray = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "array-len-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedArray = tags[0].Value as Array;
+        });
+        captureListener.Start();
+
+        var bigArray = Enumerable.Range(0, 100).Select(i => $"item{i}").ToArray();
+        var tags = new[] { new KeyValuePair<string, object>("arr", bigArray) };
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(tags), bridgedState);
+
+        Assert.That(capturedArray, Is.Not.Null);
+        Assert.That(capturedArray.Length, Is.EqualTo(64));
+    }
+
+    [Test]
+    public void FilterValidTags_WithByteArrayExceeding128000Bytes_PrunesTo128000()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        using var appMeter = new Meter("TagLimit_ByteArray");
+        var counter = appMeter.CreateCounter<int>("bytearray-limit");
+        service.OnInstrumentPublished(counter, wrapper);
+        var bridgedState = wrapper.GetState(counter);
+
+        byte[] capturedBytes = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "bytearray-limit" && !ReferenceEquals(instr.Meter, appMeter))
+                listener.EnableMeasurementEvents(instr, null);
+        };
+        captureListener.SetMeasurementEventCallback<int>((instr, value, tags, state) =>
+        {
+            if (tags.Length > 0) capturedBytes = tags[0].Value as byte[];
+        });
+        captureListener.Start();
+
+        var bigBytes = new byte[200_000];
+        var tags = new[] { new KeyValuePair<string, object>("blob", bigBytes) };
+        wrapper.GetCallback<int>()(counter, 42, new ReadOnlySpan<KeyValuePair<string, object>>(tags), bridgedState);
+
+        Assert.That(capturedBytes, Is.Not.Null);
+        Assert.That(capturedBytes.Length, Is.EqualTo(128_000));
+    }
+
+    [Test]
+    public void CreateBridgedMeter_WithMoreThan8ScopeAttributes_LimitsTo8()
+    {
+        using var wrapper = new TestMeterListenerWrapper();
+        using var service = new MeterBridgingService(wrapper, _mockConfigService, _mockMetrics);
+        service.TryInitialize();
+
+        var manyMeterTags = Enumerable.Range(0, 20)
+            .Select(i => new KeyValuePair<string, object>($"mt{i}", $"mv{i}"))
+            .ToList();
+        using var appMeter = new Meter("ScopeLimit_Test", "1.0", manyMeterTags, null);
+        var counter = appMeter.CreateCounter<int>("scope-limit-counter");
+        service.OnInstrumentPublished(counter, wrapper);
+
+        int? capturedScopeTagCount = null;
+        using var captureListener = new MeterListener();
+        captureListener.InstrumentPublished = (instr, listener) =>
+        {
+            if (instr.Name == "scope-limit-counter" && !ReferenceEquals(instr.Meter, appMeter))
+                capturedScopeTagCount = instr.Meter.Tags?.Count();
+        };
+        captureListener.Start();
+
+        Assert.That(capturedScopeTagCount, Is.Not.Null);
+        Assert.That(capturedScopeTagCount, Is.EqualTo(8));
+    }
+}
+
+/// <summary>
+/// Concrete IMeterListenerWrapper that captures SetMeasurementCallback delegates and
+/// EnableMeasurementEvents states so tests can invoke OnMeasurementRecorded directly.
+/// </summary>
+internal class TestMeterListenerWrapper : IMeterListenerWrapper
+{
+    private readonly Dictionary<Type, Delegate> _callbacks = new();
+    private readonly Dictionary<object, object> _states = new();
+
+    public Action<object, IMeterListenerWrapper> InstrumentPublished { get; set; }
+    public Action<object, object, IMeterListenerWrapper> MeasurementsCompleted { get; set; }
+    public void Start() { }
+    public void Dispose() { }
+    public void RecordObservableInstruments() { }
+    public bool IsInstrumentFromILRepackedAssembly(object instrument) => false;
+
+    public void EnableMeasurementEvents(object instrument, object state) =>
+        _states[instrument] = state;
+
+    public void SetMeasurementCallback<T>(MeasurementCallbackDelegate<T> callback) where T : struct =>
+        _callbacks[typeof(T)] = callback;
+
+    public object GetState(object instrument) =>
+        _states.TryGetValue(instrument, out var s) ? s : null;
+
+    public MeasurementCallbackDelegate<T> GetCallback<T>() where T : struct =>
+        _callbacks.TryGetValue(typeof(T), out var cb) ? (MeasurementCallbackDelegate<T>)cb : null;
 }


### PR DESCRIPTION
## Summary

Implements Phases 1-3 of NR-574462. Prunes and truncates metric attributes at NR OTLP ingest limits (REQ-015 MUST / REQ-016 SHOULD) and adds a payload size guard to prevent 413 responses.

**Phase 1 & 2 - Attribute limits (MeterBridgingService)**

| Limit | Value |
|---|---|
| Max data point attributes | 64 |
| Max attribute key length | 255 chars |
| Max string attribute value length | 4,095 chars |
| Max array attribute entries | 64 |
| Max byte array attribute size | 128,000 bytes |
| Max scope (meter) attributes | 8 |

Enforcement is split across two code paths:
- `FilterValidTags` - regular instruments (`ReadOnlySpan<KVP>` measurement tags)
- `ApplyTagLimits` - observable instruments (`IEnumerable<KVP>` measurements)
- `ApplyScopeTagLimits` - meter-level tags applied in `CreateBridgedMeter`

Resource attribute enforcement was evaluated; current usage is ~5 known attributes, well within the 64-attribute limit, so no pruning is needed.

**Phase 3 - Payload size guard (OtlpAuditHandler)**

Drops export cycles whose serialized payload exceeds 1 MB before they reach the wire, fires `ReportSupportabilityPayloadsDroppeDueToMaxPayloadSizeLimit`, and returns a synthetic 413 to the SDK (which retries on the next interval).

`OtlpAuditHandler` sits inner to `GzipCompressionHandler` (PR #3629). Once that PR merges, `bytesSent` will reflect the compressed wire payload - the limit NR enforces - with no changes needed here.

## Testing

- 11 new unit tests in `MeterBridgingServiceTagLimitTests` covering all attribute limits across both measurement paths
- 2 new unit tests in `OtlpAuditHandlerAdditionalTests` covering oversized-payload drop and at-limit passthrough
- All existing `MeterBridgingService` and `OtlpAuditHandler` tests pass