### PR TITLE
chore: Remove broken Sitecore.Logging nuget.org link from compat doc

### DIFF
--- a/build/CompatibilityDocs/compatibility.yaml
+++ b/build/CompatibilityDocs/compatibility.yaml
@@ -408,7 +408,6 @@ categories:
         minAgentVersion: "10.14.0"
         packages:
           - id: Sitecore.Logging
-            nugetUrl: https://www.nuget.org/packages/Sitecore.Logging/
             tabs: [framework]
             minVersion: "10.0.0"
         notes:

--- a/docs/net-agent-compatibility.md
+++ b/docs/net-agent-compatibility.md
@@ -188,7 +188,7 @@ The .NET agent [can be configured](https://docs.newrelic.com/docs/apm/agents/net
 | Library | NuGet package | Supported versions | Min agent version | Notes |
 | --- | --- | --- | --- | --- |
 | Log4Net | [log4net](https://www.nuget.org/packages/log4net/) | 1.2.10 – 3.3.1 | 9.7.0 |  |
-| Sitecore.Logging | [Sitecore.Logging](https://www.nuget.org/packages/Sitecore.Logging/) | 10.0.0 – 10.3.0 | 10.14.0 | <ul><li>`Sitecore.Logging` is a repackaged log4net; the agent instruments it through its log4net instrumentation.</li></ul> |
+| Sitecore.Logging | Sitecore.Logging | 10.0.0 – 10.3.0 | 10.14.0 | <ul><li>`Sitecore.Logging` is a repackaged log4net; the agent instruments it through its log4net instrumentation.</li></ul> |
 | Serilog | [Serilog](https://www.nuget.org/packages/Serilog/) | 2.0.0 – 4.3.1 | 9.7.0 |  |
 | NLog | [NLog](https://www.nuget.org/packages/NLog/) | 4.1.0 – 6.1.3 | 9.7.0 |  |
 | Microsoft.Extensions.Logging | [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/) | 3.0.0 – 10.0.8 | 9.7.0 |  |


### PR DESCRIPTION
fixes #3646 

## Summary

The nightly link check (issue #3646) flagged a 404 in `docs/net-agent-compatibility.md`:

* `[404] https://www.nuget.org/packages/Sitecore.Logging/`

`Sitecore.Logging` is not published on nuget.org -- both the gallery page and the v3 registration API return 404. It is a repackaged log4net that ships inside Sitecore's own product, not the public NuGet gallery. The link came from a hardcoded `nugetUrl` field in the compat-doc generator's source data (`build/CompatibilityDocs/compatibility.yaml`).

## Change

- Drop the `nugetUrl` for the `Sitecore.Logging` package in `compatibility.yaml`. `nugetUrl` is optional; when absent the renderer emits the package id as plain text instead of a link.
- Update the corresponding row in the generated `docs/net-agent-compatibility.md`.

The doc edit is scoped to the single affected row -- unrelated `derived` upper-bound version drift was intentionally excluded.