### PR TITLE
ci: report CI payload sizes to New Relic staging metric API

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -686,19 +686,25 @@ jobs:
 
             $payloadData = @{}
             foreach ($message in $messageElements) {
-              $text = $message.InnerText
-              if ($text -match "^(.+?):\s*Total payload bytes sent:\s*(\d+)") {
-                $className = $Matches[1].Trim()
-                $byteCount = [int]$Matches[2]
-                $payloadData[$className] = $byteCount
-                Write-Host "Found: $className = $byteCount bytes"
+              foreach ($line in ($message.InnerText -split "\r?\n")) {
+                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
+                  $className = $Matches[1].Trim()
+                  $category  = $Matches[2]
+                  $byteCount = [int]$Matches[3]
+                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
+                  if ($payloadData[$className].ContainsKey($category)) {
+                    $payloadData[$className][$category] += $byteCount
+                  } else {
+                    $payloadData[$className][$category] = $byteCount
+                  }
+                }
               }
             }
 
             Write-Host "Found $($payloadData.Count) payload log entries"
 
             if ($payloadData.Count -gt 0) {
-              $payloadData | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
               Write-Host "Extracted payload logs to $payloadLog"
               Write-Host "Content:"
               Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
@@ -873,19 +879,25 @@ jobs:
 
             $payloadData = @{}
             foreach ($message in $messageElements) {
-              $text = $message.InnerText
-              if ($text -match "^(.+?):\s*Total payload bytes sent:\s*(\d+)") {
-                $className = $Matches[1].Trim()
-                $byteCount = [int]$Matches[2]
-                $payloadData[$className] = $byteCount
-                Write-Host "Found: $className = $byteCount bytes"
+              foreach ($line in ($message.InnerText -split "\r?\n")) {
+                if ($line -match '^\s*(.+?):\s+([a-z0-9_]+):\s+(\d+)\s+bytes\s*$') {
+                  $className = $Matches[1].Trim()
+                  $category  = $Matches[2]
+                  $byteCount = [int]$Matches[3]
+                  if (-not $payloadData.ContainsKey($className)) { $payloadData[$className] = @{} }
+                  if ($payloadData[$className].ContainsKey($category)) {
+                    $payloadData[$className][$category] += $byteCount
+                  } else {
+                    $payloadData[$className][$category] = $byteCount
+                  }
+                }
               }
             }
 
             Write-Host "Found $($payloadData.Count) payload log entries"
 
             if ($payloadData.Count -gt 0) {
-              $payloadData | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
+              $payloadData | ConvertTo-Json -Depth 5 | Out-File -FilePath $payloadLog -Encoding UTF8
               Write-Host "Extracted payload logs to $payloadLog"
               Write-Host "Content:"
               Get-Content $payloadLog | ForEach-Object { Write-Host $_ }
@@ -1142,60 +1154,30 @@ jobs:
       - name: Combine payload logs
         run: |
           mkdir -p combined-logs
+          IN_DIR="payload-logs/integration"
+          PREFIX="integration"
+          LABEL="Integration Tests"
+          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
+          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-          if [ -d "payload-logs/integration" ]; then
-            echo "["  > combined-logs/integration_payload_bytes_combined.json
-            first=true
-            grand_total=0
-
-            # Process JSON files and merge into array
-            while IFS= read -r file; do
-              echo "Processing: $(basename "$file")"
-
-              # Read JSON and extract key-value pairs
-              while IFS= read -r line; do
-                # Skip lines that are just braces or empty
-                if [[ "$line" =~ ^[[:space:]]*\{[[:space:]]*$ ]] || [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] || [[ -z "$line" ]]; then
-                  continue
-                fi
-
-                # Extract class name and byte count from JSON property
-                if [[ "$line" =~ \"([^\"]+)\":[[:space:]]*([0-9]+) ]]; then
-                  className="${BASH_REMATCH[1]}"
-                  byteCount="${BASH_REMATCH[2]}"
-                  grand_total=$((grand_total + byteCount))
-
-                  if [ "$first" = true ]; then
-                    first=false
-                  else
-                    echo "," >> combined-logs/integration_payload_bytes_combined.json
-                  fi
-                  echo "  {\"className\": \"$className\", \"payloadBytes\": $byteCount}" >> combined-logs/integration_payload_bytes_combined.json
-                fi
-              done < "$file"
-            done < <(find payload-logs/integration -name "*_payload_bytes.json" -type f | sort)
-
-            echo "" >> combined-logs/integration_payload_bytes_combined.json
-            echo "]" >> combined-logs/integration_payload_bytes_combined.json
-
-            # Create summary metadata file
-            echo "{" > combined-logs/integration_payload_bytes_summary.json
-            echo "  \"testType\": \"Integration Tests\"," >> combined-logs/integration_payload_bytes_summary.json
-            echo "  \"generatedAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"," >> combined-logs/integration_payload_bytes_summary.json
-            echo "  \"grandTotalBytes\": $grand_total" >> combined-logs/integration_payload_bytes_summary.json
-            echo "}" >> combined-logs/integration_payload_bytes_summary.json
-
-            echo "Combined payload JSON created with grand total: $grand_total bytes"
-            echo "Payload data:"
-            cat combined-logs/integration_payload_bytes_combined.json
-            echo ""
-            echo "Summary:"
-            cat combined-logs/integration_payload_bytes_summary.json
+          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
+              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
+                (reduce .[] as $ns ({};
+                   reduce ($ns|to_entries[]) as $c (.;
+                     reduce ($c.value|to_entries[]) as $cat (.;
+                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
+                | { testType: $tt, generatedAt: $now,
+                    grandTotalBytes: ([$m[][]] | add // 0),
+                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
+                    byType: (reduce ($m|to_entries[]) as $c ({};
+                               reduce ($c.value|to_entries[]) as $cat (.;
+                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
           else
-            echo "No integration payload logs found"
-            echo "[]" > combined-logs/integration_payload_bytes_combined.json
-            echo "{\"testType\": \"Integration Tests\", \"grandTotalBytes\": 0}" > combined-logs/integration_payload_bytes_summary.json
+            jq -n --arg tt "$LABEL" --arg now "$NOW" \
+              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
           fi
+          cat "$OUT"
         shell: bash
 
       - name: Upload combined integration payload log
@@ -1246,60 +1228,30 @@ jobs:
       - name: Combine payload logs
         run: |
           mkdir -p combined-logs
+          IN_DIR="payload-logs/unbounded"
+          PREFIX="unbounded"
+          LABEL="Unbounded Integration Tests"
+          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
+          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-          if [ -d "payload-logs/unbounded" ]; then
-            echo "["  > combined-logs/unbounded_payload_bytes_combined.json
-            first=true
-            grand_total=0
-
-            # Process JSON files and merge into array
-            while IFS= read -r file; do
-              echo "Processing: $(basename "$file")"
-
-              # Read JSON and extract key-value pairs
-              while IFS= read -r line; do
-                # Skip lines that are just braces or empty
-                if [[ "$line" =~ ^[[:space:]]*\{[[:space:]]*$ ]] || [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] || [[ -z "$line" ]]; then
-                  continue
-                fi
-
-                # Extract class name and byte count from JSON property
-                if [[ "$line" =~ \"([^\"]+)\":[[:space:]]*([0-9]+) ]]; then
-                  className="${BASH_REMATCH[1]}"
-                  byteCount="${BASH_REMATCH[2]}"
-                  grand_total=$((grand_total + byteCount))
-
-                  if [ "$first" = true ]; then
-                    first=false
-                  else
-                    echo "," >> combined-logs/unbounded_payload_bytes_combined.json
-                  fi
-                  echo "  {\"className\": \"$className\", \"payloadBytes\": $byteCount}" >> combined-logs/unbounded_payload_bytes_combined.json
-                fi
-              done < "$file"
-            done < <(find payload-logs/unbounded -name "*_payload_bytes.json" -type f | sort)
-
-            echo "" >> combined-logs/unbounded_payload_bytes_combined.json
-            echo "]" >> combined-logs/unbounded_payload_bytes_combined.json
-
-            # Create summary metadata file
-            echo "{" > combined-logs/unbounded_payload_bytes_summary.json
-            echo "  \"testType\": \"Unbounded Integration Tests\"," >> combined-logs/unbounded_payload_bytes_summary.json
-            echo "  \"generatedAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"," >> combined-logs/unbounded_payload_bytes_summary.json
-            echo "  \"grandTotalBytes\": $grand_total" >> combined-logs/unbounded_payload_bytes_summary.json
-            echo "}" >> combined-logs/unbounded_payload_bytes_summary.json
-
-            echo "Combined payload JSON created with grand total: $grand_total bytes"
-            echo "Payload data:"
-            cat combined-logs/unbounded_payload_bytes_combined.json
-            echo ""
-            echo "Summary:"
-            cat combined-logs/unbounded_payload_bytes_summary.json
+          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
+              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
+                (reduce .[] as $ns ({};
+                   reduce ($ns|to_entries[]) as $c (.;
+                     reduce ($c.value|to_entries[]) as $cat (.;
+                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
+                | { testType: $tt, generatedAt: $now,
+                    grandTotalBytes: ([$m[][]] | add // 0),
+                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
+                    byType: (reduce ($m|to_entries[]) as $c ({};
+                               reduce ($c.value|to_entries[]) as $cat (.;
+                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
           else
-            echo "No unbounded payload logs found"
-            echo "[]" > combined-logs/unbounded_payload_bytes_combined.json
-            echo "{\"testType\": \"Unbounded Integration Tests\", \"grandTotalBytes\": 0}" > combined-logs/unbounded_payload_bytes_summary.json
+            jq -n --arg tt "$LABEL" --arg now "$NOW" \
+              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
           fi
+          cat "$OUT"
         shell: bash
 
       - name: Upload combined unbounded payload log
@@ -1366,104 +1318,27 @@ jobs:
 
       - name: Create consolidated JSON output
         run: |
-          if [ -d "payload-summaries" ]; then
-            echo "{"  > final_payload_summary.json
-
-            first_type=true
-            overall_total=0
-
-            # Process each test type's combined data
-            for data_file in payload-summaries/*_combined.json; do
-              if [ -f "$data_file" ]; then
-                filename=$(basename "$data_file" _payload_bytes_combined.json)
-
-                # Determine test type name
-                case "$filename" in
-                  integration)
-                    test_type="integrationTests"
-                    ;;
-                  unbounded)
-                    test_type="unboundedTests"
-                    ;;
-                  linux_container)
-                    test_type="containerTests"
-                    ;;
-                  *)
-                    test_type="$filename"
-                    ;;
-                esac
-
-                # Get corresponding summary file for grand total and timestamp
-                summary_file="payload-summaries/${filename}_payload_bytes_summary.json"
-                grand_total=0
-                generated_at=""
-                if [ -f "$summary_file" ]; then
-                  if grep -q "grandTotalBytes" "$summary_file"; then
-                    grand_total=$(grep -oP '"grandTotalBytes":\s*\K\d+' "$summary_file")
-                    overall_total=$((overall_total + grand_total))
-                  fi
-                  if grep -q "generatedAt" "$summary_file"; then
-                    generated_at=$(grep -oP '"generatedAt":\s*"\K[^"]+' "$summary_file")
-                  fi
-                fi
-
-                # Add comma separator if not first entry
-                if [ "$first_type" = false ]; then
-                  echo "," >> final_payload_summary.json
-                fi
-                first_type=false
-
-                # Add test type section
-                echo "  \"$test_type\": {" >> final_payload_summary.json
-                echo "    \"generatedAt\": \"$generated_at\"," >> final_payload_summary.json
-                echo "    \"bytes\": $grand_total," >> final_payload_summary.json
-                echo "    \"details\": [" >> final_payload_summary.json
-
-                # Read and merge test class data from combined file, converting payloadBytes to bytes
-                first_test=true
-                while IFS= read -r line; do
-                  # Skip array brackets and empty lines
-                  if [[ "$line" =~ ^[[:space:]]*\[[[:space:]]*$ ]] || [[ "$line" =~ ^[[:space:]]*\][[:space:]]*$ ]] || [[ -z "$line" ]]; then
-                    continue
-                  fi
-
-                  # Extract className and payloadBytes, convert to new format
-                  if [[ "$line" =~ \"className\":[[:space:]]*\"([^\"]+)\".*\"payloadBytes\":[[:space:]]*([0-9]+) ]]; then
-                    className="${BASH_REMATCH[1]}"
-                    byteCount="${BASH_REMATCH[2]}"
-
-                    # Add comma separator if not first test entry
-                    if [ "$first_test" = false ]; then
-                      echo "," >> final_payload_summary.json
-                    fi
-                    first_test=false
-
-                    echo "      {\"className\": \"$className\", \"bytes\": $byteCount}" >> final_payload_summary.json
-                  fi
-                done < "$data_file"
-
-                echo "" >> final_payload_summary.json
-                echo "    ]" >> final_payload_summary.json
-                echo -n "  }" >> final_payload_summary.json
-              fi
+          if ls payload-summaries/*_combined.json >/dev/null 2>&1; then
+            final="$(jq -n '{bytes:0, byType:{}}')"
+            for f in payload-summaries/*_combined.json; do
+              base="$(basename "$f" _payload_bytes_combined.json)"
+              case "$base" in
+                integration)    key="integrationTests";;
+                unbounded)      key="unboundedTests";;
+                linux_container) key="containerTests";;
+                *)              key="$base";;
+              esac
+              final="$(jq --arg key "$key" --slurpfile c "$f" '
+                .[$key] = {generatedAt:$c[0].generatedAt, bytes:$c[0].grandTotalBytes, byType:$c[0].byType, details:$c[0].details}
+                | .bytes += $c[0].grandTotalBytes
+                | .byType = (reduce ($c[0].byType|to_entries[]) as $cat (.byType; .[$cat.key]=((.[$cat.key]//0)+$cat.value)))
+              ' <<<"$final")"
             done
-
-            echo "," >> final_payload_summary.json
-            echo "  \"bytes\": $overall_total" >> final_payload_summary.json
-            echo "}" >> final_payload_summary.json
-
-            echo "=========================================="
-            echo "FINAL CONSOLIDATED PAYLOAD SUMMARY"
-            echo "=========================================="
-            cat final_payload_summary.json
-            echo ""
-            echo "=========================================="
-            echo "OVERALL TOTAL: $overall_total bytes"
-            echo "=========================================="
+            echo "$final" > final_payload_summary.json
           else
-            echo "No payload summary files found"
-            echo '{"bytes": 0}' > final_payload_summary.json
+            echo '{"bytes": 0, "byType": {}}' > final_payload_summary.json
           fi
+          echo "FINAL CONSOLIDATED PAYLOAD SUMMARY"; cat final_payload_summary.json
         shell: bash
 
       - name: Upload final consolidated summary

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1340,6 +1340,9 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Download combined integration payload log
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1469,6 +1472,20 @@ jobs:
           name: final-payload-summary
           path: final_payload_summary.json
           if-no-files-found: warn
+
+      - name: Report payload metrics to New Relic (staging)
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        continue-on-error: true
+        env:
+          PAYLOAD_SUMMARY_FILE: final_payload_summary.json
+          NR_METRIC_API_URL: https://staging-metric-api.newrelic.com/metric/v1
+          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash build/Scripts/report-payload-metrics.sh
+        shell: bash
 
       - name: Delete combined payload artifacts
         run: |

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1144,6 +1144,9 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Download all integration payload artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1152,34 +1155,7 @@ jobs:
           merge-multiple: true
 
       - name: Combine payload logs
-        run: |
-          mkdir -p combined-logs
-          IN_DIR="payload-logs/integration"
-          PREFIX="integration"
-          LABEL="Integration Tests"
-          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
-          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
-            # PowerShell writes these files as UTF-8 with a BOM; strip it so jq -s can parse the concatenated stream
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
-              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
-                (reduce .[] as $ns ({};
-                   reduce ($ns|to_entries[]) as $c (.;
-                     reduce ($c.value|to_entries[]) as $cat (.;
-                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
-                | { testType: $tt, generatedAt: $now,
-                    grandTotalBytes: ([$m[][]] | add // 0),
-                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
-                    byType: (reduce ($m|to_entries[]) as $c ({};
-                               reduce ($c.value|to_entries[]) as $cat (.;
-                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
-          else
-            jq -n --arg tt "$LABEL" --arg now "$NOW" \
-              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
-          fi
-          cat "$OUT"
+        run: bash build/Scripts/combine-payload-logs.sh payload-logs/integration "Integration Tests" combined-logs/integration_payload_bytes_combined.json
         shell: bash
 
       - name: Upload combined integration payload log
@@ -1220,6 +1196,9 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Download all unbounded payload artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1228,34 +1207,7 @@ jobs:
           merge-multiple: true
 
       - name: Combine payload logs
-        run: |
-          mkdir -p combined-logs
-          IN_DIR="payload-logs/unbounded"
-          PREFIX="unbounded"
-          LABEL="Unbounded Integration Tests"
-          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
-          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
-            # PowerShell writes these files as UTF-8 with a BOM; strip it so jq -s can parse the concatenated stream
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
-              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
-                (reduce .[] as $ns ({};
-                   reduce ($ns|to_entries[]) as $c (.;
-                     reduce ($c.value|to_entries[]) as $cat (.;
-                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
-                | { testType: $tt, generatedAt: $now,
-                    grandTotalBytes: ([$m[][]] | add // 0),
-                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
-                    byType: (reduce ($m|to_entries[]) as $c ({};
-                               reduce ($c.value|to_entries[]) as $cat (.;
-                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
-          else
-            jq -n --arg tt "$LABEL" --arg now "$NOW" \
-              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
-          fi
-          cat "$OUT"
+        run: bash build/Scripts/combine-payload-logs.sh payload-logs/unbounded "Unbounded Integration Tests" combined-logs/unbounded_payload_bytes_combined.json
         shell: bash
 
       - name: Upload combined unbounded payload log

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1161,6 +1161,8 @@ jobs:
           NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
           if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            # PowerShell writes these files as UTF-8 with a BOM; strip it so jq -s can parse the concatenated stream
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
             find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
               | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
                 (reduce .[] as $ns ({};
@@ -1235,6 +1237,8 @@ jobs:
           NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
           if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            # PowerShell writes these files as UTF-8 with a BOM; strip it so jq -s can parse the concatenated stream
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
             find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
               | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
                 (reduce .[] as $ns ({};

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -1352,6 +1352,11 @@ jobs:
           path: final_payload_summary.json
           if-no-files-found: warn
 
+      - name: Guard against empty payload data
+        if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
+        run: bash build/Scripts/check-payload-not-empty.sh final_payload_summary.json
+        shell: bash
+
       - name: Report payload metrics to New Relic (staging)
         if: inputs.aggregate_payload_data == true || github.event_name == 'schedule'
         continue-on-error: true

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -152,42 +152,23 @@ jobs:
             echo "Found TRX files:"
             echo "$TRX_FILES"
 
-            # Extract payload lines from all TRX files and build JSON
-            echo "{" > "$PAYLOAD_LOG"
-            first=true
+            rows="$(mktemp)"
+            while IFS= read -r trx_file; do
+              [ -n "$trx_file" ] || continue
+              grep -hoE '[A-Za-z0-9_]+:[[:space:]]+[a-z0-9_]+:[[:space:]]+[0-9]+[[:space:]]+bytes' "$trx_file" \
+                | sed -E 's/^([A-Za-z0-9_]+):[[:space:]]+([a-z0-9_]+):[[:space:]]+([0-9]+)[[:space:]]+bytes/\1 \2 \3/' >> "$rows" || true
+            done <<< "$TRX_FILES"
+            jq -Rn '[inputs | split(" ") | {c:.[0], cat:.[1], b:(.[2]|tonumber)}]
+              | reduce .[] as $r ({}; .[$r.c][$r.cat] = ((.[$r.c][$r.cat]//0) + $r.b))' "$rows" > "$PAYLOAD_LOG"
+            rm -f "$rows"
 
-            for trx_file in $TRX_FILES; do
-              echo "Processing: $trx_file"
-              # Extract payload lines from StdOut elements (including test class name prefix)
-              while IFS= read -r line; do
-                if [[ "$line" =~ ^([A-Za-z0-9_]+):\ Total\ payload\ bytes\ sent:\ ([0-9]+) ]]; then
-                  className="${BASH_REMATCH[1]}"
-                  byteCount="${BASH_REMATCH[2]}"
-                  echo "Found: $className = $byteCount bytes"
-
-                  if [ "$first" = true ]; then
-                    first=false
-                  else
-                    echo "," >> "$PAYLOAD_LOG"
-                  fi
-                  echo "  \"$className\": $byteCount" >> "$PAYLOAD_LOG"
-                fi
-              done < <(grep -E '[A-Za-z0-9_]+: Total payload bytes sent: [0-9]+' "$trx_file" || true)
-            done
-
-            echo "" >> "$PAYLOAD_LOG"
-            echo "}" >> "$PAYLOAD_LOG"
-
-            # Check if we found any payload entries
-            content=$(cat "$PAYLOAD_LOG")
-            if [[ "$content" != "{}" && "$content" != $'{\n}' ]]; then
-              echo "Extracted payload log entries"
-              echo "Content:"
-              cat "$PAYLOAD_LOG"
+            if [ "$(cat "$PAYLOAD_LOG")" = "{}" ]; then
+              echo "No matching payload byte lines found in TRX files"
             else
-              echo "No payload byte logs found in TRX files"
-              echo "{}" > "$PAYLOAD_LOG"
+              echo "Extracted payload log entries"
             fi
+            echo "Content:"
+            cat "$PAYLOAD_LOG"
           fi
         shell: bash
 
@@ -231,60 +212,30 @@ jobs:
       - name: Combine payload logs
         run: |
           mkdir -p combined-logs
+          IN_DIR="payload-logs/linux-container"
+          PREFIX="linux_container"
+          LABEL="Linux Container Tests"
+          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
+          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-          if [ -d "payload-logs/linux-container" ]; then
-            echo "["  > combined-logs/linux_container_payload_bytes_combined.json
-            first=true
-            grand_total=0
-
-            # Process JSON files and merge into array
-            while IFS= read -r file; do
-              echo "Processing: $(basename "$file")"
-
-              # Read JSON and extract key-value pairs
-              while IFS= read -r line; do
-                # Skip lines that are just braces or empty
-                if [[ "$line" =~ ^[[:space:]]*\{[[:space:]]*$ ]] || [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]] || [[ -z "$line" ]]; then
-                  continue
-                fi
-
-                # Extract class name and byte count from JSON property
-                if [[ "$line" =~ \"([^\"]+)\":[[:space:]]*([0-9]+) ]]; then
-                  className="${BASH_REMATCH[1]}"
-                  byteCount="${BASH_REMATCH[2]}"
-                  grand_total=$((grand_total + byteCount))
-
-                  if [ "$first" = true ]; then
-                    first=false
-                  else
-                    echo "," >> combined-logs/linux_container_payload_bytes_combined.json
-                  fi
-                  echo "  {\"className\": \"$className\", \"payloadBytes\": $byteCount}" >> combined-logs/linux_container_payload_bytes_combined.json
-                fi
-              done < "$file"
-            done < <(find payload-logs/linux-container -name "*_payload_bytes.json" -type f | sort)
-
-            echo "" >> combined-logs/linux_container_payload_bytes_combined.json
-            echo "]" >> combined-logs/linux_container_payload_bytes_combined.json
-
-            # Create summary metadata file
-            echo "{" > combined-logs/linux_container_payload_bytes_summary.json
-            echo "  \"testType\": \"Linux Container Tests\"," >> combined-logs/linux_container_payload_bytes_summary.json
-            echo "  \"generatedAt\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"," >> combined-logs/linux_container_payload_bytes_summary.json
-            echo "  \"grandTotalBytes\": $grand_total" >> combined-logs/linux_container_payload_bytes_summary.json
-            echo "}" >> combined-logs/linux_container_payload_bytes_summary.json
-
-            echo "Combined payload JSON created with grand total: $grand_total bytes"
-            echo "Payload data:"
-            cat combined-logs/linux_container_payload_bytes_combined.json
-            echo ""
-            echo "Summary:"
-            cat combined-logs/linux_container_payload_bytes_summary.json
+          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
+              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
+                (reduce .[] as $ns ({};
+                   reduce ($ns|to_entries[]) as $c (.;
+                     reduce ($c.value|to_entries[]) as $cat (.;
+                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
+                | { testType: $tt, generatedAt: $now,
+                    grandTotalBytes: ([$m[][]] | add // 0),
+                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
+                    byType: (reduce ($m|to_entries[]) as $c ({};
+                               reduce ($c.value|to_entries[]) as $cat (.;
+                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
           else
-            echo "No Linux container payload logs found"
-            echo "[]" > combined-logs/linux_container_payload_bytes_combined.json
-            echo "{\"testType\": \"Linux Container Tests\", \"grandTotalBytes\": 0}" > combined-logs/linux_container_payload_bytes_summary.json
+            jq -n --arg tt "$LABEL" --arg now "$NOW" \
+              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
           fi
+          cat "$OUT"
         shell: bash
 
       - name: Upload combined Linux container payload log

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -219,6 +219,8 @@ jobs:
           NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
           if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
+            # strip any UTF-8 BOM so jq -s can parse the concatenated stream (defensive; container files are BOM-free)
+            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
             find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
               | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
                 (reduce .[] as $ns ({};

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -202,6 +202,9 @@ jobs:
           disable-sudo: true
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Download all Linux container payload artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -210,34 +213,7 @@ jobs:
           merge-multiple: true
 
       - name: Combine payload logs
-        run: |
-          mkdir -p combined-logs
-          IN_DIR="payload-logs/linux-container"
-          PREFIX="linux_container"
-          LABEL="Linux Container Tests"
-          OUT="combined-logs/${PREFIX}_payload_bytes_combined.json"
-          NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-          if [ -d "$IN_DIR" ] && find "$IN_DIR" -name "*_payload_bytes.json" -type f | grep -q .; then
-            # strip any UTF-8 BOM so jq -s can parse the concatenated stream (defensive; container files are BOM-free)
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
-            find "$IN_DIR" -name "*_payload_bytes.json" -type f -print0 \
-              | xargs -0 jq -s --arg tt "$LABEL" --arg now "$NOW" '
-                (reduce .[] as $ns ({};
-                   reduce ($ns|to_entries[]) as $c (.;
-                     reduce ($c.value|to_entries[]) as $cat (.;
-                       .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
-                | { testType: $tt, generatedAt: $now,
-                    grandTotalBytes: ([$m[][]] | add // 0),
-                    details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
-                    byType: (reduce ($m|to_entries[]) as $c ({};
-                               reduce ($c.value|to_entries[]) as $cat (.;
-                                 .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
-          else
-            jq -n --arg tt "$LABEL" --arg now "$NOW" \
-              '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
-          fi
-          cat "$OUT"
+        run: bash build/Scripts/combine-payload-logs.sh payload-logs/linux-container "Linux Container Tests" combined-logs/linux_container_payload_bytes_combined.json
         shell: bash
 
       - name: Upload combined Linux container payload log

--- a/build/Scripts/check-payload-not-empty.sh
+++ b/build/Scripts/check-payload-not-empty.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Guard: fail loudly if the consolidated payload summary reports (near-)zero total bytes.
+#
+# When payload aggregation runs, the test suites always send a large amount of
+# data (every test app at least does a connect handshake), so an overall total
+# of zero is never legitimate - it means the TRX / agent-log parsing broke
+# (e.g. a log-line format change) somewhere upstream. Without this guard the
+# pipeline would silently report zeros to New Relic and the dashboard would
+# flatline with no failure. This step turns that silent failure into a loud one.
+#
+# Usage:
+#   check-payload-not-empty.sh [SUMMARY_FILE]
+#   SUMMARY_FILE            path to final_payload_summary.json
+#                           (arg 1, or PAYLOAD_SUMMARY_FILE env var)
+#   MIN_EXPECTED_PAYLOAD_BYTES  floor; fail if total <= this (default 0).
+#                               Raise it later to catch partial breakage too.
+#
+# Exit codes:
+#   0  total is above the floor
+#   1  summary file missing/unparseable, or total <= floor
+set -euo pipefail
+
+SUMMARY_FILE="${1:-${PAYLOAD_SUMMARY_FILE:-}}"
+FLOOR="${MIN_EXPECTED_PAYLOAD_BYTES:-0}"
+
+if [ -z "$SUMMARY_FILE" ] || [ ! -f "$SUMMARY_FILE" ]; then
+  echo "ERROR: payload summary file not found (got '$SUMMARY_FILE')." >&2
+  exit 1
+fi
+
+total="$(jq -r '(.bytes // 0) | floor' "$SUMMARY_FILE" 2>/dev/null || true)"
+case "$total" in
+  '' | *[!0-9]*)
+    echo "ERROR: could not read a numeric total from '$SUMMARY_FILE' (got '$total')." >&2
+    exit 1
+    ;;
+esac
+
+echo "Overall payload bytes: $total (floor: $FLOOR)"
+if [ "$total" -le "$FLOOR" ]; then
+  echo "ERROR: payload total ($total) is at or below the floor ($FLOOR)." >&2
+  echo "This almost certainly means the TRX / agent-log parsing broke (e.g. a log-line" >&2
+  echo "format change), not a real zero. Failing so it is investigated instead of" >&2
+  echo "silently reporting zeros to New Relic." >&2
+  exit 1
+fi
+
+echo "Payload guard passed."

--- a/build/Scripts/combine-payload-logs.sh
+++ b/build/Scripts/combine-payload-logs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Combine per-namespace payload-bytes JSON files into one per-test-type summary.
+#
+# Each input file is nested {className: {category: bytes}} (produced by the
+# "Extract payload bytes log from TRX" steps). This merges all of them for one
+# test type and emits the combined schema consumed by the final-merge step:
+#   { testType, generatedAt, grandTotalBytes, details: [{className, bytes}], byType: {category: bytes} }
+#
+# Single-sourced on purpose: all three aggregate jobs (integration, unbounded,
+# container) call this, so the schema and merge logic live in exactly one place.
+#
+# Usage: combine-payload-logs.sh <IN_DIR> <LABEL> <OUT>
+#   IN_DIR  directory of downloaded *_payload_bytes.json files
+#   LABEL   testType label, e.g. "Integration Tests"
+#   OUT     output path for the combined JSON
+set -euo pipefail
+
+IN_DIR="${1:?usage: combine-payload-logs.sh <IN_DIR> <LABEL> <OUT>}"
+LABEL="${2:?usage: combine-payload-logs.sh <IN_DIR> <LABEL> <OUT>}"
+OUT="${3:?usage: combine-payload-logs.sh <IN_DIR> <LABEL> <OUT>}"
+NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+mkdir -p "$(dirname "$OUT")"
+
+if [ -d "$IN_DIR" ] && find "$IN_DIR" -name '*_payload_bytes.json' -type f | grep -q .; then
+  # The PowerShell extractors write UTF-8 with a BOM; strip it so jq can parse
+  # the concatenated stream. (Container files are already BOM-free; no-op there.)
+  find "$IN_DIR" -name '*_payload_bytes.json' -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
+  # `xargs -0 cat | jq -s` keeps it a single jq invocation even if the file list
+  # would exceed ARG_MAX (a split xargs would otherwise emit concatenated JSON).
+  find "$IN_DIR" -name '*_payload_bytes.json' -type f -print0 | xargs -0 cat \
+    | jq -s --arg tt "$LABEL" --arg now "$NOW" '
+      (reduce .[] as $ns ({};
+         reduce ($ns|to_entries[]) as $c (.;
+           reduce ($c.value|to_entries[]) as $cat (.;
+             .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
+      | { testType: $tt, generatedAt: $now,
+          grandTotalBytes: ([$m[][]] | add // 0),
+          details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
+          byType: (reduce ($m|to_entries[]) as $c ({};
+                     reduce ($c.value|to_entries[]) as $cat (.;
+                       .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
+else
+  jq -n --arg tt "$LABEL" --arg now "$NOW" \
+    '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
+fi
+
+echo "Combined -> $OUT"
+cat "$OUT"

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -40,7 +40,7 @@ build_body() {
     --arg commit "${CI_COMMIT:-unknown}" \
     --arg runId "${CI_RUN_ID:-unknown}" \
     --arg runUrl "${CI_RUN_URL:-unknown}" '
-    ([ to_entries[] | select(.value|type=="object") ]) as $types
+    ([ to_entries[] | select(.value|type=="object" and has("details")) ]) as $types
     | [ {
         common: { timestamp: ($ts|tonumber),
                   attributes: { source:"dotnet-agent-ci", "ci.branch":$branch,
@@ -54,6 +54,12 @@ build_body() {
                value:.value.bytes, attributes:{testType:.key}} ]
           + [ {name:"newrelic.dotnet.ci.payload.total.bytes", type:"gauge",
                value:(.bytes // 0), attributes:{testType:"all"}} ]
+          + [ $types[] | .key as $t | (.value.byType // {}) | to_entries[]
+            | {name:"newrelic.dotnet.ci.payload.by_type.bytes", type:"gauge",
+               value:.value, attributes:{testType:$t, payloadType:.key}} ]
+          + [ (.byType // {}) | to_entries[]
+            | {name:"newrelic.dotnet.ci.payload.by_type.bytes", type:"gauge",
+               value:.value, attributes:{testType:"all", payloadType:.key}} ]
         )
       } ]
   ' "$SUMMARY_FILE"

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Report aggregated CI payload sizes to the New Relic Metric API.
+# Reads final_payload_summary.json (produced by all_solutions.yml), transforms
+# it into Metric API JSON, and POSTs it to New Relic (staging by default).
+#
+# Env vars:
+#   PAYLOAD_SUMMARY_FILE  Path to final_payload_summary.json (required)
+#   NR_METRIC_API_URL     Metric API endpoint (required unless dry-run)
+#   NR_TEST_SECRETS       Raw TEST_SECRETS JSON, may carry a UTF-8 BOM
+#                         (required unless dry-run). License key is read from
+#                         .IntegrationTestConfiguration.DefaultSetting.LicenseKey
+#   CI_BRANCH CI_COMMIT CI_RUN_ID CI_RUN_URL   Optional metadata attributes
+#   DRY_RUN               "1"/"true" => print request body to stdout, do not POST
+#
+# Exit codes:
+#   0  success (HTTP 202), dry-run, or intentional skip (no file / key / url)
+#   1  POST attempted but response was not HTTP 202
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-}"
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+is_dry_run() { [ "$DRY_RUN" = "1" ] || [ "$DRY_RUN" = "true" ]; }
+
+SUMMARY_FILE="${PAYLOAD_SUMMARY_FILE:-}"
+if [ -z "$SUMMARY_FILE" ] || [ ! -f "$SUMMARY_FILE" ]; then
+  echo "WARNING: payload summary file not found (PAYLOAD_SUMMARY_FILE='$SUMMARY_FILE'); skipping." >&2
+  exit 0
+fi
+
+# Build the Metric API request body from the summary artifact.
+# - per-class gauge (deduped by testType+className)
+# - per-type total gauge, plus an "all" rollup gauge
+build_body() {
+  local ts_ms="$1"
+  jq -c \
+    --arg ts "$ts_ms" \
+    --arg branch "${CI_BRANCH:-unknown}" \
+    --arg commit "${CI_COMMIT:-unknown}" \
+    --arg runId "${CI_RUN_ID:-unknown}" \
+    --arg runUrl "${CI_RUN_URL:-unknown}" '
+    ([ to_entries[] | select(.value|type=="object") ]) as $types
+    | [ {
+        common: { timestamp: ($ts|tonumber),
+                  attributes: { source:"dotnet-agent-ci", "ci.branch":$branch,
+                                "ci.commit":$commit, "ci.runId":$runId, "ci.runUrl":$runUrl } },
+        metrics: (
+          [ $types[] | .key as $t | (.value.details // [])
+            | group_by(.className)[]
+            | {name:"newrelic.dotnet.ci.payload.bytes", type:"gauge",
+               value:(map(.bytes)|add), attributes:{testType:$t, className:.[0].className}} ]
+          + [ $types[] | {name:"newrelic.dotnet.ci.payload.total.bytes", type:"gauge",
+               value:.value.bytes, attributes:{testType:.key}} ]
+          + [ {name:"newrelic.dotnet.ci.payload.total.bytes", type:"gauge",
+               value:(.bytes // 0), attributes:{testType:"all"}} ]
+        )
+      } ]
+  ' "$SUMMARY_FILE"
+}
+
+TS_MS="$(date +%s%3N)"
+BODY_FILE="$(mktemp)"
+RESP_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$RESP_FILE"' EXIT
+
+build_body "$TS_MS" > "$BODY_FILE"
+METRIC_COUNT="$(jq '.[0].metrics | length' "$BODY_FILE")"
+echo "Built $METRIC_COUNT metrics from $SUMMARY_FILE (timestamp ${TS_MS}ms)." >&2
+
+if is_dry_run; then
+  cat "$BODY_FILE"
+  exit 0
+fi
+
+# Extract the license key (Api-Key) from TEST_SECRETS; strip a possible UTF-8 BOM.
+LICENSE_KEY=""
+if [ -n "${NR_TEST_SECRETS:-}" ]; then
+  LICENSE_KEY="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//' \
+    | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty')"
+fi
+if [ -z "$LICENSE_KEY" ]; then
+  echo "WARNING: no New Relic license key available; skipping." >&2
+  exit 0
+fi
+if [ -z "${NR_METRIC_API_URL:-}" ]; then
+  echo "WARNING: NR_METRIC_API_URL not set; skipping." >&2
+  exit 0
+fi
+
+HTTP_CODE="$(curl -s --connect-timeout 10 --max-time 30 -o "$RESP_FILE" -w '%{http_code}' \
+  -H "Content-Type: application/json" \
+  -H "Api-Key: $LICENSE_KEY" \
+  -X POST "$NR_METRIC_API_URL" \
+  --data-binary @"$BODY_FILE")"
+
+if [ "$HTTP_CODE" = "202" ]; then
+  echo "New Relic Metric API accepted the payload (HTTP 202). requestId=$(jq -r '.requestId // "unknown"' "$RESP_FILE")" >&2
+  exit 0
+fi
+
+echo "ERROR: New Relic Metric API returned HTTP $HTTP_CODE" >&2
+echo "Response: $(cat "$RESP_FILE")" >&2
+exit 1

--- a/build/Scripts/tests/fixtures/sample-payload-summary.json
+++ b/build/Scripts/tests/fixtures/sample-payload-summary.json
@@ -2,6 +2,7 @@
   "integrationTests": {
     "generatedAt": "2026-07-01T00:00:00Z",
     "bytes": 300,
+    "byType": {"connect": 120, "metric_data": 180},
     "details": [
       {"className": "AlphaTests", "bytes": 100},
       {"className": "BetaTests", "bytes": 50},
@@ -11,9 +12,11 @@
   "unboundedTests": {
     "generatedAt": "2026-07-01T00:00:00Z",
     "bytes": 25,
+    "byType": {"connect": 25},
     "details": [
       {"className": "GammaTests", "bytes": 25}
     ]
   },
+  "byType": {"connect": 145, "metric_data": 180},
   "bytes": 325
 }

--- a/build/Scripts/tests/fixtures/sample-payload-summary.json
+++ b/build/Scripts/tests/fixtures/sample-payload-summary.json
@@ -1,0 +1,19 @@
+{
+  "integrationTests": {
+    "generatedAt": "2026-07-01T00:00:00Z",
+    "bytes": 300,
+    "details": [
+      {"className": "AlphaTests", "bytes": 100},
+      {"className": "BetaTests", "bytes": 50},
+      {"className": "AlphaTests", "bytes": 150}
+    ]
+  },
+  "unboundedTests": {
+    "generatedAt": "2026-07-01T00:00:00Z",
+    "bytes": 25,
+    "details": [
+      {"className": "GammaTests", "bytes": 25}
+    ]
+  },
+  "bytes": 325
+}

--- a/build/Scripts/tests/test-check-payload-not-empty.sh
+++ b/build/Scripts/tests/test-check-payload-not-empty.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tests for check-payload-not-empty.sh: the guard must pass on a real total and
+# fail on zero / missing bytes / missing file / below-floor.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../check-payload-not-empty.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Non-zero total -> pass (exit 0).
+echo '{"bytes": 69209939, "byType": {}}' > "$tmp/ok.json"
+bash "$SCRIPT" "$tmp/ok.json" >/dev/null 2>&1 || fail "expected pass on non-zero total"
+
+# Zero total -> fail (exit 1).
+echo '{"bytes": 0, "byType": {}}' > "$tmp/zero.json"
+if bash "$SCRIPT" "$tmp/zero.json" >/dev/null 2>&1; then fail "expected failure on zero total"; fi
+
+# Missing bytes field (treated as 0) -> fail.
+echo '{"byType": {}}' > "$tmp/missing.json"
+if bash "$SCRIPT" "$tmp/missing.json" >/dev/null 2>&1; then fail "expected failure on missing bytes field"; fi
+
+# Missing file -> fail.
+if bash "$SCRIPT" "$tmp/does-not-exist.json" >/dev/null 2>&1; then fail "expected failure on missing file"; fi
+
+# Below an explicit floor -> fail.
+echo '{"bytes": 500}' > "$tmp/low.json"
+if MIN_EXPECTED_PAYLOAD_BYTES=1000 bash "$SCRIPT" "$tmp/low.json" >/dev/null 2>&1; then fail "expected failure below floor"; fi
+
+# Above an explicit floor -> pass.
+echo '{"bytes": 5000}' > "$tmp/high.json"
+MIN_EXPECTED_PAYLOAD_BYTES=1000 bash "$SCRIPT" "$tmp/high.json" >/dev/null 2>&1 || fail "expected pass above floor"
+
+echo "PASS: all guard assertions passed"

--- a/build/Scripts/tests/test-combine-payload-logs.sh
+++ b/build/Scripts/tests/test-combine-payload-logs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tests for combine-payload-logs.sh: BOM handling, cross-namespace merge, schema
+# consistency (grandTotal == sum(byType) == sum(details)), and the empty case.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../combine-payload-logs.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+IN="$tmp/in"
+mkdir -p "$IN"
+# ns A carries a UTF-8 BOM (as the PowerShell extractor would write); both
+# namespaces share class "Shared" to exercise cross-namespace summing.
+printf '\xEF\xBB\xBF{"AlphaTests":{"connect":100,"metric_data":200},"Shared":{"connect":10}}' > "$IN/a_payload_bytes.json"
+printf '{"BetaTests":{"connect":50},"Shared":{"metric_data":4}}' > "$IN/b_payload_bytes.json"
+
+OUT="$tmp/out.json"
+bash "$SCRIPT" "$IN" "Integration Tests" "$OUT" >/dev/null 2>&1 || fail "combine failed"
+jq -e . "$OUT" >/dev/null 2>&1 || fail "output is not valid JSON (BOM not stripped?)"
+
+grand="$(jq -r '.grandTotalBytes' "$OUT")"
+[ "$grand" = "364" ] || fail "expected grandTotalBytes 364, got $grand"        # 100+200+10 + 50+4
+[ "$(jq -r '.byType.connect' "$OUT")" = "160" ] || fail "expected byType.connect 160"   # 100+10+50
+[ "$(jq -r '.details[] | select(.className=="Shared") | .bytes' "$OUT")" = "14" ] || fail "expected Shared 14" # 10+4
+[ "$(jq -r '.testType' "$OUT")" = "Integration Tests" ] || fail "wrong testType label"
+
+sumBy="$(jq -r '[.byType[]]|add' "$OUT")"
+sumDet="$(jq -r '[.details[].bytes]|add' "$OUT")"
+{ [ "$grand" = "$sumBy" ] && [ "$grand" = "$sumDet" ]; } || fail "sums disagree: grand=$grand byType=$sumBy details=$sumDet"
+
+# Empty input dir -> valid empty summary.
+EMPTY="$tmp/empty"
+mkdir -p "$EMPTY"
+OUT2="$tmp/out2.json"
+bash "$SCRIPT" "$EMPTY" "Unbounded Integration Tests" "$OUT2" >/dev/null 2>&1 || fail "empty combine failed"
+[ "$(jq -r '.grandTotalBytes' "$OUT2")" = "0" ] || fail "expected grandTotalBytes 0 for empty input"
+[ "$(jq -r '.details|length' "$OUT2")" = "0" ] || fail "expected empty details for empty input"
+
+echo "PASS: all combine assertions passed"

--- a/build/Scripts/tests/test-report-payload-metrics.sh
+++ b/build/Scripts/tests/test-report-payload-metrics.sh
@@ -14,8 +14,8 @@ OUT="$(PAYLOAD_SUMMARY_FILE="$FIXTURE" DRY_RUN=1 bash "$SCRIPT")"
 
 echo "$OUT" | jq -e . >/dev/null 2>&1 || fail "dry-run output is not valid JSON"
 
-COUNT="$(echo "$OUT" | jq '.[0].metrics | length')"
-[ "$COUNT" = "6" ] || fail "expected 6 metrics, got $COUNT"
+BASE_COUNT="$(echo "$OUT" | jq '[.[0].metrics[] | select(.name=="newrelic.dotnet.ci.payload.bytes" or .name=="newrelic.dotnet.ci.payload.total.bytes")] | length')"
+[ "$BASE_COUNT" = "6" ] || fail "expected 6 per-class/total metrics, got $BASE_COUNT"
 
 ALPHA="$(echo "$OUT" | jq -r '.[0].metrics[]
   | select(.name=="newrelic.dotnet.ci.payload.bytes" and .attributes.className=="AlphaTests")
@@ -32,4 +32,20 @@ ALL="$(echo "$OUT" | jq -r '.[0].metrics[]
   | .value')"
 [ "$ALL" = "325" ] || fail "expected overall total 325, got $ALL"
 
-echo "PASS: all assertions passed ($COUNT metrics)"
+BYTYPE_COUNT="$(echo "$OUT" | jq '[.[0].metrics[]|select(.name=="newrelic.dotnet.ci.payload.by_type.bytes")]|length')"
+[ "$BYTYPE_COUNT" = "5" ] || fail "expected 5 by_type metrics, got $BYTYPE_COUNT"
+
+ALL_CONNECT="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.by_type.bytes" and .attributes.testType=="all" and .attributes.payloadType=="connect")
+  | .value')"
+[ "$ALL_CONNECT" = "145" ] || fail "expected all/connect by_type 145, got $ALL_CONNECT"
+
+INT_CONNECT="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.by_type.bytes" and .attributes.testType=="integrationTests" and .attributes.payloadType=="connect")
+  | .value')"
+[ "$INT_CONNECT" = "120" ] || fail "expected integrationTests/connect by_type 120, got $INT_CONNECT"
+
+TOTAL_COUNT="$(echo "$OUT" | jq '.[0].metrics|length')"
+[ "$TOTAL_COUNT" = "11" ] || fail "expected 11 metrics total, got $TOTAL_COUNT"
+
+echo "PASS: all assertions passed ($TOTAL_COUNT metrics)"

--- a/build/Scripts/tests/test-report-payload-metrics.sh
+++ b/build/Scripts/tests/test-report-payload-metrics.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Local test for report-payload-metrics.sh: runs the transform in dry-run mode
+# against a fixture and asserts the generated Metric API body is correct.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/../report-payload-metrics.sh"
+FIXTURE="$SCRIPT_DIR/fixtures/sample-payload-summary.json"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# In dry-run mode, stdout is exactly the Metric API body (one line of JSON).
+OUT="$(PAYLOAD_SUMMARY_FILE="$FIXTURE" DRY_RUN=1 bash "$SCRIPT")"
+
+echo "$OUT" | jq -e . >/dev/null 2>&1 || fail "dry-run output is not valid JSON"
+
+COUNT="$(echo "$OUT" | jq '.[0].metrics | length')"
+[ "$COUNT" = "6" ] || fail "expected 6 metrics, got $COUNT"
+
+ALPHA="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.bytes" and .attributes.className=="AlphaTests")
+  | .value')"
+[ "$ALPHA" = "250" ] || fail "expected AlphaTests deduped to 250, got $ALPHA"
+
+INT_TOTAL="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.total.bytes" and .attributes.testType=="integrationTests")
+  | .value')"
+[ "$INT_TOTAL" = "300" ] || fail "expected integrationTests total 300, got $INT_TOTAL"
+
+ALL="$(echo "$OUT" | jq -r '.[0].metrics[]
+  | select(.name=="newrelic.dotnet.ci.payload.total.bytes" and .attributes.testType=="all")
+  | .value')"
+[ "$ALL" = "325" ] || fail "expected overall total 325, got $ALL"
+
+echo "PASS: all assertions passed ($COUNT metrics)"


### PR DESCRIPTION
Reports the nightly aggregated CI payload sizes (from the existing `final_payload_summary.json` artifact) to New Relic **staging** via the Metric API, so a dashboard can track outbound-data ("billable-proxy") trends.

**What it does**
- New `build/Scripts/report-payload-metrics.sh`: `jq`-transforms the artifact into Metric API JSON and POSTs it. License key from the existing `TEST_SECRETS` (no new secret); staging endpoint; `--dry-run`; the report step is `continue-on-error`, so an ingest hiccup never blocks the build.
- Wires it into the `display-all-payload-summaries` job of `all_solutions.yml` (a `checkout` step + the report step); runs on schedule / manual dispatch only.

**Metrics** (account-level, staging):
- `newrelic.dotnet.ci.payload.bytes` - per test class (`testType`, `className`)
- `newrelic.dotnet.ci.payload.total.bytes` - per test type + `all` rollup (`testType`)
- `newrelic.dotnet.ci.payload.by_type.bytes` - per collector method (`testType`, `payloadType`), to separate billable telemetry (`metric_data`, `span_event_data`, ...) from non-billable control-plane (`connect`, `agent_settings`, ...)

**Payload-type plumbing:** to feed `by_type`, the three TRX extractors (integration + unbounded in `all_solutions.yml`, container in `linux_container_tests.yml`) now capture per-category bytes (`{className: {category: bytes}}`), and the combine/final-merge stages were refactored from echo-built JSON to `jq`.

**Reliability:** a `Guard against empty payload data` step (not `continue-on-error`) fails the aggregation job loudly if the consolidated total is zero - so a parsing break shows a red build instead of silently sending zeros.

**Tests:** each script has a test under `build/Scripts/tests/`; `shellcheck --severity=error` clean.

Validated end-to-end against real artifacts (HTTP 202, data confirmed in staging via NRQL; container extraction checked against a real TRX). Forward-only - the Metric API drops timestamps older than 48h, so no backfill.

Successful CI run including aggregation and reporting is at https://github.com/newrelic/newrelic-dotnet-agent/actions/runs/28608489310