### PR TITLE
chore: Clean up incorrect attribute name in profiler instrumentation file parsing and fix typos

### DIFF
--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.0.36"/>
+    <PackageReference Include="NewRelic.Agent.Internal.Profiler" Version="10.51.1.9"/>
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -43,7 +43,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
                     }
                     else
                     {
-                        LogDebug(L"Parsing instrumentation file '", instrumentationXml.first);
+                        LogDebug(L"Parsing instrumentation file '", instrumentationXml.first, L"'");
                         GetInstrumentationPoints(instrumentationXml.second);
                     }                    
                 }
@@ -426,7 +426,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             }
         }
 
-        // the class name field of an instrumentation point may have multiple clasess listed (comma separated), we have to build instrumentation points for each
+        // the class name field of an instrumentation point may have multiple classes listed (comma separated), we have to build instrumentation points for each
         static std::set<InstrumentationPointPtr> SplitInstrumentationPointsOnClassNames(InstrumentationPointPtr instrumentationPoint)
         {
             std::set<InstrumentationPointPtr> instrumentationPoints;

--- a/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
+++ b/src/Agent/NewRelic/Profiler/Configuration/InstrumentationConfiguration.h
@@ -295,7 +295,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             instrumentationPoint->MetricName = GetAttributeOrEmptyString(tracerNode, _X("metricName"));
             instrumentationPoint->MetricType = GetAttributeOrEmptyString(tracerNode, _X("metric"));
             auto levelString = GetAttributeOrEmptyString(tracerNode, _X("level"));
-            auto suppressRecursiveCallsString = GetAttributeOrEmptyString(tracerNode, _X("level"));
+            auto suppressRecursiveCallsString = GetAttributeOrEmptyString(tracerNode, _X("suppressRecursiveCalls"));
             auto transactionTraceSegmentString = GetAttributeOrEmptyString(tracerNode, _X("transactionTraceSegment"));
             auto transactionNamingPriorityString = GetAttributeOrEmptyString(tracerNode, _X("transactionNamingPriority"));
             instrumentationPoint->AssemblyName = GetAttributeOrEmptyString(matchNode, _X("assemblyName"));
@@ -367,7 +367,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
                 instrumentationPoint->TracerFactoryArgs |= (level << 16);
             }
 
-            // suppress recusive call flag
+            // suppress recursive call flag
             if (!suppressRecursiveCallsString.empty())
             {
                 if (Strings::AreEqualCaseInsensitive(suppressRecursiveCallsString, _X("true"))) 
@@ -462,7 +462,7 @@ namespace NewRelic { namespace Profiler { namespace Configuration
             return instrumentationPoints;
         }
 
-        // given two instrumentationPoint->ClassName iterators (begin and end), return a new copy of insrtumentationPoint containing a ClassName of [begin, end)
+        // given two instrumentationPoint->ClassName iterators (begin and end), return a new copy of instrumentationPoint containing a ClassName of [begin, end)
         static InstrumentationPointPtr GetInstrumentationPointFromClassSplitIterators(InstrumentationPointPtr instrumentationPoint, xstring_t::const_iterator begin, xstring_t::const_iterator end)
         {
             // construct a new class name string from this section of the old class name split


### PR DESCRIPTION
While investigating the possibility of adding additional logging to the profiler at startup for user-supplied custom instrumentation XML files, I noticed an unrelated issue: the attribute name being parsed for the `suppressRecursiveCalls` tracer factory flag was "level" instead of "suppressRecursiveCalls".  This was probably a copy/paste error from the line above it.  I don't think this bug has ever caused us a problem because none of our instrumentation files specify the `suppressiveRecursiveCalls` attribute for a tracer factory, nor do any of them specify the `level` attribute either (which would have had the effect of setting the suppressRecursiveCalls flag to `false` instead of the default value of `true`).  However, it's worth cleaning up so that what we're parsing from instrumentation XMLs matches the XSD: https://github.com/newrelic/newrelic-dotnet-agent/blob/c29f037c08c949a58ec2e8e83471c8025843b048/src/Agent/NewRelic/Agent/Core/Extension/extension.xsd#L103

Along the way I also noticed and fixed some typos in comments.