### PR TITLE
test: Fix flaky Azure Service Bus integration tests

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
@@ -71,7 +71,7 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
         {
             new()
             {
-                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}", callCount = _destinationType == "Queue" ? 4 : 3
+                metricName = $"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}", CallCountAllHarvests = _destinationType == "Queue" ? 4 : 3
             },
             new()
             {
@@ -95,7 +95,7 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
             new()
             {
                 metricName = $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}",
-                callCount = _destinationType == "Queue" ? 6 : 5
+                CallCountAllHarvests = _destinationType == "Queue" ? 6 : 5
             },
             new()
             {
@@ -113,7 +113,7 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
             new()
             {
                 metricName = $"MessageBroker/ServiceBus/{_destinationType}/Peek/Named/{_queueOrTopicName}",
-                callCount = 1
+                CallCountAllHarvests = 1
             },
             new()
             {
@@ -125,7 +125,7 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
             new()
             {
                 metricName = $"MessageBroker/ServiceBus/{_destinationType}/Settle/Named/{_queueOrTopicName}",
-                callCount = _destinationType == "Queue" ? 5 : 4
+                CallCountAllHarvests = _destinationType == "Queue" ? 5 : 4
             },
             new()
             {
@@ -169,7 +169,7 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
                 new()
                 {
                     metricName = $"MessageBroker/ServiceBus/{_destinationType}/Cancel/Named/{_queueOrTopicName}",
-                    callCount = 1
+                    CallCountAllHarvests = 1
                 });
             expectedMetrics.Add(
                 new()


### PR DESCRIPTION
Unscoped rollup metric assertions used `callCount`, which only checks the first harvest payload. When the metrics harvest fires mid-test (e.g. during a slow Azure Service Bus send), the rollup count splits across two harvests and the assertion sees a partial count, causing intermittent failures across branches.

Switch the unscoped Produce/Consume/Peek/Settle/Cancel assertions to `CallCountAllHarvests` so they aggregate across all harvests. Scoped metrics each belong to a single transaction and harvest, so they remain on `callCount`.