### PR TITLE
ci: fix scheduled/release runs skipping all jobs after check-modified-files change

### DIFF
--- a/.github/workflows/all_solutions.yml
+++ b/.github/workflows/all_solutions.yml
@@ -82,7 +82,9 @@ jobs:
       - shellcheck
     # don't run this job if triggered by Dependabot, will cause all other jobs to be skipped as well
     # run this job if source files were modified, or if triggered by a release, a manual execution or schedule
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    # !cancelled() is required because check-modified-files is skipped on non-PR events; without it,
+    # the skipped dependency would implicitly skip this job even when the schedule/release/dispatch clauses match.
+    if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
 
     env:
       fullagent_solution_path: ${{ github.workspace }}\FullAgent.sln
@@ -197,7 +199,9 @@ jobs:
   get-test-namespaces:
     name: Get Test Namespaces
     needs: check-modified-files
-    if: github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    # !cancelled() is required because check-modified-files is skipped on non-PR events; without it,
+    # the skipped dependency would implicitly skip this job even when the schedule/release/dispatch clauses match.
+    if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && (needs.check-modified-files.outputs.source-files-changed == 'true' || github.event.release || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') }}
     runs-on: ubuntu-latest
     outputs:
       integration-namespaces: ${{ steps.compute.outputs.integration }}


### PR DESCRIPTION
Scheduled runs of All Solutions Build have been skipping nearly every job since #3686 (e.g. run 29010809127).

#3686 changed `check-modified-files` to run only on `pull_request`, so it is skipped on schedule/release/workflow_dispatch. `build-fullagent-msi` and `get-test-namespaces` both `needs: check-modified-files` with a plain boolean `if`, so the skipped dependency implicitly skipped them too - even though their `github.event_name == 'schedule'` clause matched. Every downstream job cascades off those two, so the whole graph skipped. Only `shellcheck` survived, because #3686 gave it `!cancelled()`.

This adds the same `!cancelled()` guard to those two jobs. Docs-only-PR and Dependabot skip behavior is unchanged.