### PR TITLE
fix: Bedrock Converse no longer drops events when first content block is non-text

### DIFF
--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/ConverseAsyncWrapper.cs
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Bedrock/ConverseAsyncWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using NewRelic.Agent.Api;
 using NewRelic.Agent.Extensions.Helpers;
@@ -85,12 +86,11 @@ public class ConverseAsyncWrapper : IWrapper
 
     private void ProcessConverseResponse(ISegment segment, dynamic converseRequest, dynamic converseResponse, IAgent agent, string requestModelId)
     {
-        // if request message content doesn't have a non-null Text property, we can't support instrumentation
         // last message is the current prompt
         var requestMessage = converseRequest?.Messages?[converseRequest.Messages.Count - 1];
-        if (converseRequest == null || requestMessage == null || requestMessage.Content == null || requestMessage.Content.Count == 0 || requestMessage.Content[0].Text == null)
+        if (converseRequest == null || requestMessage == null || requestMessage.Content == null || requestMessage.Content.Count == 0)
         {
-            agent.Logger.Info($"Unable to process Converse response for model {requestModelId}: request was null or message content was not Text");
+            agent.Logger.Info($"Unable to process Converse response for model {requestModelId}: request was null or had no message content");
             return;
         }
 
@@ -100,19 +100,18 @@ public class ConverseAsyncWrapper : IWrapper
             return;
         }
 
-        // if response message content doesn't have a non-null Text property, we can't support instrumentation
         var responseMessage = converseResponse.Output?.Message;
-        if (responseMessage == null || responseMessage.Content == null || responseMessage.Content.Count == 0 || responseMessage.Content[0].Text == null)
+        if (responseMessage == null || responseMessage.Content == null || responseMessage.Content.Count == 0)
         {
-            agent.Logger.Info($"Unable to process Converse response for model {requestModelId}: response was null or message content was not Text");
+            agent.Logger.Info($"Unable to process Converse response for model {requestModelId}: response message was null or had no content");
             return;
         }
 
         string requestRole = requestMessage.Role?.Value ?? "user";
-        string promptText = requestMessage.Content?[0]?.Text ?? "";
+        string promptText = ExtractTextContent(requestMessage);
 
         string responseRole = responseMessage.Role?.Value ?? "assistant";
-        string responseText = responseMessage.Content?[0]?.Text ?? "";
+        string responseText = ExtractTextContent(responseMessage);
         string stopReason = converseResponse.StopReason?.Value;
 
         string requestId = converseResponse.ResponseMetadata?.RequestId;
@@ -202,7 +201,7 @@ public class ConverseAsyncWrapper : IWrapper
         };
 
         string requestRole = requestMessage.Role?.Value ?? "user";
-        string promptText = requestMessage.Content?[0]?.Text ?? "";
+        string promptText = ExtractTextContent(requestMessage);
         int? requestMaxTokens = converseRequest.InferenceConfig?.MaxTokens;
         float? requestTemperature = converseRequest.InferenceConfig?.Temperature;
 
@@ -237,6 +236,26 @@ public class ConverseAsyncWrapper : IWrapper
                 VendorName);
     }
 
+
+    // Walks all Content[] blocks and concatenates text from Text-type blocks, joined with a newline.
+    // Non-text block types (Image, Document, Video, ReasoningContent, ToolUse, ToolResult) are skipped.
+    private static string ExtractTextContent(dynamic message)
+    {
+        if (message?.Content == null || message.Content.Count == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < message.Content.Count; i++)
+        {
+            string text = message.Content[i]?.Text;
+            if (text != null)
+            {
+                if (sb.Length > 0) sb.Append('\n');
+                sb.Append(text);
+            }
+        }
+        return sb.ToString();
+    }
 
     private string GetOrAddLibraryVersion(string assemblyFullName)
     {

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseContentBlockTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/BedrockConverseContentBlockTests.cs
@@ -1,0 +1,154 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTestHelpers.RemoteServiceFixtures;
+using NewRelic.Agent.Tests.TestSerializationHelpers.Models;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.LLM;
+
+// Coverage for Bedrock Converse responses whose Content[] contains non-text blocks. These scenarios
+// exercise the response-emittable content block types (Text, ReasoningContent, ToolUse) plus the
+// request-side ToolResult block. They live in their own fixture, separate from the basic happy-path
+// and error coverage in BedrockConverseTests, because:
+//   - the basic test's global assertions (CallCountAllHarvests, single error event) would otherwise
+//     have to track every scenario's call count, and
+//   - these responses have distinct shapes (a leading ReasoningContent block, an empty-text response
+//     on the tool_use turn, two ConverseAsync calls per tool invocation) that should not bleed into
+//     the basic test's whole-log assertions.
+public abstract class BedrockConverseContentBlockTestsBase<TFixture> : NewRelicIntegrationTest<TFixture> where TFixture : ConsoleDynamicMethodFixture
+{
+    private readonly TFixture _fixture;
+
+    // Prompts have spaces in them, which will not be parsed correctly, so they are base64-encoded.
+    private readonly string _thinkingPrompt = "In one sentence, what is a large-language model?";
+    private readonly string _toolPrompt = "What is the current weather in Seattle? Use the get_weather tool.";
+
+    private const string ExtendedThinkingTransaction =
+        "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.BedrockExerciser/ConverseWithExtendedThinking";
+    private const string ToolUseTransaction =
+        "OtherTransaction/Custom/MultiFunctionApplicationHelpers.NetStandardLibraries.LLM.BedrockExerciser/ConverseWithToolUseAndThinking";
+
+    protected BedrockConverseContentBlockTestsBase(TFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.SetTimeout(TimeSpan.FromMinutes(3));
+        _fixture.TestLogger = output;
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                new NewRelicConfigModifier(fixture.DestinationNewRelicConfigFilePath)
+                    .ForceTransactionTraces()
+                    .EnableAiMonitoring()
+                    .SetLogLevel("finest");
+            },
+            exerciseApplication: () =>
+            {
+                // Two transactions: the extended-thinking call and the (two-turn) tool-use call.
+                _fixture.AgentLog.WaitForLogLines(AgentLogBase.TransactionTransformCompletedLogLineRegex, TimeSpan.FromMinutes(3), 2);
+            }
+        );
+
+        _fixture.AddCommand($"BedrockExerciser ConverseWithExtendedThinking {LLMHelpers.ConvertToBase64(_thinkingPrompt)}");
+        _fixture.AddCommand($"BedrockExerciser ConverseWithToolUseAndThinking {LLMHelpers.ConvertToBase64(_toolPrompt)}");
+
+        _fixture.Initialize();
+    }
+
+    // Scopes custom (LLM) events to a single transaction by correlating on trace id. Both scenarios use
+    // the same model, so the model name cannot disambiguate them; the transaction's trace id can.
+    private List<CustomEventData> GetLlmEventsForTransaction(string transactionName)
+    {
+        var transactionEvent = _fixture.AgentLog.TryGetTransactionEvent(transactionName);
+        Assert.NotNull(transactionEvent);
+
+        var traceId = transactionEvent.IntrinsicAttributes["traceId"]?.ToString();
+        Assert.False(string.IsNullOrEmpty(traceId), $"Transaction '{transactionName}' had no traceId");
+
+        return _fixture.AgentLog.GetCustomEvents()
+            .Where(ce => ce.Attributes.TryGetValue("trace_id", out var t) && t?.ToString() == traceId)
+            .ToList();
+    }
+
+    private static CustomEventData ResponseMessage(IEnumerable<CustomEventData> messageEvents) =>
+        messageEvents.SingleOrDefault(m => m.Attributes.TryGetValue("is_response", out var r) && r is bool b && b);
+
+    // Extended thinking: the response's Content[0] is a ReasoningContent block and Content[1] is the Text
+    // block. Verifies the call is fully instrumented and the response text is extracted from past the
+    // leading non-text block (the original bug dropped the whole call here).
+    [Fact]
+    public void ConverseExtendedThinkingTest()
+    {
+        var events = GetLlmEventsForTransaction(ExtendedThinkingTransaction);
+
+        var summaries = events.Where(e => e.Header.Type == "LlmChatCompletionSummary").ToList();
+        var messages = events.Where(e => e.Header.Type == "LlmChatCompletionMessage").ToList();
+
+        Assert.Single(summaries);
+        Assert.Equal(2, messages.Count); // prompt + response
+
+        var responseMessage = ResponseMessage(messages);
+        Assert.NotNull(responseMessage);
+        Assert.True(responseMessage.Attributes.TryGetValue("content", out var content) && !string.IsNullOrEmpty(content?.ToString()),
+            "Extended-thinking response message content should be non-empty (text extracted past the ReasoningContent block)");
+    }
+
+    // Tool use with extended thinking is a two-turn exchange instrumented as two ConverseAsync calls in
+    // one transaction:
+    //   Turn 1 response: [ReasoningContent, ToolUse]  (no text - empty response content is expected)
+    //   Turn 2 response: [Text]                       (the model's final answer, after the ToolResult)
+    [Fact]
+    public void ConverseToolUseTest()
+    {
+        var events = GetLlmEventsForTransaction(ToolUseTransaction);
+
+        var summaries = events.Where(e => e.Header.Type == "LlmChatCompletionSummary").ToList();
+        var messages = events.Where(e => e.Header.Type == "LlmChatCompletionMessage").ToList();
+
+        Assert.Equal(2, summaries.Count);   // turn 1 + turn 2
+        Assert.Equal(4, messages.Count);    // each turn: prompt + response
+
+        // At least one response message carries the model's final text answer (turn 2). The turn-1
+        // response is a tool_use turn with no text block, so its response content is legitimately empty.
+        var responseMessages = messages.Where(m => m.Attributes.TryGetValue("is_response", out var r) && r is bool b && b).ToList();
+        Assert.Equal(2, responseMessages.Count);
+        Assert.Contains(responseMessages, m =>
+            m.Attributes.TryGetValue("content", out var c) && !string.IsNullOrEmpty(c?.ToString()));
+    }
+
+    // Both scenarios contribute ConverseAsync completion segments: 1 (extended thinking) + 2 (tool use).
+    [Fact]
+    public void ConverseContentBlockMetricsTest()
+    {
+        var expectedMetrics = new List<Assertions.ExpectedMetric>
+        {
+            new() { metricName = @"Custom/Llm/completion/Bedrock/ConverseAsync", CallCountAllHarvests = 3 },
+            new() { metricName = @"Supportability/DotNet/ML/.*", IsRegexName = true },
+            new() { metricName = @"Supportability/DotNet/LLM/.*/.*", IsRegexName = true },
+            new() { metricName = @"Supportability/DotNet/LLM/Bedrock-Converse" },
+        };
+
+        var metrics = _fixture.AgentLog.GetMetrics().ToList();
+        Assertions.MetricsExist(expectedMetrics, metrics);
+    }
+}
+
+public class BedrockConverseContentBlockTests_CoreLatest : BedrockConverseContentBlockTestsBase<ConsoleDynamicMethodFixtureCoreLatest>
+{
+    public BedrockConverseContentBlockTests_CoreLatest(ConsoleDynamicMethodFixtureCoreLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}
+
+public class BedrockConverseContentBlockTests_FWLatest : BedrockConverseContentBlockTestsBase<ConsoleDynamicMethodFixtureFWLatest>
+{
+    public BedrockConverseContentBlockTests_FWLatest(ConsoleDynamicMethodFixtureFWLatest fixture, ITestOutputHelper output)
+        : base(fixture, output)
+    {
+    }
+}

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockExerciser.cs
@@ -162,5 +162,27 @@ public class BedrockExerciser
             throw new ArgumentException("converse is not a valid model");
         }
     }
+
+    [LibraryMethod]
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task ConverseWithExtendedThinking(string base64Prompt)
+    {
+        var bytes = Convert.FromBase64String(base64Prompt);
+        var prompt = Encoding.UTF8.GetString(bytes);
+        var response = await BedrockModels.ConverseClaudeExtendedThinking(prompt, false);
+        Console.WriteLine(response);
+    }
+
+    [LibraryMethod]
+    [Transaction]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async Task ConverseWithToolUseAndThinking(string base64Prompt)
+    {
+        var bytes = Convert.FromBase64String(base64Prompt);
+        var prompt = Encoding.UTF8.GetString(bytes);
+        var response = await BedrockModels.ConverseClaudeToolUseWithThinking(prompt, false);
+        Console.WriteLine(response);
+    }
 #endif
 }

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/LLM/BedrockModels.cs
@@ -11,6 +11,10 @@ using Amazon.BedrockRuntime;
 using Amazon.BedrockRuntime.Model;
 using Amazon.Util;
 using NewRelic.Agent.IntegrationTests.Shared;
+#if NET481 || NET10_0
+using System.Collections.Generic;
+using Amazon.Runtime.Documents;
+#endif
 
 namespace MultiFunctionApplicationHelpers.NetStandardLibraries.LLM;
 
@@ -309,12 +313,9 @@ internal class BedrockModels
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static async Task<ConverseResponse> Converse(string model, string payload)
     {
-
-        // Create a request with the model ID, the user message, and an inference configuration.
         var request = new ConverseRequest
         {
             ModelId = model,
-
             Messages =
             [
                 new Message { Role = ConversationRole.User, Content = [new ContentBlock { Text = payload }] }
@@ -328,6 +329,193 @@ internal class BedrockModels
         };
 
         return await _amazonBedrockRuntimeClient.ConverseAsync(request);
+    }
+
+    // Exercises the extended-thinking path: Content[0] in the response is ReasoningContent,
+    // Content[1] is the Text block. Used to verify the agent captures events even when the
+    // first content block is non-text.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<string> ConverseClaudeExtendedThinking(string prompt, bool generateError)
+    {
+        string responseText = "";
+        try
+        {
+            // Model ID stored in a variable to avoid the SDK's compile-time pattern analyzer (BedrockRuntime1002)
+            // which only checks string literals assigned directly to ModelId.
+            var modelId = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+            var request = new ConverseRequest
+            {
+                ModelId = modelId,
+                Messages =
+                [
+                    new Message { Role = ConversationRole.User, Content = [new ContentBlock { Text = prompt }] }
+                ],
+                InferenceConfig = new InferenceConfiguration
+                {
+                    MaxTokens = 2048
+                },
+                AdditionalModelRequestFields = new Document(
+                    new Dictionary<string, Document>
+                    {
+                        ["thinking"] = new Document(
+                            new Dictionary<string, Document>
+                            {
+                                ["type"] = "enabled",
+                                ["budget_tokens"] = 1024L
+                            })
+                    })
+            };
+
+            var response = await _amazonBedrockRuntimeClient.ConverseAsync(request);
+
+            var content = response?.Output?.Message?.Content;
+            for (int i = 0; i < content?.Count; i++)
+            {
+                var text = content[i].Text;
+                if (text != null)
+                {
+                    responseText = text;
+                    break;
+                }
+            }
+        }
+        catch (AmazonBedrockRuntimeException e)
+        {
+            Console.WriteLine(e);
+        }
+        return responseText;
+    }
+
+    // Exercises the response-emittable content block types using the natural two-turn tool flow with
+    // extended thinking enabled:
+    //   Turn 1 request:  [Text]                       Turn 1 response: [ReasoningContent, ToolUse]  (stopReason=tool_use)
+    //   Turn 2 request:  [..., ToolResult]            Turn 2 response: [(ReasoningContent,) Text]
+    // Across the two instrumented ConverseAsync calls the wrapper walks Text, ReasoningContent and ToolUse
+    // (response side) plus ToolResult (request side). A single call cannot return all block types, so this
+    // is the most complete real-model coverage of the response-emittable set.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<string> ConverseClaudeToolUseWithThinking(string prompt, bool generateError)
+    {
+        string responseText = "";
+        try
+        {
+            // Model ID stored in a variable to avoid the SDK's compile-time pattern analyzer (BedrockRuntime1002).
+            var modelId = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+
+            var toolConfig = new ToolConfiguration
+            {
+                Tools =
+                [
+                    new Tool
+                    {
+                        ToolSpec = new ToolSpecification
+                        {
+                            Name = "get_weather",
+                            Description = "Get the current weather for a given city.",
+                            InputSchema = new ToolInputSchema
+                            {
+                                Json = new Document(new Dictionary<string, Document>
+                                {
+                                    ["type"] = "object",
+                                    ["properties"] = new Document(new Dictionary<string, Document>
+                                    {
+                                        ["city"] = new Document(new Dictionary<string, Document>
+                                        {
+                                            ["type"] = "string",
+                                            ["description"] = "The city name"
+                                        })
+                                    }),
+                                    ["required"] = new Document(new List<Document> { "city" })
+                                })
+                            }
+                        }
+                    }
+                ]
+            };
+
+            // Reused across both turns; thinking blocks (with signatures) must be preserved in the
+            // conversation history when continuing a tool-use exchange with extended thinking enabled.
+            var thinking = new Document(new Dictionary<string, Document>
+            {
+                ["thinking"] = new Document(new Dictionary<string, Document>
+                {
+                    ["type"] = "enabled",
+                    ["budget_tokens"] = 1024L
+                })
+            });
+
+            var messages = new List<Message>
+            {
+                new Message { Role = ConversationRole.User, Content = [new ContentBlock { Text = prompt }] }
+            };
+
+            // Turn 1: expect ReasoningContent + ToolUse.
+            var first = await _amazonBedrockRuntimeClient.ConverseAsync(new ConverseRequest
+            {
+                ModelId = modelId,
+                Messages = messages,
+                ToolConfig = toolConfig,
+                InferenceConfig = new InferenceConfiguration { MaxTokens = 2048 },
+                AdditionalModelRequestFields = thinking
+            });
+
+            // Carry the assistant's turn (reasoning + toolUse) forward in the conversation.
+            messages.Add(first.Output.Message);
+
+            ToolUseBlock toolUse = null;
+            foreach (var block in first.Output.Message.Content)
+            {
+                if (block.ToolUse != null)
+                {
+                    toolUse = block.ToolUse;
+                    break;
+                }
+            }
+
+            if (toolUse != null)
+            {
+                // Supply a (stubbed) tool result so the model can produce a final text answer.
+                messages.Add(new Message
+                {
+                    Role = ConversationRole.User,
+                    Content =
+                    [
+                        new ContentBlock
+                        {
+                            ToolResult = new ToolResultBlock
+                            {
+                                ToolUseId = toolUse.ToolUseId,
+                                Content = [new ToolResultContentBlock { Text = "{\"tempF\":58,\"conditions\":\"cloudy\"}" }]
+                            }
+                        }
+                    ]
+                });
+
+                // Turn 2: expect a Text block (often preceded by ReasoningContent).
+                var second = await _amazonBedrockRuntimeClient.ConverseAsync(new ConverseRequest
+                {
+                    ModelId = modelId,
+                    Messages = messages,
+                    ToolConfig = toolConfig,
+                    InferenceConfig = new InferenceConfiguration { MaxTokens = 2048 },
+                    AdditionalModelRequestFields = thinking
+                });
+
+                foreach (var block in second.Output.Message.Content)
+                {
+                    if (block.Text != null)
+                    {
+                        responseText = block.Text;
+                        break;
+                    }
+                }
+            }
+        }
+        catch (AmazonBedrockRuntimeException e)
+        {
+            Console.WriteLine(e);
+        }
+        return responseText;
     }
 #endif
 }


### PR DESCRIPTION
## Summary

Fixes #3645.

`ProcessConverseResponse` was bailing out with a silent log line whenever `Content[0].Text` was null, which caused complete data loss for any Converse call where the first content block is not a plain text block -- extended thinking responses (ReasoningContent first), vision-first prompts (Image first), and tool-use responses (ToolUse only).

The fix replaces both early-return `Content[0].Text == null` guards and the two point reads of `Content[0].Text` with an `ExtractTextContent` helper that iterates all `Content[]` blocks and concatenates text from any `Text`-type block. Non-text block types (Image, Document, Video, ReasoningContent, ToolUse, ToolResult) are skipped; instrumentation support for those types is deferred.

The same `Content[0].Text` read in `HandleError` (request-side prompt for faulted calls) is updated for consistency.

## Test coverage

Adds `BedrockConverseContentBlockTests` (CoreLatest + FWLatest), which exercise the non-text scenarios against real Bedrock and were validated manually against a Claude Sonnet 4.5 inference profile with extended thinking enabled:

- Extended thinking: response `Content[0]` is a ReasoningContent block and `Content[1]` is the Text block; asserts the call is instrumented and response text is extracted past the leading non-text block (the original bug dropped this call entirely).
- Two-turn tool use with thinking: turn 1 returns `[ReasoningContent, ToolUse]`, turn 2 (after a ToolResult) returns the final Text; asserts both ConverseAsync calls are instrumented (2 summaries, 4 messages) and the completion metric reflects all three calls.

Events are scoped per transaction by correlating on trace id, since both scenarios use the same model. New model helpers (`ConverseClaudeExtendedThinking`, `ConverseClaudeToolUseWithThinking`) and exerciser commands back these tests.

The existing `BedrockConverseTests` (basic text + error) remain unchanged and continue to cover the text-only happy path.

## Test plan

- [x] `BedrockConverseTests` pass (text-only responses unaffected)
- [x] `BedrockConverseContentBlockTests` pass against Bedrock with extended thinking enabled
