### PR TITLE
fix: Prevent malformed log_event_data JSON for non-serializable context values

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
+++ b/src/Agent/NewRelic/Agent/Core/JsonConverters/LogEventWireModelCollectionJsonConverter.cs
@@ -120,25 +120,33 @@ public class LogEventWireModelCollectionJsonConverter : JsonConverter<LogEventWi
                 foreach (var item in logEvent.ContextData)
                 {
                     jsonWriter.WritePropertyName(Context + "." + item.Key);
-                    string contextValueJson;
                     try
                     {
-                        contextValueJson = JsonConvert.SerializeObject(item.Value);
+                        // SerializeObject returns valid JSON text (a quoted/escaped string
+                        // for strings, an object/array for complex values), so it is safe to
+                        // write raw into the stream.
+                        var contextValueJson = JsonConvert.SerializeObject(item.Value);
+                        jsonWriter.WriteRawValue(contextValueJson);
                     }
                     catch
                     {
-                        // If JsonConvert can't serialize it, maybe it has a ToString()
+                        // The value's object graph can't be serialized (e.g. a self-referencing
+                        // type such as an ASP.NET Core Endpoint). Fall back to a string
+                        // representation, but write it with WriteValue so it is correctly quoted
+                        // and escaped. Writing it raw would emit an unquoted token and corrupt the
+                        // entire log_event_data payload, causing the whole batch to be rejected.
+                        string fallbackValue;
                         try
                         {
-                            contextValueJson = item.Value.ToString();
+                            fallbackValue = item.Value?.ToString();
                         }
                         catch
                         {
-                            // If that didn't work, just use the type name
-                            contextValueJson = item.Value.GetType().ToString();
+                            // If even ToString() throws, fall back to the type name.
+                            fallbackValue = item.Value?.GetType().ToString();
                         }
+                        jsonWriter.WriteValue(fallbackValue);
                     }
-                    jsonWriter.WriteRawValue(contextValueJson);
                 }
 
                 jsonWriter.WriteEndObject();

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -556,6 +556,16 @@ public abstract class AgentLogBase
             .SelectMany(x => x.Logs);
     }
 
+    // Returns the raw, unparsed log_event_data payload strings exactly as the agent logged
+    // them. Useful for asserting the payload is well-formed JSON (GetLogEventData parses the
+    // JSON and would throw on a malformed payload before a test could inspect it).
+    public IEnumerable<string> GetLogEventDataPayloads()
+    {
+        return TryGetLogLines(LogDataLogLineRegex)
+            .Select(match => TryExtractJson(match, 1))
+            .Where(json => json != null);
+    }
+
     #endregion LogData
 
     #region UpdateLoadedModules

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNonSerializableTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNonSerializableTests.cs
@@ -27,7 +27,7 @@ public abstract class ContextDataNonSerializableTestsBase<TFixture> : NewRelicIn
 
     // Must match NonSerializableContextValue.ToStringValue in the shared application
     // (the test project does not reference the shared app, so the value is duplicated here).
-    private const string NonSerializableToStringValue = "Packing.Api.Controllers.FeatureController.IsEnabled (Packing.Api)";
+    private const string NonSerializableToStringValue = "Sample.App.Controllers.WidgetController.IsEnabled (Sample.App)";
 
     protected ContextDataNonSerializableTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework) : base(fixture)
     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNonSerializableTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Logging/ContextDataNonSerializableTests.cs
@@ -1,0 +1,122 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.Logging.ContextData;
+
+// Regression coverage for GitHub issue #3641: a context-data value that Newtonsoft.Json
+// cannot serialize (e.g. a self-referencing object such as an ASP.NET Core Endpoint placed
+// into a logging scope) must not corrupt the log_event_data payload. Before the fix, the
+// agent wrote such a value's raw ToString() unquoted, producing invalid JSON and causing the
+// collector to reject the entire batch. These tests assert the payload is well-formed JSON
+// and that the offending value is emitted as a quoted string.
+public abstract class ContextDataNonSerializableTestsBase<TFixture> : NewRelicIntegrationTest<TFixture>
+    where TFixture : ConsoleDynamicMethodFixture
+{
+    private readonly TFixture _fixture;
+    private readonly LoggingFramework _loggingFramework;
+
+    private const string InfoMessage = "NonSerializableContextMessage";
+
+    // Must match NonSerializableContextValue.ToStringValue in the shared application
+    // (the test project does not reference the shared app, so the value is duplicated here).
+    private const string NonSerializableToStringValue = "Packing.Api.Controllers.FeatureController.IsEnabled (Packing.Api)";
+
+    protected ContextDataNonSerializableTestsBase(TFixture fixture, ITestOutputHelper output, LoggingFramework loggingFramework) : base(fixture)
+    {
+        _fixture = fixture;
+        _loggingFramework = loggingFramework;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(2));
+        _fixture.TestLogger = output;
+
+        _fixture.AddCommand($"LoggingTester SetFramework {_loggingFramework} {RandomPortGenerator.NextPort()}");
+        _fixture.AddCommand("LoggingTester Configure");
+        _fixture.AddCommand($"LoggingTester CreateSingleLogMessageWithNonSerializableContext {_loggingFramework} {InfoMessage}");
+
+        _fixture.AddActions
+        (
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath);
+
+                configModifier
+                    .EnableContextData(true)
+                    .SetLogLevel("debug");
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.LogDataLogLineRegex, TimeSpan.FromSeconds(30));
+            }
+        );
+
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void LogEventDataPayloadIsValidJson()
+    {
+        var payloads = _fixture.AgentLog.GetLogEventDataPayloads().ToArray();
+
+        Assert.NotEmpty(payloads);
+
+        // The core assertion: every log_event_data payload must parse as valid JSON, even
+        // though one of the captured context-data values could not be serialized.
+        foreach (var payload in payloads)
+        {
+            var exception = Record.Exception(() => JToken.Parse(payload));
+            Assert.True(exception == null, $"log_event_data payload is not valid JSON: {exception?.Message}\nPayload: {payload}");
+        }
+
+        // The unserializable value must be present, captured as a quoted string equal to its
+        // ToString(), and the normal sibling attribute must be unaffected.
+        var expectedAttributes = new Dictionary<string, string>
+        {
+            { "normalkey", "normalvalue" },
+            { "nonserializable", NonSerializableToStringValue },
+        };
+
+        var expectedLogLines = new[]
+        {
+            new Assertions.ExpectedLogLine
+            {
+                Level = LogUtils.GetLevelName(_loggingFramework, "INFO"),
+                LogMessage = InfoMessage,
+                Attributes = expectedAttributes
+            }
+        };
+
+        var logLines = _fixture.AgentLog.GetLogEventDataLogLines().ToArray();
+        Assertions.LogLinesExist(expectedLogLines, logLines, ignoreAttributeCount: true);
+    }
+}
+
+public class MELContextDataNonSerializableNetCoreLatestTests : ContextDataNonSerializableTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public MELContextDataNonSerializableNetCoreLatestTests(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, LoggingFramework.MicrosoftLogging)
+    {
+    }
+}
+
+public class MELContextDataNonSerializableNetCoreOldestTests : ContextDataNonSerializableTestsBase<ConsoleDynamicMethodFixtureCoreOldest>
+{
+    public MELContextDataNonSerializableNetCoreOldestTests(ConsoleDynamicMethodFixtureCoreOldest fixture, ITestOutputHelper output)
+        : base(fixture, output, LoggingFramework.MicrosoftLogging)
+    {
+    }
+}
+
+public class MELContextDataNonSerializableFWLatestTests : ContextDataNonSerializableTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public MELContextDataNonSerializableFWLatestTests(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output, LoggingFramework.MicrosoftLogging)
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/LoggingTester.cs
@@ -190,6 +190,21 @@ public class LoggingTester
         _logs[logger.ToUpper()].InfoWithContextDictionary(message, contextDict);
     }
 
+    // Logs a message whose context data contains a value that Newtonsoft.Json cannot
+    // serialize (a self-referencing object, like an ASP.NET Core Endpoint). This exercises
+    // the agent's context-data serialization fallback and verifies the resulting
+    // log_event_data payload is still valid JSON. See ContextDataNonSerializableTests.
+    [LibraryMethod]
+    public static void CreateSingleLogMessageWithNonSerializableContext(string logger, string message)
+    {
+        var contextDict = new Dictionary<string, object>
+        {
+            { "normalkey", "normalvalue" },
+            { "nonserializable", new NonSerializableContextValue() },
+        };
+        _logs[logger.ToUpper()].InfoWithContextDictionary(message, contextDict);
+    }
+
     [LibraryMethod]
     [Transaction]
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NonSerializableContextValue.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NonSerializableContextValue.cs
@@ -10,7 +10,7 @@ namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentatio
 // log_event_data payload would be unambiguously invalid JSON.
 public class NonSerializableContextValue
 {
-    public const string ToStringValue = "Packing.Api.Controllers.FeatureController.IsEnabled (Packing.Api)";
+    public const string ToStringValue = "Sample.App.Controllers.WidgetController.IsEnabled (Sample.App)";
 
     public NonSerializableContextValue Self { get; }
 

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NonSerializableContextValue.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LogInstrumentation/NonSerializableContextValue.cs
@@ -1,0 +1,23 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LogInstrumentation;
+
+// A context-data value whose object graph cannot be serialized by Newtonsoft.Json. The self
+// reference triggers "Self referencing loop detected" under default serializer settings,
+// the same way the property graph of a real ASP.NET Core Endpoint does. Its ToString()
+// contains spaces and parentheses, so if the agent ever wrote it unquoted the resulting
+// log_event_data payload would be unambiguously invalid JSON.
+public class NonSerializableContextValue
+{
+    public const string ToStringValue = "Packing.Api.Controllers.FeatureController.IsEnabled (Packing.Api)";
+
+    public NonSerializableContextValue Self { get; }
+
+    public NonSerializableContextValue()
+    {
+        Self = this;
+    }
+
+    public override string ToString() => ToStringValue;
+}

--- a/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/JsonConverters/LogEventWireModelCollectionJsonConverterTests.cs
@@ -7,6 +7,7 @@ using NewRelic.Agent.Core.Labels;
 using NewRelic.Agent.Core.WireModels;
 using NewRelic.Agent.TestUtilities;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace NewRelic.Agent.Core.Utilities;
@@ -99,5 +100,91 @@ public class LogEventWireModelCollectionJsonConverterTests
     public void DeserializeObjectFailsWithNotImplementedException()
     {
         Assert.Throws<NotImplementedException>(() =>JsonConvert.DeserializeObject<LogEventWireModelCollection>("{}"));
+    }
+
+    // A context-data value whose object graph cannot be serialized by Newtonsoft (the self
+    // reference triggers "Self referencing loop detected" under default settings, just like
+    // the property graph of an ASP.NET Core Endpoint). Its ToString() contains characters
+    // (spaces, parentheses) that would make an unquoted token unambiguously invalid JSON.
+    private class NonSerializableContextValue
+    {
+        public const string ToStringValue = "Some.Namespace.Endpoint.Action (Assembly)";
+
+        public NonSerializableContextValue Self { get; }
+
+        public NonSerializableContextValue()
+        {
+            Self = this;
+        }
+
+        public override string ToString() => ToStringValue;
+    }
+
+    // A context-data value that cannot be serialized AND whose ToString() throws, forcing the
+    // converter all the way to its type-name fallback.
+    private class ToStringThrowsContextValue
+    {
+        public ToStringThrowsContextValue Self { get; }
+
+        public ToStringThrowsContextValue()
+        {
+            Self = this;
+        }
+
+        public override string ToString() => throw new InvalidOperationException("ToString failed");
+    }
+
+    [Test]
+    public void NonSerializableContextValue_IsWrittenAsQuotedString_AndPayloadIsValidJson()
+    {
+        var contextData = new Dictionary<string, object> { { "endpoint", new NonSerializableContextValue() } };
+        var sourceObject = new LogEventWireModelCollection(
+            "myApplicationName",
+            "guid",
+            "hostname",
+            new List<Label>(),
+            new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "TestMessage", "TestLevel", "TestSpanId", "TestTraceId", contextData)
+            });
+
+        var serialized = JsonConvert.SerializeObject(sourceObject, Formatting.None);
+
+        // The whole payload must remain valid JSON - a single unserializable value must not
+        // corrupt the batch (which would cause the collector to reject every log in it).
+        Assert.DoesNotThrow(() => JToken.Parse(serialized), "log_event_data payload must be valid JSON");
+
+        var attribute = JObject.Parse(serialized)["logs"][0]["attributes"]["context.endpoint"];
+        Assert.Multiple(() =>
+        {
+            Assert.That(attribute.Type, Is.EqualTo(JTokenType.String), "value must be a quoted JSON string");
+            Assert.That(attribute.Value<string>(), Is.EqualTo(NonSerializableContextValue.ToStringValue));
+        });
+    }
+
+    [Test]
+    public void NonSerializableContextValue_WhenToStringThrows_FallsBackToTypeName_AndPayloadIsValidJson()
+    {
+        var contextData = new Dictionary<string, object> { { "endpoint", new ToStringThrowsContextValue() } };
+        var sourceObject = new LogEventWireModelCollection(
+            "myApplicationName",
+            "guid",
+            "hostname",
+            new List<Label>(),
+            new List<LogEventWireModel>
+            {
+                new LogEventWireModel(1, "TestMessage", "TestLevel", "TestSpanId", "TestTraceId", contextData)
+            });
+
+        var serialized = JsonConvert.SerializeObject(sourceObject, Formatting.None);
+
+        Assert.DoesNotThrow(() => JToken.Parse(serialized), "log_event_data payload must be valid JSON");
+
+        var attribute = JObject.Parse(serialized)["logs"][0]["attributes"]["context.endpoint"];
+        Assert.Multiple(() =>
+        {
+            Assert.That(attribute.Type, Is.EqualTo(JTokenType.String), "value must be a quoted JSON string");
+            Assert.That(attribute.Value<string>(), Is.EqualTo(typeof(ToStringThrowsContextValue).ToString()));
+        });
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3641.

When a log context-data value cannot be serialized by Newtonsoft.Json - for example a self-referencing object graph such as an ASP.NET Core `Endpoint` placed into a logging scope - `LogEventWireModelCollectionJsonConverter` fell back to writing the value's raw `ToString()` through `WriteRawValue`. `WriteRawValue` injects text verbatim, so the value landed in the stream unquoted and unescaped:

```
..."context.SomeKey":Foo.Bar.SomeType ...} ...
```

That makes the whole `log_event_data` payload invalid JSON, so the collector rejects the entire batch and every log event harvested in that cycle is dropped - not just the offending line.

## Change

- Use `WriteRawValue` only on the `SerializeObject` success path (which already returns valid JSON).
- In the fallback branches, write the stringified value through `WriteValue`, which quotes and escapes it. A value that cannot be serialized can no longer corrupt the surrounding payload.

## Test coverage

- Unit tests (`LogEventWireModelCollectionJsonConverterTests`): a non-serializable (self-referencing) context value, and one whose `ToString()` also throws, both assert the payload parses as valid JSON and the value is emitted as a quoted string.
- Integration tests (`ContextDataNonSerializableTests`, MEL on Core latest/oldest and FW latest): log a message with a non-serializable object in the logging scope and assert every `log_event_data` payload is valid JSON with the value captured as a quoted string. Verified failing without the fix and passing with it.

## Author Checklist

- [x] Unit tests added
- [x] Integration tests added
- [x] Performance implications considered (none expected; same code path, one extra string write)
