### PR TITLE
test: deflake MemorySamplerTests by mocking process memory source

### DIFF
--- a/tests/Agent/UnitTests/Core.UnitTest/Samplers/MemorySamplerTests.cs
+++ b/tests/Agent/UnitTests/Core.UnitTest/Samplers/MemorySamplerTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using NewRelic.Agent.Core.SharedInterfaces;
 using NewRelic.Agent.Core.Time;
 using NewRelic.Agent.Core.Transformers;
@@ -21,6 +19,9 @@ public class MemorySamplerTests
 
     private Action _sampleAction;
 
+    private long _privateMemorySize;
+    private long _workingSet;
+
     [SetUp]
     public void SetUp()
     {
@@ -28,7 +29,14 @@ public class MemorySamplerTests
         Mock.Arrange(() => scheduler.ExecuteEvery(Arg.IsAny<Action>(), Arg.IsAny<TimeSpan>(), Arg.IsAny<TimeSpan?>()))
             .DoInstead<Action, TimeSpan, TimeSpan?>((action, _, __) => _sampleAction = action);
         _memorySampleTransformer = Mock.Create<IMemorySampleTransformer>();
-        _memorySampler = new MemorySampler(scheduler, _memorySampleTransformer, new ProcessStatic());
+
+        var processStatic = Mock.Create<IProcessStatic>();
+        var process = Mock.Create<IProcess>();
+        Mock.Arrange(() => processStatic.GetCurrentProcess()).Returns(process);
+        Mock.Arrange(() => process.PrivateMemorySize64).Returns(() => _privateMemorySize);
+        Mock.Arrange(() => process.WorkingSet64).Returns(() => _workingSet);
+
+        _memorySampler = new MemorySampler(scheduler, _memorySampleTransformer, processStatic);
         _memorySampler.Start();
     }
 
@@ -42,6 +50,9 @@ public class MemorySamplerTests
     public void memory_sample_generated_on_sample()
     {
         // Arrange
+        _privateMemorySize = 1000;
+        _workingSet = 2000;
+
         var memorySample = null as ImmutableMemorySample;
         Mock.Arrange(() => _memorySampleTransformer.Transform(Arg.IsAny<ImmutableMemorySample>()))
             .DoInstead<ImmutableMemorySample>(sample => memorySample = sample);
@@ -57,6 +68,9 @@ public class MemorySamplerTests
     public void memory_values_increase_over_time()
     {
         // Arrange
+        _privateMemorySize = 1000;
+        _workingSet = 2000;
+
         var memorySampleBefore = null as ImmutableMemorySample;
         Mock.Arrange(() => _memorySampleTransformer.Transform(Arg.IsAny<ImmutableMemorySample>()))
             .DoInstead<ImmutableMemorySample>(sample => memorySampleBefore = sample);
@@ -64,24 +78,16 @@ public class MemorySamplerTests
         // Act
         _sampleAction();
 
-        // allocate some memory to increase .PrivateMemorySize64 and .WorkingSet64
-        var someBytes = IncreaseMemoryUsage();
-            
-        // Arrange
+        // Arrange -- simulate memory usage increasing between samples
+        _privateMemorySize = 5000;
+        _workingSet = 6000;
+
         var memorySampleAfter = null as ImmutableMemorySample;
         Mock.Arrange(() => _memorySampleTransformer.Transform(Arg.IsAny<ImmutableMemorySample>()))
             .DoInstead<ImmutableMemorySample>(sample => memorySampleAfter = sample);
 
         // Act
         _sampleAction();
-
-        foreach (byte b in someBytes)
-        {
-            if (b != 0x77)
-            {
-                Console.WriteLine("sanity check prevent array being optimized out failed");
-            }
-        }
 
         Assert.Multiple(() =>
         {
@@ -91,14 +97,33 @@ public class MemorySamplerTests
         });
     }
 
-    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-    private byte[] IncreaseMemoryUsage()
+    [Test]
+    public void memory_values_unchanged_when_reported_values_are_the_same()
     {
-        var size = 10000000;
-        byte[] bytes = new byte[size];
+        // Arrange
+        _privateMemorySize = 3000;
+        _workingSet = 4000;
 
-        Parallel.For(0, size, i => bytes[i] = 0x77);
+        var memorySampleBefore = null as ImmutableMemorySample;
+        Mock.Arrange(() => _memorySampleTransformer.Transform(Arg.IsAny<ImmutableMemorySample>()))
+            .DoInstead<ImmutableMemorySample>(sample => memorySampleBefore = sample);
 
-        return bytes;
+        // Act
+        _sampleAction();
+
+        // Arrange -- values reported by the process do not change between samples
+        var memorySampleAfter = null as ImmutableMemorySample;
+        Mock.Arrange(() => _memorySampleTransformer.Transform(Arg.IsAny<ImmutableMemorySample>()))
+            .DoInstead<ImmutableMemorySample>(sample => memorySampleAfter = sample);
+
+        // Act
+        _sampleAction();
+
+        Assert.Multiple(() =>
+        {
+            // Assert
+            Assert.That(memorySampleAfter.MemoryPrivate, Is.EqualTo(memorySampleBefore.MemoryPrivate), "PrivateMemorySize64 should not have changed");
+            Assert.That(memorySampleAfter.MemoryWorkingSet, Is.EqualTo(memorySampleBefore.MemoryWorkingSet), "WorkingSet64 should not have changed");
+        });
     }
 }


### PR DESCRIPTION
Deflakes `MemorySamplerTests.memory_values_increase_over_time`, which intermittently failed in CI (observed on the net10.0 leg).

The test built the sampler with a real `ProcessStatic`, allocated 10MB, and asserted the OS-reported `PrivateMemorySize64`/`WorkingSet64` strictly increased. In the shared test host the GC can satisfy the allocation from already-committed heap without requesting new OS pages, so the counter stays flat and the strict assert fails.

Now mocks `IProcessStatic`/`IProcess` (both interfaces) to drive the reported values deterministically -- no real allocation, no OS counters. Added a same-values case for the branch previously masked by the nondeterminism. Test-only; no production changes.