### PR TITLE
chore: Fix angler-dotnet-release skill build gate and gh release deny rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,10 +21,11 @@
       "Bash(git reset --hard *)",
       "Bash(git release *)",
       "Bash(git tag *)",
-      "Bash(gh release *)",
-      "Bash(gh tag *)",
-      "Bash(gh push --force *)",
-      "Bash(gh reset --hard *)"
+      "Bash(gh release create *)",
+      "Bash(gh release delete *)",
+      "Bash(gh release delete-asset *)",
+      "Bash(gh release edit *)",
+      "Bash(gh release upload *)"
     ]
   },
     "enabledPlugins": {

--- a/.claude/skills/angler-dotnet-release/SKILL.md
+++ b/.claude/skills/angler-dotnet-release/SKILL.md
@@ -55,10 +55,34 @@ that (a normal outcome, not an error).
 
 To target a specific version instead of the latest release, add `--version X.Y.Z`.
 
-## Step 2: Discover new supportability metrics
+## Step 2: Sync main, build the agent, and discover new supportability metrics
 
-The discovery tool reflects over the compiled agent, so `FullAgent.sln` must
-be built before running it. Ask the user for permission before building:
+The discovery tool reflects over the compiled agent, and the scan is only
+meaningful if that build reflects the **released** code on `main`. A stale
+checkout or a feature branch produces misleading candidates. So before building,
+check the checkout state:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git status --porcelain
+git fetch origin main && git rev-list --left-right --count HEAD...origin/main
+```
+
+If the checkout is not on `main`, is behind `origin/main`, or has uncommitted
+changes, tell the user and ask:
+
+> The metric scan reflects the compiled agent, so it should be built from the
+> latest `main`. You are currently on `<branch>` (`<N>` commits behind
+> `origin/main`, with uncommitted changes). Switch to `main` and pull latest
+> before building? (Answer no to build the current checkout as-is.)
+
+Only switch branches / pull when the user agrees **and** the working tree is
+clean -- never discard uncommitted work. If the user declines, build the current
+checkout and note in the final report that the scan reflects `<branch>`, not
+`main`.
+
+Then build -- the discovery tool needs a current `FullAgent.sln` build to run.
+Ask the user for permission before building:
 
 Check whether `src/Agent/newrelichome_x64_coreclr/NewRelic.Agent.Core.dll`
 exists:


### PR DESCRIPTION
A team member hit two snags running the `angler-dotnet-release` skill without auto mode enabled. Both are fixed here.

## Deny list (`.claude/settings.json`)
The blanket `Bash(gh release *)` deny rule hard-blocked read-only commands like `gh release view` (a deny rule cannot be approved interactively, which is what bit the team member without auto mode). Narrowed it to the mutating subcommands only:
- `gh release create`, `delete`, `delete-asset`, `edit`, `upload`

Read-only `gh release view`/`list`/`download` now fall through to the existing `Bash(gh *)` allow. Also dropped three dead entries -- `gh tag`, `gh push --force`, `gh reset --hard` -- which match nothing (`gh` has no such subcommands; the `git` equivalents remain denied).

## Skill (`angler-dotnet-release/SKILL.md`)
The supportability metric scan reflects over the compiled agent, so it needs a current build of released code -- but the skill never ensured the checkout was on an up-to-date `main`. Step 2 now checks branch / dirty tree / distance behind `origin/main` and prompts to sync `main` before building. It only switches/pulls with a clean tree and user consent, and if the user declines it builds as-is and flags in the report that the scan reflects the current branch rather than `main`.