### PR TITLE
test: Fix flaky Hangfire integration test

### DIFF
--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Hangfire/HangfireExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Hangfire/HangfireExerciser.cs
@@ -3,6 +3,7 @@
 
 #if NET10_0_OR_GREATER || NET481_OR_GREATER || NET8_0 || NET462
 
+using System;
 using System.Threading;
 using Hangfire;
 using NewRelic.Agent.IntegrationTests.Shared.ReflectionHelpers;
@@ -20,7 +21,8 @@ public class HangfireExerciser
         NewRelic.Api.Agent.NewRelic.StartAgent();
         var options = new BackgroundJobServerOptions
         {
-            Queues = new[] { "alpha", "default" }
+            Queues = new[] { "alpha", "default" },
+            SchedulePollingInterval = TimeSpan.FromSeconds(2)
         };
 
 #if NET10_0_OR_GREATER || NET481_OR_GREATER

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Hangfire/TestJobs.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/Hangfire/TestJobs.cs
@@ -42,14 +42,14 @@ public static class TestJobs
 
     private static void DoWork()
     {
-        _httpClient.GetAsync("https://httpbin.org/delay/1").Wait();
-        Thread.Sleep(_random.Next(25, 100));
+        _httpClient.GetAsync("http://www.google.com").Wait();
+        Thread.Sleep(1000 + _random.Next(25, 100));
     }
 
     private static async Task DoWorkAsync()
     {
-        await _httpClient.GetAsync("https://httpbin.org/delay/1");
-        await Task.Delay(_random.Next(25, 100));
+        await _httpClient.GetAsync("http://www.google.com");
+        await Task.Delay(1000 + _random.Next(25, 100));
     }
 }
 


### PR DESCRIPTION
## Summary

The Hangfire integration test was flaking in CI (see run https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/27753612923/job/82112774185) with span count falling below the expected minimum of 6.

Two compounding root causes:

- **Slow scheduler polling**: Hangfire's default `SchedulePollingInterval` is 15 seconds. Continuation jobs (enqueued via `ContinueJobWith`) sit in "awaiting" state until the scheduler polls. With a 30-second total test window, a single slow parent job could push the child pickup past the window boundary. Fix: set `SchedulePollingInterval = TimeSpan.FromSeconds(2)`.

- **Unreliable external dependency**: `httpbin.org/delay/1` was intended to provide a consistent 1-second delay while also exercising HTTP instrumentation within Hangfire jobs. In the failing CI run it took 15-22 seconds per call instead of ~1 second, consuming nearly the entire test window before all jobs could finish. Fix: replace with `http://www.google.com` (fast, reliable, still validates HTTP instrumentation) and add an explicit `Thread.Sleep`/`Task.Delay` of ~1 second locally to preserve the work-simulation behavior.

## Test plan

- Verified locally: `HangfireTests` passes with `ExerciseApplication execution time: 15.8s` (down from ~37s in the failing run).
- Confirmed `Schedule polling interval: 00:00:02` appears in the test app log.
- CI should be used to validate across all fixture variants (CoreOldest, CoreLatest, FW).