### PR TITLE
chore: add agent-skills config for engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,3 +234,21 @@ only when no suitable overload exists *and* the call is not on a hot path.
 - Compact namespaces: `namespace NewRelic::Profiler::Logger { ... }`.
 - `.clang-format` at the profiler solution root is authoritative.
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in Jira (New Relic, project `NR`) via the Atlassian MCP;
+the GitHub repo is a public code/PR mirror. External PRs are not a triage
+surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical role strings used as-is as Jira labels. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See
+`docs/agents/domain.md`.
+

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,124 @@
+# New Relic .NET Agent
+
+Domain glossary for the .NET APM agent. This file is a glossary and nothing
+else -- it names concepts, it does not describe how they are implemented.
+
+## Language
+
+### Work and timing
+
+**Transaction**:
+One unit of work inside a single process -- a web request or a background
+job. It is the root that contains the tree of segments, and it owns the
+sampling decision for that work.
+_Avoid_: request (too HTTP-specific), unit-of-work, activity
+
+**Segment**:
+A single timed node in a transaction's call tree (a method call, an external
+call, a database query). Segments are the agent's internal timing primitive
+and always exist while a transaction is running.
+_Avoid_: node, frame, operation
+
+### Tracing
+
+A segment can be projected outward two independent ways: into a transaction
+trace and into a span. Neither projection changes the segment; both are views
+of it. Because "trace" alone is ambiguous, it is a forbidden term -- always
+qualify it. A tracer (see Instrumentation and extensions) is a different
+concept and is not any kind of trace.
+
+**Span**:
+The distributed-tracing projection of a segment -- the event emitted so a
+segment can join a trace that spans processes. A span exists only when span
+events are enabled; a segment without span events emitted is not a span.
+_Avoid_: bare "trace", segment (a span is the outward view, not the node)
+
+**Root span**:
+The single parent-less span that represents the transaction itself -- the
+entry point of the process's work. Distributed tracing requires exactly one
+parent-less span per transaction, and this is it.
+_Avoid_: entry span, top segment, faux span
+
+**Transaction trace**:
+The detailed segment tree of one transaction, captured as a sample (typically
+a slow one) for the single-process waterfall view. Scoped to one process.
+_Avoid_: bare "trace", trace details, transaction sample
+
+**Distributed trace**:
+The cross-process trace, identified by a trace id and assembled from the span
+events of many transactions across many services.
+_Avoid_: bare "trace", DT (spell it out in prose)
+
+### Instrumentation and extensions
+
+**Instrumentation**:
+The mechanism by which the profiler rewrites JIT-compiled methods so their
+calls route into the agent -- IL injection. "Instrument a method" means to
+target it for this rewriting.
+_Avoid_: hooking, patching, weaving
+
+**Instrumentation XML**:
+The declarative files that tell the profiler which methods to rewrite and
+which wrapper to invoke for each. The recipe, not the mechanism.
+_Avoid_: instrumentation set, config (it is not newrelic.config)
+
+**Instrumented method**:
+A specific method that instrumentation has targeted, so its calls are routed
+through a wrapper.
+_Avoid_: hooked method, wrapped method (the method is instrumented; the call
+is wrapped)
+
+**Wrapper**:
+The managed code that runs when an instrumented method is called: it
+recognizes the method, starts a segment, and finishes it when the call
+returns. Thin by design -- interesting logic belongs in the
+NewRelic.Agent.Extensions assembly.
+_Avoid_: hook, handler, interceptor
+
+**Extension**:
+A pluggable unit the agent loads at runtime from the extensions directory --
+a wrapper (managed DLL) together with its instrumentation XML. Hot-reloadable
+without restarting the process.
+_Avoid_: plugin, module
+
+**NewRelic.Agent.Extensions**:
+The shared-helper assembly that wrappers reference (parsing, reflection,
+helper types). Despite the name it is NOT an extension: it ships no
+instrumentation and is not loaded from the extensions directory.
+_Avoid_: calling this assembly "an extension"
+
+**Tracer**:
+The legacy, low-level handle for one instrumented method call: the injected
+bytecode creates it and calls Finish when the call returns. The wrapper model
+superseded it for authoring instrumentation, but "tracer" survives at the
+injected-bytecode boundary and in the tracerFactory XML element. Prefer
+"wrapper" for new instrumentation work. A tracer is unrelated to any trace.
+_Avoid_: using "tracer" for new wrapper work (say wrapper), tracer as a
+synonym for trace
+
+**Tracer factory**:
+The tracerFactory element in instrumentation XML that names the wrapper to
+invoke for the matched methods. Despite the name it does not, in modern usage,
+produce tracers -- it selects a wrapper.
+_Avoid_: reading "tracer factory" as a factory that makes tracers
+
+### Providers
+
+**Provider**:
+Umbrella term for a pluggable implementation under the providers area. Two
+families exist -- wrapper providers and context storage providers -- so bare
+"provider" is ambiguous; say which.
+_Avoid_: bare "provider"
+
+**Wrapper provider**:
+Another name for a wrapper, reflecting that wrappers live under the providers
+area. Prefer "wrapper".
+_Avoid_: using "provider" alone to mean this
+
+**Context storage provider**:
+A runtime mechanism that stores the current transaction so it follows code
+execution across threads and async continuations (backed by thread-local,
+async-local, HttpContext, and similar). Priority-ranked: the highest-priority
+one that can serve at the moment wins.
+_Avoid_: context, storage (alone), transaction context (that is the stored
+thing, not the provider)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,48 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when
+exploring the codebase. This repo is **single-context**.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** -- read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their
+absence; don't suggest creating them upfront. The `/domain-modeling` skill
+(reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates
+them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+  CONTEXT.md
+  docs/adr/
+    0001-some-decision.md
+    0002-another-decision.md
+  src/
+```
+
+(A multi-context repo would instead have a `CONTEXT-MAP.md` at the root pointing
+at one `CONTEXT.md` per context, plus context-scoped `src/<context>/docs/adr/`.
+That layout does not apply here.)
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal,
+a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift
+to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal -- either
+you're inventing language the project doesn't use (reconsider) or there's a real
+gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than
+silently overriding:
+
+> _Contradicts ADR-0007 -- but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,76 @@
+# Issue tracker: Jira
+
+Issues and PRDs for this repo live in Jira, not GitHub Issues. The GitHub repo
+(`newrelic/newrelic-dotnet-agent`) is a public mirror for code and pull
+requests; planning and triage happen in Jira.
+
+- **Site**: new-relic.atlassian.net
+- **Project key**: `NR`
+- **Access**: the Atlassian MCP tools (`mcp__plugin_nr_atlassian-jira__*`). The
+  site host `new-relic.atlassian.net` works directly as the `cloudId` argument
+  for those tools.
+
+## Write formatting (mandatory)
+
+Every Jira write -- create, edit, comment -- must use `contentFormat: "adf"`
+with a proper ADF (Atlassian Document Format) JSON body, even for plain text.
+Follow the `nr:jira-adf-format` skill. Passing raw markdown/plain strings is
+the most common mistake.
+
+## Conventions
+
+- **Create an issue**: `createJiraIssue` with `projectKey: NR`, an
+  `issueTypeName` (`Task`, `Bug`, `Story`), a `summary`, and a `description`.
+  New issues are assigned to the "APM+ -> .NET Agent" team (team field ID
+  `ea229518-a006-4d09-b8c0-223a885aeff7-188`) via `additional_fields` unless
+  told otherwise.
+- **Read an issue**: `getJiraIssue` with the issue key (e.g. `NR-574460`).
+  Include `comment` in `fields` (or fetch `*all`) to get comments.
+- **List / search issues**: `searchJiraIssuesUsingJql`, e.g.
+  `project = NR AND labels = "needs-triage" ORDER BY created DESC`.
+- **Comment on an issue**: `addCommentToJiraIssue`.
+- **Apply / remove labels**: `editJiraIssue`, setting the `labels` field (see
+  `triage-labels.md` for the role strings).
+- **Transition state**: `getTransitionsForJiraIssue` to find the transition ID,
+  then `transitionJiraIssue`.
+- **Link issues**: `createIssueLink` (`getIssueLinkTypes` lists types; for
+  "A is blocked by B", inwardIssue = B, outwardIssue = A).
+
+## Referencing tickets in git
+
+Never link to Jira in commits or PR descriptions -- this is a public
+open-source repo and Jira is internal. Reference by ticket ID only, inline in
+prose (e.g. "from NR-574460"), never as a `Resolves` keyword.
+
+## When a skill says "publish to the issue tracker"
+
+Create a Jira issue in project `NR`.
+
+## When a skill says "fetch the relevant ticket"
+
+Read the Jira issue by key with `getJiraIssue`. The user will normally pass the
+key (e.g. `NR-574460`) directly.
+
+## Pull requests as a triage surface
+
+**No.** External GitHub PRs are not pulled into the triage queue.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single Jira issue with **child** issues
+as tickets.
+
+- **Map**: a Jira issue (type `Task`/`Story`) holding the Notes /
+  Decisions-so-far / Fog body; label it `wayfinder:map`.
+- **Child ticket**: a Jira issue linked to the map (a sub-task under the map,
+  or a `Relates` link plus `Part of NR-<map>` in the body). Label
+  `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed,
+  assign to the driving dev.
+- **Blocking**: use Jira issue links -- "is blocked by" (`createIssueLink` with
+  type `Blocks`: inwardIssue = blocker, outwardIssue = blocked). A ticket is
+  unblocked when every blocker is Done/closed.
+- **Frontier query**: JQL for the map's open children with no open blocker and
+  no assignee; first in map order wins.
+- **Claim**: assign the issue to the driving dev -- the session's first write.
+- **Resolve**: comment the answer, transition the issue to Done, then append a
+  context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -17,13 +17,36 @@ with a proper ADF (Atlassian Document Format) JSON body, even for plain text.
 Follow the `nr:jira-adf-format` skill. Passing raw markdown/plain strings is
 the most common mistake.
 
+## Team assignment (mandatory)
+
+`NR` is a single Jira project shared by dozens of teams -- there is no
+per-team project. An issue with no **Team** set never appears in the .NET
+Agent backlog, so **every** issue you create must set it (unless the user
+names a different team).
+
+- Field key: `customfield_10001` -- the platform "Team" field (schema type
+  `team`, operations `["set"]`; verified from the `NR` create metadata). This
+  is the field key; `ea229518-...-188` below is the team *value*, not the
+  field.
+- Value: the team ID as a **plain string**, not an object:
+  `ea229518-a006-4d09-b8c0-223a885aeff7-188` ("APM+ -> .NET Agent").
+- `createJiraIssue` exposes no dedicated team parameter; pass it through
+  `additional_fields`:
+
+  ```json
+  "additional_fields": { "customfield_10001": "ea229518-a006-4d09-b8c0-223a885aeff7-188" }
+  ```
+
+Set the same field via `editJiraIssue` to move a mis-filed existing issue onto
+the team.
+
 ## Conventions
 
 - **Create an issue**: `createJiraIssue` with `projectKey: NR`, an
   `issueTypeName` (`Task`, `Bug`, `Story`), a `summary`, and a `description`.
-  New issues are assigned to the "APM+ -> .NET Agent" team (team field ID
-  `ea229518-a006-4d09-b8c0-223a885aeff7-188`) via `additional_fields` unless
-  told otherwise.
+  You **must** also set the team via `additional_fields` -- see "Team
+  assignment (mandatory)" above; an issue with no team is invisible in the
+  .NET Agent backlog.
 - **Read an issue**: `getJiraIssue` with the issue key (e.g. `NR-574460`).
   Include `comment` in `fields` (or fetch `*all`) to get comments.
 - **List / search issues**: `searchJiraIssuesUsingJql`, e.g.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,22 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those
+roles to the actual label strings used in this repo's issue tracker. For this
+repo they are applied as **Jira labels** in project `NR` (see
+`issue-tracker.md`).
+
+| Role (in the skills) | Label in our tracker | Meaning                                  |
+| -------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`       | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`         | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`    | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`    | `ready-for-human`    | Requires human implementation            |
+| `wontfix`            | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table. Set the labels via `editJiraIssue`
+on the `labels` field.
+
+Edit the right-hand column to match whatever vocabulary you actually use. If you
+prefer to drive triage through Jira workflow statuses instead of labels, record
+the status names here and treat "apply label X" as "transition to status Y".


### PR DESCRIPTION
Scaffolds per-repo config so the engineering skills (triage, to-tickets, to-spec, qa, wayfinder, domain-modeling) read this repo's actual conventions instead of their defaults.

- `docs/agents/issue-tracker.md` - Jira (project NR) via the Atlassian MCP; external PRs not a triage surface.
- `docs/agents/triage-labels.md` - canonical triage roles as Jira labels.
- `docs/agents/domain.md` - single-context domain-doc layout (root CONTEXT.md + docs/adr/).
- `CLAUDE.md` - new Agent skills section pointing at the three docs.

Data/docs only - no code, hooks, or settings changes. The docs are inert unless one of the engineering skills reads them; the CLAUDE.md section is the only content auto-loaded into every session.