### PR TITLE
test: Fix MsSqlQueryParamTests datastore-metric harvest race flake

### DIFF
--- a/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
+++ b/tests/Agent/IntegrationTests/UnboundedIntegrationTests/MsSql/MsSqlQueryParamTests.cs
@@ -61,6 +61,7 @@ public abstract class MsSqlQueryParamTestsBase<TFixture> : NewRelicIntegrationTe
             {
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.AgentConnectedLogLineRegex, TimeSpan.FromMinutes(1));
                 _fixture.AgentLog.WaitForLogLine(AgentLogBase.SqlTraceDataLogLineRegex, TimeSpan.FromMinutes(1));
+                _fixture.AgentLog.WaitForMetricAggregateCallCount("Datastore/all", 2, TimeSpan.FromMinutes(2));
             }
         );
 


### PR DESCRIPTION
Gate teardown of `MsSqlQueryParamTestsBase` on both datastore calls being harvested (`WaitForMetricAggregateCallCount("Datastore/all", 2, ...)`), fixing a harvest-cycle race where only the sync transaction's metrics were captured and the async transaction was absent (`Datastore/all` count 1 vs expected 2). Same remedy as the ExpectedErrorTests flake fix (#3680).