### PR TITLE
ci: report CI payload sizes to New Relic staging metric API

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1340,6 +1340,9 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Download combined integration payload log
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1469,6 +1472,20 @@ jobs:
           name: final-payload-summary
           path: final_payload_summary.json
           if-no-files-found: warn
+
+      - name: Report payload metrics to New Relic (staging)
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        continue-on-error: true
+        env:
+          PAYLOAD_SUMMARY_FILE: final_payload_summary.json
+          NR_METRIC_API_URL: https://staging-metric-api.newrelic.com/metric/v1
+          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash build/Scripts/report-payload-metrics.sh
+        shell: bash
 
       - name: Delete combined payload artifacts
         run: |

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Report aggregated CI payload sizes to the New Relic Metric API.
+# Reads final_payload_summary.json (produced by all_solutions.yml), transforms
+# it into Metric API JSON, and POSTs it to New Relic (staging by default).
+#
+# Env vars:
+#   PAYLOAD_SUMMARY_FILE  Path to final_payload_summary.json (required)
+#   NR_METRIC_API_URL     Metric API endpoint (required unless dry-run)
+#   NR_TEST_SECRETS       Raw TEST_SECRETS JSON, may carry a UTF-8 BOM
+#                         (required unless dry-run). License key is read from
+#                         .IntegrationTestConfiguration.DefaultSetting.LicenseKey
+#   CI_BRANCH CI_COMMIT CI_RUN_ID CI_RUN_URL   Optional metadata attributes
+#   DRY_RUN               "1"/"true" => print request body to stdout, do not POST
+#
+# Exit codes:
+#   0  success (HTTP 202), dry-run, or intentional skip (no file / key / url)
+#   1  POST attempted but response was not HTTP 202
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-}"
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+is_dry_run() { [ "$DRY_RUN" = "1" ] || [ "$DRY_RUN" = "true" ]; }
+
+SUMMARY_FILE="${PAYLOAD_SUMMARY_FILE:-}"
+if [ -z "$SUMMARY_FILE" ] || [ ! -f "$SUMMARY_FILE" ]; then
+  echo "WARNING: payload summary file not found (PAYLOAD_SUMMARY_FILE='$SUMMARY_FILE'); skipping." >&2
+  exit 0
+fi
+
+# Build the Metric API request body from the summary artifact.
+# - per-class gauge (deduped by testType+className)
+# - per-type total gauge, plus an "all" rollup gauge
+build_body() {
+  local ts_ms="$1"
+  jq -c \
+    --arg ts "$ts_ms" \
+    --arg branch "${CI_BRANCH:-unknown}" \
+    --arg commit "${CI_COMMIT:-unknown}" \
+    --arg runId "${CI_RUN_ID:-unknown}" \
+    --arg runUrl "${CI_RUN_URL:-unknown}" '
+    ([ to_entries[] | select(.value|type=="object") ]) as $types
+    | [ {
+        common: { timestamp: ($ts|tonumber),
+                  attributes: { source:"dotnet-agent-ci", "ci.branch":$branch,
+                                "ci.commit":$commit, "ci.runId":$runId, "ci.runUrl":$runUrl } },
+        metrics: (
+          [ $types[] | .key as $t | (.value.details // [])
+            | group_by(.className)[]
+            | {name:"newrelic.dotnet.ci.payload.bytes", type:"gauge",
+               value:(map(.bytes)|add), attributes:{testType:$t, className:.[0].className}} ]
+          + [ $types[] | {name:"newrelic.dotnet.ci.payload.total.bytes", type:"gauge",
+               value:.value.bytes, attributes:{testType:.key}} ]
+          + [ {name:"newrelic.dotnet.ci.payload.total.bytes", type:"gauge",
+               value:(.bytes // 0), attributes:{testType:"all"}} ]
+        )
+      } ]
+  ' "$SUMMARY_FILE"
+}
+
+TS_MS="$(date +%s%3N)"
+BODY_FILE="$(mktemp)"
+RESP_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$RESP_FILE"' EXIT
+
+build_body "$TS_MS" > "$BODY_FILE"
+METRIC_COUNT="$(jq '.[0].metrics | length' "$BODY_FILE")"
+echo "Built $METRIC_COUNT metrics from $SUMMARY_FILE (timestamp ${TS_MS}ms)." >&2
+
+if is_dry_run; then
+  cat "$BODY_FILE"
+  exit 0
+fi
+
+# Extract the license key (Api-Key) from TEST_SECRETS; strip a possible UTF-8 BOM.
+LICENSE_KEY=""
+if [ -n "${NR_TEST_SECRETS:-}" ]; then
+  LICENSE_KEY="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//' \
+    | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty')"
+fi
+if [ -z "$LICENSE_KEY" ]; then
+  echo "WARNING: no New Relic license key available; skipping." >&2
+  exit 0
+fi
+if [ -z "${NR_METRIC_API_URL:-}" ]; then
+  echo "WARNING: NR_METRIC_API_URL not set; skipping." >&2
+  exit 0
+fi
+
+HTTP_CODE="$(curl -s --connect-timeout 10 --max-time 30 -o "$RESP_FILE" -w '%{http_code}' \
+  -H "Content-Type: application/json" \
+  -H "Api-Key: $LICENSE_KEY" \
+  -X POST "$NR_METRIC_API_URL" \
+  --data-binary @"$BODY_FILE")"
+
+if [ "$HTTP_CODE" = "202" ]; then
+  echo "New Relic Metric API accepted the payload (HTTP 202). requestId=$(jq -r '.requestId // "unknown"' "$RESP_FILE")" >&2
+  exit 0
+fi
+
+echo "ERROR: New Relic Metric API returned HTTP $HTTP_CODE" >&2
+echo "Response: $(cat "$RESP_FILE")" >&2
+exit 1

--- a/build/Scripts/tests/fixtures/sample-payload-summary.json
+++ b/build/Scripts/tests/fixtures/sample-payload-summary.json
@@ -1,0 +1,19 @@
+{
+  "integrationTests": {
+    "generatedAt": "2026-07-01T00:00:00Z",
+    "bytes": 300,
+    "details": [
+      {"className": "AlphaTests", "bytes": 100},
+      {"className": "BetaTests", "bytes": 50},
+      {"className": "AlphaTests", "bytes": 150}
+    ]
+  },
+  "unboundedTests": {
+    "generatedAt": "2026-07-01T00:00:00Z",
+    "bytes": 25,
+    "details": [
+      {"className": "GammaTests", "bytes": 25}
+    ]
+  },
+  "bytes": 325
+}

--- a/build/Scripts/tests/test-report-payload-metrics.sh
+++ b/build/Scripts/tests/test-report-payload-metrics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Local test for report-payload-metrics.sh: runs the transform in dry-run mode
+# against a fixture and asserts the generated Metric API body is correct.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../report-payload-metrics.sh"
+FIXTURE="$SCRIPT_DIR/fixtures/sample-payload-summary.json"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# In dry-run mode, stdout is exactly the Metric API body (one line of JSON).
+OUT="$(PAYLOAD_SUMMARY_FILE="$FIXTURE" DRY_RUN=1 bash "$SCRIPT")"
+
+echo "$OUT" | jq -e . >/dev/null 2>&1 || fail "dry-run output is not valid JSON"
+
+COUNT="$(echo "$OUT" | jq '.[0].metrics | length')"
+[ "$COUNT" = "6" ] || fail "expected 6 metrics, got $COUNT"
+
+ALPHA="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.bytes" and .attributes.className=="AlphaTests")
+  | .value')"
+[ "$ALPHA" = "250" ] || fail "expected AlphaTests deduped to 250, got $ALPHA"
+
+INT_TOTAL="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.total.bytes" and .attributes.testType=="integrationTests")
+  | .value')"
+[ "$INT_TOTAL" = "300" ] || fail "expected integrationTests total 300, got $INT_TOTAL"
+
+ALL="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.total.bytes" and .attributes.testType=="all")
+  | .value')"
+[ "$ALL" = "325" ] || fail "expected overall total 325, got $ALL"
+
+echo "PASS: all assertions passed ($COUNT metrics)"


### PR DESCRIPTION
Reports the nightly aggregated CI payload sizes (from the existing `final_payload_summary.json` artifact) to New Relic staging via the Metric API, so a dashboard can track billable-data trends.

- New `build/Scripts/report-payload-metrics.sh`: jq-transforms the artifact into Metric API JSON (per-class `newrelic.dotnet.ci.payload.bytes` deduped by testType+className, plus per-type and overall `newrelic.dotnet.ci.payload.total.bytes` rollups) and POSTs it. License key comes from the existing `TEST_SECRETS`; endpoint is staging; `--dry-run` supported; safe skip/exit semantics so it never fails the build.
- Wires a checkout step and a `continue-on-error` reporting step into the `display-all-payload-summaries` job of `all_solutions.yml` (runs on schedule / manual dispatch only).

Validated end-to-end against a real artifact (1044 metrics, HTTP 202, confirmed in staging via NRQL). Account-level metrics (no entity). Forward-only (Metric API drops timestamps older than 48h, so no backfill).