### PR TITLE
chore(otel-bridge): fix export_interval/export_timeout equality edge case in validation (NR-574464)

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -2991,8 +2991,8 @@ public class DefaultConfiguration : IConfiguration
             intervalMs = DefaultOtelExportIntervalMs;
             timeoutMs = DefaultOtelExportTimeoutMs;
         }
-        // Validation: interval must be >= timeout
-        else if (intervalMs < timeoutMs)
+        // Validation: interval must be strictly greater than timeout
+        else if (intervalMs <= timeoutMs)
         {
             Log.Warn($"OpenTelemetry metrics export interval ({intervalMs} ms) is less than export timeout ({timeoutMs} ms). Reverting to defaults: interval={DefaultOtelExportIntervalMs} ms, timeout={DefaultOtelExportTimeoutMs} ms.");
             intervalMs = DefaultOtelExportIntervalMs;

--- a/tests/Agent/IntegrationTests/IntegrationTests/OpenTelemetry/OpenTelemetryMetricsExportConfigurationTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/OpenTelemetry/OpenTelemetryMetricsExportConfigurationTests.cs
@@ -90,26 +90,32 @@ public class OpenTelemetryMetricsExportConfigurationInvalidIntervalLessThanTimeo
     }
 }
 
-public class OpenTelemetryMetricsExportConfigurationValidIntervalEqualsTimeoutTests : OpenTelemetryMetricsExportConfigurationTestsBase<OtlpMetricsWithCollectorFixtureCoreNet8>
+public class OpenTelemetryMetricsExportConfigurationInvalidIntervalEqualsTimeoutTests : OpenTelemetryMetricsExportConfigurationTestsBase<OtlpMetricsWithCollectorFixtureCoreNet8>
 {
-    public OpenTelemetryMetricsExportConfigurationValidIntervalEqualsTimeoutTests(OtlpMetricsWithCollectorFixtureCoreNet8 fixture, ITestOutputHelper outputHelper) 
+    public OpenTelemetryMetricsExportConfigurationInvalidIntervalEqualsTimeoutTests(OtlpMetricsWithCollectorFixtureCoreNet8 fixture, ITestOutputHelper outputHelper)
         : base(fixture, outputHelper)
     {
-        // Setup with interval == timeout (currently valid per implementation)
-        SetupValidConfiguration(intervalMs: 15000, timeoutMs: 15000);
+        // Setup with interval == timeout (invalid per spec REQ-012: interval must be strictly greater than timeout)
+        SetupInvalidConfiguration(intervalMs: 15000, timeoutMs: 15000);
     }
 
     [Fact]
-    public void ValidConfig_IntervalEqualsTimeout_NoWarning()
+    public void InvalidConfig_IntervalEqualsTimeout_LogsWarning()
     {
         var logLines = _fixture.AgentLog.GetFileLines().ToList();
 
         var warningLogLine = logLines.FirstOrDefault(line =>
             line.Contains("WARN") &&
             line.Contains("OpenTelemetry metrics export interval") &&
-            line.Contains("is less than export timeout"));
+            line.Contains("is less than export timeout") &&
+            line.Contains("Reverting to defaults"));
 
-        Assert.Null(warningLogLine);
+        NrAssert.Multiple(
+            () => Assert.NotNull(warningLogLine),
+            () => Assert.Contains("15000 ms", warningLogLine),
+            () => Assert.Contains("interval=60000 ms", warningLogLine),
+            () => Assert.Contains("timeout=10000 ms", warningLogLine)
+        );
     }
 }
 

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/OpenTelemetryConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/OpenTelemetryConfigurationTests.cs
@@ -345,7 +345,7 @@ public class OpenTelemetryConfigurationTests
     }
 
     [Test]
-    public void OpenTelemetryMetricsExportInterval_And_ExportTimeout_EqualValues_ShouldBeValid()
+    public void OpenTelemetryMetricsExportInterval_And_ExportTimeout_EqualValues_ShouldRevertToDefaults()
     {
         Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_INTERVAL"))
             .Returns("30000");
@@ -353,8 +353,8 @@ public class OpenTelemetryConfigurationTests
             .Returns("30000");
 
         var cfg = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
-        Assert.That(cfg.OpenTelemetryMetricsExportIntervalMs, Is.EqualTo(30000));
-        Assert.That(cfg.OpenTelemetryMetricsExportTimeoutMs, Is.EqualTo(30000));
+        Assert.That(cfg.OpenTelemetryMetricsExportIntervalMs, Is.EqualTo(60000));
+        Assert.That(cfg.OpenTelemetryMetricsExportTimeoutMs, Is.EqualTo(10000));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Fixes a spec compliance gap (NR-574464) in the OpenTelemetry metrics export configuration validation.

The spec (REQ-012) states that `export_interval` must be **strictly greater than** `export_timeout` - equal values should revert both to defaults with a warning. The prior check used `<` instead of `<=`, so equal values passed validation silently.

- Change `intervalMs < timeoutMs` to `intervalMs <= timeoutMs` in `DefaultConfiguration.cs`
- Update unit test to expect revert-to-defaults behavior when interval equals timeout