### PR TITLE
chore: Ignore docs/superpowers working docs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ build/Linux/keys
 !.claude/skills/
 !.claude/settings.json
 **/.claude/settings.local.json
+
+# Superpowers working docs (local only)
+/docs/superpowers/


### PR DESCRIPTION
Adds `/docs/superpowers/` to `.gitignore` so local-only superpowers working docs are not tracked in the repo.