### PR TITLE
chore: Add Angler release skill and metric discovery tool

### DIFF
--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: angler-dotnet-release
+description: Open an Angler PR that adds the latest .NET agent release to metric_names.txt. Use when the user asks to add a .NET agent version to Angler, update Angler for a new agent release, or "create the Angler PR" after a .NET agent release ships.
+disable-model-invocation: true
+---
+
+# Add latest .NET agent release to Angler
+
+When a new .NET agent version ships, Angler needs a one-line addition to its
+`metric_names.txt` so the new `Supportability/AgentVersion/<version>` metric is
+recognized. This skill discovers the latest release, makes that edit, and opens
+the PR end-to-end via the GitHub API -- no local clone of Angler is needed.
+
+Reference for the shape of the change: Angler PR #837
+(`https://source.datanerd.us/agents/angler/pull/837`) -- a single line added to
+`src/main/resources/metric_names.txt`.
+
+The bundled script `scripts/create_angler_pr.sh` does the work. It needs only
+`gh` plus standard shell tools (`awk`, `base64`, `grep`) that ship with the same
+Git Bash that runs `gh` -- no extra runtime to install. It manipulates the
+~7,600-line file inside the shell, so that content never enters context.
+
+## What the change looks like
+
+The latest release tag (e.g. `v10.51.1`) becomes a 4-part version `10.51.1.0`
+(a 3-part tag gets a trailing `.0`). That line is inserted at the **top** of the
+`// .NET agent version metrics` section, which is ordered newest-first:
+
+```
+// .NET agent version metrics
+Supportability/AgentVersion/10.51.1.0   <- inserted
+Supportability/AgentVersion/10.51.0.0
+```
+
+Functionally, placement does not matter -- Angler's `MetricLoader` strips
+comments/blank lines and hashes each remaining line independently, so the file
+is an unordered set. The newest-first slotting is purely for human tidiness.
+
+The PR targets `master` and is titled `Add .NET Agent v<version> to Angler`.
+It is opened **ready for review** by default, or as a **draft** when the release
+also adds supportability metrics that must be added by hand (see Step 2).
+
+## Step 0: Prerequisites
+
+Run `gh auth status`. It must report authentication for **both** `github.com`
+(to read the latest release) and `source.datanerd.us` (to open the Angler PR).
+If either is missing, stop and tell the user which host needs auth.
+
+## Step 1: Check what would change (dry run)
+
+```bash
+bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh --dry-run
+```
+
+This prints the detected version, whether its line is already present, and the
+diff -- without creating anything. If it reports `status: PRESENT`, Angler is
+already up to date for this version; stop and report that (a normal outcome, not
+an error). Note: if the version line is already present but the user has extra
+supportability metrics to add, this skill makes no PR -- those need a separate
+manual edit.
+
+To target a specific version instead of the latest release, add `--version X.Y.Z`.
+
+## Step 2: Ask about supportability metrics
+
+Some .NET agent releases also add new `Supportability/...` metrics that Angler
+needs alongside the version line. The agent team knows when this happened; the
+skill cannot reliably detect it (the names are partly composed at runtime). So
+ask the user before opening the PR:
+
+> Does this release also add new supportability metrics that need to go into
+> Angler, beyond the version line?
+
+- **No** -> open a normal, ready-for-review PR (Step 3 without `--draft`).
+- **Yes** -> open a **draft** PR so the extra metrics can be added by hand
+  first (Step 3 with `--draft`). The script prints a web-edit URL to the file on
+  the branch; relay it so the user can add the metrics and mark the PR ready.
+
+## Step 3: Open the PR
+
+```bash
+# ready for review (no extra metrics)
+bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
+
+# draft (extra supportability metrics to be added by hand)
+bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh --draft
+```
+
+Pass the same `--version X.Y.Z` here if one was used in Step 1.
+
+## Step 4: Report the result
+
+Relay what the script printed: the PR URL, and for a draft, the web-edit URL
+plus a reminder to add the extra metrics and mark the PR ready when done.
+
+If the script fails, surface the message verbatim. Common causes: not
+authenticated to one of the two hosts, or a branch/PR from a prior attempt
+already exists (the script reuses an existing branch, but the GitHub API rejects
+a duplicate open PR for the same head) -- point the user at the existing
+branch/PR rather than retrying blindly.

--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -34,10 +34,6 @@ Supportability/AgentVersion/10.51.1.0   <- inserted
 Supportability/AgentVersion/10.51.0.0
 ```
 
-Functionally, placement does not matter -- Angler's `MetricLoader` strips
-comments/blank lines and hashes each remaining line independently, so the file
-is an unordered set. The newest-first slotting is purely for human tidiness.
-
 The PR targets `master` and is titled `Add .NET Agent v<version> to Angler`.
 It is opened **ready for review** by default, or as a **draft** when the release
 also adds supportability metrics that must be added by hand (see Step 2).
@@ -54,12 +50,8 @@ If either is missing, stop and tell the user which host needs auth.
 bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh --dry-run
 ```
 
-This prints the detected version, whether its line is already present, and the
-diff -- without creating anything. If it reports `status: PRESENT`, Angler is
-already up to date for this version; stop and report that (a normal outcome, not
-an error). Note: if the version line is already present but the user has extra
-supportability metrics to add, this skill makes no PR -- those need a separate
-manual edit.
+If it reports `status: PRESENT`, Angler is already up to date; stop and report
+that (a normal outcome, not an error).
 
 To target a specific version instead of the latest release, add `--version X.Y.Z`.
 
@@ -114,8 +106,8 @@ to categorize each one:
 > The discovery tool found the following .NET supportability metrics that are
 > in the agent code but not yet in Angler:
 >
-> 1. Supportability/Dotnet/NetFramework/net481
-> 2. Supportability/DotNET/AppDomainCaching/Disabled
+> 1. <metric name>
+> 2. <metric name>
 > ...
 >
 > For each metric, reply with one of:
@@ -124,8 +116,6 @@ to categorize each one:
 > - **S** -- skip for now (take no action)
 >
 > Example: "1=A, 2=E, 3=S"
-
-Wait for the user's reply, then proceed to Step 3 with the classified lists.
 
 ### If any metrics are classified E (add to exclusions)
 
@@ -174,22 +164,19 @@ First check whether a Slack send-message tool is available in this session
 (e.g. `slack_send_message`). The plugin that provides it may not be connected --
 that is fine and **not a failure**.
 
+In both cases the message is:
+
+> An Angler PR for .NET Agent v<version> has been created and needs
+> review/approval: <PR URL>
+
 - **Slack tool available** -> post to the private channel **#dotnet-team**.
   Resolve its id by searching channels for `dotnet-team` with private channels
   included, and pick the exact-name match (the public `#dotnet-agent` also
-  matches that search -- do not post there). Send a message like:
+  matches that search -- do not post there). Do not use `@here` / `@channel`
+  unless the user asks. Report the link to the message you posted.
 
-  > An Angler PR for .NET Agent v<version> has been created and needs
-  > review/approval: <PR URL>
-
-  Do not use `@here` / `@channel` mentions unless the user asks for them. Then
-  report the link to the message you posted.
-
-- **Slack tool not available** -> not a failure. Tell the user to post to
-  #dotnet-team asking for approval, and give them ready-to-paste text:
-
-  > An Angler PR for .NET Agent v<version> has been created and needs
-  > review/approval: <PR URL>
+- **Slack tool not available** -> not a failure. Give the user the message
+  text above to post manually.
 
 ## Step 5: Report the result
 

--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -63,29 +63,103 @@ manual edit.
 
 To target a specific version instead of the latest release, add `--version X.Y.Z`.
 
-## Step 2: Ask about supportability metrics
+## Step 2: Discover new supportability metrics
 
-Some .NET agent releases also add new `Supportability/...` metrics that Angler
-needs alongside the version line. The agent team knows when this happened; the
-skill cannot reliably detect it (the names are partly composed at runtime). So
-ask the user before opening the PR:
+The discovery tool reflects over the compiled agent, so `FullAgent.sln` must
+be built before running it. Ask the user for permission before building:
 
-> Does this release also add new supportability metrics that need to go into
-> Angler, beyond the version line?
+Check whether `src/Agent/newrelichome_x64_coreclr/NewRelic.Agent.Core.dll`
+exists:
 
-- **No** -> open a normal, ready-for-review PR (Step 3 without `--draft`).
-- **Yes** -> open a **draft** PR so the extra metrics can be added by hand
-  first (Step 3 with `--draft`). The script prints a web-edit URL to the file on
-  the branch; relay it so the user can add the metrics and mark the PR ready.
+- **File is absent:** tell the user the agent has not been built and ask:
+  > `FullAgent.sln` has not been built yet. Build it now so the discovery
+  > tool can run? This may take a few minutes.
+- **File is present:** ask:
+  > `FullAgent.sln` was built previously. Rebuild now to make sure the
+  > discovery tool reflects the latest agent code? (Skip if you know the
+  > build is already current.)
+
+**If the user says yes (or the default):** run the build, then proceed:
+
+```bash
+dotnet build FullAgent.sln
+```
+
+**If the user says no and the DLL is absent:** skip discovery entirely and
+proceed to Step 3, opening the PR ready-for-review.
+
+**If the user says no and the DLL is present:** proceed with the existing
+build -- the discovery results may not reflect uncommitted changes.
+
+Once the build is confirmed, fetch the Angler file and run the tool:
+
+```bash
+# Fetch Angler file if not already on disk from Step 1
+gh api --hostname source.datanerd.us \
+  "repos/agents/angler/contents/src/main/resources/metric_names.txt?ref=master" \
+  --jq .content | base64 -d > /tmp/angler_current.txt
+
+dotnet run --project build/MetricNameDiscovery/MetricNameDiscovery.csproj \
+  -- --diff /tmp/angler_current.txt 2>/dev/null
+```
+
+Parse every line from the `=== Candidate additions ===` section (lines starting
+with `  + `). Strip the leading `  + ` to get the bare metric name.
+
+**If no candidates are found:** proceed to Step 3 and open ready-for-review.
+
+**If candidates are found:** present the numbered list to the user and ask them
+to categorize each one:
+
+> The discovery tool found the following .NET supportability metrics that are
+> in the agent code but not yet in Angler:
+>
+> 1. Supportability/Dotnet/NetFramework/net481
+> 2. Supportability/DotNET/AppDomainCaching/Disabled
+> ...
+>
+> For each metric, reply with one of:
+> - **A** -- add to Angler (include in this PR)
+> - **E** -- add to the exclusions list (creates a separate dotnet-agent PR)
+> - **S** -- skip for now (take no action)
+>
+> Example: "1=A, 2=E, 3=S"
+
+Wait for the user's reply, then proceed to Step 3 with the classified lists.
+
+### If any metrics are classified E (add to exclusions)
+
+Before opening the Angler PR, commit the exclusions to the dotnet-agent repo:
+
+1. Edit `build/MetricNameDiscovery/exclusions.txt` -- append each metric with
+   a `#` comment (ask the user for the reason if they did not provide one, or
+   use "triaged <date>" as a default).
+2. Create a branch (e.g. `chore/metric-discovery-exclusions-<version>`), commit
+   the file, and open a **draft** PR in the dotnet-agent repo:
+   - Title: `chore: Add metric discovery exclusions for v<version>`
+   - Body: list the excluded names
+3. Report the exclusions PR URL to the user before continuing.
+
+Then proceed to Step 3 for the Angler PR.
 
 ## Step 3: Open the PR
 
+Determine the flags:
+- Add one `--extra-metric "NAME"` for each metric the user classified **A** in
+  Step 2. Omit the flag entirely if none were classified A. Extra metrics are
+  inserted under the `// .NET MISC` section (not alongside the version line).
+- Add `--draft` only if there are no A metrics AND the user explicitly asked for
+  a draft. If any A metrics exist, the PR can be ready-for-review (the script
+  commits everything in one shot).
+
 ```bash
-# ready for review (no extra metrics)
+# No extra metrics -- ready for review
 bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
 
-# draft (extra supportability metrics to be added by hand)
-bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh --draft
+# With extra metrics -- still ready for review (all lines committed by the script)
+bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh \
+  --extra-metric "Supportability/Dotnet/NetFramework/net481" \
+  --extra-metric "Supportability/DotNET/AppDomainCaching/Disabled"
 ```
 
 Pass the same `--version X.Y.Z` here if one was used in Step 1.

--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -103,7 +103,7 @@ with `  + `). Strip the leading `  + ` to get the bare metric name.
 **If candidates are found:** present the numbered list to the user and ask them
 to categorize each one:
 
-> The discovery tool found the following .NET supportability metrics that are
+> The discovery tool found the following supportability metrics that are
 > in the agent code but not yet in Angler:
 >
 > 1. <metric name>

--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -8,8 +8,10 @@ disable-model-invocation: true
 
 When a new .NET agent version ships, Angler needs a one-line addition to its
 `metric_names.txt` so the new `Supportability/AgentVersion/<version>` metric is
-recognized. This skill discovers the latest release, makes that edit, and opens
-the PR end-to-end via the GitHub API -- no local clone of Angler is needed.
+recognized. This skill discovers the latest release, makes that edit, opens the
+PR end-to-end via the GitHub API (no local clone of Angler is needed), and -- for
+a ready-for-review PR -- posts an approval request to the #dotnet-team Slack
+channel if a Slack tool is connected.
 
 Reference for the shape of the change: Angler PR #837
 (`https://source.datanerd.us/agents/angler/pull/837`) -- a single line added to
@@ -88,10 +90,39 @@ bash .claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh --draft
 
 Pass the same `--version X.Y.Z` here if one was used in Step 1.
 
-## Step 4: Report the result
+## Step 4: Notify #dotnet-team on Slack
+
+A ready-for-review PR needs a teammate's approval, so let the team know. Do this
+only when the PR was opened **ready for review** -- a draft is not ready for
+approval yet, so skip this for a draft and notify once the PR is marked ready.
+
+First check whether a Slack send-message tool is available in this session
+(e.g. `slack_send_message`). The plugin that provides it may not be connected --
+that is fine and **not a failure**.
+
+- **Slack tool available** -> post to the private channel **#dotnet-team**.
+  Resolve its id by searching channels for `dotnet-team` with private channels
+  included, and pick the exact-name match (the public `#dotnet-agent` also
+  matches that search -- do not post there). Send a message like:
+
+  > An Angler PR for .NET Agent v<version> has been created and needs
+  > review/approval: <PR URL>
+
+  Do not use `@here` / `@channel` mentions unless the user asks for them. Then
+  report the link to the message you posted.
+
+- **Slack tool not available** -> not a failure. Tell the user to post to
+  #dotnet-team asking for approval, and give them ready-to-paste text:
+
+  > An Angler PR for .NET Agent v<version> has been created and needs
+  > review/approval: <PR URL>
+
+## Step 5: Report the result
 
 Relay what the script printed: the PR URL, and for a draft, the web-edit URL
-plus a reminder to add the extra metrics and mark the PR ready when done.
+plus a reminder to add the extra metrics and mark the PR ready when done. If you
+posted to Slack in Step 4, include the message link; if the Slack tool was
+unavailable, include the suggested text for the user to post manually.
 
 If the script fails, surface the message verbatim. Common causes: not
 authenticated to one of the two hosts, or a branch/PR from a prior attempt

--- a/.claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
+++ b/.claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Create an Angler PR adding the latest .NET agent release to metric_names.txt.
+#
+# The change is a single line inserted at the top of the
+# "// .NET agent version metrics" section of
+# src/main/resources/metric_names.txt in agents/angler (source.datanerd.us):
+#
+#     Supportability/AgentVersion/<X.Y.Z.0>
+#
+# Everything runs through the GitHub API via the `gh` CLI -- no local clone of
+# angler is needed. github.com is used to discover the latest dotnet-agent
+# release; source.datanerd.us hosts angler. Only gh plus standard shell tools
+# (awk, base64, grep) are required -- all ship with the Git Bash that runs gh.
+#
+# Usage:
+#   create_angler_pr.sh [--version X.Y.Z[.W]] [--draft] [--dry-run]
+#
+#   --version  Target a specific agent version instead of the latest release.
+#              A 3-part version gets a trailing ".0" (matching the file format).
+#   --draft    Open the PR as a draft and print a web-edit URL for the file on
+#              the branch. Use when the release also adds supportability metrics
+#              that must be added by hand before the PR is ready.
+#   --dry-run  Print the detected version and the diff without creating anything.
+
+set -e
+
+HOST="source.datanerd.us"
+REPO="agents/angler"
+BASE="master"
+FILE="src/main/resources/metric_names.txt"
+AGENT_REPO="newrelic/newrelic-dotnet-agent"
+
+version=""
+draft="false"
+dryrun="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) version="$2"; shift 2 ;;
+    --version=*) version="${1#*=}"; shift ;;
+    --draft) draft="true"; shift ;;
+    --dry-run) dryrun="true"; shift ;;
+    -h|--help) grep '^# ' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve the target version to its 4-part form (vX.Y.Z / X.Y.Z -> X.Y.Z.0).
+if [ -z "$version" ]; then
+  version=$(gh api "repos/$AGENT_REPO/releases/latest" --jq .tag_name)
+fi
+version="${version#v}"; version="${version#V}"
+nparts=$(echo "$version" | awk -F. '{print NF}')
+if [ "$nparts" -eq 3 ]; then
+  version="$version.0"
+elif [ "$nparts" -ne 4 ]; then
+  echo "ERROR: expected a 3- or 4-part version, got '$version'" >&2
+  exit 1
+fi
+
+line="Supportability/AgentVersion/$version"
+branch="add-dotnet-agent-v$version"
+title="Add .NET Agent v$version to Angler"
+
+echo "version:     $version"
+echo "metric line: $line"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# Fetch the current file content and its blob sha from the base branch. The
+# content is written to disk (not held in a pipe) so a downstream early-exit
+# can't trigger a SIGPIPE warning from gh, and so the large blob stays out of
+# any calling context.
+sha=$(gh api --hostname "$HOST" "repos/$REPO/contents/$FILE?ref=$BASE" --jq .sha)
+gh api --hostname "$HOST" "repos/$REPO/contents/$FILE?ref=$BASE" --jq .content \
+  | base64 -d > "$work/metrics.txt"
+
+# Idempotency: if the line already exists, there is nothing to do.
+if grep -qxF "$line" "$work/metrics.txt"; then
+  echo "status: PRESENT -- already in $FILE, no PR needed."
+  exit 0
+fi
+echo "status: ABSENT"
+
+# Insert the new line immediately after the section anchor (newest-first order).
+awk -v ins="$line" '
+  {print}
+  /^\/\/ \.NET agent version metrics[[:space:]]*$/ && !done {print ins; done=1}
+' "$work/metrics.txt" > "$work/metrics_new.txt"
+
+# Guard against a missing/renamed anchor producing an unchanged file.
+if ! grep -qxF "$line" "$work/metrics_new.txt"; then
+  echo "ERROR: anchor '// .NET agent version metrics' not found; file unchanged." >&2
+  exit 1
+fi
+
+echo
+echo "diff:"
+echo "  // .NET agent version metrics"
+echo "+ $line"
+
+if [ "$dryrun" = "true" ]; then
+  kind="PR"; [ "$draft" = "true" ] && kind="draft PR"
+  echo
+  echo "[dry-run] would create branch '$branch' and open $kind: '$title'"
+  exit 0
+fi
+
+# Create the branch from the current base head.
+basesha=$(gh api --hostname "$HOST" "repos/$REPO/git/ref/heads/$BASE" --jq .object.sha)
+if err=$(gh api --hostname "$HOST" "repos/$REPO/git/refs" \
+      -f ref="refs/heads/$branch" -f sha="$basesha" 2>&1); then
+  echo "created branch $branch"
+elif echo "$err" | grep -q "Reference already exists"; then
+  echo "branch $branch already exists -- reusing it."
+else
+  echo "$err" >&2
+  exit 1
+fi
+
+# Commit the edited file onto the branch. base64 contains no JSON-special
+# characters, so the request body can be built with printf (no jq needed) and
+# sent via --input to avoid command-line length limits on the large content.
+content=$(base64 -w0 "$work/metrics_new.txt")
+printf '{"message":"%s","content":"%s","sha":"%s","branch":"%s"}' \
+  "$title" "$content" "$sha" "$branch" > "$work/put.json"
+gh api --hostname "$HOST" -X PUT "repos/$REPO/contents/$FILE" \
+  --input "$work/put.json" >/dev/null
+echo "committed change to $FILE"
+
+# Open the PR -- ready for review by default, draft when metrics are pending.
+if [ "$draft" = "true" ]; then
+  body="Draft: additional .NET agent supportability metrics still need to be added to metric_names.txt before this is ready for review."
+  printf '{"title":"%s","head":"%s","base":"%s","body":"%s","draft":true}' \
+    "$title" "$branch" "$BASE" "$body" > "$work/pr.json"
+else
+  printf '{"title":"%s","head":"%s","base":"%s","body":""}' \
+    "$title" "$branch" "$BASE" > "$work/pr.json"
+fi
+url=$(gh api --hostname "$HOST" "repos/$REPO/pulls" --input "$work/pr.json" --jq .html_url)
+
+if [ "$draft" = "true" ]; then
+  echo "draft PR opened: $url"
+  echo "add the supportability metrics here, then mark the PR ready:"
+  echo "  https://$HOST/$REPO/edit/$branch/$FILE"
+else
+  echo "PR opened: $url"
+fi

--- a/.claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
+++ b/.claude/skills/angler-dotnet-release/scripts/create_angler_pr.sh
@@ -13,14 +13,17 @@
 # (awk, base64, grep) are required -- all ship with the Git Bash that runs gh.
 #
 # Usage:
-#   create_angler_pr.sh [--version X.Y.Z[.W]] [--draft] [--dry-run]
+#   create_angler_pr.sh [--version X.Y.Z[.W]] [--extra-metric NAME] [--draft] [--dry-run]
 #
-#   --version  Target a specific agent version instead of the latest release.
-#              A 3-part version gets a trailing ".0" (matching the file format).
-#   --draft    Open the PR as a draft and print a web-edit URL for the file on
-#              the branch. Use when the release also adds supportability metrics
-#              that must be added by hand before the PR is ready.
-#   --dry-run  Print the detected version and the diff without creating anything.
+#   --version       Target a specific agent version instead of the latest release.
+#                   A 3-part version gets a trailing ".0" (matching the file format).
+#   --extra-metric  Additional Supportability/* metric line to insert. Repeatable;
+#                   each call adds one metric. These go under "// .NET MISC",
+#                   separate from the version line.
+#   --draft         Open the PR as a draft and print a web-edit URL for the file on
+#                   the branch. Use when the release also adds supportability metrics
+#                   that must be added by hand before the PR is ready.
+#   --dry-run       Print the detected version and the diff without creating anything.
 
 set -e
 
@@ -33,11 +36,13 @@ AGENT_REPO="newrelic/newrelic-dotnet-agent"
 version=""
 draft="false"
 dryrun="false"
+extra_metrics=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --version) version="$2"; shift 2 ;;
     --version=*) version="${1#*=}"; shift ;;
+    --extra-metric) extra_metrics+=("$2"); shift 2 ;;
     --draft) draft="true"; shift ;;
     --dry-run) dryrun="true"; shift ;;
     -h|--help) grep '^# ' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
@@ -83,10 +88,23 @@ if grep -qxF "$line" "$work/metrics.txt"; then
 fi
 echo "status: ABSENT"
 
-# Insert the new line immediately after the section anchor (newest-first order).
-awk -v ins="$line" '
+# Build the extra-metrics block (newline-separated, may be empty).
+extras_block=""
+for m in "${extra_metrics[@]}"; do
+  if [ -z "$extras_block" ]; then
+    extras_block="$m"
+  else
+    extras_block="$extras_block"$'\n'"$m"
+  fi
+done
+
+# Two separate inserts:
+#   1. Version line -> top of "// .NET agent version metrics" (newest-first order)
+#   2. Extra metrics -> top of "// .NET MISC" (general catch-all section)
+awk -v ver="$line" -v extras="$extras_block" '
   {print}
-  /^\/\/ \.NET agent version metrics[[:space:]]*$/ && !done {print ins; done=1}
+  /^\/\/ \.NET agent version metrics[[:space:]]*$/ && !vdone {print ver; vdone=1}
+  /^\/\/ \.NET MISC[[:space:]]*$/ && !edone && extras != "" {print extras; edone=1}
 ' "$work/metrics.txt" > "$work/metrics_new.txt"
 
 # Guard against a missing/renamed anchor producing an unchanged file.
@@ -94,11 +112,21 @@ if ! grep -qxF "$line" "$work/metrics_new.txt"; then
   echo "ERROR: anchor '// .NET agent version metrics' not found; file unchanged." >&2
   exit 1
 fi
+if [ ${#extra_metrics[@]} -gt 0 ] && ! grep -qxF "${extra_metrics[0]}" "$work/metrics_new.txt"; then
+  echo "ERROR: anchor '// .NET MISC' not found; extra metrics were not inserted." >&2
+  exit 1
+fi
 
 echo
 echo "diff:"
 echo "  // .NET agent version metrics"
 echo "+ $line"
+if [ ${#extra_metrics[@]} -gt 0 ]; then
+  echo "  // .NET MISC"
+  for m in "${extra_metrics[@]}"; do
+    echo "+ $m"
+  done
+fi
 
 if [ "$dryrun" = "true" ]; then
   kind="PR"; [ "$draft" = "true" ] && kind="draft PR"

--- a/build/MetricNameDiscovery/MetricNameDiscovery.csproj
+++ b/build/MetricNameDiscovery/MetricNameDiscovery.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/build/MetricNameDiscovery/Program.cs
+++ b/build/MetricNameDiscovery/Program.cs
@@ -1,0 +1,277 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+string? agentHome = null;
+string? diffFile = null;
+string? exclusionsFile = null;
+
+for (int i = 0; i < args.Length; i++)
+{
+    if (args[i] == "--agent-home" && i + 1 < args.Length)
+        agentHome = args[++i];
+    else if (args[i] == "--diff" && i + 1 < args.Length)
+        diffFile = args[++i];
+    else if (args[i] == "--exclusions" && i + 1 < args.Length)
+        exclusionsFile = args[++i];
+}
+
+agentHome ??= FindAgentHome();
+exclusionsFile ??= FindExclusionsFile();
+
+var exclusions = LoadExclusions(exclusionsFile);
+
+if (agentHome == null || !Directory.Exists(agentHome))
+{
+    Console.Error.WriteLine("Could not find agent home. Build FullAgent.sln first, or pass --agent-home <path>.");
+    return 1;
+}
+
+var coreDll = Path.Combine(agentHome, "NewRelic.Agent.Core.dll");
+if (!File.Exists(coreDll))
+{
+    Console.Error.WriteLine($"NewRelic.Agent.Core.dll not found in: {agentHome}");
+    return 1;
+}
+
+Console.Error.WriteLine($"Loading from: {agentHome}");
+
+var alc = new AgentLoadContext(agentHome);
+Assembly coreAssembly;
+try
+{
+    coreAssembly = alc.LoadFromAssemblyPath(coreDll);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Failed to load Core.dll: {ex.Message}");
+    return 1;
+}
+
+var metricNamesType = coreAssembly.GetType("NewRelic.Agent.Core.Metrics.MetricNames");
+if (metricNamesType == null)
+{
+    Console.Error.WriteLine("Could not find MetricNames type. Was Core.dll built from current source?");
+    return 1;
+}
+
+var discovered = new SortedSet<string>(StringComparer.Ordinal);
+var unenumerable = new List<string>();
+
+// --- Fields: const string and static readonly (MetricName or string) ---
+foreach (var field in metricNamesType.GetFields(BindingFlags.Public | BindingFlags.Static))
+{
+    if (!field.IsLiteral && !field.IsInitOnly)
+        continue;
+    // Skip prefix constants (naming convention: field name ends with "Prefix")
+    if (field.Name.EndsWith("Prefix", StringComparison.Ordinal))
+        continue;
+
+    object? value;
+    try { value = field.GetValue(null); }
+    catch { continue; }
+
+    var str = value?.ToString();
+    if (IsSupport(str))
+        discovered.Add(str!);
+}
+
+// --- Properties: public static parameterless getters ---
+foreach (var prop in metricNamesType.GetProperties(BindingFlags.Public | BindingFlags.Static))
+{
+    var getter = prop.GetMethod;
+    if (getter == null || getter.GetParameters().Length > 0)
+        continue;
+
+    object? value;
+    try { value = prop.GetValue(null); }
+    catch { continue; }
+
+    var str = value?.ToString();
+    if (IsSupport(str))
+        discovered.Add(str!);
+}
+
+// --- Methods: public static, all params enum or bool -> cross-product invoke ---
+foreach (var method in metricNamesType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+{
+    if (method.IsSpecialName)
+        continue; // skip property accessors
+
+    // Only handle methods that can return a string metric name
+    if (method.ReturnType.FullName != "System.String")
+        continue;
+
+    var parameters = method.GetParameters();
+    if (parameters.Length == 0)
+    {
+        // Parameterless methods not exposed as properties (expression-body methods defined
+        // with () syntax instead of =>-property syntax show up as methods, not properties)
+        object? val;
+        try { val = method.Invoke(null, null); }
+        catch { continue; }
+        var s = val?.ToString();
+        if (IsSupport(s)) discovered.Add(s!);
+        continue;
+    }
+
+    bool allEnumOrBool = parameters.All(p => p.ParameterType.IsEnum || p.ParameterType.FullName == "System.Boolean");
+
+    if (!allEnumOrBool)
+    {
+        // Report non-enumerable methods that are likely Supportability-related
+        if (method.Name.StartsWith("GetSupportability") || method.Name.StartsWith("Supportability"))
+        {
+            var sig = $"{method.Name}({string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"))})";
+            unenumerable.Add(sig);
+        }
+        continue;
+    }
+
+    // Build cross-product of all argument combinations
+    var paramValueSets = parameters.Select(p => GetValues(p.ParameterType)).ToArray();
+    foreach (var argSet in CrossProduct(paramValueSets))
+    {
+        object? result;
+        try { result = method.Invoke(null, argSet); }
+        catch { continue; }
+
+        var str = result?.ToString();
+        if (IsSupport(str))
+            discovered.Add(str!);
+    }
+}
+
+// Output discovered names
+Console.WriteLine("=== Discovered Supportability metrics ===");
+foreach (var name in discovered)
+    Console.WriteLine(name);
+Console.WriteLine();
+Console.WriteLine($"Total: {discovered.Count}");
+
+// Report non-enumerable methods
+Console.WriteLine();
+Console.WriteLine("=== Methods not enumerated (string/complex params - C/D shape) ===");
+foreach (var sig in unenumerable)
+    Console.WriteLine($"  {sig}");
+
+// Diff mode
+if (diffFile != null)
+{
+    if (!File.Exists(diffFile))
+    {
+        Console.Error.WriteLine($"Diff file not found: {diffFile}");
+        return 1;
+    }
+
+    var anglerLines = File.ReadAllLines(diffFile)
+        .Select(l => l.Trim())
+        .Where(l => l.StartsWith("Supportability"))
+        .ToHashSet(StringComparer.Ordinal);
+
+    Console.WriteLine();
+    Console.WriteLine("=== Candidate additions (in code, .NET-named, absent from Angler file) ===");
+    bool any = false;
+    foreach (var name in discovered)
+    {
+        if (IsDotNetNamed(name) && !anglerLines.Contains(name) && !exclusions.Contains(name))
+        {
+            Console.WriteLine($"  + {name}");
+            any = true;
+        }
+    }
+    if (!any)
+        Console.WriteLine("  (none found)");
+}
+
+return 0;
+
+// ---- helpers ----
+
+// Reject obvious prefix leakage (e.g. SupportabilityCachePrefix ends with '/')
+static bool IsSupport(string? s) =>
+    s != null && s.StartsWith("Supportability", StringComparison.Ordinal) && !s.EndsWith('/');
+
+// Matches names the .NET agent owns by naming convention
+static bool IsDotNetNamed(string name) =>
+    name.Contains("/DotNet/") || name.Contains("/DotNET/") || name.Contains("/Dotnet/");
+
+static object[] GetValues(Type t)
+{
+    if (t.FullName == "System.Boolean")
+        return new object[] { true, false };
+    if (t.IsEnum)
+        return Enum.GetValues(t).Cast<object>().ToArray();
+    return Array.Empty<object>();
+}
+
+static IEnumerable<object[]> CrossProduct(object[][] sets)
+{
+    if (sets.Length == 0)
+    {
+        yield return Array.Empty<object>();
+        yield break;
+    }
+    foreach (var first in sets[0])
+    {
+        foreach (var rest in CrossProduct(sets[1..]))
+        {
+            var row = new object[1 + rest.Length];
+            row[0] = first;
+            rest.CopyTo(row, 1);
+            yield return row;
+        }
+    }
+}
+
+static string? FindExclusionsFile()
+{
+    var dir = AppContext.BaseDirectory;
+    while (dir != null)
+    {
+        if (File.Exists(Path.Combine(dir, "FullAgent.sln")))
+        {
+            var candidate = Path.Combine(dir, "build", "MetricNameDiscovery", "exclusions.txt");
+            return File.Exists(candidate) ? candidate : null;
+        }
+        dir = Path.GetDirectoryName(dir);
+    }
+    return null;
+}
+
+static HashSet<string> LoadExclusions(string? path)
+{
+    if (path == null || !File.Exists(path))
+        return new HashSet<string>(StringComparer.Ordinal);
+
+    return File.ReadAllLines(path)
+        .Select(l => l.Trim())
+        .Where(l => l.Length > 0 && !l.StartsWith('#'))
+        .ToHashSet(StringComparer.Ordinal);
+}
+
+static string? FindAgentHome()
+{
+    var dir = AppContext.BaseDirectory;
+    while (dir != null)
+    {
+        if (File.Exists(Path.Combine(dir, "FullAgent.sln")))
+        {
+            var candidate = Path.Combine(dir, "src", "Agent", "newrelichome_x64_coreclr");
+            return Directory.Exists(candidate) ? candidate : null;
+        }
+        dir = Path.GetDirectoryName(dir);
+    }
+    return null;
+}
+
+class AgentLoadContext(string dir) : AssemblyLoadContext(isCollectible: false)
+{
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        var path = Path.Combine(dir, assemblyName.Name + ".dll");
+        return File.Exists(path) ? LoadFromAssemblyPath(path) : null;
+    }
+}

--- a/build/MetricNameDiscovery/Program.cs
+++ b/build/MetricNameDiscovery/Program.cs
@@ -172,11 +172,11 @@ if (diffFile != null)
         .ToHashSet(StringComparer.Ordinal);
 
     Console.WriteLine();
-    Console.WriteLine("=== Candidate additions (in code, .NET-named, absent from Angler file) ===");
+    Console.WriteLine("=== Candidate additions (in code, absent from Angler file) ===");
     bool any = false;
     foreach (var name in discovered)
     {
-        if (IsDotNetNamed(name) && !anglerLines.Contains(name) && !exclusions.Contains(name))
+        if (!anglerLines.Contains(name) && !exclusions.Contains(name))
         {
             Console.WriteLine($"  + {name}");
             any = true;
@@ -194,9 +194,6 @@ return 0;
 static bool IsSupport(string? s) =>
     s != null && s.StartsWith("Supportability", StringComparison.Ordinal) && !s.EndsWith('/');
 
-// Matches names the .NET agent owns by naming convention
-static bool IsDotNetNamed(string name) =>
-    name.Contains("/DotNet/") || name.Contains("/DotNET/") || name.Contains("/Dotnet/");
 
 static object[] GetValues(Type t)
 {

--- a/build/MetricNameDiscovery/README.md
+++ b/build/MetricNameDiscovery/README.md
@@ -20,7 +20,7 @@ dotnet run --project build/MetricNameDiscovery/MetricNameDiscovery.csproj -- [op
 | Option | Description |
 |---|---|
 | `--agent-home <path>` | Path to an agent home directory containing `NewRelic.Agent.Core.dll`. Defaults to `src/Agent/newrelichome_x64_coreclr` relative to the repo root. |
-| `--diff <angler-file>` | Path to a local copy of Angler's `metric_names.txt`. Adds a `=== Candidate additions ===` section listing `.NET`-named metrics present in code but absent from the file. |
+| `--diff <angler-file>` | Path to a local copy of Angler's `metric_names.txt`. Adds a `=== Candidate additions ===` section listing all metrics present in code but absent from the file and not in the exclusions list. |
 | `--exclusions <path>` | Path to an exclusions file. Defaults to `build/MetricNameDiscovery/exclusions.txt` if it exists. |
 
 ## Output sections
@@ -30,8 +30,8 @@ dotnet run --project build/MetricNameDiscovery/MetricNameDiscovery.csproj -- [op
 - **Methods not enumerated** - methods whose parameters include free-form
   strings (shapes C/D); these cannot be enumerated without runtime data and
   are listed for manual review.
-- **Candidate additions** (diff mode only) - `.NET`-named metrics in code
-  that are absent from the Angler file and not in the exclusions list.
+- **Candidate additions** (diff mode only) - all metrics in code that are
+  absent from the Angler file and not in the exclusions list.
 
 ## Exclusions file
 

--- a/build/MetricNameDiscovery/README.md
+++ b/build/MetricNameDiscovery/README.md
@@ -1,0 +1,47 @@
+# MetricNameDiscovery
+
+Reflects over the built `NewRelic.Agent.Core.dll` to enumerate every
+`Supportability/*` metric name that can be statically derived from
+`MetricNames.cs`, and optionally diffs the result against Angler's
+`metric_names.txt` to surface candidates for addition.
+
+## Prerequisites
+
+- `FullAgent.sln` must have been built at least once so that
+  `src/Agent/newrelichome_x64_coreclr/` exists. The tool loads
+  `NewRelic.Agent.Core.dll` from that directory at runtime.
+
+## Usage
+
+```
+dotnet run --project build/MetricNameDiscovery/MetricNameDiscovery.csproj -- [options]
+```
+
+| Option | Description |
+|---|---|
+| `--agent-home <path>` | Path to an agent home directory containing `NewRelic.Agent.Core.dll`. Defaults to `src/Agent/newrelichome_x64_coreclr` relative to the repo root. |
+| `--diff <angler-file>` | Path to a local copy of Angler's `metric_names.txt`. Adds a `=== Candidate additions ===` section listing `.NET`-named metrics present in code but absent from the file. |
+| `--exclusions <path>` | Path to an exclusions file. Defaults to `build/MetricNameDiscovery/exclusions.txt` if it exists. |
+
+## Output sections
+
+- **Discovered Supportability metrics** - every metric name the tool could
+  enumerate from fields, properties, and methods with enum/bool parameters.
+- **Methods not enumerated** - methods whose parameters include free-form
+  strings (shapes C/D); these cannot be enumerated without runtime data and
+  are listed for manual review.
+- **Candidate additions** (diff mode only) - `.NET`-named metrics in code
+  that are absent from the Angler file and not in the exclusions list.
+
+## Exclusions file
+
+`build/MetricNameDiscovery/exclusions.txt` lists metric names that should
+never appear as candidates. Add an entry when a metric is intentionally
+absent from Angler (e.g. internal-only, redundant, or not yet ready).
+Blank lines and lines starting with `#` are ignored.
+
+## Integration with the Angler release skill
+
+The `angler-dotnet-release` skill runs this tool automatically during Step 2
+and presents any candidates to the user for classification before opening the
+Angler PR. See `.claude/skills/angler-dotnet-release/skill.md`.

--- a/build/MetricNameDiscovery/exclusions.txt
+++ b/build/MetricNameDiscovery/exclusions.txt
@@ -1,8 +1,101 @@
 # Metrics to exclude from Angler candidate suggestions.
 # One exact metric name per line. Blank lines and lines starting with '#' are ignored.
 # Add a comment above each entry explaining why it is excluded.
-#
-# Example:
-#   # Emitted only during agent startup, not useful for ongoing monitoring
-#   Supportability/DotNET/AgentLogging/Disabled
 
+# -----------------------------------------------------------------------
+# Cross-agent / non-.NET-specific metrics reviewed 2026-04-15.
+# Determined not useful for .NET-specific Angler tracking.
+# -----------------------------------------------------------------------
+
+# Reservoir lifecycle counters -- same shape emitted by all agents; not .NET-specific
+Supportability/AnalyticsEvents/TotalEventsCollected
+Supportability/AnalyticsEvents/TotalEventsRecollected
+Supportability/AnalyticsEvents/TryResizeReservoir
+Supportability/Events/Customer/TotalEventsCollected
+Supportability/Events/Customer/TotalEventsRecollected
+Supportability/Events/Customer/TryResizeReservoir
+
+# Trace/error/SQL lifecycle counters -- same shape emitted by all agents
+Supportability/Errors/TotalErrorsCollected
+Supportability/Errors/TotalErrorsRecollected
+Supportability/Errors/TotalErrorsSent
+Supportability/SqlTraces/TotalSqlTracesCollected
+Supportability/SqlTraces/TotalSqlTracesRecollected
+Supportability/SqlTraces/TotalSqlTracesSent
+
+# Metric harvest heartbeat -- emitted by all agents, not .NET-specific
+Supportability/MetricHarvest/transmit
+
+# RUM injection counters -- not .NET-specific
+Supportability/RUM/Footer
+Supportability/RUM/Header
+Supportability/RUM/HtmlPage
+
+# Thread profiling sample counter -- not .NET-specific
+Supportability/ThreadProfiling/SampleCount
+
+# Transaction builder GC counter -- not .NET-specific
+Supportability/TransactionBuilderGarbageCollected/all
+
+# DT late-header counter -- not .NET-specific
+Supportability/DistributedTrace/HeadersAcceptedLate
+
+# Top-level OTel bridge flags (no /DotNet/ segment) -- not .NET-specific
+Supportability/OpenTelemetryBridge/disabled
+Supportability/OpenTelemetryBridge/enabled
+
+# Custom instrumentation count -- not .NET-specific
+Supportability/CustomInst/Count
+
+# Utilization error for kubernetes -- not .NET-specific (other utilization errors already in Angler)
+Supportability/utilization/kubernetes/error
+
+# -----------------------------------------------------------------------
+# Collector HTTP error codes -- cross-agent, open-ended set, not
+# useful to track per-agent. Only the subset currently missing from
+# Angler is listed; if Angler adds more, those will pass through
+# unfiltered until reviewed.
+# -----------------------------------------------------------------------
+Supportability/Agent/Collector/HTTPError/100
+Supportability/Agent/Collector/HTTPError/101
+Supportability/Agent/Collector/HTTPError/102
+Supportability/Agent/Collector/HTTPError/103
+Supportability/Agent/Collector/HTTPError/203
+Supportability/Agent/Collector/HTTPError/204
+Supportability/Agent/Collector/HTTPError/205
+Supportability/Agent/Collector/HTTPError/206
+Supportability/Agent/Collector/HTTPError/207
+Supportability/Agent/Collector/HTTPError/208
+Supportability/Agent/Collector/HTTPError/226
+Supportability/Agent/Collector/HTTPError/300
+Supportability/Agent/Collector/HTTPError/301
+Supportability/Agent/Collector/HTTPError/302
+Supportability/Agent/Collector/HTTPError/303
+Supportability/Agent/Collector/HTTPError/304
+Supportability/Agent/Collector/HTTPError/305
+Supportability/Agent/Collector/HTTPError/306
+Supportability/Agent/Collector/HTTPError/307
+Supportability/Agent/Collector/HTTPError/308
+Supportability/Agent/Collector/HTTPError/451
+Supportability/Agent/Collector/HTTPError/504
+Supportability/Agent/Collector/HTTPError/505
+Supportability/Agent/Collector/HTTPError/506
+Supportability/Agent/Collector/HTTPError/507
+Supportability/Agent/Collector/HTTPError/508
+Supportability/Agent/Collector/HTTPError/510
+Supportability/Agent/Collector/HTTPError/511
+
+# -----------------------------------------------------------------------
+# .NET-named metrics triaged 2026-06-12 -- present in agent code but
+# not appropriate for Angler tracking.
+# -----------------------------------------------------------------------
+
+# AWS Account ID config metric -- internal config signal, not a runtime health metric
+Supportability/Dotnet/AwsAccountId/Config
+
+# OTel bridge internal counters -- high-frequency instrumentation signals,
+# not suitable for cross-account supportability tracking
+Supportability/Metrics/DotNet/OpenTelemetryBridge/EntityGuidChanged
+Supportability/Metrics/DotNet/OpenTelemetryBridge/InstrumentCreated
+Supportability/Metrics/DotNet/OpenTelemetryBridge/MeasurementRecorded
+Supportability/Metrics/DotNet/OpenTelemetryBridge/MeterProviderRecreated

--- a/build/MetricNameDiscovery/exclusions.txt
+++ b/build/MetricNameDiscovery/exclusions.txt
@@ -1,0 +1,8 @@
+# Metrics to exclude from Angler candidate suggestions.
+# One exact metric name per line. Blank lines and lines starting with '#' are ignored.
+# Add a comment above each entry explaining why it is excluded.
+#
+# Example:
+#   # Emitted only during agent startup, not useful for ongoing monitoring
+#   Supportability/DotNET/AgentLogging/Disabled
+


### PR DESCRIPTION
Adds a Claude Code skill that automates opening the Angler PR whenever a new
.NET agent release ships, along with a supporting build tool that discovers
new supportability metric names that should be added to Angler at the same time.

## angler-dotnet-release skill (.claude/skills/angler-dotnet-release/)

A new skill that handles the full Angler release flow end-to-end:

1. Detects (or accepts) the latest .NET agent release version
2. Builds FullAgent.sln if needed, then runs the discovery tool to find
   .NET-named Supportability/* metrics present in the agent but absent from
   Angler -- presents candidates to the user for classification
3. Opens a PR on source.datanerd.us/agents/angler adding the version line
   and any user-approved extra metrics (no local clone of Angler required)
4. Posts an approval request to #dotnet-team on Slack if the tool is connected

The bundled script (scripts/create_angler_pr.sh) does all file manipulation
and GitHub API calls via gh -- no extra runtime needed beyond Git Bash.

Extra metrics go under the // .NET MISC section; the version line goes under
// .NET agent version metrics (newest-first).

## MetricNameDiscovery tool (build/MetricNameDiscovery/)

A net10.0 console app that reflects over NewRelic.Agent.Core.dll at runtime
(via AssemblyLoadContext -- no project reference, no ILRepack step) to enumerate
every Supportability/* metric name derivable from MetricNames.cs:

- Shape A: public const and static readonly fields
- Shape B: static methods whose parameters are all enum or bool (cross-product invoked)
- Parameterless static methods
- Reports methods with free-form string params as non-enumerable (shapes C/D)

Diff mode (--diff <angler-file>) filters results to .NET-named candidates
absent from Angler and not listed in exclusions.txt. The exclusions file
suppresses previously triaged metrics so they don't reappear on every run.