### PR TITLE
ci: retry test jobs once on transient failure; raise SE.Redis timeouts

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -657,7 +657,30 @@ jobs:
           $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
           $json | ConvertTo-Json | Out-File "${{ env.integration_tests_path }}/xunit.runner.json"
 
-          ${{ env.integration_tests_path }}/NewRelic.Agent.IntegrationTests.exe -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+          # Retry once on failure to absorb transient infrastructure blips (e.g. port
+          # contention, SSL cert / tooling startup races, or a flaky test-app launch) that
+          # can surface as a spurious failure while the code under test is healthy. A
+          # retried-but-passing job still emits a ::warning:: so genuine regressions /
+          # flake churn stay visible in the UI.
+          $maxAttempts = 2
+          $attempt = 1
+          while ($true) {
+            & "${{ env.integration_tests_path }}/NewRelic.Agent.IntegrationTests.exe" -namespace NewRelic.Agent.IntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -eq 0) {
+              if ($attempt -gt 1) {
+                Write-Host "::warning::Integration tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+              }
+              break
+            }
+            if ($attempt -ge $maxAttempts) {
+              Write-Host "Integration tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
+              exit $exitCode
+            }
+            Write-Host "Integration tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
+            $attempt++
+            Start-Sleep -Seconds 10
+          }
 
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "Get HostableWebCore errors (if any)"
@@ -850,7 +873,29 @@ jobs:
           $json | Add-Member -Name "parallelizeTestCollections" -Value $parallelize -MemberType NoteProperty
           $json | ConvertTo-Json | Out-File "${{ env.unbounded_tests_path }}/xunit.runner.json"
 
-          ${{ env.unbounded_tests_path }}/NewRelic.Agent.UnboundedIntegrationTests.exe -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+          # Retry once on failure to absorb transient WAN/infra blips between the GitHub-hosted
+          # runner and the Azure-hosted unbounded services (e.g. brief packet loss surfacing as a
+          # client command timeout while the service itself is healthy). A retried-but-passing job
+          # still emits a ::warning:: so genuine regressions / flake churn stay visible in the UI.
+          $maxAttempts = 2
+          $attempt = 1
+          while ($true) {
+            & "${{ env.unbounded_tests_path }}/NewRelic.Agent.UnboundedIntegrationTests.exe" -namespace NewRelic.Agent.UnboundedIntegrationTests.${{ matrix.namespace }} -trx "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -eq 0) {
+              if ($attempt -gt 1) {
+                Write-Host "::warning::Unbounded tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+              }
+              break
+            }
+            if ($attempt -ge $maxAttempts) {
+              Write-Host "Unbounded tests for ${{ matrix.namespace }} failed after $attempt attempt(s) (exit code $exitCode)."
+              exit $exitCode
+            }
+            Write-Host "Unbounded tests for ${{ matrix.namespace }} failed on attempt $attempt (exit code $exitCode); retrying once to absorb a possible transient blip..."
+            $attempt++
+            Start-Sleep -Seconds 10
+          }
 
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "Get HostableWebCore errors (if any)"

--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -35,7 +35,11 @@ jobs:
             uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
             id: filter
             with:
-              base: ${{ github.ref }}
+              # 'base' is ignored (and warns) on pull_request events, where the action
+              # auto-detects the PR base branch; only pass it for push/schedule/etc.
+              # Note: the '!=' form avoids the GitHub Actions ternary pitfall where an
+              # empty-string middle operand is falsy and falls through to github.ref.
+              base: ${{ github.event_name != 'pull_request' && github.ref || '' }}
               # Look for source files that were modified, excluding workflow files and unbounded services
               predicate-quantifier: 'every'             
               filters: |

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -128,13 +128,38 @@ jobs:
       - name: Build & Run Linux Container Integration Tests
         env:
           BUILD_ARCH: ${{ matrix.arch }}
-        run: >-
-          dotnet test ./tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj
-          --framework net10.0
-          --filter "Architecture=${{ matrix.arch }}&Distro=${{ matrix.distro }}"
-          --logger "console;verbosity=detailed"
-          --logger "trx;verbosity=detailed"
-          --results-directory ${{ env.test_results_path }}
+        run: |
+          # Retry once on failure to absorb transient infrastructure blips (e.g. container
+          # image pulls, Docker networking, or service-container startup races) that can
+          # surface as a spurious failure while the code under test is healthy. A
+          # retried-but-passing job still emits a ::warning:: so genuine regressions /
+          # flake churn stay visible in the UI.
+          max_attempts=2
+          attempt=1
+          while true; do
+            set +e
+            dotnet test ./tests/Agent/IntegrationTests/ContainerIntegrationTests/ContainerIntegrationTests.csproj \
+              --framework net10.0 \
+              --filter "Architecture=${{ matrix.arch }}&Distro=${{ matrix.distro }}" \
+              --logger "console;verbosity=detailed" \
+              --logger "trx;verbosity=detailed" \
+              --results-directory ${{ env.test_results_path }}
+            exit_code=$?
+            set -e
+            if [ $exit_code -eq 0 ]; then
+              if [ $attempt -gt 1 ]; then
+                echo "::warning::Container tests for ${{ matrix.arch }}/${{ matrix.distro }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+              fi
+              break
+            fi
+            if [ $attempt -ge $max_attempts ]; then
+              echo "Container tests for ${{ matrix.arch }}/${{ matrix.distro }} failed after $attempt attempt(s) (exit code $exit_code)."
+              exit $exit_code
+            fi
+            echo "Container tests for ${{ matrix.arch }}/${{ matrix.distro }} failed on attempt $attempt (exit code $exit_code); retrying once to absorb a possible transient blip..."
+            attempt=$((attempt + 1))
+            sleep 10
+          done
 
       - name: Extract payload bytes log from TRX
         if: inputs.aggregate_payload_data == true

--- a/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Dockerfile
+++ b/tests/Agent/IntegrationTests/ContainerApplications/AwsSdkTestApp/Dockerfile
@@ -10,15 +10,15 @@ EXPOSE 80
 FROM --platform=${BUILD_ARCH} mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-${DISTRO_TAG} AS build 
 ARG TARGET_ARCH
 WORKDIR /src
+COPY ["AwsSdkTestApp/AwsSdkTestApp.csproj", "AwsSdkTestApp/"]
+RUN dotnet restore "AwsSdkTestApp/AwsSdkTestApp.csproj" -a ${TARGET_ARCH}
 
-COPY ./AwsSdkTestApp ./ContainerApplications/AwsSdkTestApp
-RUN dotnet restore "ContainerApplications/AwsSdkTestApp/AwsSdkTestApp.csproj"  -a ${TARGET_ARCH}
-
-WORKDIR "/src/ContainerApplications/AwsSdkTestApp"
-RUN dotnet build "AwsSdkTestApp.csproj" -c Release -o /app/build --os linux -a ${TARGET_ARCH}
+COPY . .
+WORKDIR "/src/AwsSdkTestApp"
+RUN dotnet build "AwsSdkTestApp.csproj" -c Release -o /app/build --os linux -a ${TARGET_ARCH} --no-restore
 
 FROM build AS publish
-RUN dotnet publish "AwsSdkTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false --os linux -a ${TARGET_ARCH}
+RUN dotnet publish "AwsSdkTestApp.csproj" -c Release -o /app/publish /p:UseAppHost=false --os linux -a ${TARGET_ARCH} --no-restore
 
 FROM base AS final
 

--- a/tests/Agent/IntegrationTests/ContainerApplications/Directory.Build.props
+++ b/tests/Agent/IntegrationTests/ContainerApplications/Directory.Build.props
@@ -1,0 +1,19 @@
+<Project>
+  <!-- Host builds: chain to the IntegrationTests/root Directory.Build.props so
+       these projects keep TreatWarningsAsErrors, the shared NoWarn set, etc.
+       Inside the container the Docker build context is only this folder, so
+       GetPathOfFileAbove finds nothing above /src and the import is skipped.
+       The path is resolved into a property first because nesting the
+       GetPathOfFileAbove call (with its quoted args) directly inside an Import
+       Condition trips the MSBuild condition parser (MSB4092). -->
+  <PropertyGroup>
+    <_ParentDirectoryBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))</_ParentDirectoryBuildProps>
+  </PropertyGroup>
+  <Import Project="$(_ParentDirectoryBuildProps)" Condition="'$(_ParentDirectoryBuildProps)' != ''" />
+  <PropertyGroup>
+    <!-- Container apps compile inside an isolated Docker context that never sees the
+         IntegrationTests Directory.Build.props, so restate the naming-convention
+         suppression here. VSTHRD002 is handled per call site with pragmas instead. -->
+    <NoWarn>$(NoWarn);VSTHRD200</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Producer.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/KafkaTestApp/Producer.cs
@@ -125,10 +125,14 @@ public class Producer
                     throw new InvalidOperationException("Kafka metadata returned zero brokers.");
                 }
 
+                // Deliberate synchronous wait: CreateTopic is synchronous startup setup and
+                // Confluent.Kafka's AdminClient only exposes CreateTopicsAsync.
+#pragma warning disable VSTHRD002
                 adminClient.CreateTopicsAsync(new TopicSpecification[] {
                     new TopicSpecification { Name = _topic, ReplicationFactor = 1, NumPartitions = 1 },
                     new TopicSpecification { Name = _burstTopic, ReplicationFactor = 1, NumPartitions = 1 }
                 }).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
 
                 _logger.LogInformation("Created topics '{Topic}' and '{BurstTopic}' on attempt {Attempt}.",
                     _topic, _burstTopic, attempt);

--- a/tests/Agent/IntegrationTests/ContainerApplications/W3CTestApp/Controllers/W3CController.cs
+++ b/tests/Agent/IntegrationTests/ContainerApplications/W3CTestApp/Controllers/W3CController.cs
@@ -63,9 +63,13 @@ public class W3CController : ControllerBase
         foreach (var model in models)
         {
             var request = BuildHttpRequest(model);
+            // Deliberate synchronous wait: the calls must run synchronously and in order so the
+            // agent injects the W3C trace context headers the harness validates (see comment above).
+#pragma warning disable VSTHRD002
             _ = client
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
                 .Result;
+#pragma warning restore VSTHRD002
         }
     }
 

--- a/tests/Agent/IntegrationTests/Directory.Build.props
+++ b/tests/Agent/IntegrationTests/Directory.Build.props
@@ -5,7 +5,8 @@
     <NoWarn>
       VSTHRD200, <!-- Use `Async` suffix for async methods -->
       VSTHRD105, <!-- Avoid method overloads that assume `TaskScheduler.Current` -->
-      VSTHRD002 <!-- Avoid problematic synchronous waits -->
+      VSTHRD002, <!-- Avoid problematic synchronous waits -->
+      NETSDK1198 <!-- SDK-style test apps have no classic LocalDeploy MSDeploy profile; PublishProfile is applied solution-wide -->
     </NoWarn>
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
+++ b/tests/Agent/IntegrationTests/SharedApplications/Common/MultiFunctionApplicationHelpers/NetStandardLibraries/StackExchangeRedisExerciser.cs
@@ -133,6 +133,17 @@ public class StackExchangeRedisExerciser
             var connectionString = StackExchangeRedisConfiguration.StackExchangeRedisConnectionString;
             _redisConfigOptions = ConfigurationOptions.Parse(connectionString);
             _redisConfigOptions.Password = StackExchangeRedisConfiguration.StackExchangeRedisPassword;
+
+            // These tests run from GitHub-hosted runners across the public internet to Azure-hosted
+            // Redis. Transient WAN packet-loss stalls can exceed the 5s SE.Redis defaults and surface
+            // as "Timeout performing <cmd>" flakes even when the server is healthy. Raise the timeouts
+            // to ride out brief blips. Command-level retries are deliberately NOT used -- they would
+            // add extra instrumented calls and perturb the metric call counts these tests assert on.
+            // Note: only properties present since SE.Redis 1.x are set here (oldest pinned is 1.x);
+            // AsyncTimeout (2.0+) is intentionally omitted, and in 1.x SyncTimeout governs async waits too.
+            _redisConfigOptions.SyncTimeout = 30000;
+            _redisConfigOptions.ConnectTimeout = 30000;
+            _redisConfigOptions.ConnectRetry = 5;
         }
         return _redisConfigOptions;
     }


### PR DESCRIPTION
Absorbs transient CI flakes without masking real regressions, and quiets long-standing container-test build warnings.

- Integration, unbounded, and container test jobs now retry once on failure. A retried-but-passing run still emits a `::warning::` so genuine flake churn stays visible. A successful retry will show a warning message in the workflow results similar to this: 
<img width="741" height="155" alt="image" src="https://github.com/user-attachments/assets/08735d71-9c19-48d8-89e0-f075d032e6a4" />

- SE.Redis client Sync/Connect timeouts and ConnectRetry raised to ride out brief WAN blips between GitHub-hosted runners and Azure-hosted Redis. Command-level retries deliberately avoided to keep instrumented call counts stable.
- Suppress container-test build warnings: container apps build in an isolated Docker context that never sees the `IntegrationTests/Directory.Build.props` vs-threading suppressions. Added a `ContainerApplications/Directory.Build.props` (VSTHRD200, chained to the parent on host builds), pragma-suppressed the two deliberate synchronous waits (VSTHRD002) in KafkaTestApp/W3CTestApp, and suppressed the benign NETSDK1198 `LocalDeploy` publish-profile warning for SDK-style test apps.
- Eliminate a warning from the check_modified_files.yml workflow