### PR TITLE
ci: add test-count metric and flaky-retry event telemetry

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -634,6 +634,13 @@ jobs:
           dotnet-quality: 'ga'
 
       - name: Run Integration Tests
+        env:
+          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
         run: |
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "List ports in use"
@@ -670,6 +677,10 @@ jobs:
             if ($exitCode -eq 0) {
               if ($attempt -gt 1) {
                 Write-Host "::warning::Integration tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+                # Best-effort flaky-retry telemetry (never fails the job).
+                $env:RETRY_TEST_TYPE = "integrationTests"
+                $env:RETRY_TEST_GROUP = "${{ matrix.namespace }}"
+                & bash build/Scripts/report-flaky-retry.sh
               }
               break
             }
@@ -696,8 +707,11 @@ jobs:
         run: |
           $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
           $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
+          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
 
           Write-Host "Checking for TRX file at: $trxFile"
+
+          $executedTests = 0
 
           if (Test-Path $trxFile) {
             $fileSize = (Get-Item $trxFile).Length
@@ -735,10 +749,19 @@ jobs:
               Write-Host "No payload byte logs found in TRX file"
               @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
             }
+
+            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
+            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
+            # (any outcome), excluding skipped / not-executed.
+            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
+            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
           } else {
             Write-Host "TRX file not found"
             @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
           }
+
+          Write-Host "Executed test count: $executedTests"
+          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
         shell: powershell
 
       - name: Upload payload bytes log
@@ -746,7 +769,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-payload-bytes-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+          path: |
+            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
           if-no-files-found: warn
 
       - name: Archive integration test results on failure
@@ -855,6 +880,13 @@ jobs:
           dotnet-quality: 'ga'
   
       - name: Run Unbounded Integration Tests
+        env:
+          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
         run: |
           if ($Env:enhanced_logging -eq $True) {
             Write-Host "List ports in use"
@@ -885,6 +917,10 @@ jobs:
             if ($exitCode -eq 0) {
               if ($attempt -gt 1) {
                 Write-Host "::warning::Unbounded tests for ${{ matrix.namespace }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+                # Best-effort flaky-retry telemetry (never fails the job).
+                $env:RETRY_TEST_TYPE = "unboundedTests"
+                $env:RETRY_TEST_GROUP = "${{ matrix.namespace }}"
+                & bash build/Scripts/report-flaky-retry.sh
               }
               break
             }
@@ -911,8 +947,11 @@ jobs:
         run: |
           $trxFile = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_testResults.trx"
           $payloadLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_payload_bytes.json"
+          $countLog = "C:\IntegrationTestWorkingDirectory\TestResults\${{ matrix.namespace }}_test_count.json"
 
           Write-Host "Checking for TRX file at: $trxFile"
+
+          $executedTests = 0
 
           if (Test-Path $trxFile) {
             $fileSize = (Get-Item $trxFile).Length
@@ -950,10 +989,19 @@ jobs:
               Write-Host "No payload byte logs found in TRX file"
               @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
             }
+
+            # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
+            # schema, emitted by the xUnit v3 runner). 'executed' counts tests that ran
+            # (any outcome), excluding skipped / not-executed.
+            $counters = $trxContent.SelectSingleNode("//*[local-name()='ResultSummary']/*[local-name()='Counters']")
+            if ($counters -ne $null -and $counters.executed) { $executedTests = [int]$counters.executed }
           } else {
             Write-Host "TRX file not found"
             @{} | ConvertTo-Json | Out-File -FilePath $payloadLog -Encoding UTF8
           }
+
+          Write-Host "Executed test count: $executedTests"
+          @{ executedTests = $executedTests } | ConvertTo-Json | Out-File -FilePath $countLog -Encoding UTF8
         shell: powershell
 
       - name: Upload payload bytes log
@@ -961,7 +1009,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unbounded-payload-bytes-${{ matrix.namespace }}
-          path: C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+          path: |
+            C:\IntegrationTestWorkingDirectory\TestResults\*_payload_bytes.json
+            C:\IntegrationTestWorkingDirectory\TestResults\*_test_count.json
           if-no-files-found: warn
 
       - name: Archive unbounded test results on failure
@@ -1320,7 +1370,7 @@ jobs:
       - name: Create consolidated JSON output
         run: |
           if ls payload-summaries/*_combined.json >/dev/null 2>&1; then
-            final="$(jq -n '{bytes:0, byType:{}}')"
+            final="$(jq -n '{bytes:0, byType:{}, executedTests:0}')"
             for f in payload-summaries/*_combined.json; do
               base="$(basename "$f" _payload_bytes_combined.json)"
               case "$base" in
@@ -1330,14 +1380,15 @@ jobs:
                 *)              key="$base";;
               esac
               final="$(jq --arg key "$key" --slurpfile c "$f" '
-                .[$key] = {generatedAt:$c[0].generatedAt, bytes:$c[0].grandTotalBytes, byType:$c[0].byType, details:$c[0].details}
+                .[$key] = {generatedAt:$c[0].generatedAt, bytes:$c[0].grandTotalBytes, executedTests:($c[0].executedTests // 0), byType:$c[0].byType, details:$c[0].details}
                 | .bytes += $c[0].grandTotalBytes
+                | .executedTests += ($c[0].executedTests // 0)
                 | .byType = (reduce ($c[0].byType|to_entries[]) as $cat (.byType; .[$cat.key]=((.[$cat.key]//0)+$cat.value)))
               ' <<<"$final")"
             done
             echo "$final" > final_payload_summary.json
           else
-            echo '{"bytes": 0, "byType": {}}' > final_payload_summary.json
+            echo '{"bytes": 0, "byType": {}, "executedTests": 0}' > final_payload_summary.json
           fi
           echo "FINAL CONSOLIDATED PAYLOAD SUMMARY"; cat final_payload_summary.json
         shell: bash

--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -41,8 +41,12 @@ env:
 jobs:
   check-modified-files:
     name: Check if source files were modified, skip remaining jobs if not
-    # skip if the PR source branch starts with "release-please"
-    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please')
+    # Only run on pull_request: this is the only event where source-files-changed is
+    # consumed (all other events force a full build via the downstream job conditions).
+    # Running it on release/workflow_dispatch/schedule does useless work and makes
+    # dorny/paths-filter warn about a missing 'before' field (no diff baseline exists
+    # off a PR). Also skip if the PR source branch starts with "release-please".
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please')
     uses: ./.github/workflows/check_modified_files.yml
     secrets: inherit
     permissions:
@@ -52,6 +56,9 @@ jobs:
   shellcheck:
     name: Validate shell scripts
     needs: check-modified-files
+    # check-modified-files is skipped on non-PR events; !cancelled() keeps shellcheck
+    # running there (a skipped dependency would otherwise cascade-skip this job).
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/linux_container_tests.yml
+++ b/.github/workflows/linux_container_tests.yml
@@ -128,6 +128,12 @@ jobs:
       - name: Build & Run Linux Container Integration Tests
         env:
           BUILD_ARCH: ${{ matrix.arch }}
+          NR_TEST_SECRETS: ${{ secrets.TEST_SECRETS }}
+          CI_BRANCH: ${{ github.ref_name }}
+          CI_COMMIT: ${{ github.sha }}
+          CI_RUN_ID: ${{ github.run_id }}
+          CI_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CI_TRIGGER: ${{ github.event_name }}
         run: |
           # Retry once on failure to absorb transient infrastructure blips (e.g. container
           # image pulls, Docker networking, or service-container startup races) that can
@@ -149,6 +155,10 @@ jobs:
             if [ $exit_code -eq 0 ]; then
               if [ $attempt -gt 1 ]; then
                 echo "::warning::Container tests for ${{ matrix.arch }}/${{ matrix.distro }} passed on attempt $attempt after a transient failure. Investigate if this recurs."
+                # Best-effort flaky-retry telemetry (never fails the job).
+                RETRY_TEST_TYPE="containerTests" \
+                RETRY_TEST_GROUP="${{ matrix.arch }}/${{ matrix.distro }}" \
+                  bash build/Scripts/report-flaky-retry.sh || true
               fi
               break
             fi
@@ -165,6 +175,7 @@ jobs:
         if: inputs.aggregate_payload_data == true
         run: |
           PAYLOAD_LOG="${{ env.test_results_path }}/${{ matrix.arch }}_${{ matrix.distro }}_payload_bytes.json"
+          COUNT_LOG="${{ env.test_results_path }}/${{ matrix.arch }}_${{ matrix.distro }}_test_count.json"
           echo "Searching for TRX files in: ${{ env.test_results_path }}"
 
           # Find all TRX files
@@ -195,6 +206,21 @@ jobs:
             echo "Content:"
             cat "$PAYLOAD_LOG"
           fi
+
+          # Extract the executed-test count from the TRX ResultSummary/Counters (VSTest
+          # schema, emitted by `dotnet test --logger trx`). 'executed' counts tests that
+          # ran (any outcome), excluding skipped / not-executed. `dotnet test` writes a
+          # uniquely-named TRX per attempt, so on a retry two TRX files exist; use only
+          # the newest (the final attempt) so the count is not double-counted.
+          executed=0
+          newest_trx="$(find "${{ env.test_results_path }}" -name '*.trx' -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)"
+          if [ -n "$newest_trx" ]; then
+            echo "Newest TRX for count: $newest_trx"
+            executed="$(grep -oE '<Counters[^>]*executed="[0-9]+"' "$newest_trx" | grep -oE 'executed="[0-9]+"' | grep -oE '[0-9]+' | head -1)"
+            [ -n "$executed" ] || executed=0
+          fi
+          echo "Executed test count: $executed"
+          jq -n --argjson e "$executed" '{executedTests:$e}' > "$COUNT_LOG"
         shell: bash
 
       - name: Upload payload bytes log
@@ -202,7 +228,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-container-payload-bytes-${{ matrix.arch }}-${{ matrix.distro }}
-          path: ${{ env.test_results_path }}/*_payload_bytes.json
+          path: |
+            ${{ env.test_results_path }}/*_payload_bytes.json
+            ${{ env.test_results_path }}/*_test_count.json
           if-no-files-found: warn
 
       - name: Archive test results

--- a/build/Scripts/combine-payload-logs.sh
+++ b/build/Scripts/combine-payload-logs.sh
@@ -22,6 +22,16 @@ NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 mkdir -p "$(dirname "$OUT")"
 
+# Sum the executed-test counts from the sibling *_test_count.json files that ride
+# in the same per-namespace artifacts. Each file is {"executedTests": N}; strip any
+# UTF-8 BOM first (the PowerShell extractors write one; container files are BOM-free).
+EXECUTED_TESTS=0
+if [ -d "$IN_DIR" ] && find "$IN_DIR" -name '*_test_count.json' -type f | grep -q .; then
+  find "$IN_DIR" -name '*_test_count.json' -type f -exec sed -i '1s/^\xEF\xBB\xBF//' {} +
+  EXECUTED_TESTS="$(find "$IN_DIR" -name '*_test_count.json' -type f -print0 | xargs -0 cat \
+    | jq -s '[.[].executedTests // 0] | add // 0')"
+fi
+
 if [ -d "$IN_DIR" ] && find "$IN_DIR" -name '*_payload_bytes.json' -type f | grep -q .; then
   # The PowerShell extractors write UTF-8 with a BOM; strip it so jq can parse
   # the concatenated stream. (Container files are already BOM-free; no-op there.)
@@ -29,20 +39,20 @@ if [ -d "$IN_DIR" ] && find "$IN_DIR" -name '*_payload_bytes.json' -type f | gre
   # `xargs -0 cat | jq -s` keeps it a single jq invocation even if the file list
   # would exceed ARG_MAX (a split xargs would otherwise emit concatenated JSON).
   find "$IN_DIR" -name '*_payload_bytes.json' -type f -print0 | xargs -0 cat \
-    | jq -s --arg tt "$LABEL" --arg now "$NOW" '
+    | jq -s --arg tt "$LABEL" --arg now "$NOW" --argjson exec "$EXECUTED_TESTS" '
       (reduce .[] as $ns ({};
          reduce ($ns|to_entries[]) as $c (.;
            reduce ($c.value|to_entries[]) as $cat (.;
              .[$c.key][$cat.key] = ((.[$c.key][$cat.key]//0) + $cat.value) )))) as $m
-      | { testType: $tt, generatedAt: $now,
+      | { testType: $tt, generatedAt: $now, executedTests: $exec,
           grandTotalBytes: ([$m[][]] | add // 0),
           details: [ $m | to_entries[] | {className:.key, bytes:([.value[]]|add // 0)} ],
           byType: (reduce ($m|to_entries[]) as $c ({};
                      reduce ($c.value|to_entries[]) as $cat (.;
                        .[$cat.key] = ((.[$cat.key]//0)+$cat.value)))) }' > "$OUT"
 else
-  jq -n --arg tt "$LABEL" --arg now "$NOW" \
-    '{testType:$tt, generatedAt:$now, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
+  jq -n --arg tt "$LABEL" --arg now "$NOW" --argjson exec "$EXECUTED_TESTS" \
+    '{testType:$tt, generatedAt:$now, executedTests:$exec, grandTotalBytes:0, details:[], byType:{}}' > "$OUT"
 fi
 
 echo "Combined -> $OUT"

--- a/build/Scripts/report-flaky-retry.sh
+++ b/build/Scripts/report-flaky-retry.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Report a single flaky-retry occurrence to the New Relic Event API (staging by
+# default) as a DotnetCiTestRetry custom event.
+#
+# Called INLINE from the retry-once loops in all_solutions.yml (integration +
+# unbounded, via `bash`) and linux_container_tests.yml (container). Emit exactly
+# one event when a test group FAILED its first attempt but PASSED on the single
+# retry -- the transient-flake signal. Fail-both is already a red build and is
+# not reported here.
+#
+# This runs on EVERY CI run (pull requests included). It is best-effort
+# telemetry: a delivery failure must NEVER fail the CI job (the tests passed),
+# so every path exits 0 and errors are swallowed with a warning.
+#
+# Env vars:
+#   NR_TEST_SECRETS   Raw TEST_SECRETS JSON, may carry a UTF-8 BOM. License key
+#                     is read from .IntegrationTestConfiguration.DefaultSetting.LicenseKey
+#                     and the account id from .IntegrationTestConfiguration.DefaultSetting.NewRelicAccountId
+#   RETRY_TEST_TYPE   testType attribute (e.g. integrationTests / unboundedTests / containerTests)
+#   RETRY_TEST_GROUP  testGroup attribute (namespace, or "<arch>/<distro>" for container)
+#   CI_BRANCH CI_COMMIT CI_RUN_ID CI_RUN_URL CI_TRIGGER   Optional metadata attributes
+#   NR_INSIGHTS_HOST  Event API host (default staging-insights-collector.newrelic.com)
+#   DRY_RUN           "1"/"true" (or first arg --dry-run) => print body, do not POST
+set -uo pipefail
+
+DRY_RUN="${DRY_RUN:-}"
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+is_dry_run() { [ "$DRY_RUN" = "1" ] || [ "$DRY_RUN" = "true" ]; }
+
+TEST_TYPE="${RETRY_TEST_TYPE:-unknown}"
+TEST_GROUP="${RETRY_TEST_GROUP:-unknown}"
+INSIGHTS_HOST="${NR_INSIGHTS_HOST:-staging-insights-collector.newrelic.com}"
+
+# Build the Event API request body: a single-element array with one custom event.
+BODY="$(jq -cn \
+  --arg tt "$TEST_TYPE" \
+  --arg tg "$TEST_GROUP" \
+  --arg branch "${CI_BRANCH:-unknown}" \
+  --arg commit "${CI_COMMIT:-unknown}" \
+  --arg runId "${CI_RUN_ID:-unknown}" \
+  --arg runUrl "${CI_RUN_URL:-unknown}" \
+  --arg trigger "${CI_TRIGGER:-unknown}" '
+  [ { eventType: "DotnetCiTestRetry",
+      testType: $tt,
+      testGroup: $tg,
+      source: "dotnet-agent-ci",
+      "ci.branch": $branch,
+      "ci.commit": $commit,
+      "ci.runId": $runId,
+      "ci.runUrl": $runUrl,
+      "ci.trigger": $trigger } ]')"
+
+echo "Flaky-retry event for testType=$TEST_TYPE testGroup=$TEST_GROUP" >&2
+
+if is_dry_run; then
+  echo "$BODY"
+  exit 0
+fi
+
+# Parse license key + account id from TEST_SECRETS (nested JSON); strip a UTF-8 BOM.
+LICENSE_KEY=""
+ACCOUNT_ID=""
+if [ -n "${NR_TEST_SECRETS:-}" ]; then
+  CLEAN_SECRETS="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//')"
+  LICENSE_KEY="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty' 2>/dev/null)"
+  ACCOUNT_ID="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.NewRelicAccountId // empty' 2>/dev/null)"
+fi
+if [ -z "$LICENSE_KEY" ] || [ -z "$ACCOUNT_ID" ]; then
+  echo "WARNING: no New Relic license key / account id available; skipping flaky-retry event." >&2
+  exit 0
+fi
+
+EVENT_URL="https://${INSIGHTS_HOST}/v1/accounts/${ACCOUNT_ID}/events"
+RESP_FILE="$(mktemp)"
+trap 'rm -f "$RESP_FILE"' EXIT
+
+HTTP_CODE="$(curl -s --connect-timeout 10 --max-time 30 -o "$RESP_FILE" -w '%{http_code}' \
+  -H "Content-Type: application/json" \
+  -H "Api-Key: $LICENSE_KEY" \
+  -X POST "$EVENT_URL" \
+  --data-binary "$BODY" 2>/dev/null || echo "000")"
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo "New Relic Event API accepted the DotnetCiTestRetry event (HTTP 200)." >&2
+else
+  echo "WARNING: New Relic Event API returned HTTP $HTTP_CODE for flaky-retry event (ignored)." >&2
+fi
+
+# Best-effort telemetry: never fail the job.
+exit 0

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -60,6 +60,10 @@ build_body() {
           + [ (.byType // {}) | to_entries[]
             | {name:"newrelic.dotnet.ci.payload.by_type.bytes", type:"gauge",
                value:.value, attributes:{testType:"all", payloadType:.key}} ]
+          + [ $types[] | {name:"newrelic.dotnet.ci.tests.count", type:"gauge",
+               value:(.value.executedTests // 0), attributes:{testType:.key}} ]
+          + [ {name:"newrelic.dotnet.ci.tests.count", type:"gauge",
+               value:(.executedTests // 0), attributes:{testType:"all"}} ]
         )
       } ]
   ' "$SUMMARY_FILE"


### PR DESCRIPTION
Extends the existing CI test-metrics pipeline with two new telemetry signals to the staging New Relic account. Pure CI plumbing (GitHub Actions YAML + bash/jq); no agent or profiler code.

## Feature 1 - test-count metric
New gauge `newrelic.dotnet.ci.tests.count` with `testType` in {integrationTests, unboundedTests, containerTests, all}. Counts executed tests (ran, any outcome; excludes skips) parsed from the TRX `ResultSummary/Counters` `executed` attribute. Sibling `<unit>_test_count.json` files ride the existing per-namespace payload artifacts, are summed in `combine-payload-logs.sh`, carried through the final summary, and emitted in the same Metric API POST as the byte gauges. Rides the existing byte gate (nightly/dispatch only, never PRs).

## Feature 2 - flaky-retry event
New event type `DotnetCiTestRetry` via `build/Scripts/report-flaky-retry.sh`, emitted inline from all three retry-once loops only when a test group failed its first attempt and passed on the single retry. Runs on every CI run (PRs included), posts to the staging Event API, and swallows all errors so telemetry delivery can never fail a passing job. Attributes: `testType`, `testGroup`, `source`, and `ci.branch/commit/runId/runUrl/trigger`.

## Verification
- Confirmed the xUnit v3 (integration/unbounded) and `dotnet test` (container) TRX both use the VSTest `<Counters executed="N">` schema; container extraction takes the newest TRX to avoid double-counting across a retry.
- Real staging Event API POST with the test license key returned HTTP 200.
- Exercised the full Feature 1 chain and both script dry-runs against sample fixtures.

## Dashboard NRQL (widgets out of scope)
```
SELECT max(newrelic.dotnet.ci.tests.count) FROM Metric WHERE source = 'dotnet-agent-ci' FACET testType SINCE 1 month ago TIMESERIES
```
```
SELECT count(*) FROM DotnetCiTestRetry WHERE source = 'dotnet-agent-ci' FACET testType, testGroup SINCE 1 month ago
```
