### PR TITLE
test: Validate all collector payloads are valid JSON in integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogFile.cs
@@ -115,48 +115,49 @@ public class AgentLogFile : AgentLogBase
         } while (timeTaken.Elapsed < timeout);
     }
 
-    public long GetTotalPayloadBytes()
+    // Matches every collector request the agent logs at debug level. Group 1 is the collector
+    // method (e.g. log_event_data, metric_data, analytic_event_data); group 2 is the raw JSON
+    // payload sent for that method.
+    private const string PayloadInvocationRegex = @"Request\(.{36}\): Invoked ""([^""]+)"" with : (.*)";
+
+    /// <summary>
+    /// Returns every payload sent to the collector as (category, json) pairs, where category is
+    /// the collector method name and json is the raw serialized payload, regardless of data type.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, string>> GetCollectorPayloads()
     {
-        const string payloadInvocationRegex = @"Request\(.{36}\): Invoked ""[^""]+"" with : (.*)";
-        var regex = new Regex(payloadInvocationRegex);
-        long totalBytes = 0;
-
-        foreach (var line in GetFileLines())
-        {
-            var match = regex.Match(line);
-            if (match.Success && match.Groups.Count > 1)
-            {
-                var jsonPayload = match.Groups[1].Value;
-                totalBytes += Encoding.UTF8.GetByteCount(jsonPayload);
-            }
-        }
-
-        return totalBytes;
-    }
-
-    public Dictionary<string, long> GetPayloadBytesByCategory()
-    {
-        const string payloadInvocationRegex = @"Request\(.{36}\): Invoked ""([^""]+)"" with : (.*)";
-        var regex = new Regex(payloadInvocationRegex);
-        var payloadBytesByCategory = new Dictionary<string, long>();
+        var regex = new Regex(PayloadInvocationRegex);
 
         foreach (var line in GetFileLines())
         {
             var match = regex.Match(line);
             if (match.Success && match.Groups.Count > 2)
             {
-                var category = match.Groups[1].Value;
-                var jsonPayload = match.Groups[2].Value;
-                var byteCount = Encoding.UTF8.GetByteCount(jsonPayload);
+                yield return new KeyValuePair<string, string>(match.Groups[1].Value, match.Groups[2].Value);
+            }
+        }
+    }
 
-                if (payloadBytesByCategory.ContainsKey(category))
-                {
-                    payloadBytesByCategory[category] += byteCount;
-                }
-                else
-                {
-                    payloadBytesByCategory[category] = byteCount;
-                }
+    public long GetTotalPayloadBytes()
+    {
+        return GetCollectorPayloads().Sum(payload => (long)Encoding.UTF8.GetByteCount(payload.Value));
+    }
+
+    public Dictionary<string, long> GetPayloadBytesByCategory()
+    {
+        var payloadBytesByCategory = new Dictionary<string, long>();
+
+        foreach (var payload in GetCollectorPayloads())
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(payload.Value);
+
+            if (payloadBytesByCategory.ContainsKey(payload.Key))
+            {
+                payloadBytesByCategory[payload.Key] += byteCount;
+            }
+            else
+            {
+                payloadBytesByCategory[payload.Key] = byteCount;
             }
         }
 

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -730,9 +730,20 @@ public abstract class RemoteApplicationFixture : IDisposable
         {
             try
             {
-                // JToken.Parse rather than JObject.Parse: several payloads (e.g. metric_data and
+                // JToken rather than JObject: several payloads (e.g. metric_data and
                 // analytic_event_data) are top-level JSON arrays, not objects.
-                JToken.Parse(payload.Value);
+                //
+                // A hand-built JsonTextReader rather than JToken.Parse: JToken.Parse uses Newtonsoft's
+                // default MaxDepth of 64, which rejects legitimately deep payloads. profile_data is a
+                // recursive thread-profile call tree that nests one array level per stack frame and
+                // routinely exceeds 64 levels - that is valid JSON, not a corrupt payload. MaxDepth =
+                // null removes the limit; the trailing Read() loop preserves JToken.Parse's rejection
+                // of additional content after the root token.
+                using (var jsonReader = new JsonTextReader(new StringReader(payload.Value)) { MaxDepth = null })
+                {
+                    JToken.ReadFrom(jsonReader);
+                    while (jsonReader.Read()) { }
+                }
             }
             catch (Exception ex)
             {

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/RemoteServiceFixtures/RemoteApplicationFixture.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading;
 using NewRelic.Agent.IntegrationTests.Shared;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
@@ -20,6 +21,13 @@ public abstract class RemoteApplicationFixture : IDisposable
     public virtual string TestSettingCategory { get { return "Default"; } }
 
     public int? BaselinePayloadBytes { get; set; }
+
+    /// <summary>
+    /// When true (the default), the fixture asserts after the application exits that every payload
+    /// the agent sent to the collector is well-formed JSON. Override and return false for tests
+    /// that intentionally produce malformed payloads.
+    /// </summary>
+    protected virtual bool ValidateCollectorPayloadJson => true;
 
     private Action _setupConfiguration;
     private Action _exerciseApplication;
@@ -411,6 +419,11 @@ public abstract class RemoteApplicationFixture : IDisposable
                     if (!applicationHadNonZeroExitCode)
                     {
                         TestForKnownProblems();
+
+                        if (ValidateCollectorPayloadJson)
+                        {
+                            ValidateAllCollectorPayloadsAreValidJson();
+                        }
                     }
                 }
 
@@ -693,5 +706,75 @@ public abstract class RemoteApplicationFixture : IDisposable
         }
 
         TestLogger?.WriteLine("Finished known problems check.");
+    }
+
+    /// <summary>
+    /// Asserts that every payload the agent sent to the collector is well-formed JSON. Runs
+    /// automatically for every integration test via the Initialize() teardown path, so a
+    /// regression that corrupts any outgoing payload (see GitHub issue #3641, where an
+    /// unserializable log context value produced invalid log_event_data) fails the test that
+    /// produced it - no per-test assertion required.
+    /// </summary>
+    private void ValidateAllCollectorPayloadsAreValidJson()
+    {
+        // Using AgentLog when the file doesn't exist results in a 3 minute wait - manually checking is faster.
+        if (!Directory.Exists(DestinationNewRelicLogFileDirectoryPath) ||
+            !File.Exists(AgentLog.FilePath))
+        {
+            return;
+        }
+
+        var invalidPayloads = new List<string>();
+
+        foreach (var payload in AgentLog.GetCollectorPayloads())
+        {
+            try
+            {
+                // JToken.Parse rather than JObject.Parse: several payloads (e.g. metric_data and
+                // analytic_event_data) are top-level JSON arrays, not objects.
+                JToken.Parse(payload.Value);
+            }
+            catch (Exception ex)
+            {
+                invalidPayloads.Add($"  {payload.Key} ({payload.Value.Length} chars): {ex.Message}{Environment.NewLine}    Payload: {BuildPayloadPreview(payload.Value, ex)}");
+            }
+        }
+
+        if (invalidPayloads.Count > 0)
+        {
+            TestLogger?.WriteLine("WARNING: Found one or more collector payloads that are not valid JSON!");
+            Assert.Fail($"{invalidPayloads.Count} collector payload(s) were not valid JSON:{Environment.NewLine}" + string.Join(Environment.NewLine, invalidPayloads));
+        }
+
+        TestLogger?.WriteLine("Finished collector payload JSON validation.");
+    }
+
+    /// <summary>
+    /// Builds a bounded preview of a payload that failed JSON validation. For payloads larger than
+    /// the window, the preview is centered on the parse failure position so the offending region is
+    /// visible rather than truncated away; the head of the payload is used when no position is known.
+    /// </summary>
+    private static string BuildPayloadPreview(string payload, Exception parseException)
+    {
+        const int windowRadius = 250;
+
+        if (payload.Length <= 2 * windowRadius)
+        {
+            return payload;
+        }
+
+        // For single-line JSON payloads the reader's LinePosition is effectively the character
+        // offset of the failure, so center the window there. Defaults to 0 (head of payload) for a
+        // non-reader exception or when no position is available.
+        var errorPosition = (parseException as JsonReaderException)?.LinePosition ?? 0;
+        errorPosition = Math.Max(0, Math.Min(errorPosition, payload.Length));
+
+        var start = Math.Max(0, errorPosition - windowRadius);
+        var length = Math.Min(2 * windowRadius, payload.Length - start);
+
+        var prefix = start > 0 ? "..." : "";
+        var suffix = start + length < payload.Length ? "..." : "";
+
+        return $"{prefix}{payload.Substring(start, length)}{suffix}";
     }
 }


### PR DESCRIPTION
## What

Adds a global guardrail in the integration test base fixture
(`RemoteApplicationFixture`) that asserts **every** payload the agent sends to
the collector is well-formed JSON. It runs automatically in the `Initialize()`
teardown path for every integration test - no per-test changes required.

## Why

Issue #3641 was a malformed `log_event_data` payload (an unserializable log
context value written unquoted) that the collector rejected. Nothing in the
test suite would have caught it generically - only a test that specifically
inspected the payload would. This check closes that gap: a regression that
corrupts any outgoing payload now fails the test that produced it, identifying
the payload type, size, parse error, and the offending region.

## Changes

- **AgentLogFile**: new `GetCollectorPayloads()` yields `(category, json)` for
  every collector invocation. `GetTotalPayloadBytes` and
  `GetPayloadBytesByCategory` now reuse it, consolidating the catch-all payload
  regex in one place.
- **RemoteApplicationFixture**: `ValidateAllCollectorPayloadsAreValidJson()`
  parses each payload with `JToken.Parse` (so top-level array payloads like
  `metric_data` and `analytic_event_data` are handled, not just objects). On
  failure it reports the collector method, payload length, the Newtonsoft parse
  error (with JSON path/position), and a preview centered on the failure
  position. Invoked from the existing teardown alongside `TestForKnownProblems`,
  gated on a clean process exit.
- Opt-out via the virtual `ValidateCollectorPayloadJson` property for any future
  test that intentionally emits a malformed payload.

## Testing

`IntegrationTestHelpers` builds clean. Full validation is the integration suite
run in CI on this branch - the check is exercised by every existing logging,
metric, span, error, and custom-event test.
