### PR TITLE
chore: Ignore local .codegraph database directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ build/Linux/keys
 
 # Superpowers working docs (local only)
 /docs/superpowers/
+
+# Codegraph database (local only)
+.codegraph


### PR DESCRIPTION
Adds the `.codegraph` directory (local Codegraph index database) to `.gitignore` so it is not tracked.