### PR TITLE
chore(otel-bridge): Use base-2 exponential bucket histogram aggregation for OTLP metrics (NR-574463)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
@@ -118,6 +118,7 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = config.OpenTelemetryMetricsExportIntervalMs;
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = config.OpenTelemetryMetricsExportTimeoutMs;
                 metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                metricReaderOptions.DefaultHistogramAggregation = MetricReaderHistogramAggregation.Base2ExponentialBucketHistogram;
             });
 
         _meterProvider = providerBuilder.Build();

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
@@ -25,6 +26,13 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
     private readonly IOtelBridgeSupportabilityMetricCounters _supportabilityMetricCounters;
     private readonly IAgentHealthReporter _agentHealthReporter;
     private readonly MeterBridgeConfiguration _bridgeConfiguration;
+
+    // Reflection cache for setting the base-2 exponential histogram aggregation (see
+    // TrySetBase2ExponentialHistogramAggregation). Resolved once and reused across recreations.
+    private static PropertyInfo _defaultHistogramAggregationProperty;
+    private static object _base2ExponentialAggregationValue;
+    private static bool _histogramAggregationReflectionInitialized;
+
     private MeterProvider _meterProvider;
     private readonly object _meterProviderLock = new object();
     private HttpClient _httpClient;
@@ -118,11 +126,60 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = config.OpenTelemetryMetricsExportIntervalMs;
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = config.OpenTelemetryMetricsExportTimeoutMs;
                 metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
-                metricReaderOptions.DefaultHistogramAggregation = MetricReaderHistogramAggregation.Base2ExponentialBucketHistogram;
+                TrySetBase2ExponentialHistogramAggregation(metricReaderOptions);
             });
 
         _meterProvider = providerBuilder.Build();
         _supportabilityMetricCounters?.Record(OtelBridgeSupportabilityMetric.MeterProviderRecreated);
+    }
+
+    /// <summary>
+    /// Sets the metric reader's default histogram aggregation to base-2 exponential bucket histograms,
+    /// which the NR OTLP ingest endpoint prefers over explicit-bucket histograms.
+    /// </summary>
+    /// <remarks>
+    /// In SDK 1.15.3 <c>MetricReaderOptions.DefaultHistogramAggregation</c> (a nullable
+    /// <c>MetricReaderHistogramAggregation</c>) and the enum itself are internal in every target framework
+    /// - the public surface is gated behind an experimental compile flag the shipped package does not set -
+    /// so the value is set via reflection. Customer <c>AddView</c> overrides still take precedence
+    /// (SDK-guaranteed). Failures are non-fatal: the SDK default (explicit bucket histogram) is used instead.
+    /// </remarks>
+    private static void TrySetBase2ExponentialHistogramAggregation(MetricReaderOptions metricReaderOptions)
+    {
+        try
+        {
+            if (!_histogramAggregationReflectionInitialized)
+            {
+                _histogramAggregationReflectionInitialized = true;
+
+                var property = typeof(MetricReaderOptions).GetProperty("DefaultHistogramAggregation",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (property != null)
+                {
+                    var enumType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+                    if (enumType.IsEnum && Enum.IsDefined(enumType, "Base2ExponentialBucketHistogram"))
+                    {
+                        _base2ExponentialAggregationValue = Enum.Parse(enumType, "Base2ExponentialBucketHistogram");
+                        _defaultHistogramAggregationProperty = property;
+                    }
+                }
+
+                if (_defaultHistogramAggregationProperty == null)
+                {
+                    Log.Debug("Could not resolve MetricReaderOptions.DefaultHistogramAggregation via reflection; OTLP histogram instruments will use the SDK default (explicit bucket) aggregation.");
+                }
+                else
+                {
+                    Log.Debug("Successfully resolved MetricReaderOptions.DefaultHistogramAggregation via reflection; OTLP histogram instruments will use base-2 exponential bucket aggregation.");
+                }
+            }
+
+            _defaultHistogramAggregationProperty?.SetValue(metricReaderOptions, _base2ExponentialAggregationValue);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Failed to set base-2 exponential histogram aggregation on OTLP metric reader options; falling back to SDK default.");
+        }
     }
 
     private HttpClient CreateHttpClientWithProxyAndRetry(IConnectionInfo connectionInfo)

--- a/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
+++ b/src/Agent/NewRelic/Agent/Core/OpenTelemetryBridge/Metrics/OtlpExporterConfigurationService.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using NewRelic.Agent.Configuration;
 using NewRelic.Agent.Core.AgentHealth;
 using NewRelic.Agent.Core.DataTransport;
@@ -26,13 +26,6 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
     private readonly IOtelBridgeSupportabilityMetricCounters _supportabilityMetricCounters;
     private readonly IAgentHealthReporter _agentHealthReporter;
     private readonly MeterBridgeConfiguration _bridgeConfiguration;
-
-    // Reflection cache for setting the base-2 exponential histogram aggregation (see
-    // TrySetBase2ExponentialHistogramAggregation). Resolved once and reused across recreations.
-    private static PropertyInfo _defaultHistogramAggregationProperty;
-    private static object _base2ExponentialAggregationValue;
-    private static bool _histogramAggregationReflectionInitialized;
-
     private MeterProvider _meterProvider;
     private readonly object _meterProviderLock = new object();
     private HttpClient _httpClient;
@@ -116,6 +109,15 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
                 .AddTelemetrySdk()
                 .AddAttributes(new[] { new KeyValuePair<string, object>("entity.guid", _lastEntityGuid ?? config.EntityGuid) }))
             .AddMeter("*")
+            // Default histogram instruments to base-2 exponential bucket aggregation, which the NR OTLP
+            // ingest endpoint prefers over explicit-bucket histograms (higher fidelity, fewer buckets).
+            // A null return leaves non-histogram instruments on their default aggregation, and explicit
+            // customer AddView overrides registered elsewhere still take precedence (SDK-guaranteed).
+            .AddView(instrument =>
+                instrument.GetType().IsGenericType
+                && instrument.GetType().GetGenericTypeDefinition() == typeof(Histogram<>)
+                    ? new Base2ExponentialBucketHistogramConfiguration()
+                    : null)
             .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
             {
                 exporterOptions.Endpoint = endpoint;
@@ -126,60 +128,10 @@ public class OtlpExporterConfigurationService : DisposableService, IOtlpExporter
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = config.OpenTelemetryMetricsExportIntervalMs;
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = config.OpenTelemetryMetricsExportTimeoutMs;
                 metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
-                TrySetBase2ExponentialHistogramAggregation(metricReaderOptions);
             });
 
         _meterProvider = providerBuilder.Build();
         _supportabilityMetricCounters?.Record(OtelBridgeSupportabilityMetric.MeterProviderRecreated);
-    }
-
-    /// <summary>
-    /// Sets the metric reader's default histogram aggregation to base-2 exponential bucket histograms,
-    /// which the NR OTLP ingest endpoint prefers over explicit-bucket histograms.
-    /// </summary>
-    /// <remarks>
-    /// In SDK 1.15.3 <c>MetricReaderOptions.DefaultHistogramAggregation</c> (a nullable
-    /// <c>MetricReaderHistogramAggregation</c>) and the enum itself are internal in every target framework
-    /// - the public surface is gated behind an experimental compile flag the shipped package does not set -
-    /// so the value is set via reflection. Customer <c>AddView</c> overrides still take precedence
-    /// (SDK-guaranteed). Failures are non-fatal: the SDK default (explicit bucket histogram) is used instead.
-    /// </remarks>
-    private static void TrySetBase2ExponentialHistogramAggregation(MetricReaderOptions metricReaderOptions)
-    {
-        try
-        {
-            if (!_histogramAggregationReflectionInitialized)
-            {
-                _histogramAggregationReflectionInitialized = true;
-
-                var property = typeof(MetricReaderOptions).GetProperty("DefaultHistogramAggregation",
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                if (property != null)
-                {
-                    var enumType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
-                    if (enumType.IsEnum && Enum.IsDefined(enumType, "Base2ExponentialBucketHistogram"))
-                    {
-                        _base2ExponentialAggregationValue = Enum.Parse(enumType, "Base2ExponentialBucketHistogram");
-                        _defaultHistogramAggregationProperty = property;
-                    }
-                }
-
-                if (_defaultHistogramAggregationProperty == null)
-                {
-                    Log.Debug("Could not resolve MetricReaderOptions.DefaultHistogramAggregation via reflection; OTLP histogram instruments will use the SDK default (explicit bucket) aggregation.");
-                }
-                else
-                {
-                    Log.Debug("Successfully resolved MetricReaderOptions.DefaultHistogramAggregation via reflection; OTLP histogram instruments will use base-2 exponential bucket aggregation.");
-                }
-            }
-
-            _defaultHistogramAggregationProperty?.SetValue(metricReaderOptions, _base2ExponentialAggregationValue);
-        }
-        catch (Exception ex)
-        {
-            Log.Debug(ex, "Failed to set base-2 exponential histogram aggregation on OTLP metric reader options; falling back to SDK default.");
-        }
     }
 
     private HttpClient CreateHttpClientWithProxyAndRetry(IConnectionInfo connectionInfo)

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Protos/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Protos/opentelemetry/proto/metrics/v1/metrics.proto
@@ -20,12 +20,14 @@ message Metric {
   string description = 2;
   string unit = 3;
 
+  // Field numbers must match the official OTLP spec and the values emitted by the agent's exporter.
+  // (https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto).
   oneof data {
     Gauge gauge = 5;
-    Sum sum = 6;
-    Histogram histogram = 7;
-    ExponentialHistogram exponential_histogram = 8;
-    Summary summary = 9;
+    Sum sum = 7;
+    Histogram histogram = 9;
+    ExponentialHistogram exponential_histogram = 10;
+    Summary summary = 11;
   }
 }
 

--- a/tests/Agent/IntegrationTests/IntegrationTests/OpenTelemetry/OpenTelemetryMetricsTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/OpenTelemetry/OpenTelemetryMetricsTests.cs
@@ -47,7 +47,7 @@ public abstract class OpenTelemetryMetricsTestsBase<TFixture> : NewRelicIntegrat
     }
 
     [Fact]
-    public void Metrics_are_collected_and_match_expected_names_with_positive_counts()
+    public void OtlpMetrics_are_collected_with_expected_names_counts_and_histogram_aggregation()
     {
         Assert.NotNull(_otlpSummaries);
         Assert.NotEmpty(_otlpSummaries);
@@ -87,12 +87,38 @@ public abstract class OpenTelemetryMetricsTestsBase<TFixture> : NewRelicIntegrat
             var found = aggregatedTotals.Any(m => m.Name == expectedMetric);
             Assert.True(found, $"Expected metric '{expectedMetric}' not found. Available metrics: {string.Join(", ", aggregatedTotals.Select(m => m.Name))}");
         }
+
+        // The agent configures base-2 exponential bucket histograms (via an AddView registration on
+        // the MeterProvider), so no histogram instrument should be exported as the SDK-default
+        // explicit-bucket "Histogram". If that configuration silently regressed, the explicit-bucket
+        // type would show up here.
+        var explicitBucketHistograms = metricEntries
+            .Where(m => m.Type == "Histogram")
+            .Select(m => m.Name)
+            .Distinct()
+            .ToList();
+        Assert.True(explicitBucketHistograms.Count == 0,
+            $"Expected no explicit-bucket Histogram metrics (base-2 exponential is configured), but found: {string.Join(", ", explicitBucketHistograms)}");
+
+        // Where a histogram instrument is exported on this platform, confirm it is an ExponentialHistogram.
+        var histogramMetricName = GetExpectedExponentialHistogramMetricName();
+        if (histogramMetricName != null)
+        {
+            var match = metricEntries.FirstOrDefault(m => m.Name == histogramMetricName);
+            Assert.True(match != null,
+                $"Expected histogram metric '{histogramMetricName}' was not exported. Available: {string.Join(", ", metricEntries.Select(m => m.Name).Distinct())}");
+            Assert.Equal("ExponentialHistogram", match.Type);
+        }
     }
 
     protected virtual string[] GetExpectedMetrics()
     {
         return new[] { "requests_total", "payload_size_bytes", "active_requests", "queue_depth", "cpu_usage_percent", "active_connections" };
     }
+
+    // The histogram instrument expected to be exported on this platform, or null if histogram
+    // instruments are not bridged here (e.g. .NET Framework, which omits payload_size_bytes).
+    protected virtual string GetExpectedExponentialHistogramMetricName() => "payload_size_bytes";
 }
 
 // NET10 test targets DiagnosticSource v10.x
@@ -112,6 +138,7 @@ public class OpenTelemetryMetricsTestsFw472 : OpenTelemetryMetricsTestsBase<Otlp
 {
     public OpenTelemetryMetricsTestsFw472(OtlpMetricsWithCollectorFixtureFW472 fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     protected override string[] GetExpectedMetrics() => new[] { "active_requests", "queue_depth", "cpu_usage_percent", "active_connections" };
+    protected override string GetExpectedExponentialHistogramMetricName() => null;
 }
 
 // Net481 test targets DiagnosticSource v9.x
@@ -119,4 +146,5 @@ public class OpenTelemetryMetricsTestsFw481 : OpenTelemetryMetricsTestsBase<Otlp
 {
     public OpenTelemetryMetricsTestsFw481(OtlpMetricsWithCollectorFixtureFW481 fixture, ITestOutputHelper outputHelper) : base(fixture, outputHelper) { }
     protected override string[] GetExpectedMetrics() => new[] { "active_requests", "queue_depth", "cpu_usage_percent", "active_connections" };
+    protected override string GetExpectedExponentialHistogramMetricName() => null;
 }


### PR DESCRIPTION
## Summary

Satisfies the spec SHOULD requirement (REQ-021) from NR-574463 to default histogram instruments to base-2 exponential bucket aggregation rather than the SDK-default explicit-bucket histogram. The NR OTLP ingest endpoint prefers exponential histograms (higher fidelity, fewer buckets).

## Implementation

Registers a view on the OTLP `MeterProvider` via `MeterProviderBuilder.AddView(Func<Instrument, MetricStreamConfiguration>)` that returns a `Base2ExponentialBucketHistogramConfiguration` for `Histogram<T>` instruments and `null` (default aggregation) for everything else.

Non-histogram instruments keep their default aggregation, and explicit customer `AddView` overrides registered elsewhere still take precedence (SDK-guaranteed behavior).

## Testing

Extends the OTLP metrics integration test to assert that no instrument is exported as an explicit-bucket `Histogram` and that the histogram instrument (`payload_size_bytes`) is exported as an `ExponentialHistogram`.

Also corrects the `data` oneof field numbers (`sum`/`histogram`/`exponential_histogram`/`summary`) in the MockNewRelic collector's bundled OTLP `metrics.proto` to match the official OTLP spec, so the collector decodes the metric data type correctly.
