### PR TITLE
test: Remove flaky transaction-sample assertions from Azure Service Bus tests

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusProcessorTests.cs
@@ -57,15 +57,13 @@ public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicInte
                 configModifier
                     .SetLogLevel("finest")
                     .EnableDistributedTrace()
-                    .ForceTransactionTraces()
                     .ConfigureFasterMetricsHarvestCycle(20)
-                    .ConfigureFasterSpanEventsHarvestCycle(20)
-                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+                    .ConfigureFasterSpanEventsHarvestCycle(20);
 
             },
             exerciseApplication: () =>
             {
-                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionSampleLogLineRegex,
+                _fixture.AgentLog.WaitForLogLine(AgentLogBase.TransactionTransformCompletedLogLineRegex,
                     TimeSpan.FromMinutes(1));
             }
         );
@@ -127,23 +125,13 @@ public abstract class AzureServiceBusProcessorTestsBase<TFixture> : NewRelicInte
 
         var spanEvents = _fixture.AgentLog.GetSpanEvents().ToList();
 
-        var expectedTransactionTraceSegments = new List<string>
-        {
-            $"{_processMetricNameBase}/{_queueOrTopicName}",
-            _onProcessMessageMethodSegmentMetricName,
-            $"{_settleMetricNameBase}/{_queueOrTopicName}",
-        };
-
-        var transactionSample = _fixture.AgentLog.TryGetTransactionSample($"{_transactionNameBase}/{_queueOrTopicName}{_topicScopeSuffix}");
         var queueProcessSpanEvent = _fixture.AgentLog.TryGetSpanEvent($"{_processMetricNameBase}/{_queueOrTopicName}");
 
 
         Assert.Multiple(
             () => Assert.Equal(2, processorTransactionEvents.Count),
             () => Assertions.MetricsExist(expectedMetrics, metrics),
-            () => Assert.NotNull(transactionSample),
             () => Assert.NotNull(queueProcessSpanEvent),
-            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
             () => Assert.NotEmpty(spanEvents));
 
         // verify processor transaction events have the expected DT attributes

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusTests.cs
@@ -48,10 +48,8 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
                 configModifier
                     .SetLogLevel("finest")
                     .EnableDistributedTrace()
-                    .ForceTransactionTraces()
                     .ConfigureFasterMetricsHarvestCycle(20)
                     .ConfigureFasterSpanEventsHarvestCycle(20)
-                    .ConfigureFasterTransactionTracesHarvestCycle(25)
                     ;
             }
         );
@@ -184,15 +182,6 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
             _fixture.AgentLog.TryGetTransactionEvent(
                 $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
 
-        var expectedTransactionTraceSegments = new List<string>
-        {
-            $"MessageBroker/ServiceBus/{_destinationType}/Consume/Named/{_queueOrTopicName}"
-        };
-
-        var transactionSample =
-            _fixture.AgentLog.TryGetTransactionSample(
-                $"{_metricScopeBase}/ExerciseMultipleReceiveOperationsOnAMessageFor{_destinationType}");
-
         var queueProduceSpanEvents =
             _fixture.AgentLog.TryGetSpanEvent($"MessageBroker/ServiceBus/Queue/Produce/Named/{_queueOrTopicName}");
         var queueConsumeSpanEvents =
@@ -226,8 +215,6 @@ public abstract class AzureServiceBusTestsBase<TFixture> : NewRelicIntegrationTe
         NrAssert.Multiple(
             () => Assert.True(exerciseMultipleReceiveOperationsOnAMessageTransactionEvent != null,
                 "ExerciseMultipleReceiveOperationsOnAMessageTransactionEvent should not be null"),
-            () => Assert.True(transactionSample != null, "transactionSample should not be null"),
-            () => Assertions.TransactionTraceSegmentsExist(expectedTransactionTraceSegments, transactionSample),
 
             () => Assertions.SpanEventHasAttributes(expectedProduceAgentAttributes,
                 Tests.TestSerializationHelpers.Models.SpanEventAttributeType.Agent, queueProduceSpanEvents),

--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/AzureServiceBus/AzureServiceBusW3CTests.cs
@@ -44,10 +44,8 @@ public abstract class AzureServiceBusW3CTestsBase<TFixture> : NewRelicIntegratio
                 configModifier
                     .SetLogLevel("finest")
                     .EnableDistributedTrace()
-                    .ForceTransactionTraces()
                     .ConfigureFasterMetricsHarvestCycle(20)
-                    .ConfigureFasterSpanEventsHarvestCycle(20)
-                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+                    .ConfigureFasterSpanEventsHarvestCycle(20);
             },
             exerciseApplication: () =>
             {
@@ -251,10 +249,8 @@ public abstract class AzureServiceBusW3CDTHeaderReplacementTestsBase<TFixture> :
                 configModifier
                     .SetLogLevel("finest")
                     .EnableDistributedTrace()
-                    .ForceTransactionTraces()
                     .ConfigureFasterMetricsHarvestCycle(20)
-                    .ConfigureFasterSpanEventsHarvestCycle(20)
-                    .ConfigureFasterTransactionTracesHarvestCycle(25);
+                    .ConfigureFasterSpanEventsHarvestCycle(20);
             },
             exerciseApplication: () =>
             {


### PR DESCRIPTION
- Remove the intermittently-failing `transactionSample` assertions (and their now-unused trace-forcing config); with `ForceTransactionTraces` every transaction competed for the single slowest-trace slot, so the Exercise trace was dropped whenever another transaction ran slower. The `Consume` segment stays covered by the existing span-event assertions.