### PR TITLE
test: Fix ExpectedErrorTests Sent-metric flake

### DIFF
--- a/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTestHelpers/AgentLogBase.cs
@@ -161,6 +161,29 @@ public abstract class AgentLogBase
         throw new Exception(message);
     }
 
+    public IEnumerable<Metric> WaitForMetricAggregateCallCount(string metricName, int minimumCallCount, TimeSpan timeout)
+    {
+        var deadline = DateTime.Now + timeout;
+        while (DateTime.Now < deadline)
+        {
+            var matches = GetMetrics().Where(m => m.MetricSpec.Name == metricName).ToList();
+            decimal totalCallCount = 0;
+            foreach (var match in matches)
+            {
+                totalCallCount += match.Values.CallCount;
+            }
+
+            if (totalCallCount >= minimumCallCount)
+            {
+                return matches;
+            }
+
+            Thread.Sleep(500);
+        }
+
+        throw new Exception($"Metric '{metricName}' did not reach an aggregate CallCount of {minimumCallCount} within {timeout.TotalSeconds:N0} seconds.");
+    }
+
     public IEnumerable<Match> WaitForLogLines(string regularExpression, TimeSpan? timeoutOrZero = null)
     {
         return WaitForLogLines(regularExpression, timeoutOrZero, 1);

--- a/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
+++ b/tests/Agent/IntegrationTests/IntegrationTests/Errors/ExpectedErrorTests.cs
@@ -42,6 +42,7 @@ public class ExpectedErrorTests : NewRelicIntegrationTest<RemoteServiceFixtures.
                 _fixture.ThrowExceptionWithMessage("test exception message");
                 _fixture.ThrowCustomException();
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.ErrorTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("Supportability/Events/TransactionError/Sent", 3, TimeSpan.FromMinutes(1));
             }
         );
         _fixture.Initialize();


### PR DESCRIPTION
Fixes an `ExpectedErrorTests.Test` flake where `Supportability/Events/TransactionError/Sent` read 1 instead of 3: `Sent` is shipped a metric-harvest after it's recorded, but the exercise tore the app down on a proxy signal (first error-trace harvest) before it propagated. Now waits on the asserted metric via a new `AgentLogBase.WaitForMetricAggregateCallCount` helper instead of widening the timing window. Verified passing against staging.
