### PR TITLE
ci: mask extracted license keys in CI logs

### DIFF
--- a/.github/actions/run-perf-test/action.yml
+++ b/.github/actions/run-perf-test/action.yml
@@ -53,6 +53,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mask license key in logs
+      if: inputs.attach-agent == 'true' && inputs.license-key != ''
+      shell: bash
+      env:
+        LICENSE_KEY: ${{ inputs.license-key }}
+      run: echo "::add-mask::$LICENSE_KEY"
+
     - name: Create agent-home directory
       shell: bash
       run: mkdir -p "${{ github.workspace }}/${{ env.PERF_TEST_DIR }}/agent-home"

--- a/build/Scripts/report-flaky-retry.sh
+++ b/build/Scripts/report-flaky-retry.sh
@@ -67,6 +67,11 @@ if [ -n "${NR_TEST_SECRETS:-}" ]; then
   LICENSE_KEY="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty' 2>/dev/null)"
   ACCOUNT_ID="$(printf '%s' "$CLEAN_SECRETS" | jq -r '.IntegrationTestConfiguration.DefaultSetting.NewRelicAccountId // empty' 2>/dev/null)"
 fi
+
+# Mask the extracted license key in CI logs. GitHub Actions only auto-masks the
+# exact TEST_SECRETS blob, not this jq-extracted substring. No-op outside Actions.
+[ -n "$LICENSE_KEY" ] && echo "::add-mask::$LICENSE_KEY"
+
 if [ -z "$LICENSE_KEY" ] || [ -z "$ACCOUNT_ID" ]; then
   echo "WARNING: no New Relic license key / account id available; skipping flaky-retry event." >&2
   exit 0

--- a/build/Scripts/report-payload-metrics.sh
+++ b/build/Scripts/report-payload-metrics.sh
@@ -89,6 +89,11 @@ if [ -n "${NR_TEST_SECRETS:-}" ]; then
   LICENSE_KEY="$(printf '%s' "$NR_TEST_SECRETS" | sed '1s/^\xEF\xBB\xBF//' \
     | jq -r '.IntegrationTestConfiguration.DefaultSetting.LicenseKey // empty')"
 fi
+
+# Mask the extracted license key in CI logs. GitHub Actions only auto-masks the
+# exact TEST_SECRETS blob, not this jq-extracted substring. No-op outside Actions.
+[ -n "$LICENSE_KEY" ] && echo "::add-mask::$LICENSE_KEY"
+
 if [ -z "$LICENSE_KEY" ]; then
   echo "WARNING: no New Relic license key available; skipping." >&2
   exit 0


### PR DESCRIPTION
Harden CI secret handling: register jq-extracted New Relic license keys via `::add-mask::` so they are redacted in logs. GitHub only auto-masks the exact `TEST_SECRETS` secret, not substrings extracted from it.

Covers `report-flaky-retry.sh`, `report-payload-metrics.sh`, and the `run-perf-test` composite action (masks are job-scoped, so the perf-test key is masked at its point of use). Only the high-entropy license key is masked; numeric account id / collector host are left alone.