### PR TITLE
feat: Support server-side configuration for AI Monitoring settings

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/DefaultConfiguration.cs
@@ -1966,16 +1966,22 @@ public class DefaultConfiguration : IConfiguration
     #region AI Monitoring
 
     public bool AiMonitoringEnabled =>
-        // AI Monitoring is disabled in High Security Mode and can be disabled at the account level
-        !HighSecurityModeEnabled && ServerCanDisable(_serverConfiguration.AICollectionEnabled, EnvironmentOverrides(_localConfiguration.aiMonitoring.enabled, "NEW_RELIC_AI_MONITORING_ENABLED"));
+        // HSM disables AIM (defense-in-depth; connect-service also strips the keys server-side).
+        // Precedence: agent_config ai_monitoring.enabled (full override) > collect_ai (disable-only) > local/env.
+        !HighSecurityModeEnabled &&
+        ServerOverrides(_serverConfiguration.RpmConfig.AiMonitoringEnabled,
+            ServerCanDisable(_serverConfiguration.AICollectionEnabled,
+                EnvironmentOverrides(_localConfiguration.aiMonitoring.enabled, "NEW_RELIC_AI_MONITORING_ENABLED")));
 
     public bool AiMonitoringStreamingEnabled =>
         AiMonitoringEnabled &&
-        EnvironmentOverrides(_localConfiguration.aiMonitoring.streaming.enabled, "NEW_RELIC_AI_MONITORING_STREAMING_ENABLED");
+        ServerOverrides(_serverConfiguration.RpmConfig.AiMonitoringStreamingEnabled,
+            EnvironmentOverrides(_localConfiguration.aiMonitoring.streaming.enabled, "NEW_RELIC_AI_MONITORING_STREAMING_ENABLED"));
 
     public bool AiMonitoringRecordContentEnabled =>
         AiMonitoringEnabled &&
-        EnvironmentOverrides(_localConfiguration.aiMonitoring.recordContent.enabled, "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED");
+        ServerOverrides(_serverConfiguration.RpmConfig.AiMonitoringRecordContentEnabled,
+            EnvironmentOverrides(_localConfiguration.aiMonitoring.recordContent.enabled, "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED"));
 
     public Func<string, string, int> LlmTokenCountingCallback => _runTimeConfiguration.LlmTokenCountingCallback;
 

--- a/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
+++ b/src/Agent/NewRelic/Agent/Core/Configuration/ServerConfiguration.cs
@@ -245,6 +245,15 @@ public class ServerConfiguration
 
         [JsonProperty("capture_params")]
         public bool? CaptureParametersEnabled { get; set; }
+
+        [JsonProperty("ai_monitoring.enabled")]
+        public bool? AiMonitoringEnabled { get; set; }
+
+        [JsonProperty("ai_monitoring.streaming.enabled")]
+        public bool? AiMonitoringStreamingEnabled { get; set; }
+
+        [JsonProperty("ai_monitoring.record_content.enabled")]
+        public bool? AiMonitoringRecordContentEnabled { get; set; }
     }
 
     public class InstrumentationConfig

--- a/tests/Agent/IntegrationTests/Applications/MockNewRelic/Controllers/AgentListenerController.cs
+++ b/tests/Agent/IntegrationTests/Applications/MockNewRelic/Controllers/AgentListenerController.cs
@@ -36,6 +36,8 @@ public class AgentListenerController : Controller
         "</extension>";
 
     private static bool _setLiveInstrumentationOnConnect = false;
+    private static Dictionary<string, object> _aiMonitoringAgentConfigOnConnect = null;
+    private static bool? _collectAiOnConnect = null;
     private static HeaderValidationData _headerValidationData = new HeaderValidationData();
 
     [HttpGet]
@@ -90,6 +92,16 @@ public class AgentListenerController : Controller
                     };
 
                     serverConfig["instrumentation"] = instrumentations;
+                }
+
+                if (_aiMonitoringAgentConfigOnConnect != null)
+                {
+                    serverConfig["agent_config"] = _aiMonitoringAgentConfigOnConnect;
+                }
+
+                if (_collectAiOnConnect != null)
+                {
+                    serverConfig["collect_ai"] = _collectAiOnConnect.Value;
                 }
 
                 serverConfig["request_headers_map"] = _requestHeaderMap;
@@ -194,6 +206,21 @@ public class AgentListenerController : Controller
     {
         _setLiveInstrumentationOnConnect = true;
         return "_setLiveInstrumentationOnConnect was enabled";
+    }
+
+    [HttpGet]
+    [Route("SetAiMonitoringServerConfigOnConnect")]
+    public string SetAiMonitoringServerConfigOnConnect(string enabled = null, string streaming = null, string recordContent = null, string collectAi = null)
+    {
+        var agentConfig = new Dictionary<string, object>();
+        if (enabled != null) agentConfig["ai_monitoring.enabled"] = bool.Parse(enabled);
+        if (streaming != null) agentConfig["ai_monitoring.streaming.enabled"] = bool.Parse(streaming);
+        if (recordContent != null) agentConfig["ai_monitoring.record_content.enabled"] = bool.Parse(recordContent);
+
+        _aiMonitoringAgentConfigOnConnect = agentConfig.Count > 0 ? agentConfig : null;
+        _collectAiOnConnect = collectAi != null ? bool.Parse(collectAi) : (bool?)null;
+
+        return "AI Monitoring server config set for next connect";
     }
 
     [HttpGet]

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -40,6 +40,7 @@ public abstract class AgentLogBase
     public const string ThreadProfileDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""profile_data"" with : (.*)";
     public const string UpdateLoadedModulesLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""update_loaded_modules"" with : (.*)";
     public const string CustomEventDataLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""custom_event_data"" with : (.*)";
+    public const string AgentSettingsLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invoked ""agent_settings"" with : (.*)";
 
     // Collector responses
     public const string ConnectResponseLogLineRegex = DebugLogLinePrefixRegex + @"Request\(.{36}\): Invocation of ""connect"" yielded response : {""return_value"":(.*)";
@@ -513,6 +514,19 @@ public abstract class AgentLogBase
     public ConnectResponseData GetConnectResponseData()
     {
         return GetConnectResponseDatas().FirstOrDefault();
+    }
+
+    public bool? GetReportedAiMonitoringSetting(string jsonKey)
+    {
+        var match = TryGetLogLine(AgentSettingsLogLineRegex);
+        if (match == null || !match.Success)
+        {
+            return null;
+        }
+
+        var payload = match.Groups[1].Value;
+        var valueMatch = System.Text.RegularExpressions.Regex.Match(payload, "\"" + System.Text.RegularExpressions.Regex.Escape(jsonKey) + "\":(true|false)");
+        return valueMatch.Success ? bool.Parse(valueMatch.Groups[1].Value) : (bool?)null;
     }
 
     public IEnumerable<ConnectResponseData> GetConnectResponseDatas()

--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/NewRelicConfigModifier.cs
@@ -505,6 +505,26 @@ public class NewRelicConfigModifier
         return this;
     }
 
+    public NewRelicConfigModifier EnableAiMonitoringStreaming(bool enabled = true)
+    {
+        CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(
+            _configFilePath,
+            new[] { "configuration", "aiMonitoring", "streaming" },
+            "enabled",
+            enabled.ToString().ToLower());
+        return this;
+    }
+
+    public NewRelicConfigModifier EnableAiMonitoringRecordContent(bool enabled = true)
+    {
+        CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(
+            _configFilePath,
+            new[] { "configuration", "aiMonitoring", "recordContent" },
+            "enabled",
+            enabled.ToString().ToLower());
+        return this;
+    }
+
     public void SetCompleteTransactionsOnThread(bool enable)
     {
         CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_configFilePath, new[] { "configuration", "service" },

--- a/tests/Agent/IntegrationTests/IntegrationTests/LLM/AimServerSideConfigTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/LLM/AimServerSideConfigTests.cs
@@ -1,0 +1,106 @@
+// Copyright 2020 New Relic, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using NewRelic.Agent.IntegrationTestHelpers;
+using NewRelic.Agent.IntegrationTests.RemoteServiceFixtures;
+using NewRelic.Testing.Assertions;
+using Xunit;
+
+namespace NewRelic.Agent.IntegrationTests.LLM;
+
+// Local config: AIM off, streaming on, record_content on.
+// Server agent_config: AIM on, streaming off, record_content off.
+// Expect resolved: enabled=true (SSC enables master), streaming=false, record_content=false (SSC overrides local).
+public class AimServerSideConfigOverridesLocal : NewRelicIntegrationTest<MvcWithCollectorFixture>
+{
+    private readonly MvcWithCollectorFixture _fixture;
+
+    public AimServerSideConfigOverridesLocal(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_fixture.DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "autoStart", "false");
+                configModifier.SetLogLevel("finest");
+                configModifier.EnableAiMonitoring(false);
+                configModifier.EnableAiMonitoringStreaming(true);
+                configModifier.EnableAiMonitoringRecordContent(true);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.SetAiMonitoringServerConfigOnConnect(enabled: true, streaming: false, recordContent: false);
+                _fixture.Get();
+                _fixture.StartAgent();
+                _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentSettingsLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void ServerSideConfigOverridesLocal()
+    {
+        var enabled = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.enabled");
+        var streaming = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.streaming.enabled");
+        var recordContent = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.record_content.enabled");
+
+        NrAssert.Multiple(
+            () => Assert.True(enabled, "ai_monitoring.enabled should be enabled by server-side config"),
+            () => Assert.False(streaming, "ai_monitoring.streaming.enabled should be disabled by server-side config"),
+            () => Assert.False(recordContent, "ai_monitoring.record_content.enabled should be disabled by server-side config")
+        );
+    }
+}
+
+// Local HSM on, AIM off locally. Server agent_config tries to enable AIM.
+// Expect resolved: enabled=false (local HSM defense-in-depth wins over SSC).
+public class AimServerSideConfigIgnoredUnderHsm : NewRelicIntegrationTest<MvcWithCollectorFixture>
+{
+    private readonly MvcWithCollectorFixture _fixture;
+
+    public AimServerSideConfigIgnoredUnderHsm(MvcWithCollectorFixture fixture, ITestOutputHelper output) : base(fixture)
+    {
+        _fixture = fixture;
+        _fixture.TestLogger = output;
+
+        _fixture.AddActions(
+            setupConfiguration: () =>
+            {
+                var configModifier = new NewRelicConfigModifier(_fixture.DestinationNewRelicConfigFilePath);
+                CommonUtils.ModifyOrCreateXmlAttributeInNewRelicConfig(_fixture.DestinationNewRelicConfigFilePath, new[] { "configuration", "service" }, "autoStart", "false");
+                configModifier.SetLogLevel("finest");
+                configModifier.SetHighSecurityMode(true);
+                configModifier.EnableAiMonitoring(false);
+            },
+            exerciseApplication: () =>
+            {
+                _fixture.SetAiMonitoringServerConfigOnConnect(enabled: true, streaming: true, recordContent: true);
+                _fixture.Get();
+                _fixture.StartAgent();
+                _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForLogLine(AgentLogFile.AgentSettingsLogLineRegex, TimeSpan.FromMinutes(1));
+            }
+        );
+        _fixture.Initialize();
+    }
+
+    [Fact]
+    public void HighSecurityModeIgnoresServerSideConfig()
+    {
+        var enabled = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.enabled");
+        var streaming = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.streaming.enabled");
+        var recordContent = _fixture.AgentLog.GetReportedAiMonitoringSetting("ai_monitoring.record_content.enabled");
+
+        NrAssert.Multiple(
+            () => Assert.False(enabled, "ai_monitoring.enabled must remain disabled under High Security Mode even when server-side config enables it"),
+            () => Assert.False(streaming, "ai_monitoring.streaming.enabled must remain disabled under High Security Mode even when server-side config enables it"),
+            () => Assert.False(recordContent, "ai_monitoring.record_content.enabled must remain disabled under High Security Mode even when server-side config enables it")
+        );
+    }
+}

--- a/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/RemoteServiceFixtures/MockNewRelicFixture.cs
@@ -107,6 +107,22 @@ public class MockNewRelicFixture : RemoteApplicationFixture
         GetStringAndIgnoreResult(address);
     }
 
+    public void SetAiMonitoringServerConfigOnConnect(bool? enabled = null, bool? streaming = null, bool? recordContent = null, bool? collectAi = null)
+    {
+        var query = new List<string>();
+        if (enabled.HasValue) query.Add($"enabled={enabled.Value.ToString().ToLower()}");
+        if (streaming.HasValue) query.Add($"streaming={streaming.Value.ToString().ToLower()}");
+        if (recordContent.HasValue) query.Add($"recordContent={recordContent.Value.ToString().ToLower()}");
+        if (collectAi.HasValue) query.Add($"collectAi={collectAi.Value.ToString().ToLower()}");
+
+        var queryString = query.Count > 0 ? "?" + string.Join("&", query) : string.Empty;
+        var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/SetAiMonitoringServerConfigOnConnect{queryString}";
+
+        TestLogger?.WriteLine($"[MockNewRelicFixture] Set AI Monitoring server config on connect via: {address}");
+
+        GetStringAndIgnoreResult(address);
+    }
+
     public HeaderValidationData GetRequestHeaderMapValidationData()
     {
         var address = $"https://localhost:{MockNewRelicApplication.Port}/agent_listener/HeaderValidation";

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/DefaultConfigurationTests.cs
@@ -4219,6 +4219,76 @@ public class DefaultConfigurationTests
     }
     #endregion
 
+    #region AI Monitoring server-side config (NR-538711)
+
+    // ai_monitoring.enabled: local x collect_ai x agent_config x HSM
+    [TestCase(false, null, null, false, ExpectedResult = false)] // 1: default baseline
+    [TestCase(true, null, null, false, ExpectedResult = true)]   // 2: local enables
+    [TestCase(false, null, true, false, ExpectedResult = true)]  // 4: SSC enables over local-disabled
+    [TestCase(true, null, false, false, ExpectedResult = false)] // 5: SSC disables over local-enabled
+    [TestCase(true, false, null, false, ExpectedResult = false)] // collect_ai disables (no agent_config)
+    [TestCase(true, false, true, false, ExpectedResult = true)]  // agent_config overrides collect_ai=false
+    [TestCase(true, null, true, true, ExpectedResult = false)]   // 7: HSM ignores SSC
+    public bool AiMonitoringEnabled_resolves_with_correct_precedence(bool local, bool? collectAi, bool? agentConfig, bool hsm)
+    {
+        _localConfig.aiMonitoring.enabled = local;
+        _serverConfig.AICollectionEnabled = collectAi;
+        _serverConfig.RpmConfig.AiMonitoringEnabled = agentConfig;
+        _localConfig.highSecurity.enabled = hsm;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        return _defaultConfig.AiMonitoringEnabled;
+    }
+
+    [Test]
+    public void AiMonitoringEnabled_server_overrides_env_var()
+    {
+        Mock.Arrange(() => _environment.GetEnvironmentVariableFromList("NEW_RELIC_AI_MONITORING_ENABLED")).Returns("true");
+        _localConfig.aiMonitoring.enabled = true;
+        _serverConfig.RpmConfig.AiMonitoringEnabled = false; // server disables despite env+local true
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        Assert.That(_defaultConfig.AiMonitoringEnabled, Is.False);
+    }
+
+    // streaming.enabled: gated behind master; agent_config overrides local both directions
+    [TestCase(true, true, null, ExpectedResult = true)]   // master on, local true, no SSC
+    [TestCase(true, true, false, ExpectedResult = false)] // 5: SSC disables sub over local-true
+    [TestCase(true, false, true, ExpectedResult = true)]  // 4: SSC enables sub over local-false
+    [TestCase(false, true, true, ExpectedResult = false)] // master off -> sub off regardless
+    public bool AiMonitoringStreamingEnabled_resolves_with_correct_precedence(bool master, bool localStreaming, bool? agentConfigStreaming)
+    {
+        _localConfig.aiMonitoring.enabled = master;
+        _serverConfig.RpmConfig.AiMonitoringEnabled = master; // ensure resolved master matches intent
+        _localConfig.aiMonitoring.streaming.enabled = localStreaming;
+        _serverConfig.RpmConfig.AiMonitoringStreamingEnabled = agentConfigStreaming;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        return _defaultConfig.AiMonitoringStreamingEnabled;
+    }
+
+    // record_content.enabled: gated behind master; agent_config overrides local both directions
+    [TestCase(true, true, null, ExpectedResult = true)]
+    [TestCase(true, true, false, ExpectedResult = false)] // SSC disables content over local-true
+    [TestCase(true, false, true, ExpectedResult = true)]  // SSC enables content over local-false
+    [TestCase(false, true, true, ExpectedResult = false)] // master off -> content off regardless
+    public bool AiMonitoringRecordContentEnabled_resolves_with_correct_precedence(bool master, bool localRecord, bool? agentConfigRecord)
+    {
+        _localConfig.aiMonitoring.enabled = master;
+        _serverConfig.RpmConfig.AiMonitoringEnabled = master;
+        _localConfig.aiMonitoring.recordContent.enabled = localRecord;
+        _serverConfig.RpmConfig.AiMonitoringRecordContentEnabled = agentConfigRecord;
+
+        _defaultConfig = new TestableDefaultConfiguration(_environment, _localConfig, _serverConfig, _runTimeConfig, _securityPoliciesConfiguration, _bootstrapConfiguration, _processStatic, _httpRuntimeStatic, _configurationManagerStatic, _dnsStatic);
+
+        return _defaultConfig.AiMonitoringRecordContentEnabled;
+    }
+
+    #endregion
+
     #region Agent Logs
 
     [TestCase(null, true, ExpectedResult = true)]

--- a/tests/Agent/UnitTests/Core.UnitTest/Configuration/ServerConfiguration.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Configuration/ServerConfiguration.cs
@@ -86,6 +86,41 @@ public class Method_FromDeserializedReturnValue
         Assert.Throws(Is.InstanceOf<Exception>(), () => ServerConfiguration.FromDeserializedReturnValue(new Dictionary<string, object> { { "agent_run_id", 0 }, { "apdex_t", "not a double" } }));
     }
 
+    [Test]
+    public void ai_monitoring_agent_config_keys_deserialize_correctly()
+    {
+        var agentConfig = new Dictionary<string, object>
+        {
+            { "ai_monitoring.enabled", true },
+            { "ai_monitoring.streaming.enabled", false },
+            { "ai_monitoring.record_content.enabled", false }
+        };
+
+        var serverConfiguration = ServerConfiguration.FromDeserializedReturnValue(
+            new Dictionary<string, object> { { "agent_run_id", 0 }, { "agent_config", agentConfig } });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringEnabled, Is.True);
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringStreamingEnabled, Is.False);
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringRecordContentEnabled, Is.False);
+        });
+    }
+
+    [Test]
+    public void ai_monitoring_agent_config_keys_are_null_when_absent()
+    {
+        var serverConfiguration = ServerConfiguration.FromDeserializedReturnValue(
+            new Dictionary<string, object> { { "agent_run_id", 0 } });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringEnabled, Is.Null);
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringStreamingEnabled, Is.Null);
+            Assert.That(serverConfiguration.RpmConfig.AiMonitoringRecordContentEnabled, Is.Null);
+        });
+    }
+
 }
 
 [TestFixture, Category("Configuration")]


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Support server-side configuration for AI Monitoring settings (#3664)
END_COMMIT_OVERRIDE

## What

Makes the three AI Monitoring settings server-side configurable via the connect-response `agent_config` block, from NR-538711:

- `ai_monitoring.enabled`
- `ai_monitoring.streaming.enabled`
- `ai_monitoring.record_content.enabled`

## Precedence

When more than one source sets a value, the first one that applies wins:

1. **High-security mode (local):** if on, AI Monitoring is forced off and nothing can re-enable it.
2. **`agent_config` (server):** can turn a setting on or off, overriding local config.
3. **`collect_ai` (server):** can only turn the master `ai_monitoring.enabled` off, never on.
4. **Local config / environment variable.**

The two sub-settings (`streaming.enabled`, `record_content.enabled`) only take effect when the master `ai_monitoring.enabled` resolves to on.

## Testing

- Unit: resolution-precedence matrix in `DefaultConfigurationTests` plus `agent_config` deserialization tests in `ServerConfiguration` tests.
- Integration: MockNewRelic-based tests (`AimServerSideConfigTests`) covering server-config-overrides-local and high-security-mode-forces-off, asserting the resolved values from the agent's `agent_settings` payload.
