### PR TITLE
chore: Add per-TFM major-version ceiling support to Dotty

### DIFF
--- a/build/Dotty/CsprojHandler.cs
+++ b/build/Dotty/CsprojHandler.cs
@@ -33,7 +33,7 @@ public class CsprojHandler
                 {
                     // check whether packageReferences contains the package
                     var matchingPackages =
-                        packageReferences.Where(p => p.Include == versionData.PackageName).ToList();
+                        packageReferences.Where(p => string.Equals(p.Include, versionData.PackageName, StringComparison.OrdinalIgnoreCase)).ToList();
                     if (matchingPackages.Count == 0)
                     {
                         //Log.Warning($"No matching packages found in csproj file for {versionData.PackageName}");
@@ -50,7 +50,26 @@ public class CsprojHandler
                         if (condition?.StartsWith("'$(TargetFramework)'") ?? false)
                             tfm = condition?.Split("==").LastOrDefault()?.Trim('\'', ' ', ';');
 
-                        if (version.AsVersion() < versionData.NewVersion.AsVersion() &&
+                        // resolve per-TFM target if available, otherwise fall back to global latest
+                        string targetVersion;
+                        if (!string.IsNullOrEmpty(tfm) &&
+                            versionData.TfmTargetVersions != null &&
+                            versionData.TfmTargetVersions.ContainsKey(tfm))
+                        {
+                            var cappedValue = versionData.TfmTargetVersions[tfm];
+                            if (cappedValue == null)
+                            {
+                                Log.Warning($"Not updating {packageReference.Include} for {tfm}; no version within the configured major ceiling. Leaving pinned.");
+                                continue;
+                            }
+                            targetVersion = cappedValue;
+                        }
+                        else
+                        {
+                            targetVersion = versionData.NewVersion;
+                        }
+
+                        if (version.AsVersion() < targetVersion.AsVersion() &&
                             !string.IsNullOrEmpty(versionData.IgnoreTfMs) &&
                             versionData.IgnoreTfMs.Split(",").Contains(tfm))
                         {
@@ -58,15 +77,15 @@ public class CsprojHandler
                             continue;
                         }
 
-                        if (version.AsVersion() < versionData.NewVersion.AsVersion())
+                        if (version.AsVersion() < targetVersion.AsVersion())
                         {
-                            Log.Information($"{Path.GetFileName(csprojPath)}: Updating {packageReference.Include}{(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} from {version} to {versionData.NewVersion}");
+                            Log.Information($"{Path.GetFileName(csprojPath)}: Updating {packageReference.Include}{(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} from {version} to {targetVersion}");
 
-                            packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")!.Value = versionData.NewVersion;
+                            packageReference.Metadata.FirstOrDefault(m => m.Name == "Version")!.Value = targetVersion;
 
                             updatedCsProj = true;
 
-                            updateLog.Add($"- Package [{versionData.PackageName}]({versionData.Url}){(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} was updated from {version} to {versionData.NewVersion}.");
+                            updateLog.Add($"- Package [{versionData.PackageName}]({versionData.Url}){(!string.IsNullOrEmpty(tfm) ? $" for {tfm}" : "")} was updated from {version} to {targetVersion}.");
                         }
                     }
                 }

--- a/build/Dotty/NugetVersionData.cs
+++ b/build/Dotty/NugetVersionData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Dotty;
 
@@ -11,9 +12,10 @@ public class NugetVersionData
     public string Url { get; set; }
     public DateTime PublishDate { get; set; }
     public string IgnoreTfMs { get; }
+    public Dictionary<string, string> TfmTargetVersions { get; }
 
     public NugetVersionData(string packageName, string oldVersion, string newVersion, string url,
-        DateTime publishDate, string ignoreTfMs)
+        DateTime publishDate, string ignoreTfMs, Dictionary<string, string> tfmTargetVersions = null)
     {
         PackageName = packageName;
         OldVersion = oldVersion;
@@ -22,5 +24,6 @@ public class NugetVersionData
         Url = url;
         PublishDate = publishDate;
         IgnoreTfMs = ignoreTfMs;
+        TfmTargetVersions = tfmTargetVersions;
     }
 }

--- a/build/Dotty/PackageInfo.cs
+++ b/build/Dotty/PackageInfo.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Dotty;
@@ -16,4 +17,6 @@ public class PackageInfo
     public string IgnoreReason {get; set;}
     [JsonPropertyName("ignoreTFMs")]
     public string IgnoreTFMs { get; set; }
+    [JsonPropertyName("tfmMaxMajorVersion")]
+    public Dictionary<string, int> TfmMaxMajorVersion { get; set; }
 }

--- a/build/Dotty/Program.cs
+++ b/build/Dotty/Program.cs
@@ -192,6 +192,45 @@ public class Program
         // get the second most recent version of the package (if there is one)
         var previous = metaData.Skip(1).FirstOrDefault();
 
+        // per-TFM major-version ceiling path (mutually exclusive with ignorePatch/Minor/Major)
+        if (package.TfmMaxMajorVersion != null && package.TfmMaxMajorVersion.Count > 0)
+        {
+            var tfmTargets = new Dictionary<string, string>();
+            var anyCappedAdvanced = false;
+
+            foreach (var (tfm, cap) in package.TfmMaxMajorVersion)
+            {
+                var capped = metaData.FirstOrDefault(v => v.Identity.Version.Major <= cap);
+                if (capped != null)
+                {
+                    var cappedVersionStr = capped.Identity.Version.ToNormalizedString();
+                    tfmTargets[tfm] = cappedVersionStr;
+                    Log.Information($"Package {packageName}: TFM {tfm} capped at major {cap}, resolved to {cappedVersionStr}.");
+                    if (capped.Published >= searchTime)
+                        anyCappedAdvanced = true;
+                }
+                else
+                {
+                    Log.Warning($"Package {packageName}: TFM {tfm} capped at major {cap}, but no matching version found. Leaving pinned.");
+                    tfmTargets[tfm] = null;
+                }
+            }
+
+            var globalAdvanced = latest.Published >= searchTime;
+
+            if (!globalAdvanced && !anyCappedAdvanced)
+            {
+                Log.Information($"Package {packageName} has NOT been updated.");
+                return;
+            }
+
+            var previousVersionDescription = previous?.Identity.Version.ToNormalizedString() ?? "Unknown";
+            var latestVersionDescription = latest.Identity.Version.ToNormalizedString();
+            Log.Information($"Package {packageName} global latest is {latestVersionDescription}; per-TFM targets resolved.");
+            _newVersions.Add(new NugetVersionData(packageName, previousVersionDescription, latestVersionDescription, latest.PackageDetailsUrl.ToString(), (latest.Published?.Date ?? DateTime.UtcNow.Date), package.IgnoreTFMs, tfmTargets));
+            return;
+        }
+
         // check publish date
         if (latest.Published >= searchTime)
         {


### PR DESCRIPTION
- Adds an opt-in `tfmMaxMajorVersion` config so a TFM can cap at a major version (e.g. net481 tracks latest Npgsql 8.x) while uncapped TFMs track the global latest. Inert when unset.
- Fixes case-insensitive package-id matching so a lowercase csproj `Include` (e.g. `npgsql`) matches NuGet's canonical id (`Npgsql`); the previous case-sensitive comparison silently skipped the update.