### PR TITLE
chore(build): adopt Central Package Management for FullAgent.sln projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,13 @@ updates:
 #        patterns:
 #          - "*"
 
-  # Update all NuGet packages used by core agent projects
+  # Update all NuGet packages used by core agent projects. Under CPM, dependabot
+  # updates the central Directory.Packages.props via any in-scope project that
+  # references its packages, so the narrow directory list below is sufficient
+  # and, more importantly, keeps wrapper/integration/perf/MSI/profiler pins
+  # (which intentionally reference old library versions) out of scope. Root '/'
+  # is NOT scanned here because that would pull FullAgent.sln's full project
+  # graph including the Providers/Wrapper/* projects.
   - package-ecosystem: nuget
     directories: # not recursive - only the specified directory will be scanned for .csproj or .sln files
       - /src/Agent/NewRelic/Agent/Core # Core.csproj
@@ -32,19 +38,21 @@ updates:
       - /src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions # NewRelic.Agent.Extensions.csproj
       # Do not scan the /src/Agent/NewRelic/Agent/Extensions/Providers folder, as those projects intentionally reference old versions of the Nuget packages they instrument.
       # Do not scan the src/Agent/MsiInstaller folder. We are not updating Wix packages to v6.x currently and there are no non-Wix packages referenced there.
+      # Do not scan the src/Agent/NewRelic/Home folder. Its only PackageReference, NewRelic.Agent.Internal.Profiler, has its Version= rewritten by the profiler's update-nuget-reference CI job.
     schedule:
       interval: weekly
     commit-message:
       prefix: "chore(deps):"
-    groups: 
+    groups:
       nuget-agent:
         patterns:
           - "*"
     ignore:
       - dependency-name: "Autofac" # v6+ doesn't support .NET Framework; we could upgerade to v5.x but there's no good reason for it
       - dependency-name: "Microsoft.Extensions.Configuration*"
+      - dependency-name: "NewRelic.Agent.Internal.Profiler" # version owned by the profiler's own update-nuget-reference CI job (Home.csproj); defensive - Home is out of scope above
       - dependency-name: "SharpZipLib" # we can't upgrade beyond 1.3.3
-      - dependency-name: "System.Diagnostics.DiagnosticSource" 
+      - dependency-name: "System.Diagnostics.DiagnosticSource"
         update-types: ["version-update:semver-major"] # not ready to upgrade to v9 yet
 
   # Update all NuGet packages used by build/release tool projects
@@ -60,7 +68,12 @@ updates:
         patterns:
           - "*"
 
-  # Update a specific set of packages for unit and integration tests
+  # Update a specific set of packages for unit and integration tests.
+  # Root '/' picks up FullAgent.sln (which contains the unit tests); the
+  # allow-list restricts updates to test-framework packages so wrapper
+  # subtree pins (intentionally old) are never touched. Under CPM the
+  # unit-test-framework versions live in the central Directory.Packages.props,
+  # which is what these updates land on for the sln-graph scan.
   - package-ecosystem: nuget
     directories: # not recursive - only the specified directory will be scanned for .csproj or .sln files
       - /tests/Agent/IntegrationTests # will pick up container, integration and unbounded test solutions

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ManagePackageVersionsCentrally Condition="'$(ManagePackageVersionsCentrally)' == ''">true</ManagePackageVersionsCentrally>
     <LangVersion>default</LangVersion>
     <RootProjectDirectory>$(MSBuildThisFileDirectory)</RootProjectDirectory>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,11 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)\build\Versioning.targets" Condition="Exists('$(MSBuildThisFileDirectory)\build\Versioning.targets')" />
+
+  <!-- StyleCop.Analyzers added here so Directory.Build.targets (auto-imported last) sees the final
+       ManagePackageVersionsCentrally value: versionless under CPM (central pins it), inline for opt-outs.
+       Gated on the _UsesStyleCop marker set by build/StyleCop.props so only StyleCop consumers get it. -->
+  <ItemGroup Condition="'$(_UsesStyleCop)' == 'true'">
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Condition="'$(ManagePackageVersionsCentrally)' == 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="'$(ManagePackageVersionsCentrally)' != 'true'" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,52 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Autofac" Version="[4.5.0]" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc" Version="2.46.6" />
+    <PackageVersion Include="Grpc.Core" Version="2.46.6" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
+    <PackageVersion Include="ILRepack" Version="2.0.46" />
+    <PackageVersion Include="JustMock" Version="2025.3.813.457" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
+    <PackageVersion Include="MoreLinq" Version="2.4.0" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Nito.AsyncEx.Context" Version="5.1.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
+    <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
+    <PackageVersion Include="Verify.NUnit" Version="31.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3.core" Version="3.1.0" />
+    <PackageVersion Include="xunit.v3.runner.console" Version="3.1.0" />
+  </ItemGroup>
+</Project>

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'FullAgent.sln'))\build\StyleCop.props" />
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>

--- a/build/StyleCop.props
+++ b/build/StyleCop.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\Common.ruleset</CodeAnalysisRuleSet>
+    <_UsesStyleCop>true</_UsesStyleCop>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/build/build_functions.ps1
+++ b/build/build_functions.ps1
@@ -284,9 +284,13 @@ function Get-GrpcPackagePath {
 
     $ErrorActionPreference = "Stop"
 
-    $match = Select-String -Path "$RootDirectory\src\Agent\NewRelic\Agent\Core\Core.csproj" -Pattern '<PackageReference Include="Grpc.Core"'
-    $versionIndex = $match.Line.IndexOf('"', $match.Line.IndexOf('Version')) + 1
-    $grpcVersion = $match.Line.TrimEnd('/>').TrimEnd(' ').TrimEnd('"').Substring($versionIndex)
+    # Grpc.Core is centrally managed (CPM): its version lives in the root Directory.Packages.props,
+    # not inline on Core.csproj's PackageReference (which no longer carries a Version= attribute).
+    $match = Select-String -Path "$RootDirectory\Directory.Packages.props" -Pattern '<PackageVersion Include="Grpc.Core"'
+    if (-not ($match.Line -match 'Version="([^"]+)"')) {
+        throw "Get-GrpcPackagePath: could not parse Grpc.Core version from Directory.Packages.props"
+    }
+    $grpcVersion = $Matches[1]
     $rawpkgList = $(dotnet nuget locals global-packages --list)
     $pkgList = $rawpkgList -Replace "global-packages: "
     $grpcDir = "$pkgList\Grpc.Core\$grpcVersion"

--- a/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
+++ b/src/Agent/NewRelic.Api.Agent/NewRelic.Api.Agent.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
+    <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Agent/NewRelic/Agent/Core/Core.csproj
+++ b/src/Agent/NewRelic/Agent/Core/Core.csproj
@@ -39,29 +39,29 @@
 
   <ItemGroup>
     <!-- Autofac v6+ doesn't support framework. We could possibly upgrade to v5.x but there's no compelling reason for it. -->
-    <PackageReference Include="Autofac" Version="[4.5.0]" />
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.82.0">
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.4.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="ILRepack" Version="2.0.46">
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
+    <PackageReference Include="Serilog.Sinks.EventLog" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="ILRepack">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
     <!-- 1.3.3 is the latest package of SharpZipLib that still has a .NET Framework target. Later versions
     only have a .NET Standard target -->
-    <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
-    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="SharpZipLib" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
   <ItemGroup>
@@ -71,18 +71,18 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <!-- .NET Framework needs to use the legacy gRPC library -->
-    <PackageReference Include="Grpc" Version="2.46.6" />
-    <PackageReference Include="Grpc.Core" Version="2.46.6" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.6.2" />
+    <PackageReference Include="Grpc" />
+    <PackageReference Include="Grpc.Core" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
+++ b/src/Agent/NewRelic/Agent/Extensions/NewRelic.Agent.Extensions/NewRelic.Agent.Extensions.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="ILRepack" Version="2.0.46">
+    <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="ILRepack">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Directory.Build.props
+++ b/src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/Directory.Build.props
@@ -2,5 +2,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
   <PropertyGroup>
     <NuGetAudit>false</NuGetAudit>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>

--- a/src/Agent/NewRelic/AssemblyModifier/AssemblyModifier.csproj
+++ b/src/Agent/NewRelic/AssemblyModifier/AssemblyModifier.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="Mono.Cecil" />
   </ItemGroup>
 
 </Project>

--- a/src/Agent/NewRelic/Home/Home.csproj
+++ b/src/Agent/NewRelic/Home/Home.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>NewRelic.Home</RootNamespace>
     <AssemblyName>NewRelic.Home</AssemblyName>
     <Description>This project is used to run build_home.ps1 to create the home folders.  It is empty on purpose.</Description>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/Agent/NewRelic/Profiler/Directory.Build.props
+++ b/src/Agent/NewRelic/Profiler/Directory.Build.props
@@ -11,4 +11,7 @@
   <PropertyGroup>
     <NativeToolset Condition="'$(NativeToolset)'==''">v145</NativeToolset>
   </PropertyGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
 </Project>

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -20,6 +20,49 @@ src/Agent/
 └── Scripts/             # Misc maintenance scripts (e.g. flush_dotnet_temp.cmd)
 ```
 
+## Central Package Management (CPM)
+
+`FullAgent.sln` projects use .NET Central Package Management. Package
+versions live in the root `Directory.Packages.props` as
+`<PackageVersion Include="X" Version="Y" />`; add new package versions
+there and reference packages in `.csproj` files with no `Version=`
+attribute.
+
+The enabling flag (`ManagePackageVersionsCentrally=true`) is set as a
+conditional default in the root `Directory.Build.props`, **not** in
+`Directory.Packages.props` -- deliberately, so subtree opt-outs can
+override it. The SDK imports `Directory.Packages.props` after the
+`Directory.Build.props` chain, so a flag set there would clobber subtree
+opt-outs.
+
+**Opt-outs** (`ManagePackageVersionsCentrally=false` in a
+`Directory.Build.props`, because they intentionally pin specific/old
+versions):
+- `Agent/NewRelic/Agent/Extensions/Providers/Wrapper/` (wrapper subtree)
+- `Agent/NewRelic/Profiler/` (profiler solution's managed projects)
+- `Agent/MsiInstaller/` (MSI/Wix)
+- `tests/Agent/IntegrationTests/` (integration / MFA compat apps)
+- `tests/Agent/PerformanceTests/`
+- `build/` (build tools)
+
+`Home.csproj` opts out at the project level and keeps
+`NewRelic.Agent.Internal.Profiler` pinned inline with a `Version=`
+attribute, because the profiler's `update-nuget-reference` job in
+`build_profiler.yml` rewrites that attribute -- it would break if the
+attribute were gone under CPM.
+
+`StyleCop.Analyzers` is shared across the CPM boundary (imported via
+`build/StyleCop.props` by both in-scope and opted-out projects). It is
+centrally versioned: `build/StyleCop.props` sets a `_UsesStyleCop` marker,
+and the root `Directory.Build.targets` adds the reference gated on that
+marker (versionless under CPM, inline `1.1.118` for opt-outs). This lives
+in `Directory.Build.targets` because it's auto-imported last, once the
+final CPM flag value is known.
+
+For a one-off in-scope version exception, use `VersionOverride=` (e.g.
+`SharpZipLib` in `tests/Agent/Shared/TestSerializationHelpers` overrides
+to `1.4.2` while the central version is `1.3.3`).
+
 ## Profiler (`Agent/NewRelic/Profiler/`)
 
 Native C++ implementing the CLR Profiling API. On JIT, matches methods

--- a/tests/Agent/IntegrationTests/Directory.Build.props
+++ b/tests/Agent/IntegrationTests/Directory.Build.props
@@ -9,5 +9,6 @@
       NETSDK1198 <!-- SDK-style test apps have no classic LocalDeploy MSDeploy profile; PublishProfile is applied solution-wide -->
     </NoWarn>
     <NuGetAudit>false</NuGetAudit>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>

--- a/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
+++ b/tests/Agent/NewRelic.Testing.Assertions/NewRelic.Testing.Assertions.csproj
@@ -3,12 +3,12 @@
     <TargetFrameworks>net481;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/PerformanceTests/Directory.Build.props
+++ b/tests/Agent/PerformanceTests/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'FullAgent.sln'))\build\StyleCop.props" />
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>

--- a/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
+++ b/tests/Agent/Shared/TestSerializationHelpers.Test/TestSerializationHelpers.Test.csproj
@@ -7,19 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.1.0" />
-    <PackageReference Include="xunit.v3.assert" Version="3.1.0" />
-    <PackageReference Include="xunit.v3.core" Version="3.1.0" />
-    <PackageReference Include="xunit.v3.runner.console" Version="3.1.0">
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.core" />
+    <PackageReference Include="xunit.v3.runner.console">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Agent/Shared/TestSerializationHelpers/TestSerializationHelpers.csproj
+++ b/tests/Agent/Shared/TestSerializationHelpers/TestSerializationHelpers.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="SharpZipLib" VersionOverride="1.4.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
+++ b/tests/Agent/UnitTests/AsyncLocalTests/AsyncLocalTests.csproj
@@ -8,22 +8,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2025.3.813.457" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
+++ b/tests/Agent/UnitTests/CompositeTests/CompositeTests.csproj
@@ -7,26 +7,26 @@
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2025.3.813.457" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="MoreLinq" Version="2.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MoreLinq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="Microsoft.CSharp" />

--- a/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
+++ b/tests/Agent/UnitTests/Core.UnitTest/Core.UnitTest.csproj
@@ -7,27 +7,27 @@
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2025.3.813.457" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="MoreLinq" Version="2.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MoreLinq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Nito.AsyncEx.Context" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
     <Reference Include="System" />

--- a/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.Extensions.Tests/NewRelic.Agent.Extensions.Tests.csproj
@@ -7,22 +7,22 @@
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2025.3.813.457" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Data.SqlClient" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net481'">

--- a/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Agent.TestUtilities/NewRelic.Agent.TestUtilities.csproj
@@ -5,18 +5,18 @@
     <AssemblyName>NewRelic.Agent.TestUtilities</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="4.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RootProjectDirectory)\src\Agent\NewRelic\Agent\Core\Core.csproj" />

--- a/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
+++ b/tests/Agent/UnitTests/NewRelic.Testing.Assertions.UnitTests/NewRelic.Testing.Assertions.UnitTests.csproj
@@ -19,16 +19,16 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/Agent/UnitTests/ParsingTests/ParsingTests.csproj
+++ b/tests/Agent/UnitTests/ParsingTests/ParsingTests.csproj
@@ -8,22 +8,22 @@
     <RunSettingsFilePath>$(SolutionDir)test.runsettings</RunSettingsFilePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="System.Data.SqlClient" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />

--- a/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
+++ b/tests/Agent/UnitTests/PublicApiChangeTests/PublicApiChangeTests.csproj
@@ -10,22 +10,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PublicApiGenerator" Version="11.4.6" />
-    <PackageReference Include="Verify.NUnit" Version="31.0.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="PublicApiGenerator" />
+    <PackageReference Include="Verify.NUnit" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2025.3.813.457" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="MoreLinq" Version="2.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MoreLinq" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/NewRelic.Core.Tests/NewRelic.Core.Tests.csproj
+++ b/tests/NewRelic.Core.Tests/NewRelic.Core.Tests.csproj
@@ -4,18 +4,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JustMock" Version="2023.3.1122.188" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="JustMock" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="NUnit3TestAdapter">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Adopts [.NET Central Package Management (CPM)](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) for the projects `FullAgent.sln` builds, so shared package versions have a single source of truth and a dependabot bump can no longer leave one project behind (the NU1605 drift that broke #3692).

## Boundary

- Root `Directory.Packages.props` holds every centrally-managed version. Enable flag lives in root `Directory.Build.props` as a conditional default so subtree opt-outs can override it (the SDK imports `Directory.Packages.props` after the `Directory.Build.props` chain).
- Opt-outs: 
  - wrapper providers
  - MSI/Wix
  - the profiler solution's managed projects
  - integration/MFA compat apps
  - performance tests
  - build tools.
- `Home.csproj` is a project-level opt-out and keeps `NewRelic.Agent.Internal.Profiler` pinned inline so the existing `build_profiler.yml` workflow continues to work without modification.
- `StyleCop.Analyzers` is imported across the CPM boundary via `build/StyleCop.props`. It is centrally versioned; `StyleCop.props` sets a `_UsesStyleCop` marker and the root `Directory.Build.targets` (auto-imported last) adds the reference gated on that marker -- versionless under CPM, inline `1.1.118` for opt-outs.
- One `VersionOverride` exception: `SharpZipLib=1.4.2` in `TestSerializationHelpers` (Core caps at 1.3.3).
- `build/build_functions.ps1`'s `Get-GrpcPackagePath` now reads `Grpc.Core` from `Directory.Packages.props` (it previously scraped the stripped `Core.csproj` line).
- Dependabot config keeps `nuget-agent` narrowly scoped to the in-scope src project directories so it does not sweep the wrapper subtree's intentional old pins; the `nuget-tests` allow-list plus its `/` scan handles centrally-versioned test packages.
